### PR TITLE
ydb-bench: harden local YDB measurements and search

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.cpp
@@ -114,7 +114,8 @@ void TTopicWorkloadStatsCollector::PrintWindowStatsLoop() {
         };
         if (Now() > windowTime(windowIt) && !*ErrorFlag) {
             CollectThreadEvents();
-            PrintWindowStats(windowIt++);
+            PrintWindowStats(windowIt, windowTime(windowIt));
+            ++windowIt;
         }
         Sleep(std::max(TDuration::Zero(), windowTime(windowIt) - Now()));
     }
@@ -122,17 +123,17 @@ void TTopicWorkloadStatsCollector::PrintWindowStatsLoop() {
     CollectThreadEvents();
 }
 
-void TTopicWorkloadStatsCollector::PrintWindowStats(ui32 windowIt) {
-    PrintStats(windowIt);
+void TTopicWorkloadStatsCollector::PrintWindowStats(ui32 windowIt, TInstant windowTime) {
+    PrintStats(windowIt, windowTime);
 
     WindowStats = MakeHolder<TTopicWorkloadStats>();
 }
 void TTopicWorkloadStatsCollector::PrintTotalStats() const {
     PrintHeader(true);
-    PrintStats({});
+    PrintStats({}, Now());
 }
 
-void TTopicWorkloadStatsCollector::PrintStats(TMaybe<ui32> windowIt) const {
+void TTopicWorkloadStatsCollector::PrintStats(TMaybe<ui32> windowIt, TInstant windowTime) const {
     if (Quiet && windowIt.Defined()) {
         return;
     }
@@ -163,7 +164,7 @@ void TTopicWorkloadStatsCollector::PrintStats(TMaybe<ui32> windowIt) const {
         Cout << "\t" << stats.CommitTxTimeHist.GetValueAtPercentile(Percentile) << "\t";
     }
     if (PrintTimestamp) {
-        Cout << "\t" << Now().ToStringUpToSeconds();
+        Cout << "\t" << windowTime.ToStringUpToSeconds();
     }
     Cout << Endl;
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.cpp
@@ -42,17 +42,20 @@ TTopicWorkloadStatsCollector::TTopicWorkloadStatsCollector(
 }
 
 void TTopicWorkloadStatsCollector::PrintHeader(bool total) const {
-    if (Quiet && !total)
+    if (Quiet && !total) {
         return;
+    }
 
     TStringBuilder header;
 
     header << "Window\t";
-    if (WriterCount > 0)
+    if (WriterCount > 0) {
         header << "Write speed\tWrite time\tInflight\t";
+    }
     if (ReaderCount > 0) {
-        if (!TransferMode)
+        if (!TransferMode) {
             header << "Lag\t\tLag time\t";
+        }
         header << "Read speed\t";
         if (TransferMode) {
             header << "Topic time\t";
@@ -65,17 +68,20 @@ void TTopicWorkloadStatsCollector::PrintHeader(bool total) const {
         header << "Upsert time\t";
         header << "Commit time\t";
     }
-    if (PrintTimestamp)
+    if (PrintTimestamp) {
         header << "Timestamp";
+    }
 
     header << "\n";
 
     header << "#\t";
-    if (WriterCount > 0)
+    if (WriterCount > 0) {
         header << "msg/s\tMB/s\tpercentile,ms\tpercentile,msg\t";
+    }
     if (ReaderCount > 0) {
-        if (!TransferMode)
+        if (!TransferMode) {
             header << "percentile,msg\tpercentile,ms\t";
+        }
         header << "msg/s\tMB/s\tpercentile,ms\t";
     }
     if (TransferMode) {
@@ -110,7 +116,7 @@ void TTopicWorkloadStatsCollector::PrintWindowStatsLoop() {
             CollectThreadEvents();
             PrintWindowStats(windowIt++);
         }
-        Sleep(std::max(TDuration::Zero(), Now() - windowTime(windowIt)));
+        Sleep(std::max(TDuration::Zero(), windowTime(windowIt) - Now()));
     }
 
     CollectThreadEvents();
@@ -127,8 +133,9 @@ void TTopicWorkloadStatsCollector::PrintTotalStats() const {
 }
 
 void TTopicWorkloadStatsCollector::PrintStats(TMaybe<ui32> windowIt) const {
-    if (Quiet && windowIt.Defined())
+    if (Quiet && windowIt.Defined()) {
         return;
+    }
 
     const auto& stats = windowIt.Empty() ? TotalStats : *WindowStats;
     double seconds = windowIt.Empty() ? TotalSec - WarmupSec : WindowSec;
@@ -174,7 +181,7 @@ void TTopicWorkloadStatsCollector::CollectThreadEvents()
     CollectThreadEvents(WriterCommitTxEventQueues);
 }
 
-template<class T>
+template <class T>
 void TTopicWorkloadStatsCollector::CollectThreadEvents(TEventQueues<T>& queues)
 {
     for (auto& queue : queues) {
@@ -186,7 +193,7 @@ void TTopicWorkloadStatsCollector::CollectThreadEvents(TEventQueues<T>& queues)
     }
 }
 
-template<class T>
+template <class T>
 void TTopicWorkloadStatsCollector::AddQueue(TEventQueues<T>& queues)
 {
     auto queue = MakeHolder<TAutoLockFreeQueue<T>>();
@@ -246,7 +253,7 @@ void TTopicWorkloadStatsCollector::AddWriterCommitTxEvent(size_t writerIdx, cons
     AddEvent(writerIdx, WriterCommitTxEventQueues, event);
 }
 
-template<class T>
+template <class T>
 void TTopicWorkloadStatsCollector::AddEvent(size_t index, TEventQueues<T>& queues, const T& event)
 {
     if ((WarmupTime != TInstant()) && (Now() >= WarmupTime)) {

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.h
@@ -53,8 +53,8 @@ namespace NYdb {
             template<class T>
             void AddEvent(size_t index, TEventQueues<T>& queues, const T& event);
 
-            void PrintWindowStats(ui32 windowIt);
-            void PrintStats(TMaybe<ui32> windowIt) const;
+            void PrintWindowStats(ui32 windowIt, TInstant windowTime);
+            void PrintStats(TMaybe<ui32> windowIt, TInstant windowTime) const;
 
             size_t WriterCount;
             size_t ReaderCount;

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -119,6 +119,9 @@ Config V2 cluster backed by in-memory SectorMap PDisks, and stops it after the
 profile. `single` always uses one dynamic node. `storage` may grow the
 dynamic-node count up to `max-dynamic-nodes` when dynamic CPU is saturated but
 static/storage CPU is not; `custom` keeps the explicitly requested geometry.
+Across scaled stages, latency search selects the highest feasible load, while
+manual points and throughput search select the highest observed throughput;
+ties prefer fewer dynamic nodes.
 Each static node gets its own `NONE`-profile SectorMap with the virtual size
 specified by `disk-size-gb`, so benchmark results are not limited by a host
 block device.
@@ -254,9 +257,11 @@ throughput drift, and CPU saturation do not claim statistical reproducibility.
 
 Workloads with geometry-scoped datasets initialize and import once for each
 dynamic-node count, reuse that dataset across every search attempt at the same
-geometry, and clean it before adding nodes. The final geometry remains open for
-verification and is cleaned only after the holdout finishes. Shared setup and
-cleanup commands are stored under that geometry's `workload/commands.json`.
+geometry, and clean it before adding nodes. When the winning stage is the last
+one, its geometry remains open until verification finishes. If an earlier stage
+wins, verification recreates its geometry on a fresh cluster; that cluster's
+configuration is stored in `verification-cluster/cluster.yaml`. Shared setup
+and cleanup commands are stored under the corresponding `workload/commands.json`.
 
 During a local YDB run, the CLI reports cluster startup, workload initialization,
 warmup, measurement, cleanup, evaluation, and dynamic-node scaling milestones.

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -144,6 +144,9 @@ saturated measurement. A plateau is confirmed only when the selected role's
 CPU is saturated. `latency-slo` uses the configured `multiplier` to find the
 first failing point, then a binary search to find the highest load whose
 millisecond percentile, error count, and achieved-rate ratio satisfy the SLO.
+Automatic search is limited to 64 measurements. Configuration validation
+rejects ranges, multipliers, or resolutions whose worst-case search path can
+exceed that limit, so the computed profile timeout remains a real upper bound.
 For example:
 
 ```yaml

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -123,6 +123,12 @@ Each static node gets its own `NONE`-profile SectorMap with the virtual size
 specified by `disk-size-gb`, so benchmark results are not limited by a host
 block device.
 
+An explicitly configured profile `timeout` caps every YDB CLI setup, warmup,
+measurement, and cleanup command. Workload-specific safety limits still apply
+when they are shorter. Without an explicit cap, setup and cleanup retain their
+workload-specific budgets; the computed default covers cluster control and the
+configured search measurements.
+
 `load.parameter` selects the one monotonic YDB CLI setting controlled by the
 benchmark: `rate` maps to `--rate`, while `threads` maps to `--threads`. Topic
 also searches `rate`, but maps it to the Topic CLI's `--message-rate`. The `kv`
@@ -231,9 +237,10 @@ compatibility, but newly generated YAML uses `search` and `objective`.
 point. Set `measurement.verification-repetitions` to run additional independent
 samples at the load selected by the search; it defaults to `0` so existing
 configurations keep their previous runtime and is limited to 20. These
-post-search samples contribute to the automatically computed default command
-timeout; `timeout` remains a per-command safety bound rather than an absolute
-profile deadline. Verification never
+post-search samples are included when deriving the default cluster-control
+timeout. An explicitly configured `timeout` also caps each workload command;
+it remains a per-command safety bound rather than an absolute profile deadline.
+Verification never
 changes the selected load or dynamic-node scaling decision. Its holdout samples
 are written separately to `verification-repetitions.csv` and
 `verification-summary.csv`; a completed holdout becomes the reported metric

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -208,10 +208,10 @@ reader threads. The CLI receives `--seconds` equal to warmup plus measurement
 duration, one-second reporting windows with UTC timestamps, and a fixed p99
 percentile. Metrics aggregate every numbered measurement window after warmup:
 rates use the mean while percentiles, lag, and inflight values use the maximum.
-CPU aggregation starts at the timestamp boundary immediately before the first
-measurement window and ends at the last measurement-window timestamp, so it
-covers the same interval; with zero warmup the first timestamp minus one second
-is used as that boundary.
+The CLI timestamps each row with its nominal window boundary, so delayed
+printing cannot create gaps or duplicates in the timeline. CPU aggregation
+ends at the last measurement-window timestamp and starts exactly the requested
+measurement duration earlier.
 
 Canonical Topic throughput is the smaller of the write rate and the aggregate
 read rate divided by `consumers`. The raw aggregate read rate and normalized

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -129,8 +129,9 @@ block device.
 An explicitly configured profile `timeout` caps every YDB CLI setup, warmup,
 measurement, and cleanup command. Workload-specific safety limits still apply
 when they are shorter. Without an explicit cap, setup and cleanup retain their
-workload-specific budgets; the computed default covers cluster control and the
-configured search measurements.
+workload-specific budgets. The computed default is used as a conservative
+per-command budget for cluster control; it is not a deadline or an estimate of
+the total profile runtime.
 
 `load.parameter` selects the one monotonic YDB CLI setting controlled by the
 benchmark: `rate` maps to `--rate`, while `threads` maps to `--threads`. Topic
@@ -148,6 +149,8 @@ CPU is saturated. `latency-slo` uses the configured `multiplier` to find the
 first failing point, then a binary search to find the highest load whose
 millisecond percentile, error count, and achieved-rate ratio satisfy the SLO.
 Automatic search is limited to 64 measurements per cluster-geometry stage.
+The `storage` preset can run a separate search after each dynamic-node scaling
+step, so a complete profile can contain more than 64 measurements.
 Latency-SLO configuration validation rejects ranges, multipliers, or
 resolutions whose deterministic worst-case search path can exceed that limit.
 Throughput search stops at the limit and reports the best point measured so far
@@ -247,9 +250,10 @@ compatibility, but newly generated YAML uses `search` and `objective`.
 point. Set `measurement.verification-repetitions` to run additional independent
 samples at the load selected by the search; it defaults to `0` so existing
 configurations keep their previous runtime and is limited to 20. These
-post-search samples are included when deriving the default cluster-control
-timeout. An explicitly configured `timeout` also caps each workload command;
-it remains a per-command safety bound rather than an absolute profile deadline.
+post-search samples are included when deriving the conservative default
+cluster-control command budget. An explicitly configured `timeout` also caps
+each workload command; it remains a per-command safety bound rather than an
+absolute profile deadline.
 Verification never
 changes the selected load or dynamic-node scaling decision. Its holdout samples
 are written separately to `verification-repetitions.csv` and

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -194,9 +194,12 @@ the next search or verification sample. `partitions`, `consumers`,
 `--consumer-threads`; with multiple consumers, each consumer receives that many
 reader threads. The CLI receives `--seconds` equal to warmup plus measurement
 duration, one-second reporting windows with UTC timestamps, and a fixed p99
-percentile. CPU aggregation is anchored to the CLI timestamps at windows
-`warmup + 1` and `warmup + duration`; this excludes topic/session startup and
-the first measurement interval from the approximate CPU window.
+percentile. Metrics aggregate every numbered measurement window after warmup:
+rates use the mean while percentiles, lag, and inflight values use the maximum.
+CPU aggregation starts at the timestamp boundary immediately before the first
+measurement window and ends at the last measurement-window timestamp, so it
+covers the same interval; with zero warmup the first timestamp minus one second
+is used as that boundary.
 
 Canonical Topic throughput is the smaller of the write rate and the aggregate
 read rate divided by `consumers`. The raw aggregate read rate and normalized

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -167,15 +167,17 @@ The result is rejected if the CLI reports a different number of execution
 threads than `client.threads`, which prevents CPU-based CLI clamping from
 silently changing the configuration being compared.
 
-TPC-C warmup is inline. The CLI receives the explicit value
-`max(measurement.warmup, floor(warehouses / 10) + 1)` so terminal startup is
-complete before measurement; YAML `warmup: 0` requests that minimum rather
-than the CLI's adaptive warmup. Measurement duration must be at least two
-seconds. Canonical throughput is uncapped successful NewOrder transactions per
-requested admission second. Requests admitted before the deadline may finish
-during graceful drain; `cli_elapsed_seconds` exposes that drain-inclusive CLI
-interval. The CLI-reported, warehouse-capped `tpmC` and efficiency remain
-drain-inclusive diagnostics. Latency SLOs use the admitted latency of
+TPC-C warmup is inline. When `measurement.warmup` is omitted, `--warmup` is
+also omitted and the CLI selects its adaptive warmup from the warehouse count.
+Timeouts and progress use the same heuristic as the CLI. An explicit value is
+raised to at least `floor(warehouses / 10) + 1` seconds so terminal startup is
+complete before measurement; YAML `warmup: 0` therefore requests that minimum.
+Measurement duration must be at least two seconds. Canonical throughput is
+uncapped successful NewOrder transactions per requested admission second.
+Requests admitted before the deadline may finish during graceful drain;
+`cli_elapsed_seconds` exposes that drain-inclusive CLI interval. The
+CLI-reported, warehouse-capped `tpmC` and efficiency remain drain-inclusive
+diagnostics. Latency SLOs use the admitted latency of
 `latency-transaction`: it excludes the queue created by the configured
 `max-sessions` limit, but includes session acquisition and SDK retries. This
 keeps the latency signal monotonic enough for load search; the full terminal

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -147,9 +147,12 @@ saturated measurement. A plateau is confirmed only when the selected role's
 CPU is saturated. `latency-slo` uses the configured `multiplier` to find the
 first failing point, then a binary search to find the highest load whose
 millisecond percentile, error count, and achieved-rate ratio satisfy the SLO.
-Automatic search is limited to 64 measurements. Configuration validation
-rejects ranges, multipliers, or resolutions whose worst-case search path can
-exceed that limit, so the computed profile timeout remains a real upper bound.
+Automatic search is limited to 64 measurements per cluster-geometry stage.
+Latency-SLO configuration validation rejects ranges, multipliers, or
+resolutions whose deterministic worst-case search path can exceed that limit.
+Throughput search stops at the limit and reports the best point measured so far
+with a `search-limit-reached` outcome, because its path depends on measured
+throughput, feasibility, and cached probes.
 For example:
 
 ```yaml

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -172,8 +172,10 @@ TPC-C warmup is inline. The CLI receives the explicit value
 complete before measurement; YAML `warmup: 0` requests that minimum rather
 than the CLI's adaptive warmup. Measurement duration must be at least two
 seconds. Canonical throughput is uncapped successful NewOrder transactions per
-measured second. The CLI-reported, warehouse-capped `tpmC` remains available as
-the separate `tpcc_tpmc` metric. Latency SLOs use the admitted latency of
+requested admission second. Requests admitted before the deadline may finish
+during graceful drain; `cli_elapsed_seconds` exposes that drain-inclusive CLI
+interval. The CLI-reported, warehouse-capped `tpmC` and efficiency remain
+drain-inclusive diagnostics. Latency SLOs use the admitted latency of
 `latency-transaction`: it excludes the queue created by the configured
 `max-sessions` limit, but includes session acquisition and SDK retries. This
 keeps the latency signal monotonic enough for load search; the full terminal

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -211,7 +211,8 @@ rates use the mean while percentiles, lag, and inflight values use the maximum.
 The CLI timestamps each row with its nominal window boundary, so delayed
 printing cannot create gaps or duplicates in the timeline. CPU aggregation
 ends at the last measurement-window timestamp and starts exactly the requested
-measurement duration earlier.
+measurement duration earlier. Warmup plus measurement duration is limited to
+one hour so the per-second CLI output and parser state remain bounded.
 
 Canonical Topic throughput is the smaller of the write rate and the aggregate
 read rate divided by `consumers`. The raw aggregate read rate and normalized

--- a/ydb/tools/ydb_bench/benchmarks/local_ydb.py
+++ b/ydb/tools/ydb_bench/benchmarks/local_ydb.py
@@ -65,10 +65,11 @@ def validate_metrics(rows, configuration, _case):
         raise BenchmarkError("YDB CLI workload reported {} errors".format(errors))
 
 
-def summarize_metrics(repetition_rows, benchmark, metric_names=None):
+def summarize_metrics(repetition_rows, benchmark, metric_names=None, metric_aggregations=None):
     metric_names = (
         tuple(metric_names) if metric_names is not None else tuple(metric.name for metric in benchmark.metrics)
     )
+    metric_aggregations = metric_aggregations or {}
     grouped = {}
     for row in repetition_rows:
         key = tuple(row[item.name] for item in benchmark.dimensions)
@@ -91,17 +92,22 @@ def summarize_metrics(repetition_rows, benchmark, metric_names=None):
             record["median_" + name] = statistics.median(values)
             record["min_" + name] = min(values)
             record["max_" + name] = max(values)
+            if metric_aggregations.get(name) == "sum":
+                record["sum_" + name] = sum(values)
         result.append(record)
     return result
 
 
-def render_summary(rows, benchmark, metric_names=None):
+def render_summary(rows, benchmark, metric_names=None, metric_aggregations=None):
     metric_names = (
         tuple(metric_names) if metric_names is not None else tuple(metric.name for metric in benchmark.metrics)
     )
+    metric_aggregations = metric_aggregations or {}
     columns = ["affinity_mode"] + [item.name for item in benchmark.dimensions] + ["samples"]
     for name in metric_names:
         columns += ["median_" + name, "min_" + name, "max_" + name]
+        if metric_aggregations.get(name) == "sum":
+            columns.append("sum_" + name)
     output = io.StringIO()
     writer = csv.DictWriter(output, fieldnames=columns, lineterminator="\n")
     writer.writeheader()

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -22,7 +22,11 @@ from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
     workload_effective_warmup_seconds,
     workload_config_schema,
 )
-from ydb.tools.ydb_bench.lib.load_control import MAX_AUTOMATIC_SEARCH_ATTEMPTS, validate_search_attempt_bound
+from ydb.tools.ydb_bench.lib.load_control import (
+    MAX_AUTOMATIC_SEARCH_ATTEMPTS,
+    MAX_LOAD_VALUE,
+    validate_search_attempt_bound,
+)
 from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES
 
 PROFILE_NAME_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$"
@@ -146,12 +150,12 @@ def _profile_schema(benchmark):
                         "allow-errors": {"type": "boolean"},
                         "values": {
                             "type": "array",
-                            "items": {"type": "integer", "minimum": 1},
+                            "items": {"type": "integer", "minimum": 1, "maximum": MAX_LOAD_VALUE},
                             "minItems": 1,
                             "uniqueItems": True,
                         },
-                        "start": {"type": "integer", "minimum": 1},
-                        "maximum": {"type": "integer", "minimum": 1},
+                        "start": {"type": "integer", "minimum": 1, "maximum": MAX_LOAD_VALUE},
+                        "maximum": {"type": "integer", "minimum": 1, "maximum": MAX_LOAD_VALUE},
                         "multiplier": {"type": "number", "exclusiveMinimum": 1},
                         "target-role": {"enum": ["static", "dynamic", "total"]},
                         "plateau-gain-percent": {"type": "number", "minimum": 0},
@@ -181,8 +185,8 @@ def _profile_schema(benchmark):
                             "additionalProperties": False,
                             "required": ["start", "maximum"],
                             "properties": {
-                                "start": {"type": "integer", "minimum": 1},
-                                "maximum": {"type": "integer", "minimum": 1},
+                                "start": {"type": "integer", "minimum": 1, "maximum": MAX_LOAD_VALUE},
+                                "maximum": {"type": "integer", "minimum": 1, "maximum": MAX_LOAD_VALUE},
                                 "multiplier": {"type": "number", "exclusiveMinimum": 1},
                                 "resolution-percent": {
                                     "type": "number",
@@ -399,6 +403,22 @@ def _positive_integer(value, location):
     return value
 
 
+def _load_value(value, location):
+    result = _positive_integer(value, location)
+    if result > MAX_LOAD_VALUE:
+        _config_error(location, "must be at most {}".format(MAX_LOAD_VALUE))
+    return result
+
+
+def _load_value_list(value, location):
+    if not isinstance(value, list) or not value:
+        _config_error(location, "must be a non-empty array of positive integers")
+    parsed = tuple(_load_value(item, "{}[{}]".format(location, index)) for index, item in enumerate(value))
+    if len(set(parsed)) != len(parsed):
+        _config_error(location, "must not contain duplicate values")
+    return parsed
+
+
 def _positive_integer_list(value, location):
     if not isinstance(value, list) or not value:
         _config_error(location, "must be a non-empty array of positive integers")
@@ -445,7 +465,10 @@ def _background_load_modes(value, location):
 def _timeout(value, location):
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         _config_error(location, "must be a finite positive number")
-    value = float(value)
+    try:
+        value = float(value)
+    except (TypeError, ValueError, OverflowError):
+        _config_error(location, "must be a finite positive number")
     if value <= 0 or not math.isfinite(value):
         _config_error(location, "must be a finite positive number")
     return value
@@ -481,9 +504,12 @@ def _nonnegative_integer(value, location):
 
 
 def _finite_number(value, location, minimum=None, maximum=None, exclusive_minimum=False):
-    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError):
         _config_error(location, "must be a finite number")
-    result = float(value)
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(result):
+        _config_error(location, "must be a finite number")
     if minimum is not None and (result <= minimum if exclusive_minimum else result < minimum):
         _config_error(location, "must be {} {}".format("greater than" if exclusive_minimum else "at least", minimum))
     if maximum is not None and result > maximum:
@@ -621,7 +647,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
         if load_mode == "points":
             if "values" not in load:
                 _config_error(location + ".load", "manual load requires values")
-            load_config["values"] = list(_positive_integer_list(load["values"], location + ".load.values"))
+            load_config["values"] = list(_load_value_list(load["values"], location + ".load.values"))
         else:
             for required in ("start", "maximum"):
                 if required not in load:
@@ -657,8 +683,8 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
         for required in ("start", "maximum"):
             if required not in search:
                 _config_error(location + ".load.search", "missing required field: {}".format(required))
-        start = _positive_integer(search["start"], location + ".load.search.start")
-        maximum = _positive_integer(search["maximum"], location + ".load.search.maximum")
+        start = _load_value(search["start"], location + ".load.search.start")
+        maximum = _load_value(search["maximum"], location + ".load.search.maximum")
         if maximum < start:
             _config_error(location + ".load.search.maximum", "must not be below start")
         load_config["search"] = {

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -22,6 +22,7 @@ from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
     workload_effective_warmup_seconds,
     workload_config_schema,
 )
+from ydb.tools.ydb_bench.lib.load_control import MAX_AUTOMATIC_SEARCH_ATTEMPTS, validate_search_attempt_bound
 from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES
 
 PROFILE_NAME_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$"
@@ -754,6 +755,10 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
                 }
             )
         load_config["objective"] = parsed_objective
+        try:
+            validate_search_attempt_bound(load_config)
+        except BenchmarkError as error:
+            _config_error(location + ".load.search", str(error))
 
     measurement = _mapping(
         value.get("measurement"),
@@ -797,7 +802,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
         ),
     }
 
-    attempts = len(load_config.get("values", ())) or 64
+    attempts = len(load_config.get("values", ())) or MAX_AUTOMATIC_SEARCH_ATTEMPTS
     measurement_runs = attempts * measurement_config["repetitions"] + measurement_config["verification_repetitions"]
     effective_warmup = workload_effective_warmup_seconds(workload, measurement_config["warmup"])
     computed_timeout = 300 + measurement_runs * (effective_warmup + measurement_config["duration"] + 10)

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -512,6 +512,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
         _config_error(location, "does not support --perf; CPU utilization is collected per process role")
 
     workload = normalize_workload(value.get("workload"), location + ".workload")
+    workload_metadata = workload_definition(workload["type"])
 
     geometry = _mapping(
         value.get("geometry"),
@@ -554,7 +555,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
 
     client = _mapping(value.get("client"), location + ".client", ("threads",))
     client_threads = _positive_integer(
-        client.get("threads", workload_definition(workload["type"]).default_client_threads),
+        client.get("threads", workload_metadata.default_client_threads),
         location + ".client.threads",
     )
 
@@ -769,8 +770,13 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
             verification_location,
             "must be at most {}".format(MAX_LOCAL_YDB_VERIFICATION_REPETITIONS),
         )
+    configured_warmup = (
+        _nonnegative_integer(measurement["warmup"], location + ".measurement.warmup")
+        if "warmup" in measurement
+        else workload_metadata.default_warmup_seconds
+    )
     measurement_config = {
-        "warmup": _nonnegative_integer(measurement.get("warmup", 10), location + ".measurement.warmup"),
+        "warmup": configured_warmup,
         "duration": _positive_integer(measurement.get("duration", 30), location + ".measurement.duration"),
         "repetitions": _positive_integer(measurement.get("repetitions", 3), location + ".measurement.repetitions"),
         "verification_repetitions": verification_repetitions,

--- a/ydb/tools/ydb_bench/lib/load_control.py
+++ b/ydb/tools/ydb_bench/lib/load_control.py
@@ -47,26 +47,14 @@ def _maximum_latency_attempts(search):
     return worst
 
 
-def _maximum_throughput_attempts(search):
-    width = search["maximum"] - search["start"]
-    resolution = max(1, int(round(width * search["resolution_percent"] / 100.0)))
-    attempts = 1
-    while width > resolution:
-        third = max(1, width // 3)
-        if third >= width - third:
-            break
-        attempts += 2
-        width = width - third - 1
-        if attempts > MAX_AUTOMATIC_SEARCH_ATTEMPTS:
-            return attempts
-    return attempts + 3
-
-
 def validate_search_attempt_bound(config):
-    """Reject automatic searches whose worst path exceeds the runtime budget."""
+    """Reject latency searches whose worst path exceeds the runtime budget."""
     objective_type = config["objective"]["type"]
     if objective_type == "maximize-throughput":
-        attempts = _maximum_throughput_attempts(config["search"])
+        # Throughput search branches on both feasibility and observed throughput.
+        # It is stopped gracefully by the runtime budget instead of rejecting a
+        # range using a pessimistic estimate which cannot account for cached probes.
+        return
     elif objective_type == "latency-slo":
         attempts = _maximum_latency_attempts(config["search"])
     else:
@@ -219,6 +207,7 @@ def _run_throughput(config, measure, on_attempt):
     failing_load = None
     plateau = 0
     plateau_confirmed = False
+    search_limit_reached = False
 
     def sample(load, reason, baseline=None, search_low=None, search_high=None):
         nonlocal failing_load
@@ -280,11 +269,17 @@ def _run_throughput(config, measure, on_attempt):
         upper_load = high - third
         if lower_load >= upper_load:
             break
+        if len(attempts) >= MAX_AUTOMATIC_SEARCH_ATTEMPTS and lower_load not in measured:
+            search_limit_reached = True
+            break
         lower = sample(lower_load, "lower ternary probe", search_low=low, search_high=high)
         if not lower["passed"]:
             plateau = 0
             high = lower_load - 1
             continue
+        if len(attempts) >= MAX_AUTOMATIC_SEARCH_ATTEMPTS and upper_load not in measured:
+            search_limit_reached = True
+            break
         upper = sample(
             upper_load,
             "upper ternary probe",
@@ -312,13 +307,21 @@ def _run_throughput(config, measure, on_attempt):
             low = lower_load + 1
 
     for load in sorted({low, (low + high) // 2, high}):
+        if len(attempts) >= MAX_AUTOMATIC_SEARCH_ATTEMPTS and load not in measured:
+            search_limit_reached = True
+            break
         sample(load, "final ternary candidate", search_low=low, search_high=high)
     selected = (
         _lowest_saturated_plateau_load(attempts, objective["plateau_gain_percent"])
         if plateau_confirmed
         else _best_throughput(attempts)
     )
-    if selected is None:
+    if search_limit_reached:
+        outcome = "search-limit-reached"
+        stop_reason = "throughput search reached its {}-attempt safety limit".format(
+            MAX_AUTOMATIC_SEARCH_ATTEMPTS
+        )
+    elif selected is None:
         outcome = "no-feasible-point"
         stop_reason = "ternary search found no feasible load"
     elif plateau_confirmed:

--- a/ydb/tools/ydb_bench/lib/load_control.py
+++ b/ydb/tools/ydb_bench/lib/load_control.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 
 from ydb.tools.ydb_bench.lib.common import BenchmarkError
 
+MAX_AUTOMATIC_SEARCH_ATTEMPTS = 64
+
 
 @dataclass(frozen=True)
 class LoadSearchResult:
@@ -18,6 +20,69 @@ class LoadSearchResult:
 def _next_geometric(current, maximum, multiplier):
     candidate = max(current + 1, int(round(current * multiplier)))
     return min(maximum, candidate)
+
+
+def _binary_probe_count(low, high, resolution):
+    probes = 0
+    width = high - low
+    while width > resolution:
+        probes += 1
+        width = (width + 1) // 2
+    return probes
+
+
+def _maximum_latency_attempts(search):
+    current = search["start"]
+    maximum = search["maximum"]
+    probes = 1
+    worst = probes
+    while current < maximum:
+        previous = current
+        current = _next_geometric(current, maximum, search["multiplier"])
+        probes += 1
+        resolution = max(1, int(round(max(current, 1) * search["resolution_percent"] / 100.0)))
+        worst = max(worst, probes + _binary_probe_count(previous, current, resolution))
+        if worst > MAX_AUTOMATIC_SEARCH_ATTEMPTS:
+            return worst
+    return worst
+
+
+def _maximum_throughput_attempts(search):
+    width = search["maximum"] - search["start"]
+    resolution = max(1, int(round(width * search["resolution_percent"] / 100.0)))
+    attempts = 1
+    while width > resolution:
+        third = max(1, width // 3)
+        if third >= width - third:
+            break
+        attempts += 2
+        width = width - third - 1
+        if attempts > MAX_AUTOMATIC_SEARCH_ATTEMPTS:
+            return attempts
+    return attempts + 3
+
+
+def validate_search_attempt_bound(config):
+    """Reject automatic searches whose worst path exceeds the runtime budget."""
+    objective_type = config["objective"]["type"]
+    if objective_type == "maximize-throughput":
+        attempts = _maximum_throughput_attempts(config["search"])
+    elif objective_type == "latency-slo":
+        attempts = _maximum_latency_attempts(config["search"])
+    else:
+        raise BenchmarkError("unsupported load objective: {}".format(objective_type))
+    if attempts > MAX_AUTOMATIC_SEARCH_ATTEMPTS:
+        raise BenchmarkError(
+            "automatic load search may require more than {} attempts; "
+            "narrow the range or increase multiplier/resolution-percent".format(MAX_AUTOMATIC_SEARCH_ATTEMPTS)
+        )
+
+
+def _ensure_attempt_capacity(attempts):
+    if len(attempts) >= MAX_AUTOMATIC_SEARCH_ATTEMPTS:
+        raise BenchmarkError(
+            "automatic load search exceeded its {}-attempt safety limit".format(MAX_AUTOMATIC_SEARCH_ATTEMPTS)
+        )
 
 
 def _target_cpu(metrics, target_role):
@@ -159,6 +224,7 @@ def _run_throughput(config, measure, on_attempt):
         nonlocal failing_load
         if load in measured:
             return measured[load]
+        _ensure_attempt_capacity(attempts)
         metrics = measure(load)
         saturated = _target_cpu(metrics, objective["target_role"]) >= objective["cpu_saturation_percent"]
         passed, evaluation_reason = evaluate_load(config, load, metrics)
@@ -295,6 +361,7 @@ def _run_latency(config, measure, on_attempt):
     def sample(load):
         if load in measured:
             return measured[load]
+        _ensure_attempt_capacity(attempts)
         metrics = measure(load)
         passed, reason = evaluate_load(config, load, metrics)
         record = _with_decision(metrics, load, passed, reason)
@@ -366,6 +433,7 @@ def search_load(config, measure, on_attempt=None):
     """Run the configured controller using ``measure(load) -> metrics``."""
     if "values" in config:
         return _run_points(config, measure, on_attempt)
+    validate_search_attempt_bound(config)
     objective_type = config["objective"]["type"]
     if objective_type == "maximize-throughput":
         return _run_throughput(config, measure, on_attempt)

--- a/ydb/tools/ydb_bench/lib/load_control.py
+++ b/ydb/tools/ydb_bench/lib/load_control.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from ydb.tools.ydb_bench.lib.common import BenchmarkError
 
 MAX_AUTOMATIC_SEARCH_ATTEMPTS = 64
+MAX_LOAD_VALUE = (1 << 53) - 1
 
 
 @dataclass(frozen=True)
@@ -18,6 +19,8 @@ class LoadSearchResult:
 
 
 def _next_geometric(current, maximum, multiplier):
+    if multiplier >= maximum / current:
+        return maximum
     candidate = max(current + 1, int(round(current * multiplier)))
     return min(maximum, candidate)
 

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -1161,7 +1161,7 @@ class WorkloadLifecycle:
                 load,
                 self.measurement["duration"],
                 self.client_threads,
-                warmup_seconds=warmup if self.definition.warmup_mode == "inline" else 0,
+                warmup_seconds=configured_warmup if self.definition.warmup_mode == "inline" else 0,
             )
             self.cluster.ensure_running("cannot start workload measurement")
             progress_fields = {
@@ -1177,7 +1177,7 @@ class WorkloadLifecycle:
             }
             if self.definition.warmup_mode == "inline":
                 progress_fields["inline_warmup_seconds"] = warmup
-                if warmup != configured_warmup:
+                if configured_warmup is not None and warmup != configured_warmup:
                     progress_fields["configured_warmup_seconds"] = configured_warmup
             self.progress(phases["measure"], **progress_fields)
             result = run_command(

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -602,11 +602,7 @@ class LocalYdbCluster:
         while time.monotonic() < deadline:
             self._check_cancelled()
             last_result = run_command(command, {}, 10, work_dir_hint=self.directory, cancel_event=self.cancel_event)
-            if (
-                not last_result.exit_code
-                and not last_result.timed_out
-                and _database_status_ready(last_result.stdout)
-            ):
+            if not last_result.exit_code and not last_result.timed_out and _database_status_ready(last_result.stdout):
                 atomic_write_text(self.directory / "database-status.txt", last_result.stdout)
                 return
             if any(process.poll() is not None for process in self.static_processes + self.dynamic_processes):
@@ -1325,6 +1321,7 @@ def run_local_ydb(
     definition = workload_definition(profile["workload"]["type"])
     workload_metrics = definition.result_adapter.metrics
     metric_columns = _workload_metric_columns(benchmark, workload_metrics)
+    metric_aggregations = {metric.name: metric.repetition_aggregation for metric in workload_metrics}
     topology = discover_topology()
     affinities = plan_role_affinity(profile["affinity"], topology)
     _validate_role_affinity(profile["geometry"], affinities)
@@ -1579,7 +1576,12 @@ def run_local_ydb(
             )
             cluster.add_dynamic_nodes(new_count - dynamic_nodes)
 
-        summary_rows = benchmark.summarize_metrics(repetition_rows, benchmark, metric_columns)
+        summary_rows = benchmark.summarize_metrics(
+            repetition_rows,
+            benchmark,
+            metric_columns,
+            metric_aggregations,
+        )
         _write_csv(
             output_directory / "repetitions.csv",
             repetition_rows,
@@ -1587,7 +1589,7 @@ def run_local_ydb(
         )
         atomic_write_text(
             output_directory / "summary.csv",
-            benchmark.render_summary(summary_rows, benchmark, metric_columns),
+            benchmark.render_summary(summary_rows, benchmark, metric_columns, metric_aggregations),
         )
 
         verification_repetitions = profile["measurement"].get("verification_repetitions", 0)
@@ -1650,10 +1652,20 @@ def run_local_ydb(
                         verification_rows,
                         [item.name for item in benchmark.dimensions] + ["repetition"] + metric_columns,
                     )
-                    partial_summary = benchmark.summarize_metrics(verification_rows, benchmark, metric_columns)
+                    partial_summary = benchmark.summarize_metrics(
+                        verification_rows,
+                        benchmark,
+                        metric_columns,
+                        metric_aggregations,
+                    )
                     atomic_write_text(
                         output_directory / "verification-summary.csv",
-                        benchmark.render_summary(partial_summary, benchmark, metric_columns),
+                        benchmark.render_summary(
+                            partial_summary,
+                            benchmark,
+                            metric_columns,
+                            metric_aggregations,
+                        ),
                     )
                     verification.update(
                         {

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -827,6 +827,7 @@ class WorkloadLifecycle:
         affinities,
         cancel_event,
         progress,
+        command_timeout_seconds=None,
     ):
         self.cluster = cluster
         self.workload_cli = workload_cli
@@ -839,11 +840,21 @@ class WorkloadLifecycle:
         self.affinities = affinities
         self.cancel_event = cancel_event
         self.progress = progress
+        if command_timeout_seconds is not None and (
+            not _is_finite_number(command_timeout_seconds) or command_timeout_seconds <= 0
+        ):
+            raise BenchmarkError("workload command timeout must be a positive finite number")
+        self.command_timeout_seconds = command_timeout_seconds
         self.definition = workload_definition(workload["type"])
         self._profile_opened = False
         self._profile_closed = False
         self._profile_state = None
         self._geometry_state = None
+
+    def _plan_timeout(self, plan):
+        if self.command_timeout_seconds is None:
+            return plan.timeout_seconds
+        return min(plan.timeout_seconds, self.command_timeout_seconds)
 
     @property
     def profile_commands(self):
@@ -924,7 +935,7 @@ class WorkloadLifecycle:
                         self.affinities["ydb_cli"],
                     ),
                 )
-                result, attempts = self.cluster.init_workload(plan.argv, timeout=plan.timeout_seconds)
+                result, attempts = self.cluster.init_workload(plan.argv, timeout=self._plan_timeout(plan))
                 state.commands.extend(
                     _command_record(
                         phase,
@@ -996,7 +1007,7 @@ class WorkloadLifecycle:
             try:
                 result = self.cluster._run(
                     plan.argv,
-                    timeout=plan.timeout_seconds,
+                    timeout=self._plan_timeout(plan),
                     cpu_affinity=self.affinities["ydb_cli"],
                     ignore_cancellation=True,
                 )
@@ -1123,7 +1134,7 @@ class WorkloadLifecycle:
             )
             result = self.cluster._run(
                 warmup_plan.argv,
-                timeout=warmup_plan.timeout_seconds,
+                timeout=self._plan_timeout(warmup_plan),
                 cpu_affinity=self.affinities["ydb_cli"],
             )
             commands.append(
@@ -1183,7 +1194,7 @@ class WorkloadLifecycle:
             result = run_command(
                 plan.argv,
                 {},
-                plan.timeout_seconds,
+                self._plan_timeout(plan),
                 cpu_affinity=self.affinities["ydb_cli"],
                 cancel_event=self.cancel_event,
                 on_process_started=lambda process: cli_pids.append(process.pid),
@@ -1437,6 +1448,7 @@ def run_local_ydb(
             affinities,
             cancel_event,
             publish_progress,
+            command_timeout_seconds=(configuration.timeout_seconds if configuration.timeout_explicit else None),
         )
         lifecycle.open_profile(output_directory / "workload", "ydb_bench_profile")
         while True:

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -768,6 +768,18 @@ def _search_scaling_evidence(result, saturation_percent):
     return None, None
 
 
+def _search_stage_score(load_config, search_record):
+    selected = search_record.get("selected_metrics")
+    if selected is None or search_record.get("selected_load") is None:
+        return None
+    objective_type = load_config.get("objective", {}).get("type", "points")
+    dynamic_nodes = search_record["dynamic_nodes"]
+    selected_load = search_record["selected_load"]
+    if objective_type == "latency-slo":
+        return selected_load, -dynamic_nodes, selected["throughput"]
+    return selected["throughput"], -dynamic_nodes, -selected_load
+
+
 def _role_capacity(mask, topology):
     return len(mask) if mask is not None else len(topology.allowed_cpus)
 
@@ -1048,7 +1060,7 @@ class WorkloadLifecycle:
                 raise errors[0]
             raise BenchmarkError("workload cleanup failed: {}".format("; ".join(map(str, errors))))
 
-    def open_profile(self, directory, table_path):
+    def open_profile(self, directory, table_path, purpose="profile", progress_fields=None):
         if self._profile_opened:
             raise BenchmarkError("workload profile lifecycle is already open")
         self._profile_opened = True
@@ -1059,14 +1071,14 @@ class WorkloadLifecycle:
         state = _DatasetState(
             directory=directory,
             table_path=table_path,
-            purpose="profile",
+            purpose=purpose,
             repetition=None,
-            fields={"profile_dataset": True},
+            fields={**(progress_fields or {}), "profile_dataset": True},
         )
         self._profile_state = state
         self._prepare_dataset(state)
 
-    def open_geometry(self, directory, table_path, dynamic_nodes, progress_fields=None):
+    def open_geometry(self, directory, table_path, dynamic_nodes, progress_fields=None, purpose="geometry"):
         if not self._profile_opened or self._profile_closed:
             raise BenchmarkError("workload profile lifecycle is not open")
         self._check_cancelled()
@@ -1081,7 +1093,7 @@ class WorkloadLifecycle:
         state = _DatasetState(
             directory=directory,
             table_path=table_path,
-            purpose="geometry",
+            purpose=purpose,
             repetition=None,
             fields={**(progress_fields or {}), "geometry_dataset": True, "dynamic_nodes": dynamic_nodes},
         )
@@ -1409,18 +1421,38 @@ def run_local_ydb(
                 compact[name] = {key: value for key, value in metrics.items() if key != "commands"}
         return compact
 
-    cluster = LocalYdbCluster(
-        binaries["ydbd"].path,
-        binaries["ydb_cli"].path,
-        binaries["process_guard"].path,
-        output_directory / "cluster",
-        profile["geometry"],
-        affinities,
-        configuration.timeout_seconds,
-        cancel_event,
-        publish_progress,
-    )
+    def create_cluster(directory, geometry):
+        return LocalYdbCluster(
+            binaries["ydbd"].path,
+            binaries["ydb_cli"].path,
+            binaries["process_guard"].path,
+            directory,
+            geometry,
+            affinities,
+            configuration.timeout_seconds,
+            cancel_event,
+            publish_progress,
+        )
+
+    def create_lifecycle(target_cluster):
+        return WorkloadLifecycle(
+            target_cluster,
+            WorkloadCli(target_cluster.ydb_cli, target_cluster.client_endpoint, target_cluster.database),
+            profile["workload"],
+            profile["load"],
+            profile["measurement"],
+            profile["client"]["threads"],
+            benchmark,
+            topology,
+            affinities,
+            cancel_event,
+            publish_progress,
+            command_timeout_seconds=(configuration.timeout_seconds if configuration.timeout_explicit else None),
+        )
+
+    cluster = create_cluster(output_directory / "cluster", profile["geometry"])
     repetition_rows = []
+    best_search_record = None
     cluster_stopped = False
     lifecycle = None
 
@@ -1435,21 +1467,7 @@ def run_local_ydb(
 
     try:
         cluster.start()
-        workload_cli = WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database)
-        lifecycle = WorkloadLifecycle(
-            cluster,
-            workload_cli,
-            profile["workload"],
-            profile["load"],
-            profile["measurement"],
-            profile["client"]["threads"],
-            benchmark,
-            topology,
-            affinities,
-            cancel_event,
-            publish_progress,
-            command_timeout_seconds=(configuration.timeout_seconds if configuration.timeout_explicit else None),
-        )
+        lifecycle = create_lifecycle(cluster)
         lifecycle.open_profile(output_directory / "workload", "ydb_bench_profile")
         while True:
             dynamic_nodes = len(cluster.dynamic_nodes)
@@ -1560,22 +1578,27 @@ def run_local_ydb(
             else:
                 new_count = None
                 search_record["next_action"] = "finish"
+            score = _search_stage_score(profile["load"], search_record)
+            best_score = _search_stage_score(profile["load"], best_search_record or {})
+            if score is not None and (best_score is None or score > best_score):
+                best_search_record = search_record
             manifest["searches"].append(search_record)
             write_manifest(manifest_path, manifest)
 
             if new_count is None:
+                selected_search = best_search_record or search_record
                 manifest["result"] = {
-                    "outcome": result.outcome,
+                    "outcome": selected_search["outcome"],
                     "objective": profile["load"].get("objective", {}).get("type", "points"),
                     "parameter": profile["load"]["parameter"],
                     "allow_errors": profile["load"].get("allow_errors", False),
-                    "search_stage": search_stage,
-                    "dynamic_nodes": dynamic_nodes,
-                    "selected_load": result.selected_load,
-                    "selected_metrics": selected,
-                    "passing_load": result.passing_load,
-                    "failing_load": result.failing_load,
-                    "stop_reason": result.stop_reason,
+                    "search_stage": selected_search["stage"],
+                    "dynamic_nodes": selected_search["dynamic_nodes"],
+                    "selected_load": selected_search["selected_load"],
+                    "selected_metrics": selected_search["selected_metrics"],
+                    "passing_load": selected_search["passing_load"],
+                    "failing_load": selected_search["failing_load"],
+                    "stop_reason": selected_search["stop_reason"],
                 }
                 break
             lifecycle.close_geometry()
@@ -1606,6 +1629,7 @@ def run_local_ydb(
 
         verification_repetitions = profile["measurement"].get("verification_repetitions", 0)
         selected_load = manifest["result"]["selected_load"]
+        selected_dynamic_nodes = manifest["result"]["dynamic_nodes"]
         manifest["result"]["metrics_source"] = "search"
         verification = {
             "status": "disabled" if verification_repetitions == 0 else "pending",
@@ -1626,17 +1650,52 @@ def run_local_ydb(
         elif verification_repetitions:
             verification_started_at = _utc_now()
             verification_started_monotonic = time.monotonic()
+            fresh_verification_cluster = selected_dynamic_nodes != len(cluster.dynamic_nodes)
             verification.update(
                 {
                     "status": "running",
                     "started_at": verification_started_at,
                     "load": selected_load,
-                    "dynamic_nodes": dynamic_nodes,
+                    "dynamic_nodes": selected_dynamic_nodes,
+                    "cluster": "fresh" if fresh_verification_cluster else "search",
                 }
             )
             write_manifest(manifest_path, manifest)
             verification_rows = []
             try:
+                if fresh_verification_cluster:
+                    close_lifecycle()
+                    lifecycle = None
+                    publish_progress(
+                        "restarting-verification-cluster",
+                        search_stage=manifest["result"]["search_stage"],
+                        dynamic_nodes=selected_dynamic_nodes,
+                    )
+                    cluster.stop()
+                    cluster_stopped = True
+                    verification_geometry = {
+                        **profile["geometry"],
+                        "dynamic_nodes": selected_dynamic_nodes,
+                        "max_dynamic_nodes": selected_dynamic_nodes,
+                    }
+                    cluster = create_cluster(output_directory / "verification-cluster", verification_geometry)
+                    cluster_stopped = False
+                    cluster.start()
+                    lifecycle = create_lifecycle(cluster)
+                    lifecycle.open_profile(
+                        output_directory / "verification" / "workload" / "profile",
+                        "ydb_bench_verify_profile",
+                        purpose="verification",
+                        progress_fields={"search_stage": manifest["result"]["search_stage"]},
+                    )
+                    lifecycle.open_geometry(
+                        output_directory / "verification" / "workload" / "geometry",
+                        "ydb_bench_verify_geometry_{:02d}".format(selected_dynamic_nodes),
+                        selected_dynamic_nodes,
+                        progress_fields={"search_stage": manifest["result"]["search_stage"]},
+                        purpose="verification",
+                    )
+                dynamic_nodes = selected_dynamic_nodes
                 for repetition in range(1, verification_repetitions + 1):
                     directory = output_directory / "verification" / "repeat-{:03d}".format(repetition)
                     table_path = "ydb_bench_verify_{}_{}_{}".format(dynamic_nodes, selected_load, repetition)
@@ -1788,6 +1847,8 @@ def run_local_ydb(
             ]
             if verification["status"] == "completed":
                 artifacts += ["verification-summary.csv", "verification-repetitions.csv"]
+                if verification.get("cluster") == "fresh":
+                    artifacts.append("verification-cluster/cluster.yaml")
             event_sink(
                 {
                     "type": "step-artifacts",

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -383,6 +383,7 @@ TPCC_JSON_RESULT = WorkloadResultAdapter(
 _TOPIC_CONSUMER_PREFIX = "ydb-bench-consumer"
 _TOPIC_PERCENTILE = 99
 _TOPIC_OUTPUT_MAX_BYTES = 1024 * 1024
+_TOPIC_MAX_TOTAL_SECONDS = 3600
 _TOPIC_METRIC_MAX = (1 << 64) - 1
 _TOPIC_TIMESTAMP_PATTERN = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z")
 
@@ -1181,7 +1182,7 @@ def _validate_tpcc_profile(workload, load, measurement, location):
 
 
 def _validate_topic_profile(workload, load, measurement, location):
-    del workload, measurement
+    del workload
     if load["allow_errors"]:
         _config_error(location + ".load.allow-errors", "must be false because Topic does not report errors")
     objective = load.get("objective")
@@ -1189,6 +1190,12 @@ def _validate_topic_profile(workload, load, measurement, location):
         _config_error(
             location + ".load.objective.max-errors",
             "must be zero because Topic does not report errors",
+        )
+    total_seconds = measurement["warmup"] + measurement["duration"]
+    if total_seconds > _TOPIC_MAX_TOTAL_SECONDS:
+        _config_error(
+            location + ".measurement",
+            "warmup plus duration must not exceed {} seconds for bounded Topic output".format(_TOPIC_MAX_TOTAL_SECONDS),
         )
 
 

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -130,6 +130,7 @@ GENERIC_TOTAL_RESULT = WorkloadResultAdapter(
     ),
 )
 
+_DEFAULT_CLEANUP_TIMEOUT_SECONDS = 120
 _TPCC_TRANSACTION_NAMES = ("NewOrder", "Delivery", "OrderStatus", "Payment", "StockLevel")
 _TPCC_PERCENTILES = (
     ("50", "p50_ms"),
@@ -282,10 +283,7 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
         "errors": sum(transaction["failed_count"] for transaction in parsed_transactions.values()),
     }
     metrics.update(
-        {
-            metric_name: value
-            for (_percentile, metric_name), value in zip(_TPCC_PERCENTILES, selected["percentiles_ms"])
-        }
+        {metric_name: value for (_percentile, metric_name), value in zip(_TPCC_PERCENTILES, selected["percentiles_ms"])}
     )
     return WorkloadResult(
         metrics,
@@ -1708,7 +1706,7 @@ def build_clean_argv(cli, path, workload_type):
     return _workload_base(cli, definition, path) + ["clean"]
 
 
-def _validate_command_plans(plans, description, allow_default_timeout=False):
+def _validate_command_plans(plans, description):
     if not isinstance(plans, tuple) or not plans:
         raise BenchmarkError("{} must produce a non-empty tuple of command plans".format(description))
     for plan in plans:
@@ -1718,9 +1716,7 @@ def _validate_command_plans(plans, description, allow_default_timeout=False):
             raise BenchmarkError("{} produced an invalid command plan name".format(description))
         if not isinstance(plan.argv, tuple) or not plan.argv:
             raise BenchmarkError("{} command {} must have a non-empty argv tuple".format(description, plan.name))
-        if plan.timeout_seconds is None and allow_default_timeout:
-            pass
-        elif not _is_finite_number(plan.timeout_seconds) or plan.timeout_seconds <= 0:
+        if not _is_finite_number(plan.timeout_seconds) or plan.timeout_seconds <= 0:
             raise BenchmarkError("{} command {} must have a positive timeout".format(description, plan.name))
         if plan.measurement_window_builder is not None and not callable(plan.measurement_window_builder):
             raise BenchmarkError(
@@ -1817,16 +1813,12 @@ def build_cleanup_plan(cli, path, workload):
             WorkloadCommandPlan(
                 "clean",
                 tuple(_workload_base(cli, definition, path) + ["clean"]),
-                None,
+                _DEFAULT_CLEANUP_TIMEOUT_SECONDS,
             ),
         )
     else:
         plans = definition.cleanup_plan_builder(cli, definition, path, workload)
-    return _validate_command_plans(
-        plans,
-        "{} cleanup plan".format(definition.name),
-        allow_default_timeout=True,
-    )
+    return _validate_command_plans(plans, "{} cleanup plan".format(definition.name))
 
 
 def workload_definition(workload_type):

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -394,7 +394,7 @@ def _topic_stats_row(values, location):
     return metric_values, timestamp
 
 
-def _parse_topic_total_result(command_result, normalized_workload, request):
+def _parse_topic_window_result(command_result, normalized_workload, request):
     stdout = command_result.stdout
     if not isinstance(stdout, str):
         _topic_result_error("is not text or exceeds {} bytes".format(_TOPIC_OUTPUT_MAX_BYTES))
@@ -405,11 +405,13 @@ def _parse_topic_total_result(command_result, normalized_workload, request):
     if output_size > _TOPIC_OUTPUT_MAX_BYTES:
         _topic_result_error("is not text or exceeds {} bytes".format(_TOPIC_OUTPUT_MAX_BYTES))
 
-    start_index = request.warmup_seconds + 1
-    finish_index = request.warmup_seconds + request.duration_seconds
-    if start_index >= finish_index:
+    first_index = request.warmup_seconds + 1
+    last_index = request.warmup_seconds + request.duration_seconds
+    if request.duration_seconds < 2:
         _topic_result_error("requires a measurement duration of at least two seconds")
-    boundary_rows = {str(start_index): [], str(finish_index): []}
+    boundary_index = first_index - 1
+    required_indexes = range(max(1, boundary_index), last_index + 1)
+    window_rows = {str(index): [] for index in required_indexes}
     total_rows = []
     for line in stdout.splitlines():
         values = line.split()
@@ -417,24 +419,29 @@ def _parse_topic_total_result(command_result, normalized_workload, request):
             continue
         if values[0] == "Total":
             total_rows.append(values)
-        elif values[0] in boundary_rows:
-            boundary_rows[values[0]].append(values)
+        elif values[0] in window_rows:
+            window_rows[values[0]].append(values)
     if len(total_rows) != 1:
         _topic_result_error("must contain exactly one Total row")
-    for index, rows in boundary_rows.items():
+    _topic_stats_row(total_rows[0], "Total row")
+
+    parsed_windows = {}
+    for index, rows in window_rows.items():
         if len(rows) != 1:
             _topic_result_error("must contain exactly one window row for index {}".format(index))
-    metric_values, _total_timestamp = _topic_stats_row(total_rows[0], "Total row")
-    _start_metrics, measurement_started_at = _topic_stats_row(
-        boundary_rows[str(start_index)][0],
-        "window row {}".format(start_index),
-    )
-    _finish_metrics, measurement_finished_at = _topic_stats_row(
-        boundary_rows[str(finish_index)][0],
-        "window row {}".format(finish_index),
-    )
-    if measurement_started_at >= measurement_finished_at:
-        _topic_result_error("measurement window timestamps must be increasing")
+        parsed_windows[int(index)] = _topic_stats_row(rows[0], "window row {}".format(index))
+    ordered_indexes = sorted(parsed_windows)
+    for previous, current in zip(ordered_indexes, ordered_indexes[1:]):
+        if parsed_windows[current][1] - parsed_windows[previous][1] != current - previous:
+            _topic_result_error("window row timestamps must advance by one second per index")
+
+    measurement_rows = [parsed_windows[index][0] for index in range(first_index, last_index + 1)]
+
+    def mean_metric(index):
+        return sum(row[index] for row in measurement_rows) / len(measurement_rows)
+
+    def max_metric(index):
+        return max(row[index] for row in measurement_rows)
 
     (
         write_messages_s,
@@ -446,7 +453,21 @@ def _parse_topic_total_result(command_result, normalized_workload, request):
         read_messages_s,
         read_mib_s,
         full_p99_ms,
-    ) = metric_values
+    ) = (
+        mean_metric(0),
+        mean_metric(1),
+        max_metric(2),
+        max_metric(3),
+        max_metric(4),
+        max_metric(5),
+        mean_metric(6),
+        mean_metric(7),
+        max_metric(8),
+    )
+    measurement_started_at = (
+        parsed_windows[boundary_index][1] if boundary_index >= 1 else parsed_windows[first_index][1] - 1
+    )
+    measurement_finished_at = parsed_windows[last_index][1]
     consumers = normalized_workload["options"]["consumers"]
     read_per_consumer_messages_s = read_messages_s / consumers
     throughput = min(write_messages_s, read_per_consumer_messages_s)
@@ -466,7 +487,13 @@ def _parse_topic_total_result(command_result, normalized_workload, request):
     }
     return WorkloadResult(
         metrics,
-        details={"percentile": _TOPIC_PERCENTILE, "total": metrics},
+        details={
+            "percentile": _TOPIC_PERCENTILE,
+            "window_seconds": 1,
+            "measurement_windows": len(measurement_rows),
+            "rate_aggregation": "mean",
+            "percentile_aggregation": "maximum",
+        },
         measurement_window=(
             measurement_started_at,
             measurement_finished_at,
@@ -474,83 +501,84 @@ def _parse_topic_total_result(command_result, normalized_workload, request):
     )
 
 
-TOPIC_TOTAL_RESULT = WorkloadResultAdapter(
-    schema_id="topic-total-v1",
-    parse=_parse_topic_total_result,
+TOPIC_WINDOW_RESULT = WorkloadResultAdapter(
+    schema_id="topic-window-v1",
+    parse=_parse_topic_window_result,
     metrics=(
         WorkloadMetric(
             "transactions",
             "estimated messages",
             required=True,
             description=(
-                "Conservative completed-message estimate derived from truncated CLI rates; used to reject empty samples"
+                "Conservative completed-message estimate derived from mean per-window CLI rates; used to reject "
+                "empty samples"
             ),
         ),
         WorkloadMetric(
             "throughput",
             "messages/s",
             required=True,
-            description="Minimum of write rate and aggregate read rate divided by the number of consumers",
+            description=("Minimum of mean write rate and mean aggregate read rate divided by the number of consumers"),
         ),
         WorkloadMetric(
             "write_messages_s",
             "messages/s",
             required=True,
-            description="CLI-reported successful write rate",
+            description="Mean successful write rate across one-second measurement windows",
         ),
         WorkloadMetric(
             "read_messages_s",
             "deliveries/s",
             required=True,
-            description="CLI-reported aggregate delivery rate across all consumers",
+            description="Mean aggregate delivery rate across all consumers and one-second measurement windows",
         ),
         WorkloadMetric(
             "read_per_consumer_messages_s",
             "messages/s",
             required=True,
-            description="Aggregate delivery rate divided by the configured number of consumers",
+            description="Mean aggregate delivery rate divided by the configured number of consumers",
         ),
         WorkloadMetric(
             "write_mib_s",
             "logical MiB/s",
             required=True,
-            description="CLI-reported uncompressed logical write bandwidth",
+            description="Mean uncompressed logical write bandwidth across one-second measurement windows",
         ),
         WorkloadMetric(
             "read_mib_s",
             "logical MiB/s",
             required=True,
-            description="CLI-reported aggregate uncompressed logical read bandwidth",
+            description="Mean aggregate uncompressed logical read bandwidth across one-second measurement windows",
         ),
         WorkloadMetric(
             "write_p99_ms",
             "ms",
             required=True,
-            description="p99 time from scheduled message creation to write acknowledgement",
+            description="Worst per-window p99 time from scheduled message creation to write acknowledgement",
         ),
         WorkloadMetric(
             "inflight_p99_messages",
             "messages",
             required=True,
-            description="p99 number of messages awaiting write acknowledgement",
+            description="Worst per-window p99 number of messages awaiting write acknowledgement",
         ),
         WorkloadMetric(
             "lag_p99_messages",
             "messages",
             required=True,
-            description="p99 unread-message lag across consumers",
+            description="Worst per-window p99 unread-message lag across consumers",
         ),
         WorkloadMetric(
             "lag_p99_ms",
             "ms",
             required=True,
-            description="p99 consumer lag time",
+            description="Worst per-window p99 consumer lag time",
         ),
         WorkloadMetric(
             "full_p99_ms",
             "ms",
             required=True,
-            description="p99 end-to-end time from scheduled message creation to delivery",
+            description="Worst per-window p99 end-to-end time from scheduled message creation to delivery",
         ),
     ),
     slo_metrics=(("p99", "full_p99_ms"),),
@@ -1505,7 +1533,7 @@ _DEFINITIONS = (
         prepare_plan_builder=_topic_prepare_plan_builder,
         run_plan_builder=_topic_run_plan_builder,
         cleanup_plan_builder=_topic_cleanup_plan_builder,
-        result_adapter=TOPIC_TOTAL_RESULT,
+        result_adapter=TOPIC_WINDOW_RESULT,
         throughput_unit="messages/s",
         profile_validator=_validate_topic_profile,
         minimum_duration_seconds=2,

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -277,7 +277,8 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
     metrics = {
         "transactions": selected["ok_count"] if new_orders > 0 else 0,
         "new_orders": new_orders,
-        "throughput": new_orders / measured_seconds,
+        "throughput": new_orders / request.duration_seconds,
+        "cli_elapsed_seconds": measured_seconds,
         "tpcc_tpmc": tpcc_tpmc,
         "efficiency_pct": efficiency,
         "errors": sum(transaction["failed_count"] for transaction in parsed_transactions.values()),
@@ -296,7 +297,7 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
 
 
 TPCC_JSON_RESULT = WorkloadResultAdapter(
-    schema_id="tpcc-json-v2",
+    schema_id="tpcc-json-v3",
     parse=_parse_tpcc_json_result,
     metrics=(
         WorkloadMetric(
@@ -312,25 +313,34 @@ TPCC_JSON_RESULT = WorkloadResultAdapter(
             "new_orders",
             "new orders",
             required=True,
-            description="Successful NewOrder transactions in the measurement window",
+            description=(
+                "Successful NewOrder transactions admitted during the requested measurement interval; completion "
+                "may include graceful drain"
+            ),
         ),
         WorkloadMetric(
             "throughput",
             "new orders/s",
             required=True,
-            description="Successful NewOrder transactions divided by measured seconds",
+            description="Successful NewOrder transactions divided by the requested admission interval",
+        ),
+        WorkloadMetric(
+            "cli_elapsed_seconds",
+            "s",
+            required=True,
+            description="CLI-reported elapsed measurement time including graceful drain",
         ),
         WorkloadMetric(
             "tpcc_tpmc",
             "tpmC",
             required=True,
-            description="CLI-reported capped TPC-C tpmC",
+            description="CLI-reported capped TPC-C tpmC using the drain-inclusive elapsed time",
         ),
         WorkloadMetric(
             "efficiency_pct",
             "%",
             required=True,
-            description="CLI-reported TPC-C efficiency",
+            description="CLI-reported TPC-C efficiency using the drain-inclusive elapsed time",
         ),
         WorkloadMetric(
             "errors",

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -148,6 +148,7 @@ _TPCC_SLO_METRICS = (
 )
 _TPCC_TERMINALS_PER_WAREHOUSE = 10
 _TPCC_MIN_WARMUP_PER_TERMINAL_MS = 10
+_TPCC_MAX_ADAPTIVE_WARMUP_SECONDS = 60 * 60
 _TPCC_JSON_MAX_BYTES = 1024 * 1024
 
 
@@ -191,10 +192,24 @@ def _tpcc_percentile_values(value, location):
 
 
 def _tpcc_effective_warmup_seconds(workload, requested_seconds):
+    # Keep this in sync with the adaptive heuristic in
+    # ydb/library/workload/tpcc/runner.cpp::TPCCRunner::RunSync.
     warehouses = workload["options"]["warehouses"]
     terminals = warehouses * _TPCC_TERMINALS_PER_WAREHOUSE
     minimum = terminals * _TPCC_MIN_WARMUP_PER_TERMINAL_MS // 1000 + 1
-    return max(requested_seconds, minimum)
+    if requested_seconds is not None:
+        return max(requested_seconds, minimum)
+    if warehouses <= 10:
+        adaptive = 30
+    elif warehouses <= 100:
+        adaptive = 5 * 60
+    elif warehouses <= 1000:
+        adaptive = 10 * 60
+    elif warehouses <= 10000:
+        adaptive = 20 * 60
+    else:
+        adaptive = 30 * 60
+    return min(max(adaptive, minimum), _TPCC_MAX_ADAPTIVE_WARMUP_SECONDS)
 
 
 def _parse_tpcc_json_result(command_result, normalized_workload, request):
@@ -702,6 +717,7 @@ class WorkloadDefinition:
     minimum_duration_seconds: int = 1
     load_limits: tuple = ()
     default_client_threads: int = 64
+    default_warmup_seconds: int | None = 10
 
 
 def _config_error(location, message):
@@ -909,13 +925,17 @@ def _tpcc_init_builder(cli, definition, path, workload):
 
 def _tpcc_run_command(cli, definition, path, workload, load, seconds, client_threads, warmup_seconds):
     options = workload["options"]
-    effective_warmup = _tpcc_effective_warmup_seconds(workload, warmup_seconds)
     command = _workload_base(cli, definition, path) + [
         "run",
         "--warehouses",
         options["warehouses"],
-        "--warmup",
-        "{}s".format(effective_warmup),
+    ]
+    if warmup_seconds is not None:
+        command += [
+            "--warmup",
+            "{}s".format(_tpcc_effective_warmup_seconds(workload, warmup_seconds)),
+        ]
+    command += [
         "--time",
         "{}s".format(seconds),
         "--max-sessions",
@@ -986,7 +1006,7 @@ def _tpcc_run_plan_builder(
                 load,
                 seconds,
                 client_threads,
-                effective_warmup,
+                warmup_seconds,
             )
         ),
         effective_warmup + seconds + 60,
@@ -1316,6 +1336,14 @@ def _validate_catalog(definitions):
                 raise ValueError("{} must be callable for {}".format(name, definition.name))
         if definition.warmup_mode == "inline" and definition.run_plan_builder is None:
             raise ValueError("inline warmup requires a run plan builder for {}".format(definition.name))
+        if definition.default_warmup_seconds is not None and (
+            isinstance(definition.default_warmup_seconds, bool)
+            or not isinstance(definition.default_warmup_seconds, int)
+            or definition.default_warmup_seconds < 0
+        ):
+            raise ValueError("default warmup must be a non-negative integer or None for {}".format(definition.name))
+        if definition.default_warmup_seconds is None and definition.effective_warmup_builder is None:
+            raise ValueError("automatic warmup requires an effective warmup builder for {}".format(definition.name))
         if (
             isinstance(definition.minimum_duration_seconds, bool)
             or not isinstance(definition.minimum_duration_seconds, int)
@@ -1521,6 +1549,7 @@ _DEFINITIONS = (
         minimum_duration_seconds=2,
         load_limits=(("max-sessions", "warehouses", _TPCC_TERMINALS_PER_WAREHOUSE),),
         default_client_threads=2,
+        default_warmup_seconds=None,
     ),
     WorkloadDefinition(
         name="topic",
@@ -1651,6 +1680,7 @@ def web_workload_catalog():
             "result_schema_id": definition.result_adapter.schema_id,
             "minimum_duration_seconds": definition.minimum_duration_seconds,
             "default_client_threads": definition.default_client_threads,
+            "default_warmup_seconds": definition.default_warmup_seconds,
             "load_limits": {
                 parameter: {"option": option, "multiplier": multiplier}
                 for parameter, option, multiplier in definition.load_limits
@@ -1712,15 +1742,27 @@ def validate_workload_profile(workload, load, measurement, location):
 
 
 def workload_effective_warmup_seconds(workload, requested_seconds):
-    """Return the explicit warmup passed to the CLI for one workload run."""
+    """Return the numeric warmup expected from one workload run."""
 
-    if isinstance(requested_seconds, bool) or not isinstance(requested_seconds, int) or requested_seconds < 0:
-        raise BenchmarkError("workload warmup must be a non-negative integer")
     definition = _definition(workload["type"])
+    if requested_seconds is None:
+        if definition.default_warmup_seconds is not None:
+            raise BenchmarkError("{} does not support automatic warmup".format(definition.name))
+        if definition.effective_warmup_builder is None:
+            raise BenchmarkError("{} does not support automatic warmup".format(definition.name))
+    if requested_seconds is not None and (
+        isinstance(requested_seconds, bool) or not isinstance(requested_seconds, int) or requested_seconds < 0
+    ):
+        raise BenchmarkError("workload warmup must be a non-negative integer")
     if definition.effective_warmup_builder is None:
         return requested_seconds
     effective = definition.effective_warmup_builder(workload, requested_seconds)
-    if isinstance(effective, bool) or not isinstance(effective, int) or effective < requested_seconds:
+    if (
+        isinstance(effective, bool)
+        or not isinstance(effective, int)
+        or effective < 0
+        or (requested_seconds is not None and effective < requested_seconds)
+    ):
         raise BenchmarkError("{} returned an invalid effective warmup".format(definition.name))
     return effective
 
@@ -1797,6 +1839,7 @@ def build_run_plan(
     """Build one pure workload command plan without executing a process."""
 
     definition = _definition(workload["type"])
+    workload_effective_warmup_seconds(workload, warmup_seconds)
     if load_parameter not in definition.load_parameters:
         raise BenchmarkError(
             "local YDB workload {} does not support load parameter {}".format(definition.name, load_parameter)

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -457,8 +457,8 @@ def _parse_topic_window_result(command_result, normalized_workload, request):
         parsed_windows[int(index)] = _topic_stats_row(rows[0], "window row {}".format(index))
     ordered_indexes = sorted(parsed_windows)
     for previous, current in zip(ordered_indexes, ordered_indexes[1:]):
-        if parsed_windows[current][1] - parsed_windows[previous][1] != current - previous:
-            _topic_result_error("window row timestamps must advance by one second per index")
+        if parsed_windows[current][1] < parsed_windows[previous][1]:
+            _topic_result_error("window row timestamps must not move backwards")
 
     measurement_rows = [parsed_windows[index][0] for index in range(first_index, last_index + 1)]
 
@@ -489,10 +489,8 @@ def _parse_topic_window_result(command_result, normalized_workload, request):
         mean_metric(7),
         max_metric(8),
     )
-    measurement_started_at = (
-        parsed_windows[boundary_index][1] if boundary_index >= 1 else parsed_windows[first_index][1] - 1
-    )
     measurement_finished_at = parsed_windows[last_index][1]
+    measurement_started_at = measurement_finished_at - request.duration_seconds
     consumers = normalized_workload["options"]["consumers"]
     read_per_consumer_messages_s = read_messages_s / consumers
     throughput = min(write_messages_s, read_per_consumer_messages_s)

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -714,6 +714,7 @@ class WorkloadDefinition:
     profile_validator: object = None
     effective_warmup_builder: object = None
     minimum_duration_seconds: int = 1
+    maximum_total_seconds: int | None = None
     load_limits: tuple = ()
     default_client_threads: int = 64
     default_warmup_seconds: int | None = 10
@@ -1355,6 +1356,24 @@ def _validate_catalog(definitions):
             or definition.minimum_duration_seconds <= 0
         ):
             raise ValueError("minimum duration must be a positive integer for {}".format(definition.name))
+        if definition.maximum_total_seconds is not None and (
+            isinstance(definition.maximum_total_seconds, bool)
+            or not isinstance(definition.maximum_total_seconds, int)
+            or definition.maximum_total_seconds <= 0
+        ):
+            raise ValueError(
+                "maximum total duration must be a positive integer or None for {}".format(definition.name)
+            )
+        minimum_total_seconds = definition.minimum_duration_seconds + (definition.default_warmup_seconds or 0)
+        if (
+            definition.maximum_total_seconds is not None
+            and definition.maximum_total_seconds < minimum_total_seconds
+        ):
+            raise ValueError(
+                "maximum total duration cannot fit the default warmup and minimum duration for {}".format(
+                    definition.name
+                )
+            )
         if (
             isinstance(definition.default_client_threads, bool)
             or not isinstance(definition.default_client_threads, int)
@@ -1581,6 +1600,7 @@ _DEFINITIONS = (
         throughput_unit="messages/s",
         profile_validator=_validate_topic_profile,
         minimum_duration_seconds=2,
+        maximum_total_seconds=_TOPIC_MAX_TOTAL_SECONDS,
         default_client_threads=1,
     ),
 )
@@ -1684,6 +1704,7 @@ def web_workload_catalog():
             "reports_errors": any(metric.name == "errors" for metric in definition.result_adapter.metrics),
             "result_schema_id": definition.result_adapter.schema_id,
             "minimum_duration_seconds": definition.minimum_duration_seconds,
+            "maximum_total_seconds": definition.maximum_total_seconds,
             "default_client_threads": definition.default_client_threads,
             "default_warmup_seconds": definition.default_warmup_seconds,
             "load_limits": {

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -1279,7 +1279,7 @@ function mountLocalYdbComparisonCurves(container,comparisonData,chartData,baseli
     ['cli_cpu','median_cli_cpu_mean','YDB CLI CPU (%)']
   ];
   const customSpecifications=curveMetrics.map(metric=>[
-    'workload_'+metric.name,(metric.name==='errors'?'max_':'median_')+metric.name,
+    'workload_'+metric.name,(metric.repetition_aggregation==='sum'?'sum_':'median_')+metric.name,
     localMetricLabel(schema,metric.name)+' ('+metric.unit+')'
   ]);
   const [percentile,sloMetric]=localPreferredSlo(schema,objective);
@@ -1287,7 +1287,7 @@ function mountLocalYdbComparisonCurves(container,comparisonData,chartData,baseli
     ['throughput','median_throughput','Achieved throughput ('+schema.throughput_unit+')'],
     ['latency_ms','median_'+sloMetric,percentile+' latency (ms)'],
     ...cpuSpecifications,
-    ['errors','max_errors','Maximum errors per repetition']
+    ['errors','sum_errors','Errors across repetitions']
   ]:customSpecifications.concat(cpuSpecifications)).filter(([,metric])=>groups.some(group=>[...group.rows.values()]
     .some(row=>Number.isFinite(chartNumber(row[metric])))));
   if(!specifications.length){
@@ -2618,7 +2618,7 @@ def chart_data(output, run_ids, benchmark_filter=None):
                 benchmark_definition = BENCHMARKS.get(benchmark_name) if benchmark_name in BENCHMARKS else None
                 normalized_repetitions = benchmark_name == "memory-bandwidth-bench"
                 has_memory_fairness = False
-                prefixes = ("median_", "mean_", "min_", "max_")
+                prefixes = ("median_", "mean_", "min_", "max_", "sum_")
                 metric_fields = [name for name in fields if name.startswith(prefixes)]
                 dimension_fields = [
                     name
@@ -2707,7 +2707,10 @@ def chart_data(output, run_ids, benchmark_filter=None):
                             "unit": descriptor["unit"],
                             "description": descriptor.get("description", ""),
                         }
-                        for prefix in ("median_", "min_", "max_"):
+                        prefixes = ["median_", "min_", "max_"]
+                        if descriptor["repetition_aggregation"] == "sum":
+                            prefixes.append("sum_")
+                        for prefix in prefixes:
                             file_metric_metadata[prefix + descriptor["name"]] = metadata
                 for name, metadata in file_metric_metadata.items():
                     _merge_chart_metric_metadata(metric_metadata, name, metadata)

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -1207,7 +1207,8 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     'function localComparisonContext(item){return {\n'
     "  'Host':item.platform?.uname?.node??'—','CPU':item.platform?.cpu_model??'—',\n"
     "  'Kernel':item.platform?.uname?.release??'—','CPU topology':JSON.stringify(localComparisonStable(item.cpu_topology??null)),\n"
-    "  'YDB CLI build':item.binaries?.ydb_cli?.sha256??'—'\n"
+    "  'YDB CLI build':item.binaries?.ydb_cli?.sha256??'—',\n"
+    "  'Verification cluster':localResultMetrics(item.result).verified?localVerificationClusterLabel(item.verification):'not applicable'\n"
     '}}\n'
     "function localComparisonBuild(item){return {'ydbd':item.binaries?.ydbd?.sha256??'—','Tool revision':item.tool_revision??'—'}}\n"
     'function localComparisonStable(value){\n'
@@ -1238,6 +1239,11 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     'function localVerificationCount(result,parameters={},verification={}){\n'
     '  return result?.verification_repetitions??verification?.configured_repetitions??verification?.completed_repetitions??\n'
     '    parameters?.measurement?.verification_repetitions??0\n'
+    '}\n'
+    'function localVerificationClusterLabel(verification={}){\n'
+    "  if(verification?.cluster==='fresh')return 'fresh cluster';\n"
+    "  if(verification?.cluster==='search')return 'retained search cluster';\n"
+    "  return 'unknown cluster'\n"
     '}\n'
     'function localVerificationBadge(result,parameters={},verification={}){\n'
     '  const view=localResultMetrics(result);if(!view.verified)return \'\';\n'
@@ -1524,6 +1530,7 @@ function localVerificationSummary(data){
     repetitions+' independent holdout repetition'+(Number(repetitions)===1?'':'s'):
     'Independent holdout measurements';
   const outcomes=[];
+  if(verification.cluster)outcomes.push(localVerificationClusterLabel(verification));
   if(verification.decision){
     outcomes.push((verification.evaluation_kind==='objective'?'Objective':'Validity check')+': '+verification.decision)
   }
@@ -3725,6 +3732,7 @@ class RunService:
                             "finished_at",
                             "load",
                             "dynamic_nodes",
+                            "cluster",
                             "configured_repetitions",
                             "completed_repetitions",
                             "accepted",

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -263,9 +263,34 @@ function localYdbDefaultWarmupSeconds(definition){
   const value=Number(definition?.default_warmup_seconds);
   return Number.isSafeInteger(value)&&value>=0?value:10
 }
+function localYdbMeasurementMaximumDuration(definition,warmup){
+  const total=Number(definition?.maximum_total_seconds),warmupSeconds=Number(warmup);
+  if(!Number.isSafeInteger(total)||total<=0||warmup===null||
+      !Number.isSafeInteger(warmupSeconds)||warmupSeconds<0)return null;
+  return total-warmupSeconds
+}
+function localYdbMeasurementForWorkload(measurement,definition){
+  const warmup=localYdbDefaultWarmupSeconds(definition),minimum=definition.minimum_duration_seconds||1;
+  let duration=Number(measurement.duration);
+  if(!Number.isSafeInteger(duration)||duration<minimum)duration=minimum;
+  const maximum=localYdbMeasurementMaximumDuration(definition,warmup);
+  if(maximum!==null)duration=Math.min(duration,maximum);
+  return {...measurement,warmup,duration}
+}
+function localYdbValidateMeasurement(measurement,definition){
+  const maximum=localYdbMeasurementMaximumDuration(definition,measurement.warmup);
+  if(maximum!==null&&measurement.duration>maximum){
+    throw Error('Warmup plus duration must not exceed '+definition.maximum_total_seconds+' seconds.')
+  }
+  return measurement
+}
 function localYdbWarmupInput(id,definition){
   const raw=document.querySelector('#'+id).value.trim();
   return raw===''?localYdbDefaultWarmupSeconds(definition):localInteger(id,0)
+}
+function localYdbNeedsRerender(id,loadLimitInputs=[]){
+  return ['profile-name','local-geometry-preset','local-load-allow-errors',
+    'local-measurement-warmup'].includes(id)||loadLimitInputs.includes(id)
 }
 function localYdbParameterDefaults(parameter,definition=null,workload=null){
   const source=localYdbLoadDefaults[parameter]||localYdbLoadDefaults.threads;
@@ -443,6 +468,9 @@ function localYdbProfileEditor(profile){
     'Empty uses the workload default ('+localYdbDefaultWarmupSeconds(definition)+' seconds).';
   const clientThreadsHelp=workload.type==='topic'?
     'Applied to both producer and consumer thread counts; every consumer gets this many reader threads.':'';
+  const durationMaximum=localYdbMeasurementMaximumDuration(definition,measurement.warmup);
+  const durationHelp=definition.maximum_total_seconds?
+    'Warmup plus duration must not exceed '+definition.maximum_total_seconds+' seconds.':'';
   const loadMode=load.values?'points':load.objective.type;
   const sloPercentiles=Object.keys(definition.slo_metrics||{});
   const objectiveChoices=['points','maximize-throughput',...(sloPercentiles.length?['latency-slo']:[])];
@@ -517,8 +545,9 @@ function localYdbProfileEditor(profile){
     loadCommon+loadFields+'</div>'+slo+'<h3>Measurement</h3><div class=form-grid>'+
     localField('local-measurement-warmup','Warmup (seconds)',measurement.warmup,warmupHelp,'type=number min=0')+
     localField(
-      'local-measurement-duration','Duration (seconds)',measurement.duration,'',
-      'type=number min='+(definition.minimum_duration_seconds||1)
+      'local-measurement-duration','Duration (seconds)',measurement.duration,durationHelp,
+      'type=number min='+(definition.minimum_duration_seconds||1)+
+        (durationMaximum===null?'':' max='+durationMaximum)
     )+
     localField('local-measurement-repetitions','Repetitions',measurement.repetitions,'','type=number min=1')+
     localField(
@@ -576,11 +605,8 @@ function bindLocalYdbEditor(profile){
       const nextDefinition=localYdbWorkloadDefinition(event.target.value);
       const parameters=nextDefinition.load_parameters;
       config.client.threads=localYdbDefaultClientThreads(nextDefinition);
-      config.measurement.warmup=localYdbDefaultWarmupSeconds(nextDefinition);
+      config.measurement=localYdbMeasurementForWorkload(config.measurement,nextDefinition);
       config.load=localYdbLoadForWorkload(config.load,parameters,nextDefinition,config.workload);
-      config.measurement.duration=Math.max(
-        config.measurement.duration,nextDefinition.minimum_duration_seconds||1
-      );
       if(!nextDefinition.reports_errors){
         config.load.allow_errors=false;
         if(config.load.objective?.type==='latency-slo')config.load.objective.max_errors=0
@@ -692,12 +718,12 @@ function bindLocalYdbEditor(profile){
       })
     }
     config.load=localYdbClampLoad(config.load,workloadDefinition,config.workload);
-    config.measurement={
+    config.measurement=localYdbValidateMeasurement({
       warmup:localYdbWarmupInput('local-measurement-warmup',workloadDefinition),
       duration:localInteger('local-measurement-duration',workloadDefinition.minimum_duration_seconds||1),
       repetitions:localInteger('local-measurement-repetitions'),
       verification_repetitions:localInteger('local-measurement-verification-repetitions',0,20)
-    };
+    },workloadDefinition);
     for(const key of Object.keys(localYdbAffinityKeys)){
       const mode=document.querySelector('#local-affinity-'+key+'-mode').value;
       config.affinity[key]={mode,cpus:localCpu('local-affinity-'+key+'-cpus',mode)}
@@ -710,8 +736,7 @@ function bindLocalYdbEditor(profile){
     const loadLimitInputs=Object.values(workloadDefinition.load_limits||{}).map(
       constraint=>'local-option-'+constraint.option
     );
-    if(['profile-name','local-geometry-preset','local-load-allow-errors'].includes(event.target.id)||
-      loadLimitInputs.includes(event.target.id))renderNew()
+    if(localYdbNeedsRerender(event.target.id,loadLimitInputs))renderNew()
   }catch(error){message().innerHTML=displayError(error)}};
   for(const input of document.querySelectorAll('#local-editor input,#local-editor select'))input.onchange=update;
   document.querySelector('#delete-profile').onclick=()=>{

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -1420,7 +1420,8 @@ const localPhaseLabels={
   'verification-initializing':'Preparing verification workload','verification-warmup':'Warming up verification',
   'verification-measuring':'Measuring verification','verification-cleanup':'Cleaning verification workload',
   'verification-evaluating':'Evaluating verification','verification-completed':'Verification completed',
-  'scaling-dynamic-nodes':'Scaling dynamic nodes','stopping-cluster':'Stopping cluster','finishing':'Writing results',
+  'scaling-dynamic-nodes':'Scaling dynamic nodes','restarting-verification-cluster':'Restarting verification cluster',
+  'stopping-cluster':'Stopping cluster','finishing':'Writing results',
   completed:'Completed',failed:'Failed',cancelled:'Cancelled'
 };
 function localPhaseLabel(phase){return localPhaseLabels[phase]||String(phase||'Preparing').replaceAll('-',' ')}

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -258,6 +258,15 @@ function localYdbDefaultClientThreads(definition){
   const value=Number(definition?.default_client_threads);
   return Number.isSafeInteger(value)&&value>0?value:64
 }
+function localYdbDefaultWarmupSeconds(definition){
+  if(definition?.default_warmup_seconds===null)return null;
+  const value=Number(definition?.default_warmup_seconds);
+  return Number.isSafeInteger(value)&&value>=0?value:10
+}
+function localYdbWarmupInput(id,definition){
+  const raw=document.querySelector('#'+id).value.trim();
+  return raw===''?localYdbDefaultWarmupSeconds(definition):localInteger(id,0)
+}
 function localYdbParameterDefaults(parameter,definition=null,workload=null){
   const source=localYdbLoadDefaults[parameter]||localYdbLoadDefaults.threads;
   const limit=localYdbLoadLimit(definition,workload,parameter);
@@ -295,7 +304,7 @@ function localYdbLoadForWorkload(load,parameters,definition=null,workload=null){
     "ions}}\n"
     "function defaultLocalYdb(){const definition=localYdbWorkloadDefinition('kv');return {workload:defaultLocalYdbWorkload('kv'),"
     "geometry:{preset:'single',static_nodes:1,dynamic_nodes:1,max_dynamic_nodes:1,disk_size_gb:64,storage_groups:1},client"
-    ":{threads:localYdbDefaultClientThreads(definition)},load:{parameter:'rate',allow_errors:false,values:[1000]},measurement:{warmup:10,duration:30,rep"
+    ":{threads:localYdbDefaultClientThreads(definition)},load:{parameter:'rate',allow_errors:false,values:[1000]},measurement:{warmup:localYdbDefaultWarmupSeconds(definition),duration:30,rep"
     "etitions:3,verification_repetitions:3},affinity:{ydb_cli:{mode:'pack-numa-pack-chiplet-spread-core',cpus:'one-chiplet'},static_nodes:{mode:'none'"
     ",cpus:null},dynamic_nodes:{mode:'none',cpus:null}}}}\n"
     "function serializeLocalYdb(lines,profile){const config=profile.local_ydb,workload=config.workload;lines.push('    work"
@@ -311,8 +320,9 @@ function localYdbLoadForWorkload(load,parameters,definition=null,workload=null){
     "ive.type);if(config.load.objective.type==='maximize-throughput')for(const [key,yamlKey] of Object.entries(localYdbOb"
     "jectiveKeys))lines.push('        '+yamlKey+': '+config.load.objective[key]);else{lines.push('        percentile: '+config.load.o"
     "bjective.percentile);for(const [key,yamlKey] of Object.entries(localYdbSloKeys))lines.push('        '+yamlKey+': '+con"
-    "fig.load.objective[key])}}lines.push('    measurement:','      warmup: '+config.measurement.warmup,' "
-    "     duration: '+config.measurement.duration,'      repetitions: '+config.measurement.repetitions,"
+    "fig.load.objective[key])}}lines.push('    measurement:');if("
+    "config.measurement.warmup!==null&&config.measurement.warmup!==undefined)lines.push('      warmup: '+config.measurement.warmup);lines.push("
+    "'      duration: '+config.measurement.duration,'      repetitions: '+config.measurement.repetitions,"
     "'      verification-repetitions: '+(config.measurement.verification_repetitions??0),'    affinity:');f"
     "or(const [key,yamlKey] of Object.entries(localYdbAffinityKeys)){const role=config.affinity[key];lines.push('      '+yam"
     "lKey+':','        mode: '+role.mode);if(role.cpus!==null&&role.cpus!==undefined)lines.push('        cpus: '+role.cpus)}"
@@ -428,6 +438,9 @@ function localYdbSloPercentile(definition,requested=null){
 function localYdbProfileEditor(profile){
   const config=profile.local_ydb,workload=config.workload,geometry=config.geometry,load=config.load,measurement=config.measurement;
   const definition=localYdbWorkloadDefinition(workload.type);
+  const warmupHelp=definition.default_warmup_seconds===null?
+    'Empty uses adaptive YDB CLI warmup.':
+    'Empty uses the workload default ('+localYdbDefaultWarmupSeconds(definition)+' seconds).';
   const clientThreadsHelp=workload.type==='topic'?
     'Applied to both producer and consumer thread counts; every consumer gets this many reader threads.':'';
   const loadMode=load.values?'points':load.objective.type;
@@ -502,7 +515,7 @@ function localYdbProfileEditor(profile){
     '</div><h3>Client and load</h3><div class=form-grid>'+
     localField('local-client-threads','YDB CLI threads',config.client.threads,clientThreadsHelp,'type=number min=1')+
     loadCommon+loadFields+'</div>'+slo+'<h3>Measurement</h3><div class=form-grid>'+
-    localField('local-measurement-warmup','Warmup (seconds)',measurement.warmup,'','type=number min=0')+
+    localField('local-measurement-warmup','Warmup (seconds)',measurement.warmup,warmupHelp,'type=number min=0')+
     localField(
       'local-measurement-duration','Duration (seconds)',measurement.duration,'',
       'type=number min='+(definition.minimum_duration_seconds||1)
@@ -563,6 +576,7 @@ function bindLocalYdbEditor(profile){
       const nextDefinition=localYdbWorkloadDefinition(event.target.value);
       const parameters=nextDefinition.load_parameters;
       config.client.threads=localYdbDefaultClientThreads(nextDefinition);
+      config.measurement.warmup=localYdbDefaultWarmupSeconds(nextDefinition);
       config.load=localYdbLoadForWorkload(config.load,parameters,nextDefinition,config.workload);
       config.measurement.duration=Math.max(
         config.measurement.duration,nextDefinition.minimum_duration_seconds||1
@@ -679,7 +693,7 @@ function bindLocalYdbEditor(profile){
     }
     config.load=localYdbClampLoad(config.load,workloadDefinition,config.workload);
     config.measurement={
-      warmup:localInteger('local-measurement-warmup',0),
+      warmup:localYdbWarmupInput('local-measurement-warmup',workloadDefinition),
       duration:localInteger('local-measurement-duration',workloadDefinition.minimum_duration_seconds||1),
       repetitions:localInteger('local-measurement-repetitions'),
       verification_repetitions:localInteger('local-measurement-verification-repetitions',0,20)
@@ -1170,10 +1184,12 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     'function localComparisonConfig(item){\n'
     '  const parameters=item.parameters||{},workload=parameters.workload||{},geometry=parameters.geometry||{},client=parameters.client||{};\n'
     '  const measurement=parameters.measurement||{},load=parameters.load||{},objective=load.objective||{};\n'
+    "  const warmup=Object.prototype.hasOwnProperty.call(measurement,'warmup')?"
+    "(measurement.warmup===null?'automatic':measurement.warmup):'—';\n"
     "  const values={\n"
     "    'Workload':workload.type??'—','Operation':workload.operation??'—','Load parameter':load.parameter??'—',\n"
     "    'Load values':JSON.stringify(localComparisonStable(load.values??null)),\n"
-    "    'Objective':objective.type??'points','Warmup seconds':measurement.warmup??'—',\n"
+    "    'Objective':objective.type??'points','Warmup seconds':warmup,\n"
     "    'Duration seconds':measurement.duration??'—','Repetitions':measurement.repetitions??'—',\n"
     "    'Verification repetitions':measurement.verification_repetitions??0,\n"
     "    'Geometry preset':geometry.preset??'—','Static nodes':geometry.static_nodes??'—',\n"

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -38,6 +38,7 @@ _CSP = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self';
 _STREAM_CHUNK_SIZE = 1024 * 1024
 _CHART_DATA_ROW_LIMIT = 100000
 _LOCAL_YDB_ACTIVITY_LIMIT = 200
+_LOCAL_YDB_ACTIVITY_SCAN_BYTES = 4 * 1024 * 1024
 _EVENT_LOG_RECORD_BYTES = 4 * 1024 * 1024
 _LOCAL_YDB_ACTIVITY_RESPONSE_BYTES = 512 * 1024
 _MAX_SAFE_JSON_INTEGER = (1 << 53) - 1
@@ -3474,6 +3475,7 @@ class RunService:
         cursor = after
         matched = 0
         activity = deque(maxlen=_LOCAL_YDB_ACTIVITY_LIMIT)
+        replay_gap = False
 
         def consume(event):
             nonlocal cursor, matched
@@ -3513,8 +3515,21 @@ class RunService:
             except OSError as error:
                 raise BenchmarkError("cannot read run event log") from error
             with stream:
-                remaining = snapshot_size
-                previous_sequence = 0
+                replay_start = max(
+                    0,
+                    snapshot_size - _LOCAL_YDB_ACTIVITY_SCAN_BYTES - _EVENT_LOG_RECORD_BYTES,
+                )
+                if replay_start:
+                    stream.seek(replay_start - 1)
+                    starts_at_record_boundary = stream.read(1) == b"\n"
+                    stream.seek(replay_start)
+                    if not starts_at_record_boundary:
+                        partial = stream.readline(min(snapshot_size - replay_start, _EVENT_LOG_RECORD_BYTES + 1))
+                        if len(partial) > _EVENT_LOG_RECORD_BYTES or not partial.endswith(b"\n"):
+                            raise BenchmarkError("run event log contains an oversized or incomplete event")
+                remaining = snapshot_size - stream.tell()
+                previous_sequence = None
+                first_sequence = None
                 while remaining:
                     line = stream.readline(min(remaining, _EVENT_LOG_RECORD_BYTES + 1))
                     if not line:
@@ -3532,15 +3547,20 @@ class RunService:
                     if (
                         not isinstance(sequence, int)
                         or isinstance(sequence, bool)
-                        or sequence <= previous_sequence
+                        or sequence <= 0
+                        or (previous_sequence is not None and sequence <= previous_sequence)
                         or sequence > _MAX_SAFE_JSON_INTEGER
                     ):
                         raise BenchmarkError("run event log sequences must be strictly increasing integers")
+                    if first_sequence is None:
+                        first_sequence = sequence
                     previous_sequence = sequence
                     if not isinstance(event.get("type"), str):
                         raise BenchmarkError("run event log event type must be a string")
                     consume(event)
-
+                if replay_start and first_sequence is None:
+                    raise BenchmarkError("run event log contains an oversized or incomplete event")
+                replay_gap = bool(replay_start and first_sequence > after + 1)
         bounded = deque()
         response_bytes = 0
         for item in reversed(activity):
@@ -3554,7 +3574,7 @@ class RunService:
         return {
             "events": list(bounded),
             "after": cursor,
-            "truncated": matched > len(bounded),
+            "truncated": replay_gap or matched > len(bounded),
         }
 
     def local_ydb_comparison(self, run_ids):

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -1847,7 +1847,7 @@ function renderLocalYdbProfile(container,data){
       )).join('')+
       localChart('CPU by role','cpu_percent',xName,xValues,cpuSeries)+
       (errorSeries.length?localChart('Errors and retries','errors',xName,xValues,errorSeries):'')+'</div>';
-    const displayedMetrics=localDisplayedMetrics(resultSchema);
+    const displayedMetrics=localDisplayedMetrics(resultSchema,objective);
     const workloadHeaders=displayedMetrics.map(metric=>'<th title="'+
       esc(metric.description||'')+'">'+esc(localMetricLabel(resultSchema,metric.name))+
       (metric.unit?' ('+esc(metric.unit)+')':'')+'</th>').join('');

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -36,6 +36,7 @@ from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES, discover_topology, 
 
 _CSP = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
 _STREAM_CHUNK_SIZE = 1024 * 1024
+_CHART_DATA_ROW_LIMIT = 100000
 _LOCAL_YDB_ACTIVITY_LIMIT = 200
 _EVENT_LOG_RECORD_BYTES = 4 * 1024 * 1024
 _LOCAL_YDB_ACTIVITY_RESPONSE_BYTES = 512 * 1024
@@ -879,10 +880,13 @@ function addProfile(){
     'r){alert(error.message)}}\n'
     "const chartColors=['#1b62b9','#c2410c','#087443','#7c3aed','#be185d','#0e7490','#854d0e','#94a3b8','#ef4444','#818cf8','"
     "#22c55e','#d946ef'];\n"
+    "const chartPointLimit=10000;\n"
     'function metricLabel(value){const number=Number(value);if(!Number.isFinite(number))return String(value);return Math.abs('
     "number)>=1e9?(number/1e9).toFixed(2)+'B':Math.abs(number)>=1e6?(number/1e6).toFixed(2)+'M':Math.abs(number)>=1e3?(number"
     "/1e3).toFixed(2)+'k':Number.isInteger(number)?String(number):number.toFixed(2)}\n"
     "function chartNumber(value){return value===null||value===undefined||typeof value==='string'&&!value.trim()?NaN:Number(value)}\n"
+    'function chartExtent(values){let minimum=Infinity,maximum=-Infinity;for(const value of values){const number=Number(value);'
+    'if(!Number.isFinite(number))continue;minimum=Math.min(minimum,number);maximum=Math.max(maximum,number)}return minimum===Infinity?null:[minimum,maximum]}\n'
     "function chartSeriesLabel(series,compact=false){return compact?series.affinity:series.run+' / '+series.profile+' / '+ser"
     'ies.affinity}\n'
     "function seriesCpuNote(series){if(series.cpu_masks&&Object.keys(series.cpu_masks).length)return 'CPUs by threads: '+Obje"
@@ -892,12 +896,13 @@ function addProfile(){
     'function svgChart(metric,xName,xValues,seriesRows,colors){\n'
     '  const width=900,height=330,left=78,right=24,top=24,bottom=52,plotWidth=width-left-right,plotHeight=height-top-bottom,v'
     'alueFor=(item,row)=>chartNumber(row?.[item.metric||metric]);\n'
-    '  const values=[];for(const item of seriesRows)for(const x of xValues){const value=valueFor(item,item.rows.get(String(x)'
-    '));if(Number.isFinite(value))values.push(value)}\n'
+    '  const xKeys=new Set(xValues.map(String)),values=[];for(const item of seriesRows)for(const [x,row] of item.rows){if(!xKeys.has(String(x)))continue;'
+    'const value=valueFor(item,row);if(Number.isFinite(value))values.push(value);if(values.length>chartPointLimit)return '
+    "'<div class=notice>Chart omitted because it has more than '+chartPointLimit+' numeric points. Select fewer runs or lines.</div>'}\n"
     "  if(!values.length)return '<div class=empty>No numeric values for '+esc(metric)+'.</div>';\n"
-    '  let yMin=Math.min(...values),yMax=Math.max(...values);if(yMin===yMax){const pad=Math.abs(yMin)*.05||1;yMin-=pad;yMax+='
+    '  let [yMin,yMax]=chartExtent(values);if(yMin===yMax){const pad=Math.abs(yMin)*.05||1;yMin-=pad;yMax+='
     'pad}else{const pad=(yMax-yMin)*.08;yMin-=pad;yMax+=pad}\n'
-    '  const numericX=xValues.map(Number),xMin=Math.min(...numericX),xMax=Math.max(...numericX),xPos=value=>left+(xMax===xMin'
+    '  const [xMin,xMax]=chartExtent(xValues),xPos=value=>left+(xMax===xMin'
     '?plotWidth/2:(Number(value)-xMin)/(xMax-xMin)*plotWidth),yPos=value=>top+(yMax-Number(value))/(yMax-yMin)*plotHeight;\n'
     '  let svg=\'<svg viewBox="0 0 \'+width+\' \'+height+\'" role=img aria-label="\'+esc(metric)+\' by \'+esc(xName)+\'">\';\n'
     "  for(let tick=0;tick<=4;tick++){const y=top+plotHeight*tick/4,value=yMax-(yMax-yMin)*tick/4;svg+='<line class=chart-gri"
@@ -924,9 +929,6 @@ function addProfile(){
     '}\n'
     """
 function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,synchronize=false){
-  const width=900,left=78,right=24,plotWidth=width-left-right,numericX=xValues.map(Number);
-  const xMin=Math.min(...numericX),xMax=Math.max(...numericX);
-  const xPos=value=>left+(xMax===xMin?plotWidth/2:(Number(value)-xMin)/(xMax-xMin)*plotWidth);
   const seriesFor=metric=>Array.isArray(seriesRows)?seriesRows:(seriesRows[metric]||[]);
   const panels=[...container.querySelectorAll('.chart-panel')].map(panel=>({
     panel,
@@ -936,6 +938,9 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     tooltip:panel.querySelector('.chart-tooltip'),
     cursor:panel.querySelector('.chart-cursor'),
   })).filter(item=>item.svg&&item.surface&&item.tooltip&&item.cursor&&metrics.includes(item.metric));
+  const xExtent=chartExtent(xValues);if(!panels.length||!xExtent)return;
+  const width=900,left=78,right=24,plotWidth=width-left-right,[xMin,xMax]=xExtent;
+  const xPos=value=>left+(xMax===xMin?plotWidth/2:(Number(value)-xMin)/(xMax-xMin)*plotWidth);
   const hideAll=()=>{for(const item of panels){
     item.tooltip.hidden=true;item.cursor.setAttribute('visibility','hidden');
     item.cursor.removeAttribute('data-selected-x')
@@ -1260,9 +1265,7 @@ function mountLocalYdbComparisonCurves(container,comparisonData,chartData,baseli
   }
   groups.sort((left,right)=>left.label.localeCompare(right.label,undefined,{numeric:true}));
   groups.forEach((group,index)=>group.colorIndex=index);
-  const xValues=[...new Set(groups.flatMap(group=>[...group.rows.keys()].map(Number)))]
-    .sort((left,right)=>left-right);
-  if(!xValues.length){
+  if(!groups.some(group=>group.rows.size)){
     container.innerHTML='<div class=empty>No compatible local YDB search summaries are available.</div>';
     return
   }
@@ -1290,6 +1293,16 @@ function mountLocalYdbComparisonCurves(container,comparisonData,chartData,baseli
     container.innerHTML='<div class=empty>No numeric local YDB search metrics are available.</div>';
     return
   }
+  let pointCount=0;
+  for(const [,metric] of specifications)for(const group of groups)for(const row of group.rows.values()){
+    if(Number.isFinite(chartNumber(row[metric]))&&++pointCount>chartPointLimit){
+      container.innerHTML='<div class=notice>Search curves omitted because they have more than '+chartPointLimit+
+        ' numeric points. Select fewer runs.</div>';
+      return
+    }
+  }
+  const xValues=[...new Set(groups.flatMap(group=>[...group.rows.keys()].map(Number)))]
+    .sort((left,right)=>left-right);
   const seriesByMetric=Object.fromEntries(specifications.map(([alias,metric])=>[
     alias,groups.map(group=>({...group,metric}))
   ]));
@@ -2566,6 +2579,7 @@ def chart_data(output, run_ids, benchmark_filter=None):
     if benchmark_filter is not None and benchmark_filter not in BENCHMARKS:
         raise BenchmarkError("unknown chart benchmark: {}".format(benchmark_filter))
     result = []
+    result_row_count = 0
     dimensions, metrics, metric_metadata, dimension_metadata = set(), set(), {}, {}
     for run_id in run_ids:
         root = _run_directory(output, run_id)
@@ -2652,6 +2666,9 @@ def chart_data(output, run_ids, benchmark_filter=None):
                     metric_fields = [metric.name for metric in benchmark_definition.metrics]
                     if has_memory_fairness:
                         metric_fields += list(_MEMORY_FAIRNESS_METRICS)
+                result_row_count += sum(len(rows) for rows in grouped.values())
+                if result_row_count > _CHART_DATA_ROW_LIMIT:
+                    raise BenchmarkError("selected chart data has too many rows")
                 dimensions.update(dimension_fields)
                 metrics.update(metric_fields)
                 file_metric_metadata = {}

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -544,6 +544,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[4]["default_client_threads"], 1)
         self.assertEqual([item["default_warmup_seconds"] for item in catalog[:3] + catalog[4:]], [10] * 4)
         self.assertEqual(catalog[4]["minimum_duration_seconds"], 2)
+        self.assertEqual([item["maximum_total_seconds"] for item in catalog], [None, None, None, None, 3600])
         self.assertEqual(
             {option["name"]: option["default"] for option in catalog[4]["options"]},
             {"partitions": 128, "consumers": 1, "message-size": 10240, "codec": "raw"},
@@ -778,6 +779,19 @@ class YdbBenchTest(unittest.TestCase):
             )
         )
         self.assertEqual(bounded.runs[0].parameters["local_ydb"]["measurement"]["duration"], 3599)
+        zero_warmup_boundary = load_config(
+            self._config(
+                """
+                local-ydb:
+                  topic-zero-warmup-boundary:
+                    workload: {type: topic, operation: full}
+                    load: {parameter: rate, values: [100]}
+                    measurement: {warmup: 0, duration: 3600, repetitions: 1}
+                """,
+                "topic-zero-warmup-boundary.yaml",
+            )
+        )
+        self.assertEqual(zero_warmup_boundary.runs[0].parameters["local_ydb"]["measurement"]["duration"], 3600)
 
         latency = (
             load_config(
@@ -1437,6 +1451,15 @@ class YdbBenchTest(unittest.TestCase):
             local_ydb_workloads._validate_catalog((replace(definition, run_plan_builder=None),))
         with self.assertRaisesRegex(ValueError, "default client threads"):
             local_ydb_workloads._validate_catalog((replace(definition, default_client_threads=0),))
+        for invalid_maximum in (0, True, "10"):
+            with self.subTest(maximum_total_seconds=invalid_maximum), self.assertRaisesRegex(
+                ValueError, "maximum total duration"
+            ):
+                local_ydb_workloads._validate_catalog(
+                    (replace(definition, maximum_total_seconds=invalid_maximum),)
+                )
+        with self.assertRaisesRegex(ValueError, "cannot fit"):
+            local_ydb_workloads._validate_catalog((replace(definition, maximum_total_seconds=10),))
         for invalid_warmup in (-1, True, "10"):
             with self.subTest(default_warmup_seconds=invalid_warmup), self.assertRaisesRegex(
                 ValueError, "default warmup"
@@ -3534,7 +3557,8 @@ class YdbBenchTest(unittest.TestCase):
               load_limits:{'max-sessions':{option:'warehouses',multiplier:10}}
             };
             const topicDefinition={
-              load_parameters:['rate'],default_client_threads:1,default_warmup_seconds:10,load_limits:{}
+              load_parameters:['rate'],default_client_threads:1,default_warmup_seconds:10,
+              minimum_duration_seconds:2,maximum_total_seconds:3600,load_limits:{}
             };
             const tpccWorkload={options:{warehouses:10}};
             const switchedToTpcc=localYdbLoadForWorkload(
@@ -3551,9 +3575,24 @@ class YdbBenchTest(unittest.TestCase):
             const switchedBack=localYdbLoadForWorkload(
               switchedToTpcc,['rate','threads'],{load_limits:{}},{options:{}}
             );
+            const topicMeasurement=localYdbMeasurementForWorkload(
+              {warmup:1,duration:5000,repetitions:3,verification_repetitions:2},topicDefinition
+            );
+            const validTopic=localYdbValidateMeasurement(
+              {warmup:1,duration:3599},topicDefinition
+            );
+            const zeroWarmupTopic=localYdbValidateMeasurement(
+              {warmup:0,duration:3600},topicDefinition
+            );
+            const warmupRerenders=localYdbNeedsRerender('local-measurement-warmup');
+            const durationRerenders=localYdbNeedsRerender('local-measurement-duration');
+            let invalidTopic='';
+            try{localYdbValidateMeasurement({warmup:1,duration:3600},topicDefinition)}
+            catch(error){invalidTopic=error.message}
             process.stdout.write(JSON.stringify({
               points,automatic,compatible,same_reference:compatible===custom,
               switchedToTpcc,warehouseOnePoints,warehouseOneSearch,switchedBack,
+              topicMeasurement,validTopic,zeroWarmupTopic,warmupRerenders,durationRerenders,invalidTopic,
               tpccThreads:localYdbDefaultClientThreads(tpccDefinition),
               topicThreads:localYdbDefaultClientThreads(topicDefinition),
               fallbackThreads:localYdbDefaultClientThreads({}),
@@ -3612,6 +3651,15 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(result["switchedBack"]["parameter"], "rate")
         self.assertEqual(result["switchedBack"]["search"]["start"], 1000)
         self.assertEqual(result["switchedBack"]["search"]["maximum"], 100000)
+        self.assertEqual(
+            result["topicMeasurement"],
+            {"warmup": 10, "duration": 3590, "repetitions": 3, "verification_repetitions": 2},
+        )
+        self.assertEqual(result["validTopic"], {"warmup": 1, "duration": 3599})
+        self.assertEqual(result["zeroWarmupTopic"], {"warmup": 0, "duration": 3600})
+        self.assertTrue(result["warmupRerenders"])
+        self.assertFalse(result["durationRerenders"])
+        self.assertIn("must not exceed 3600 seconds", result["invalidTopic"])
         self.assertEqual(result["tpccThreads"], 2)
         self.assertEqual(result["topicThreads"], 1)
         self.assertEqual(result["fallbackThreads"], 64)
@@ -3674,7 +3722,10 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(result["blankKv"], 10)
         self.assertEqual(result["comparisonAutomatic"], "automatic")
         self.assertEqual(result["comparisonMissing"], "—")
-        self.assertIn("config.measurement.warmup=localYdbDefaultWarmupSeconds(nextDefinition)", web._JS)
+        self.assertIn(
+            "config.measurement=localYdbMeasurementForWorkload(config.measurement,nextDefinition)", web._JS
+        )
+        self.assertIn("config.measurement=localYdbValidateMeasurement({", web._JS)
 
     @unittest.skipUnless(shutil.which("node"), "node is required for the verification provenance UI test")
     def test_local_ydb_web_shows_verification_cluster_provenance(self):
@@ -3939,10 +3990,15 @@ class YdbBenchTest(unittest.TestCase):
             const esc=value=>String(value??'');
             const localYdbGeometryKeys={static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes',max_dynamic_nodes:'max-dynamic-nodes',disk_size_gb:'disk-size-gb',storage_groups:'storage-groups'};
             const localYdbAffinityKeys={ydb_cli:'ydb-cli',static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes'};
-            const definition={type:'fake',operations:['run'],load_parameters:['rate'],options:[],slo_metrics:{p90:'latency_ms'},reports_errors:false};
+            const definition={type:'fake',operations:['run'],load_parameters:['rate'],options:[],
+              slo_metrics:{p90:'latency_ms'},reports_errors:false,minimum_duration_seconds:1,
+              maximum_total_seconds:3600};
             const editor={model:{local_ydb_workloads:[definition],affinity_modes:['none'],benchmarks:[{name:'local-ydb'}]}};
             function localYdbWorkloadDefinition(){return definition}
             function localYdbDefaultWarmupSeconds(){return 10}
+            function localYdbMeasurementMaximumDuration(definition,warmup){
+              return definition.maximum_total_seconds-warmup
+            }
         """
             + web._JS[start:finish]
             + """
@@ -3957,6 +4013,7 @@ class YdbBenchTest(unittest.TestCase):
             const html=localYdbProfileEditor(profile);
             process.stdout.write(JSON.stringify({
               error_toggle:html.includes('local-load-allow-errors'),error_limit:html.includes('local-slo-max-errors'),
+              duration_limit:html.includes('Warmup plus duration must not exceed 3600 seconds.'),
               p90:html.includes('value="p90"'),p99_default:localYdbSloPercentile({slo_metrics:{p50:'x',p99:'y'}},'missing'),
               first_default:localYdbSloPercentile({slo_metrics:{p90:'x'}},'missing')
             }));
@@ -3972,6 +4029,7 @@ class YdbBenchTest(unittest.TestCase):
         result = json.loads(completed.stdout)
         self.assertFalse(result["error_toggle"])
         self.assertFalse(result["error_limit"])
+        self.assertTrue(result["duration_limit"])
         self.assertTrue(result["p90"])
         self.assertEqual(result["p99_default"], "p99")
         self.assertEqual(result["first_default"], "p90")

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -3676,6 +3676,78 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(result["comparisonMissing"], "—")
         self.assertIn("config.measurement.warmup=localYdbDefaultWarmupSeconds(nextDefinition)", web._JS)
 
+    @unittest.skipUnless(shutil.which("node"), "node is required for the verification provenance UI test")
+    def test_local_ydb_web_shows_verification_cluster_provenance(self):
+        label_start = web._JS.index("function localVerificationClusterLabel")
+        label_finish = web._JS.index("function localVerificationBadge", label_start)
+        summary_start = web._JS.index("function localVerificationSummary")
+        summary_finish = web._JS.index("function localElapsed", summary_start)
+        context_start = web._JS.index("function localComparisonContext")
+        context_finish = web._JS.index("function localComparisonBuild", context_start)
+        mount_start = web._JS.index("function mountLocalYdbComparison(container")
+        mount_finish = web._JS.index("const localPhaseLabels", mount_start)
+        script = (
+            """
+            const esc=value=>String(value??'');
+            const metricLabel=value=>String(value??'—');
+            const localVerificationCount=()=>1;
+            const localVerificationBadge=()=>'<badge>';
+            const localComparisonStable=value=>value;
+            const localResultMetrics=result=>({
+              verified:result?.metrics_source==='verification',
+              source:result?.metrics_source==='verification'?'Holdout':'Search',
+              metrics:result?.verified_metrics||result?.selected_metrics||{}
+            });
+            """
+            + web._JS[label_start:label_finish]
+            + web._JS[summary_start:summary_finish]
+            + web._JS[context_start:context_finish]
+            + """
+            const localComparisonKey=item=>JSON.stringify([item.run,item.profile]);
+            const localComparisonId=item=>item.run+' / '+item.profile;
+            const localResultSchema=()=>({schema_id:'test',throughput_unit:'items/s'});
+            const localDisplayedMetrics=()=>[];
+            const localComparisonConfig=()=>({});
+            const localComparisonBuild=()=>({});
+            const localComparisonSemantic=()=>({same:true});
+            const localMetricLabel=()=>'';
+            const localMetricDirection=()=>null;
+            const localComparisonDelta=()=>'';
+            const mountLocalYdbComparisonCurves=()=>{};
+            """
+            + web._JS[mount_start:mount_finish]
+            + """
+            const verified=cluster=>({
+              result:{metrics_source:'verification',verified_metrics:{throughput:1},holdout_accepted:true},
+              parameters:{},verification:{cluster,status:'completed',accepted:true}
+            });
+            const container={dataset:{},closest:()=>({}),querySelector:()=>({}),_html:'',
+              set innerHTML(value){this._html=value},get innerHTML(){return this._html}};
+            mountLocalYdbComparison(container,{entries:[
+              {run:'base',profile:'p',state:'passed',...verified('search')},
+              {run:'candidate',profile:'p',state:'passed',...verified('fresh')}
+            ]});
+            process.stdout.write(JSON.stringify({
+              fresh:localVerificationSummary(verified('fresh')),
+              search:localVerificationSummary(verified('search')),
+              comparison:container.innerHTML
+            }));
+            """
+        )
+        completed = subprocess.run(
+            [shutil.which("node"), "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        result = json.loads(completed.stdout)
+        self.assertIn("fresh cluster", result["fresh"])
+        self.assertIn("retained search cluster", result["search"])
+        self.assertIn("Comparable with warnings", result["comparison"])
+        self.assertIn("Verification cluster", result["comparison"])
+        self.assertIn("retained search cluster → fresh cluster", result["comparison"])
+
     @unittest.skipUnless(shutil.which("node"), "node is required for the local YDB validity UI test")
     def test_local_ydb_web_hides_latency_for_empty_measurements(self):
         result_start = web._JS.index("function localResultMetrics")
@@ -7241,6 +7313,7 @@ class WebTest(unittest.TestCase):
         verified=False,
         result_schema=None,
         extra_metrics=None,
+        verification_cluster="search",
     ):
         self._manifest(directory)
         main_path = directory / "run.json"
@@ -7304,6 +7377,7 @@ class WebTest(unittest.TestCase):
             )
             verification = {
                 "status": "completed",
+                "cluster": verification_cluster,
                 "configured_repetitions": 3,
                 "completed_repetitions": 3,
                 "accepted": True,
@@ -8129,6 +8203,7 @@ class WebTest(unittest.TestCase):
             self.assertEqual(comparison["entries"][0]["result"]["verified_metrics"]["throughput"], 1050)
             self.assertNotIn("commands", comparison["entries"][0]["result"]["verified_metrics"])
             self.assertTrue(comparison["entries"][0]["verification"]["accepted"])
+            self.assertEqual(comparison["entries"][0]["verification"]["cluster"], "search")
             self.assertNotIn("samples", comparison["entries"][0]["verification"])
             self.assertEqual(comparison["entries"][1]["parameters"]["workload"]["operation"], "mixed")
             with self.assertRaisesRegex(BenchmarkError, "between 1 and 20"):

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -4650,6 +4650,32 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
         summary = LOCAL_YDB_BENCHMARK.summarize_metrics(rows, LOCAL_YDB_BENCHMARK)
         self.assertEqual([(row["load"], row["dynamic_nodes"]) for row in summary], [(2, 1)])
 
+    def test_local_ydb_summary_exports_schema_aggregation(self):
+        rows = [
+            {"load": 10, "dynamic_nodes": 1, "throughput": 100, "errors": 1},
+            {"load": 10, "dynamic_nodes": 1, "throughput": 120, "errors": 1},
+            {"load": 10, "dynamic_nodes": 1, "throughput": 110, "errors": 1},
+        ]
+        metric_names = ("throughput", "errors")
+        aggregations = {"throughput": "median", "errors": "sum"}
+        summary = LOCAL_YDB_BENCHMARK.summarize_metrics(
+            rows,
+            LOCAL_YDB_BENCHMARK,
+            metric_names,
+            aggregations,
+        )
+        self.assertEqual(summary[0]["median_throughput"], 110)
+        self.assertEqual(summary[0]["max_errors"], 1)
+        self.assertEqual(summary[0]["sum_errors"], 3)
+        rendered = LOCAL_YDB_BENCHMARK.render_summary(
+            summary,
+            LOCAL_YDB_BENCHMARK,
+            metric_names,
+            aggregations,
+        )
+        parsed = next(csv.DictReader(io.StringIO(rendered)))
+        self.assertEqual(parsed["sum_errors"], "3")
+
     def test_local_ydb_scaling_uses_failing_boundary_and_minimum_attempt(self):
         attempts = (
             {"load": 50, "dynamic_cpu_mean": 90, "static_cpu_mean": 20},
@@ -7768,9 +7794,18 @@ class WebTest(unittest.TestCase):
             row = {"load": load, "dynamic_nodes": dynamic_nodes}
             row.update({metric.name: (index + 1) * scale for index, metric in enumerate(LOCAL_YDB_BENCHMARK.metrics)})
             rows.append(row)
-        summarized = LOCAL_YDB_BENCHMARK.summarize_metrics(rows, LOCAL_YDB_BENCHMARK)
+        aggregations = {"errors": "sum"}
+        summarized = LOCAL_YDB_BENCHMARK.summarize_metrics(
+            rows,
+            LOCAL_YDB_BENCHMARK,
+            metric_aggregations=aggregations,
+        )
         summary.write_text(
-            LOCAL_YDB_BENCHMARK.render_summary(summarized, LOCAL_YDB_BENCHMARK),
+            LOCAL_YDB_BENCHMARK.render_summary(
+                summarized,
+                LOCAL_YDB_BENCHMARK,
+                metric_aggregations=aggregations,
+            ),
             encoding="utf-8",
         )
 
@@ -7787,6 +7822,7 @@ class WebTest(unittest.TestCase):
         self.assertIn("median_p99_ms", value["metrics"])
         self.assertIn("median_dynamic_cpu_mean", value["metrics"])
         self.assertIn("max_errors", value["metrics"])
+        self.assertIn("sum_errors", value["metrics"])
         unrelated = self.root / "complete" / "ping-bench" / "broken" / "summary.csv"
         unrelated.parent.mkdir(parents=True)
         with unrelated.open("wb") as stream:
@@ -8004,7 +8040,8 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"...Object.keys(config)", script)
                 self.assertIn(b"series.benchmark!=='local-ydb'", script)
                 self.assertIn(b"const curveMetrics=localComparisonCurveMetrics", script)
-                self.assertIn(b"(metric.name==='errors'?'max_':'median_')+metric.name", script)
+                self.assertIn(b"metric.repetition_aggregation==='sum'?'sum_':'median_'", script)
+                self.assertIn(b"['errors','sum_errors','Errors across repetitions']", script)
                 self.assertIn(b"localMetricLabel(schema,metric.name)", script)
                 self.assertIn(b"dynamicNodes", script)
                 self.assertIn(b"connectMeasuredPoints", script)

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -487,7 +487,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[2]["options"][4]["choices"], ["row", "column"])
         self.assertEqual(
             [item["result_schema_id"] for item in catalog],
-            ["generic-total-v1"] * 3 + ["tpcc-json-v2", "topic-window-v1"],
+            ["generic-total-v1"] * 3 + ["tpcc-json-v3", "topic-window-v1"],
         )
         self.assertEqual(
             [item["throughput_unit"] for item in catalog],
@@ -1445,7 +1445,7 @@ class YdbBenchTest(unittest.TestCase):
         for call in monitor.summary.call_args_list:
             self.assertEqual(call.kwargs, {"started_at_unix": 1001.0, "finished_at_unix": 1010.0})
         details = json.loads((self.root / "tpcc-repeat-1" / "workload-result.json").read_text(encoding="utf-8"))
-        self.assertEqual(details["schema_id"], "tpcc-json-v2")
+        self.assertEqual(details["schema_id"], "tpcc-json-v3")
         self.assertEqual(details["details"], payload)
         self.assertEqual(
             [item["phase"] for item in progress],
@@ -2183,7 +2183,8 @@ class YdbBenchTest(unittest.TestCase):
             {
                 "transactions": 300,
                 "new_orders": 120,
-                "throughput": 10,
+                "throughput": 12,
+                "cli_elapsed_seconds": 12,
                 "tpcc_tpmc": 25.5,
                 "efficiency_pct": 80.25,
                 "errors": 10,
@@ -2197,7 +2198,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(result.details, payload)
         self.assertEqual(result.measurement_window, (1001.0, 1010.0))
         schema = local_ydb_workloads.workload_result_schema("tpcc")
-        self.assertEqual(schema["schema_id"], "tpcc-json-v2")
+        self.assertEqual(schema["schema_id"], "tpcc-json-v3")
         self.assertEqual(schema["throughput_unit"], "new orders/s")
         self.assertEqual(schema["slo_metrics"]["p999"], "p999_ms")
         self.assertNotIn("p99.9", schema["slo_metrics"])

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -7603,6 +7603,21 @@ class WebTest(unittest.TestCase):
         self.assertEqual(value["series"][1]["cpus"], [0, 1, 2, 4])
         self.assertIn("dimension_metadata", value)
 
+    def test_chart_data_bounds_total_rows_across_selected_runs(self):
+        for run_id in ("first", "second"):
+            self._manifest(self.root / run_id)
+            summary = self.root / run_id / "ping-bench" / "baseline" / "summary.csv"
+            summary.parent.mkdir(parents=True)
+            summary.write_text(
+                "affinity_mode,threads,median_msgs_per_sec\n" "none,1,10\n" "none,2,20\n",
+                encoding="utf-8",
+            )
+
+        with mock.patch.object(web, "_CHART_DATA_ROW_LIMIT", 3), self.assertRaisesRegex(
+            BenchmarkError, "selected chart data has too many rows"
+        ):
+            chart_data(self.root, ["first", "second"])
+
     def test_local_ydb_summary_is_available_to_comparison_charts(self):
         self._manifest(self.root / "complete")
         summary = self.root / "complete" / "local-ydb" / "capacity" / "summary.csv"
@@ -7884,6 +7899,14 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"class=modal-backdrop", script)
                 self.assertIn(b"role=dialog", script)
                 self.assertIn(b"function bindChartTooltips", script)
+                self.assertIn(b"const chartPointLimit=10000", script)
+                self.assertIn(b"function chartExtent", script)
+                self.assertIn(b"Chart omitted because it has more than", script)
+                self.assertIn(b"Search curves omitted because they have more than", script)
+                self.assertNotIn(b"Math.min(...values)", script)
+                self.assertNotIn(b"Math.max(...values)", script)
+                self.assertNotIn(b"Math.min(...numericX)", script)
+                self.assertNotIn(b"Math.max(...numericX)", script)
                 self.assertIn(b"function chartNumber", script)
                 self.assertIn(b"synchronize=false", script)
                 self.assertIn(b"targets=synchronize?panels:[active]", script)

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -499,6 +499,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[3]["load_parameters"], ["max-sessions"])
         self.assertEqual(catalog[3]["slo_metrics"]["p999"], "p999_ms")
         self.assertEqual(catalog[3]["default_client_threads"], 2)
+        self.assertIsNone(catalog[3]["default_warmup_seconds"])
         self.assertEqual(catalog[3]["minimum_duration_seconds"], 2)
         self.assertEqual(
             catalog[3]["load_limits"],
@@ -508,6 +509,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[4]["load_parameters"], ["rate"])
         self.assertEqual(catalog[4]["slo_metrics"], {"p99": "full_p99_ms"})
         self.assertEqual(catalog[4]["default_client_threads"], 1)
+        self.assertEqual([item["default_warmup_seconds"] for item in catalog[:3] + catalog[4:]], [10] * 4)
         self.assertEqual(catalog[4]["minimum_duration_seconds"], 2)
         self.assertEqual(
             {option["name"]: option["default"] for option in catalog[4]["options"]},
@@ -595,6 +597,74 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(local_ydb_workloads.workload_effective_warmup_seconds(profile["workload"], 1), 2)
         self.assertEqual(local_ydb_workloads.workload_effective_warmup_seconds(profile["workload"], 7), 7)
 
+        automatic = load_config(
+            self._config(
+                """
+            local-ydb:
+              tpcc-automatic:
+                workload: {type: tpcc, operation: run}
+                load: {parameter: max-sessions, values: [1]}
+                measurement: {duration: 2, repetitions: 1}
+        """,
+                "tpcc-automatic.yaml",
+            )
+        )
+        automatic_profile = automatic.runs[0].parameters["local_ydb"]
+        self.assertIsNone(automatic_profile["measurement"]["warmup"])
+        self.assertEqual(
+            local_ydb_workloads.workload_effective_warmup_seconds(automatic_profile["workload"], None),
+            30,
+        )
+        self.assertEqual(automatic.runs[0].timeout_seconds, 300 + 30 + 2 + 10)
+
+        explicit_null = self._config(
+            """
+            local-ydb:
+              invalid-tpcc-warmup:
+                workload: {type: tpcc, operation: run}
+                load: {parameter: max-sessions, values: [1]}
+                measurement: {warmup: null, duration: 2, repetitions: 1}
+        """,
+            "tpcc-null-warmup.yaml",
+        )
+        with self.assertRaisesRegex(BenchmarkError, "warmup"):
+            load_config(explicit_null)
+
+    def test_local_ydb_tpcc_adaptive_warmup_matches_cli_heuristic(self):
+        for warehouses, expected in (
+            (10, 30),
+            (11, 300),
+            (100, 300),
+            (101, 600),
+            (1000, 600),
+            (1001, 1200),
+            (10000, 1200),
+            (10001, 1800),
+            (20000, 2001),
+            (100000, 3600),
+        ):
+            with self.subTest(warehouses=warehouses):
+                workload = local_ydb_workloads.normalize_workload(
+                    {"type": "tpcc", "operation": "run", "options": {"warehouses": warehouses}},
+                    "workload",
+                )
+                self.assertEqual(local_ydb_workloads.workload_effective_warmup_seconds(workload, None), expected)
+
+        kv = local_ydb_workloads.normalize_workload({"type": "kv", "operation": "upsert"}, "workload")
+        with self.assertRaisesRegex(BenchmarkError, "does not support automatic warmup"):
+            local_ydb_workloads.workload_effective_warmup_seconds(kv, None)
+        with self.assertRaisesRegex(BenchmarkError, "does not support automatic warmup"):
+            local_ydb_workloads.build_run_plan(
+                local_ydb_workloads.WorkloadCli("ydb", "grpc://host:2135", "/Root/bench"),
+                "table",
+                kv,
+                "rate",
+                1,
+                1,
+                1,
+                warmup_seconds=None,
+            )
+
         invalid_profiles = (
             (
                 """
@@ -647,6 +717,19 @@ class YdbBenchTest(unittest.TestCase):
         )
         self.assertEqual(profile["client"]["threads"], 1)
         self.assertEqual(profile["load"], {"parameter": "rate", "allow_errors": False, "values": [100]})
+        default_warmup = load_config(
+            self._config(
+                """
+            local-ydb:
+              topic-default-warmup:
+                workload: {type: topic, operation: full}
+                load: {parameter: rate, values: [100]}
+                measurement: {duration: 2, repetitions: 1}
+        """,
+                "topic-default-warmup.yaml",
+            )
+        )
+        self.assertEqual(default_warmup.runs[0].parameters["local_ydb"]["measurement"]["warmup"], 10)
         definition = local_ydb_workloads.workload_definition("topic")
         self.assertEqual((definition.dataset_scope, definition.warmup_mode), ("sample", "inline"))
 
@@ -1090,6 +1173,33 @@ class YdbBenchTest(unittest.TestCase):
         )
         self.assertEqual(run.timeout_seconds, 92)
         self.assertEqual(run.progress_duration_seconds, 32)
+        automatic_warmup = local_ydb_workloads.build_run_plan(
+            cli_context,
+            "tpcc-dataset",
+            workload,
+            "max-sessions",
+            50,
+            30,
+            3,
+            warmup_seconds=None,
+        )
+        self.assertNotIn("--warmup", automatic_warmup.argv)
+        self.assertEqual(automatic_warmup.timeout_seconds, 390)
+        self.assertEqual(automatic_warmup.progress_duration_seconds, 330)
+        for invalid_warmup in (-1, True):
+            with self.subTest(invalid_warmup=invalid_warmup), self.assertRaisesRegex(
+                BenchmarkError, "non-negative integer"
+            ):
+                local_ydb_workloads.build_run_plan(
+                    cli_context,
+                    "tpcc-dataset",
+                    workload,
+                    "max-sessions",
+                    50,
+                    30,
+                    3,
+                    warmup_seconds=invalid_warmup,
+                )
         requested_warmup = local_ydb_workloads.build_run_plan(
             cli_context,
             "tpcc-dataset",
@@ -1271,6 +1381,15 @@ class YdbBenchTest(unittest.TestCase):
             local_ydb_workloads._validate_catalog((replace(definition, run_plan_builder=None),))
         with self.assertRaisesRegex(ValueError, "default client threads"):
             local_ydb_workloads._validate_catalog((replace(definition, default_client_threads=0),))
+        for invalid_warmup in (-1, True, "10"):
+            with self.subTest(default_warmup_seconds=invalid_warmup), self.assertRaisesRegex(
+                ValueError, "default warmup"
+            ):
+                local_ydb_workloads._validate_catalog((replace(definition, default_warmup_seconds=invalid_warmup),))
+        with self.assertRaisesRegex(ValueError, "automatic warmup requires"):
+            local_ydb_workloads._validate_catalog(
+                (replace(definition, default_warmup_seconds=None, effective_warmup_builder=None),)
+            )
         string_limit = replace(
             definition,
             options=(local_ydb_workloads.WorkloadOption("scale", "auto", kind="string"),),
@@ -1371,7 +1490,7 @@ class YdbBenchTest(unittest.TestCase):
             warehouses=2,
             max_sessions=20,
             threads=2,
-            warmup_seconds=1,
+            warmup_seconds=30,
             time_seconds=10,
             new_orders=100,
         )
@@ -1395,7 +1514,7 @@ class YdbBenchTest(unittest.TestCase):
                 local_ydb_workloads.WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database),
                 workload,
                 {"parameter": "max-sessions"},
-                {"warmup": 0, "duration": 10},
+                {"warmup": None, "duration": 10},
                 2,
                 LOCAL_YDB_BENCHMARK,
                 topology_record,
@@ -1437,7 +1556,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual([command["phase"] for command in first_commands], ["measuring"])
         self.assertEqual([command["phase"] for command in second_commands], ["verification-measuring"])
         run_argv = execute.call_args_list[0].args[0]
-        self.assertEqual(run_argv[run_argv.index("--warmup") + 1], "1s")
+        self.assertNotIn("--warmup", run_argv)
         self.assertEqual(run_argv[run_argv.index("--threads") + 1], 2)
         self.assertEqual(first_metrics["throughput"], 10)
         self.assertEqual(second_metrics["transactions"], 300)
@@ -1458,6 +1577,9 @@ class YdbBenchTest(unittest.TestCase):
                 "cleaning-rmdir",
             ],
         )
+        measurements = [item for item in progress if item["phase"].endswith("measuring")]
+        self.assertTrue(all(item["inline_warmup_seconds"] == 30 for item in measurements))
+        self.assertTrue(all("configured_warmup_seconds" not in item for item in measurements))
 
     def test_local_ydb_profile_inline_lifecycle_prepares_once_and_cleans_once(self):
         definition, workload = self._synthetic_profile_workload()
@@ -3157,9 +3279,12 @@ class YdbBenchTest(unittest.TestCase):
             const compatible=localYdbLoadForWorkload(custom,['rate','threads']);
             const tpccDefinition={
               load_parameters:['max-sessions'],default_client_threads:2,
+              default_warmup_seconds:null,
               load_limits:{'max-sessions':{option:'warehouses',multiplier:10}}
             };
-            const topicDefinition={load_parameters:['rate'],default_client_threads:1,load_limits:{}};
+            const topicDefinition={
+              load_parameters:['rate'],default_client_threads:1,default_warmup_seconds:10,load_limits:{}
+            };
             const tpccWorkload={options:{warehouses:10}};
             const switchedToTpcc=localYdbLoadForWorkload(
               custom,tpccDefinition.load_parameters,tpccDefinition,tpccWorkload
@@ -3181,6 +3306,7 @@ class YdbBenchTest(unittest.TestCase):
               tpccThreads:localYdbDefaultClientThreads(tpccDefinition),
               topicThreads:localYdbDefaultClientThreads(topicDefinition),
               fallbackThreads:localYdbDefaultClientThreads({}),
+              warmups:[tpccDefinition,topicDefinition,{}].map(localYdbDefaultWarmupSeconds),
               units:['kv','stock','log','topic','future'].map(localYdbThroughputUnit),
               axes:['kv','stock','topic'].map(workload=>localSearchAxisLabel('rate',workload))
             }));
@@ -3238,6 +3364,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(result["tpccThreads"], 2)
         self.assertEqual(result["topicThreads"], 1)
         self.assertEqual(result["fallbackThreads"], 64)
+        self.assertEqual(result["warmups"], [None, 10, 10])
         self.assertEqual(
             result["units"],
             ["requests/s", "transactions/s", "batches/s", "messages/s", "operations/s"],
@@ -3246,6 +3373,57 @@ class YdbBenchTest(unittest.TestCase):
             result["axes"],
             ["Offered rate (requests/s)", "Offered rate (transactions/s)", "Offered rate (messages/s)"],
         )
+
+    @unittest.skipUnless(shutil.which("node"), "node is required for the web Builder warmup test")
+    def test_local_ydb_web_builder_omits_automatic_tpcc_warmup(self):
+        start = web._JS.index("function yamlArray")
+        finish = web._JS.index("async function syncEditor", start)
+        comparison_start = web._JS.index("function localComparisonConfig")
+        comparison_finish = web._JS.index("function localComparisonSemantic", comparison_start)
+        script = (
+            """
+            const editor={model:{local_ydb_workloads:[]}};
+            const document={querySelector:()=>({value:''})};
+            function localInteger(){throw Error('blank automatic warmup must not be parsed as an integer')}
+        """
+            + web._JS[start:finish]
+            + web._JS[comparison_start:comparison_finish]
+            + """
+            const tpcc={default_warmup_seconds:null};
+            const kv={default_warmup_seconds:10};
+            function profile(warmup){return {timeout:null,local_ydb:{
+              workload:{type:'tpcc',operation:'run',options:{warehouses:10}},
+              geometry:{preset:'single',static_nodes:1,dynamic_nodes:1,max_dynamic_nodes:1,disk_size_gb:64,storage_groups:1},
+              client:{threads:2},load:{parameter:'max-sessions',allow_errors:false,values:[1]},
+              measurement:{warmup,duration:2,repetitions:1,verification_repetitions:0},
+              affinity:{ydb_cli:{mode:'none',cpus:null},static_nodes:{mode:'none',cpus:null},dynamic_nodes:{mode:'none',cpus:null}}
+            }}}
+            const automatic=[];serializeLocalYdb(automatic,profile(null));
+            const explicit=[];serializeLocalYdb(explicit,profile(0));
+            process.stdout.write(JSON.stringify({
+              automatic:automatic.join('\\n'),explicit:explicit.join('\\n'),
+              blankTpcc:localYdbWarmupInput('warmup',tpcc),
+              blankKv:localYdbWarmupInput('warmup',kv),
+              comparisonAutomatic:localComparisonConfig({parameters:{measurement:{warmup:null}}})['Warmup seconds'],
+              comparisonMissing:localComparisonConfig({parameters:{measurement:{}}})['Warmup seconds']
+            }));
+        """
+        )
+        completed = subprocess.run(
+            [shutil.which("node"), "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        result = json.loads(completed.stdout)
+        self.assertNotIn("warmup:", result["automatic"])
+        self.assertIn("warmup: 0", result["explicit"])
+        self.assertIsNone(result["blankTpcc"])
+        self.assertEqual(result["blankKv"], 10)
+        self.assertEqual(result["comparisonAutomatic"], "automatic")
+        self.assertEqual(result["comparisonMissing"], "—")
+        self.assertIn("config.measurement.warmup=localYdbDefaultWarmupSeconds(nextDefinition)", web._JS)
 
     @unittest.skipUnless(shutil.which("node"), "node is required for the local YDB validity UI test")
     def test_local_ydb_web_hides_latency_for_empty_measurements(self):
@@ -3441,6 +3619,7 @@ class YdbBenchTest(unittest.TestCase):
             const definition={type:'fake',operations:['run'],load_parameters:['rate'],options:[],slo_metrics:{p90:'latency_ms'},reports_errors:false};
             const editor={model:{local_ydb_workloads:[definition],affinity_modes:['none'],benchmarks:[{name:'local-ydb'}]}};
             function localYdbWorkloadDefinition(){return definition}
+            function localYdbDefaultWarmupSeconds(){return 10}
         """
             + web._JS[start:finish]
             + """

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -4744,7 +4744,7 @@ Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
         self.assertEqual(no_feasible_latency.failing_load, 10)
         self.assertEqual(below_start_attempts, [10])
 
-    def test_load_controllers_reject_automatic_search_that_exceeds_attempt_budget(self):
+    def test_load_controllers_bound_automatic_search_attempts(self):
         measure = mock.Mock()
         latency = {
             "parameter": "rate",
@@ -4782,9 +4782,34 @@ Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
                 "plateau_points": 2,
             },
         }
-        with self.assertRaisesRegex(BenchmarkError, "more than 64 attempts"):
-            load_control.search_load(throughput, measure)
-        measure.assert_not_called()
+        result = load_control.search_load(
+            throughput,
+            lambda load: {
+                "throughput": load,
+                "errors": 0,
+                "dynamic_cpu_mean": 0,
+                "static_cpu_mean": 0,
+                "host_cpu_mean": 0,
+            },
+        )
+        self.assertLessEqual(len(result.attempts), load_control.MAX_AUTOMATIC_SEARCH_ATTEMPTS)
+        self.assertNotEqual(result.outcome, "search-limit-reached")
+
+        bounded = load_control.search_load(
+            {
+                **throughput,
+                "search": {**throughput["search"], "maximum": 10**15},
+            },
+            lambda load: {
+                "throughput": load,
+                "errors": 0,
+                "dynamic_cpu_mean": 0,
+                "static_cpu_mean": 0,
+                "host_cpu_mean": 0,
+            },
+        )
+        self.assertEqual(len(bounded.attempts), load_control.MAX_AUTOMATIC_SEARCH_ATTEMPTS)
+        self.assertEqual(bounded.outcome, "search-limit-reached")
 
     def test_throughput_plateau_uses_absolute_gain_and_stable_lowest_load(self):
         result = load_control.search_load(

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -975,7 +975,21 @@ class YdbBenchTest(unittest.TestCase):
         )
         self.assertEqual(run.timeout_seconds, 60)
         self.assertEqual(cleanup[0].argv, tuple(base + ["clean"]))
-        self.assertIsNone(cleanup[0].timeout_seconds)
+        self.assertEqual(cleanup[0].timeout_seconds, 120)
+
+    def test_local_ydb_cleanup_plan_rejects_custom_plan_without_timeout(self):
+        cli_context = local_ydb_workloads.WorkloadCli(Path("ydb"), "grpc://host:2135", "/Root/bench")
+
+        def unbounded_cleanup(*_args):
+            return (local_ydb_workloads.WorkloadCommandPlan("clean", ("ydb", "clean")),)
+
+        definition = replace(
+            local_ydb_workloads.workload_definition("kv"),
+            cleanup_plan_builder=unbounded_cleanup,
+        )
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+            with self.assertRaisesRegex(BenchmarkError, "must have a positive timeout"):
+                local_ydb_workloads.build_cleanup_plan(cli_context, "table-prefix", {"type": "kv"})
 
     def test_local_ydb_tpcc_builds_golden_prepare_run_and_cleanup_plans(self):
         cli_context = local_ydb_workloads.WorkloadCli(
@@ -2098,7 +2112,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertTrue(self.last_local_ydb_cluster._run.call_args.kwargs["ignore_cancellation"])
         self.last_local_ydb_cluster.stop.assert_called_once_with()
 
-    def test_local_ydb_cleanup_plan_uses_cluster_configuration_timeout(self):
+    def test_local_ydb_cleanup_plan_uses_bounded_default_timeout(self):
         cluster = local_ydb.LocalYdbCluster(
             self.root / "ydbd",
             self.root / "ydb",
@@ -2106,7 +2120,7 @@ class YdbBenchTest(unittest.TestCase):
             self.root / "cluster-timeout",
             {"static_nodes": 1, "dynamic_nodes": 1},
             {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
-            73,
+            10000,
         )
         cli_context = local_ydb_workloads.WorkloadCli(cluster.ydb_cli, "grpc://host:2135", cluster.database)
         plan = local_ydb_workloads.build_cleanup_plan(
@@ -2118,8 +2132,8 @@ class YdbBenchTest(unittest.TestCase):
         with mock.patch.object(local_ydb, "run_command", return_value=result) as execute:
             cluster._run(plan.argv, timeout=plan.timeout_seconds, ignore_cancellation=True)
 
-        self.assertIsNone(plan.timeout_seconds)
-        self.assertEqual(execute.call_args.args[2], 73)
+        self.assertEqual(plan.timeout_seconds, 120)
+        self.assertEqual(execute.call_args.args[2], 120)
 
     def test_local_ydb_cli_total_row_is_parsed_in_milliseconds(self):
         metrics = parse_cli_metrics("""

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -3229,6 +3229,37 @@ class YdbBenchTest(unittest.TestCase):
         ):
             load_config(invalid)
 
+    def test_local_ydb_search_numbers_are_overflow_safe(self):
+        huge_multiplier = load_config(self._config("""
+            local-ydb:
+              bounded:
+                workload: {type: kv, operation: upsert}
+                load:
+                  parameter: rate
+                  search: {start: 10, maximum: 100, multiplier: 1.0e+308}
+                  objective: {type: latency-slo, percentile: p99, max-ms: 10}
+        """)).runs[0]
+        self.assertEqual(
+            huge_multiplier.parameters["local_ydb"]["load"]["search"]["multiplier"],
+            1.0e308,
+        )
+
+        invalid = self._config(
+            """
+            local-ydb:
+              too-large:
+                workload: {type: kv, operation: upsert}
+                load:
+                  parameter: rate
+                  search:
+                    start: 1
+                    maximum: __MAXIMUM__
+                  objective: {type: maximize-throughput}
+            """.replace("__MAXIMUM__", str(10**400))
+        )
+        with self.assertRaisesRegex(BenchmarkError, r"load\.search\.maximum.*must be at most"):
+            load_config(invalid)
+
     def test_local_ydb_verification_config_is_optional_bounded_and_counted_in_default_timeout(self):
         loaded = load_config(self._config("""
             local-ydb:
@@ -4743,6 +4774,25 @@ Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
         self.assertEqual(no_feasible_latency.outcome, "no-feasible-point")
         self.assertEqual(no_feasible_latency.failing_load, 10)
         self.assertEqual(below_start_attempts, [10])
+
+        huge_multiplier_attempts = []
+        huge_multiplier = load_control.search_load(
+            {
+                "parameter": "rate",
+                "search": {"start": 10, "maximum": 100, "multiplier": 1.0e308, "resolution_percent": 5},
+                "objective": {
+                    "type": "latency-slo",
+                    "percentile": "p99",
+                    "max_ms": 10,
+                    "max_errors": 0,
+                    "min_achieved_rate_ratio": 0.98,
+                },
+            },
+            lambda load: {"throughput": load, "errors": 0, "p99_ms": 5},
+            on_attempt=lambda attempt: huge_multiplier_attempts.append(attempt["load"]),
+        )
+        self.assertEqual(huge_multiplier.selected_load, 100)
+        self.assertEqual(huge_multiplier_attempts, [10, 100])
 
     def test_load_controllers_bound_automatic_search_attempts(self):
         measure = mock.Mock()
@@ -6265,7 +6315,7 @@ Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
 
     def test_config_rejects_non_finite_timeout(self):
         """Reject NaN, positive infinity, then negative infinity as profile timeouts."""
-        for value in (".nan", ".inf", "-.inf"):
+        for index, value in enumerate((".nan", ".inf", "-.inf", str(10**400))):
             with self.subTest(value=value), self.assertRaisesRegex(BenchmarkError, "finite positive number"):
                 load_config(
                     self._config(
@@ -6278,7 +6328,7 @@ Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
                             affinity: [none]
                             timeout: {}
                         """.format(value),
-                        name="timeout-{}.yaml".format(value.replace("/", "_")),
+                        name="timeout-{}.yaml".format(index),
                     )
                 )
 

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -7202,6 +7202,58 @@ class WebTest(unittest.TestCase):
             worker.join()
             server.server_close()
 
+    def test_local_ydb_activity_bounds_persisted_replay_to_recent_tail(self):
+        run_root = self.root / "local-ydb-tail-activity"
+        self._manifest(run_root)
+        manifest_path = run_root / "run.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["runs"] = [{"benchmark": "local-ydb", "profile": "capacity", "status": "running"}]
+        manifest["steps"] = [
+            {
+                "id": "capacity-step",
+                "benchmark": "local-ydb",
+                "profile": "capacity",
+                "state": "running",
+            }
+        ]
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        events = [
+            {
+                "sequence": sequence,
+                "type": "step-progress",
+                "step_id": "capacity-step",
+                "fields": {"progress": {"phase": "measuring", "attempt": sequence, "padding": "x" * 80}},
+            }
+            for sequence in range(1, 21)
+        ]
+        (run_root / "events.jsonl").write_text(
+            "".join(json.dumps(event, separators=(",", ":")) + "\n" for event in events),
+            encoding="utf-8",
+        )
+
+        with mock.patch.object(web, "_LOCAL_YDB_ACTIVITY_SCAN_BYTES", 256), mock.patch.object(
+            web, "_EVENT_LOG_RECORD_BYTES", 512
+        ):
+            service = RunService(self.root)
+            try:
+                activity = service.local_ydb_activity("local-ydb-tail-activity", "capacity")
+                self.assertTrue(activity["truncated"])
+                self.assertGreater(activity["events"][0]["sequence"], 1)
+                self.assertEqual(activity["events"][-1]["sequence"], 20)
+                self.assertEqual(activity["after"], 20)
+
+                first_sequence = activity["events"][0]["sequence"]
+                replay = service.local_ydb_activity(
+                    "local-ydb-tail-activity",
+                    "capacity",
+                    after=first_sequence - 1,
+                )
+                self.assertFalse(replay["truncated"])
+                self.assertEqual(replay["events"], activity["events"])
+                self.assertEqual(replay["after"], 20)
+            finally:
+                service.shutdown()
+
     def test_local_ydb_profile_projection_supports_preparing_and_live_results(self):
         run_root = self.root / "local-ydb-run"
         self._manifest(run_root, "running")

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -3266,6 +3266,81 @@ Total 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:14Z
         self.assertEqual(result["legacy_identity"], result["explicit_legacy_identity"])
         self.assertFalse(result["empty_number"])
 
+    @unittest.skipUnless(shutil.which("node"), "node is required for the local YDB attempts UI test")
+    def test_local_ydb_web_attempts_use_objective_latency_percentile(self):
+        schema_start = web._JS.index("function localLegacyResultSchema")
+        schema_finish = web._JS.index("function localChart", schema_start)
+        render_start = web._JS.index("function renderLocalYdbProfile")
+        render_finish = web._JS.index("async function mountLocalYdbProfile", render_start)
+        script = (
+            """
+            const esc=value=>String(value??'');
+            const metricLabel=value=>String(value??'—');
+            const elapsedLabel=value=>String(value??0);
+            const localElapsed=()=>0;
+            const localPhaseLabel=value=>value||'';
+            const localActivityLog=()=>'';
+            const localRestoreActivityScroll=()=>{};
+            const localProfileDetails=()=>'';
+            const localVerificationSummary=()=>'';
+            const localKpi=()=>'';
+            const localOutcomeLabel=value=>value||'';
+            const localSearchAxisLabel=value=>value||'load';
+            const localBestRows=(attempts,objective,xField)=>new Map(
+              attempts.map(item=>[String(item[xField]),item])
+            );
+            const chartColors=[];
+            const localChart=()=>'';
+            const localCommandDetails=()=>'';
+            const bindChartTooltips=()=>{};
+            """
+            + web._JS[schema_start:schema_finish]
+            + web._JS[render_start:render_finish]
+            + """
+            const schema={
+              schema_id:'generic-total-v1',throughput_unit:'requests/s',reports_errors:true,
+              metrics:[
+                {name:'throughput',unit:'requests/s',repetition_aggregation:'median'},
+                {name:'errors',unit:'errors',repetition_aggregation:'sum'},
+                {name:'p95_ms',unit:'ms',repetition_aggregation:'median'},
+                {name:'p99_ms',unit:'ms',repetition_aggregation:'median'}
+              ],
+              slo_metrics:{p95:'p95_ms',p99:'p99_ms'}
+            };
+            const container={
+              dataset:{},innerHTML:'',querySelector:()=>null,querySelectorAll:()=>[]
+            };
+            renderLocalYdbProfile(container,{
+              state:'passed',started_at:'2025-01-01T00:00:00Z',progress:{search_stage:1},searches:[],
+              parameters:{
+                workload:{type:'kv'},
+                load:{parameter:'rate',objective:{type:'latency-slo',percentile:'p95',max_ms:10}}
+              },
+              workload_result_schema:schema,
+              attempts:[{
+                attempt:1,search_stage:1,dynamic_nodes:1,load:90,throughput:80,
+                p95_ms:5.95,p99_ms:99.99,errors:0,empty_repetitions:0,
+                static_cpu_mean:10,dynamic_cpu_mean:20,cli_cpu_mean:30,
+                passed:true,decision:'within SLO',duration_seconds:1
+              }]
+            });
+            const table=container.innerHTML.slice(container.innerHTML.indexOf('<table class=local-attempts>'));
+            process.stdout.write(JSON.stringify({table}));
+            """
+        )
+        completed = subprocess.run(
+            [shutil.which("node"), "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        table = json.loads(completed.stdout)["table"]
+        self.assertIn(">p95 (ms)</th>", table)
+        self.assertNotIn(">p99 (ms)</th>", table)
+        self.assertIn(">5.95</td>", table)
+        self.assertNotIn(">99.99</td>", table)
+
     @unittest.skipUnless(shutil.which("node"), "node is required for the schema-aware Builder test")
     def test_local_ydb_web_builder_omits_unsupported_error_controls(self):
         start = web._JS.index("function localField")

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -391,7 +391,13 @@ class YdbBenchTest(unittest.TestCase):
         return definition, {"type": "synthetic", "operation": "run", "options": {}}
 
     @staticmethod
-    def _synthetic_workload_lifecycle(workload, cluster, progress, cancel_event=None):
+    def _synthetic_workload_lifecycle(
+        workload,
+        cluster,
+        progress,
+        cancel_event=None,
+        command_timeout_seconds=None,
+    ):
         topology = CpuTopology(
             allowed_cpus=(0,),
             numa_nodes=((0, (0,)),),
@@ -410,6 +416,7 @@ class YdbBenchTest(unittest.TestCase):
             {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
             cancel_event,
             lambda phase, **fields: progress.append({"phase": phase, **fields}),
+            command_timeout_seconds=command_timeout_seconds,
         )
 
     def _worker_metrics_benchmark(self):
@@ -1641,6 +1648,7 @@ class YdbBenchTest(unittest.TestCase):
                 workload,
                 cluster,
                 progress,
+                command_timeout_seconds=3,
             )
             lifecycle.open_profile(profile_directory, "tpcc-dataset")
             first_metrics, first_commands = lifecycle.run_sample(
@@ -1666,10 +1674,11 @@ class YdbBenchTest(unittest.TestCase):
 
         self.assertEqual(cluster.init_workload.call_count, 2)
         self.assertEqual([call.args[0][2] for call in cluster.init_workload.call_args_list], ["init", "import"])
+        self.assertTrue(all(call.kwargs["timeout"] == 3 for call in cluster.init_workload.call_args_list))
         self.assertEqual(execute.call_count, 2)
         self.assertEqual(cluster._run.call_count, 1)
         self.assertTrue(cluster._run.call_args.kwargs["ignore_cancellation"])
-        self.assertEqual(cluster._run.call_args.kwargs["timeout"], 5)
+        self.assertEqual(cluster._run.call_args.kwargs["timeout"], 3)
         self.assertEqual(
             [item["phase"] for item in progress],
             [
@@ -1694,7 +1703,7 @@ class YdbBenchTest(unittest.TestCase):
         for call in execute.call_args_list:
             argv = call.args[0]
             self.assertEqual(argv[argv.index("--warmup") + 1], 5)
-            self.assertEqual(call.args[2], 45)
+            self.assertEqual(call.args[2], 3)
         profile_commands = lifecycle.profile_commands
         self.assertEqual([item["argv"][2] for item in profile_commands], ["init", "import", "clean"])
 
@@ -4194,6 +4203,7 @@ Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
         with (output / "verification-summary.csv").open(newline="", encoding="utf-8") as stream:
             verification_summary = list(csv.DictReader(stream))
         self.assertEqual([float(row["throughput"]) for row in search_rows], [10])
+
         self.assertEqual([float(row["throughput"]) for row in verification_rows], [20, 30])
         self.assertNotIn("passed", verification_rows[0])
         self.assertEqual(verification_summary[0]["samples"], "2")
@@ -4214,6 +4224,47 @@ Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
         )
         artifacts = next(event["artifacts"] for event in events if event["type"] == "step-artifacts")
         self.assertIn("verification-repetitions.csv", artifacts)
+
+    def test_local_ydb_only_explicit_profile_timeout_caps_workload_commands(self):
+        def configuration(name, timeout=""):
+            return load_config(
+                self._config(
+                    """
+                    local-ydb:
+                      {name}:
+                        {timeout}
+                        workload: {{type: kv, operation: upsert}}
+                        load: {{parameter: threads, values: [1]}}
+                        measurement: {{warmup: 0, duration: 1, repetitions: 1}}
+                        affinity:
+                          ydb-cli: {{mode: none}}
+                          static-nodes: {{mode: none}}
+                          dynamic-nodes: {{mode: none}}
+                    """.format(name=name, timeout=timeout),
+                    name + ".yaml",
+                )
+            ).runs[0]
+
+        original_lifecycle = local_ydb.WorkloadLifecycle
+        command_timeouts = []
+
+        def lifecycle(*args, **kwargs):
+            command_timeouts.append(kwargs.get("command_timeout_seconds"))
+            return original_lifecycle(*args, **kwargs)
+
+        with mock.patch.object(local_ydb, "WorkloadLifecycle", side_effect=lifecycle):
+            self._run_mock_local_ydb(
+                configuration("default-timeout"),
+                "default-timeout",
+                [{"throughput": 1}],
+            )
+            self._run_mock_local_ydb(
+                configuration("explicit-timeout", "timeout: 3"),
+                "explicit-timeout",
+                [{"throughput": 1}],
+            )
+
+        self.assertEqual(command_timeouts, [None, 3])
 
     def test_local_ydb_disabled_verification_keeps_search_metrics(self):
         configuration = load_config(self._config("""

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -487,7 +487,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[2]["options"][4]["choices"], ["row", "column"])
         self.assertEqual(
             [item["result_schema_id"] for item in catalog],
-            ["generic-total-v1"] * 3 + ["tpcc-json-v2", "topic-total-v1"],
+            ["generic-total-v1"] * 3 + ["tpcc-json-v2", "topic-window-v1"],
         )
         self.assertEqual(
             [item["throughput_unit"] for item in catalog],
@@ -2339,19 +2339,37 @@ class YdbBenchTest(unittest.TestCase):
                     request,
                 )
 
-    def test_local_ydb_topic_total_result_normalizes_aggregate_consumer_rate(self):
+    def test_local_ydb_topic_window_result_aggregates_exact_measurement_windows(self):
         workload = local_ydb_workloads.normalize_workload(
             {"type": "topic", "operation": "full", "options": {"consumers": 2}},
             "workload",
         )
         request = local_ydb_workloads.WorkloadRunRequest("rate", 150, 10, 3, 4, None)
-        stdout = """
-Window\tWrite speed\tWrite time\tInflight\tLag\t\tLag time\tRead speed\tFull time\tTimestamp
-#\tmsg/s\tMB/s\tpercentile,ms\tpercentile,msg\tpercentile,msg\tpercentile,ms\tmsg/s\tMB/s\tpercentile,ms
-4\t0\t0\t0\t\t0\t\t0\t\t0\t\t0\t0\t0\t2026-08-25T10:00:04Z
-13\t0\t0\t0\t\t0\t\t0\t\t0\t\t0\t0\t0\t2026-08-25T10:00:13Z
-Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
-"""
+
+        def row(index, metrics, second):
+            return "{} {} 2026-08-25T10:00:{:02d}Z".format(index, " ".join(map(str, metrics)), second)
+
+        rows = [row(3, [0] * 9, 3)]
+        for offset, index in enumerate(range(4, 14)):
+            rows.append(
+                row(
+                    index,
+                    [
+                        100 + offset,
+                        10 + offset,
+                        1 + offset,
+                        20 + offset,
+                        30 + offset,
+                        40 + offset,
+                        200 + 2 * offset,
+                        50 + offset,
+                        60 + offset,
+                    ],
+                    index,
+                )
+            )
+        rows.append(row("Total", [999] * 9, 14))
+        stdout = "\n".join(rows)
         result = local_ydb_workloads.parse_workload_result(
             "topic",
             self._local_ydb_command_result(("ydb", "workload", "topic", "run", "full"), stdout),
@@ -2361,22 +2379,31 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
         self.assertEqual(
             result.metrics,
             {
-                "transactions": 900,
-                "throughput": 90,
-                "write_messages_s": 120,
-                "write_mib_s": 1,
-                "write_p99_ms": 4,
-                "inflight_p99_messages": 7,
-                "lag_p99_messages": 8,
-                "lag_p99_ms": 9,
-                "read_messages_s": 180,
-                "read_per_consumer_messages_s": 90,
-                "read_mib_s": 2,
-                "full_p99_ms": 12,
+                "transactions": 1045,
+                "throughput": 104.5,
+                "write_messages_s": 104.5,
+                "write_mib_s": 14.5,
+                "write_p99_ms": 10,
+                "inflight_p99_messages": 29,
+                "lag_p99_messages": 39,
+                "lag_p99_ms": 49,
+                "read_messages_s": 209,
+                "read_per_consumer_messages_s": 104.5,
+                "read_mib_s": 54.5,
+                "full_p99_ms": 69,
             },
         )
-        self.assertEqual(result.details, {"percentile": 99, "total": result.metrics})
-        self.assertEqual(result.measurement_window, (1787652004.0, 1787652013.0))
+        self.assertEqual(
+            result.details,
+            {
+                "percentile": 99,
+                "window_seconds": 1,
+                "measurement_windows": 10,
+                "rate_aggregation": "mean",
+                "percentile_aggregation": "maximum",
+            },
+        )
+        self.assertEqual(result.measurement_window, (1787652003.0, 1787652013.0))
         passed, reason = load_control.evaluate_load(
             {
                 "parameter": "rate",
@@ -2386,7 +2413,7 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
                     "type": "latency-slo",
                     "percentile": "p99",
                     "latency_metric": "full_p99_ms",
-                    "max_ms": 20,
+                    "max_ms": 100,
                     "max_errors": 0,
                     "min_achieved_rate_ratio": 0.98,
                 },
@@ -2395,10 +2422,10 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
             result.metrics,
         )
         self.assertFalse(passed)
-        self.assertIn("achieved rate ratio 0.6000", reason)
+        self.assertIn("achieved rate ratio 0.6967", reason)
 
         schema = local_ydb_workloads.workload_result_schema("topic")
-        self.assertEqual(schema["schema_id"], "topic-total-v1")
+        self.assertEqual(schema["schema_id"], "topic-window-v1")
         self.assertEqual(schema["throughput_unit"], "messages/s")
         self.assertEqual(schema["slo_metrics"], {"p99": "full_p99_ms"})
         self.assertFalse(schema["reports_errors"])
@@ -2407,16 +2434,10 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
             "deliveries/s",
         )
 
+        zero_stdout = "\n".join([row(index, [0] * 9, index) for index in range(3, 14)] + [row("Total", [999] * 9, 14)])
         zero_result = local_ydb_workloads.parse_workload_result(
             "topic",
-            self._local_ydb_command_result(
-                ("ydb",),
-                """
-4 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:04Z
-13 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:13Z
-Total 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:14Z
-""",
-            ),
+            self._local_ydb_command_result(("ydb",), zero_stdout),
             workload,
             request,
         )
@@ -2434,7 +2455,32 @@ Total 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:14Z
         self.assertFalse(passed)
         self.assertIn("zero successful operations", reason)
 
-    def test_local_ydb_topic_total_result_rejects_ambiguous_or_unsafe_output(self):
+    def test_local_ydb_topic_window_result_supports_zero_warmup(self):
+        workload = local_ydb_workloads.normalize_workload(
+            {"type": "topic", "operation": "full"},
+            "workload",
+        )
+        request = local_ydb_workloads.WorkloadRunRequest("rate", 100, 2, 0, 1, None)
+        stdout = "\n".join(
+            (
+                "1 10 20 3 4 5 6 30 40 7 2026-08-25T10:00:01Z",
+                "2 20 30 8 9 10 11 40 50 12 2026-08-25T10:00:02Z",
+                "Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:03Z",
+            )
+        )
+        result = local_ydb_workloads.parse_workload_result(
+            "topic",
+            self._local_ydb_command_result(("ydb",), stdout),
+            workload,
+            request,
+        )
+        self.assertEqual(result.metrics["write_messages_s"], 15)
+        self.assertEqual(result.metrics["write_p99_ms"], 8)
+        self.assertEqual(result.metrics["read_messages_s"], 35)
+        self.assertEqual(result.metrics["full_p99_ms"], 12)
+        self.assertEqual(result.measurement_window, (1787652000.0, 1787652002.0))
+
+    def test_local_ydb_topic_window_result_rejects_ambiguous_or_unsafe_output(self):
         workload = local_ydb_workloads.normalize_workload(
             {"type": "topic", "operation": "full"},
             "workload",
@@ -2444,53 +2490,94 @@ Total 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:14Z
         def row(index, timestamp, metrics="1 2 3 4 5 6 7 8 9"):
             return "{} {} {}".format(index, metrics, timestamp)
 
+        boundary = row(1, "2026-08-25T10:00:01Z")
         start = row(2, "2026-08-25T10:00:02Z")
         finish = row(3, "2026-08-25T10:00:03Z")
         total = row("Total", "2026-08-25T10:00:04Z")
-        valid = "\n".join((start, finish, total))
+        valid = "\n".join((boundary, start, finish, total))
         invalid = (
             (None, "is not text"),
             ("\ud800", "not valid UTF-8 text"),
-            ("\n".join((start, finish)), "exactly one Total row"),
+            ("\n".join((boundary, start, finish)), "exactly one Total row"),
             (valid + "\n" + total, "exactly one Total row"),
-            ("\n".join((start, finish, "Total 1 2 3 4 5 6 7 8 9")), "Total row.*11 columns"),
+            ("\n".join((boundary, start, finish, "Total 1 2 3 4 5 6 7 8 9")), "Total row.*11 columns"),
             (valid + " extra", "Total row.*11 columns"),
             (
-                "\n".join((start, finish, row("Total", "2026-08-25T10:00:04Z", "-1 2 3 4 5 6 7 8 9"))),
-                "Total row metrics.*unsigned 64-bit",
-            ),
-            (
-                "\n".join((start, finish, row("Total", "2026-08-25T10:00:04Z", "1.0 2 3 4 5 6 7 8 9"))),
-                "Total row metrics.*unsigned 64-bit",
-            ),
-            (
-                "\n".join((start, finish, row("Total", "2026-08-25T10:00:04Z", "١ 2 3 4 5 6 7 8 9"))),
+                "\n".join((boundary, start, finish, row("Total", "2026-08-25T10:00:04Z", "-1 2 3 4 5 6 7 8 9"))),
                 "Total row metrics.*unsigned 64-bit",
             ),
             (
                 "\n".join(
-                    (start, finish, row("Total", "2026-08-25T10:00:04Z", "000000000000000000001 2 3 4 5 6 7 8 9"))
+                    (
+                        boundary,
+                        start,
+                        finish,
+                        row("Total", "2026-08-25T10:00:04Z", "1.0 2 3 4 5 6 7 8 9"),
+                    )
+                ),
+                "Total row metrics.*unsigned 64-bit",
+            ),
+            (
+                "\n".join((boundary, start, finish, row("Total", "2026-08-25T10:00:04Z", "١ 2 3 4 5 6 7 8 9"))),
+                "Total row metrics.*unsigned 64-bit",
+            ),
+            (
+                "\n".join(
+                    (
+                        boundary,
+                        start,
+                        finish,
+                        row("Total", "2026-08-25T10:00:04Z", "000000000000000000001 2 3 4 5 6 7 8 9"),
+                    )
                 ),
                 "Total row metrics.*unsigned 64-bit",
             ),
             (
                 "\n".join(
-                    (start, finish, row("Total", "2026-08-25T10:00:04Z", "18446744073709551616 2 3 4 5 6 7 8 9"))
+                    (
+                        boundary,
+                        start,
+                        finish,
+                        row("Total", "2026-08-25T10:00:04Z", "18446744073709551616 2 3 4 5 6 7 8 9"),
+                    )
                 ),
                 "Total row metrics.*unsigned 64-bit",
             ),
-            ("\n".join((finish, total)), "window row for index 2"),
-            ("\n".join((start, start, finish, total)), "window row for index 2"),
-            ("\n".join((row("٢", "2026-08-25T10:00:02Z"), finish, total)), "window row for index 2"),
-            ("\n".join(("2 1 2 3 4 5 6 7 8 9", finish, total)), "window row 2.*11 columns"),
+            ("\n".join((start, finish, total)), "window row for index 1"),
+            ("\n".join((boundary, finish, total)), "window row for index 2"),
+            ("\n".join((boundary, start, start, finish, total)), "window row for index 2"),
             (
-                "\n".join((row(2, "2026-08-25T10:00:02Z", "-1 2 3 4 5 6 7 8 9"), finish, total)),
+                "\n".join((boundary, row("٢", "2026-08-25T10:00:02Z"), finish, total)),
+                "window row for index 2",
+            ),
+            (
+                "\n".join((boundary, "2 1 2 3 4 5 6 7 8 9", finish, total)),
+                "window row 2.*11 columns",
+            ),
+            (
+                "\n".join((boundary, row(2, "2026-08-25T10:00:02Z", "-1 2 3 4 5 6 7 8 9"), finish, total)),
                 "window row 2 metrics.*unsigned 64-bit",
             ),
-            ("\n".join((start, finish, row("Total", "2026-08-25T10:00:04"))), "Total row timestamp.*ISO UTC"),
-            ("\n".join((row(2, "2026-08-25T10:00:02+00:00"), finish, total)), "window row 2 timestamp.*ISO UTC"),
-            ("\n".join((row(2, "2026-02-30T10:00:02Z"), finish, total)), "window row 2 timestamp.*ISO UTC"),
-            ("\n".join((row(2, "2026-08-25T10:00:03Z"), finish, total)), "timestamps must be increasing"),
+            (
+                "\n".join((boundary, start, finish, row("Total", "2026-08-25T10:00:04"))),
+                "Total row timestamp.*ISO UTC",
+            ),
+            (
+                "\n".join((boundary, row(2, "2026-08-25T10:00:02+00:00"), finish, total)),
+                "window row 2 timestamp.*ISO UTC",
+            ),
+            (
+                "\n".join((boundary, row(2, "2026-02-30T10:00:02Z"), finish, total)),
+                "window row 2 timestamp.*ISO UTC",
+            ),
+            (
+                "\n".join((boundary, row(2, "2026-08-25T10:00:03Z"), finish, total)),
+                "timestamps must advance by one second",
+            ),
+            (
+                "\n".join((boundary, start, row(3, "2026-08-25T10:00:04Z"), total)),
+                "timestamps must advance by one second",
+            ),
             ("x" * (1024 * 1024 + 1), "exceeds 1048576 bytes"),
         )
         for stdout, message in invalid:
@@ -3660,9 +3747,10 @@ Total 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:14Z
             "workload",
         )
         output = """
-2 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:12Z
-3 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:13Z
-Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
+1 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:11Z
+2 120 1 4 7 8 9 180 2 12 2026-08-25T10:00:12Z
+3 120 1 4 7 8 9 180 2 12 2026-08-25T10:00:13Z
+Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
 """
         cluster = mock.Mock(
             ydb_cli=Path("/tmp/ydb"),
@@ -3760,8 +3848,8 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
         self.assertEqual(
             monitor.summary.call_args_list,
             [
-                mock.call(started_at_unix=1787652012.0, finished_at_unix=1787652013.0),
-                mock.call(started_at_unix=1787652012.0, finished_at_unix=1787652013.0),
+                mock.call(started_at_unix=1787652011.0, finished_at_unix=1787652013.0),
+                mock.call(started_at_unix=1787652011.0, finished_at_unix=1787652013.0),
             ],
         )
         self.assertEqual(

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -3018,6 +3018,29 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(profile["affinity"]["ydb_cli"]["cpus"], "one-chiplet")
         self.assertEqual(profile["measurement"]["verification_repetitions"], 0)
 
+    def test_local_ydb_rejects_automatic_search_that_exceeds_attempt_budget(self):
+        invalid = self._config("""
+            local-ydb:
+              unbounded:
+                workload: {type: kv, operation: upsert}
+                load:
+                  parameter: rate
+                  search:
+                    start: 1
+                    maximum: 1000000
+                    multiplier: 1.000001
+                    resolution-percent: 2
+                  objective:
+                    type: latency-slo
+                    percentile: p99
+                    max-ms: 10
+        """)
+        with self.assertRaisesRegex(
+            BenchmarkError,
+            r"load\.search.*more than 64 attempts",
+        ):
+            load_config(invalid)
+
     def test_local_ydb_verification_config_is_optional_bounded_and_counted_in_default_timeout(self):
         loaded = load_config(self._config("""
             local-ydb:
@@ -4532,6 +4555,48 @@ Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
         self.assertEqual(no_feasible_latency.outcome, "no-feasible-point")
         self.assertEqual(no_feasible_latency.failing_load, 10)
         self.assertEqual(below_start_attempts, [10])
+
+    def test_load_controllers_reject_automatic_search_that_exceeds_attempt_budget(self):
+        measure = mock.Mock()
+        latency = {
+            "parameter": "rate",
+            "search": {
+                "start": 1,
+                "maximum": 1000000,
+                "multiplier": 1.000001,
+                "resolution_percent": 2,
+            },
+            "objective": {
+                "type": "latency-slo",
+                "percentile": "p99",
+                "max_ms": 10,
+                "max_errors": 0,
+                "min_achieved_rate_ratio": 0.98,
+            },
+        }
+        with self.assertRaisesRegex(BenchmarkError, "more than 64 attempts"):
+            load_control.search_load(latency, measure)
+        measure.assert_not_called()
+
+        throughput = {
+            "parameter": "rate",
+            "search": {
+                "start": 1,
+                "maximum": 1000000,
+                "multiplier": 2,
+                "resolution_percent": 0.000001,
+            },
+            "objective": {
+                "type": "maximize-throughput",
+                "target_role": "dynamic",
+                "cpu_saturation_percent": 90,
+                "plateau_gain_percent": 1,
+                "plateau_points": 2,
+            },
+        }
+        with self.assertRaisesRegex(BenchmarkError, "more than 64 attempts"):
+            load_control.search_load(throughput, measure)
+        measure.assert_not_called()
 
     def test_throughput_plateau_uses_absolute_gain_and_stable_lowest_load(self):
         result = load_control.search_load(

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -2856,12 +2856,8 @@ class YdbBenchTest(unittest.TestCase):
                 "window row 2 timestamp.*ISO UTC",
             ),
             (
-                "\n".join((boundary, row(2, "2026-08-25T10:00:03Z"), finish, total)),
-                "timestamps must advance by one second",
-            ),
-            (
-                "\n".join((boundary, start, row(3, "2026-08-25T10:00:04Z"), total)),
-                "timestamps must advance by one second",
+                "\n".join((boundary, row(2, "2026-08-25T10:00:00Z"), finish, total)),
+                "timestamps must not move backwards",
             ),
             ("x" * (1024 * 1024 + 1), "exceeds 1048576 bytes"),
         )
@@ -2873,6 +2869,22 @@ class YdbBenchTest(unittest.TestCase):
                     workload,
                     request,
                 )
+
+        jittered = "\n".join(
+            (
+                boundary,
+                row(2, "2026-08-25T10:00:01Z"),
+                row(3, "2026-08-25T10:00:03Z"),
+                total,
+            )
+        )
+        result = local_ydb_workloads.parse_workload_result(
+            "topic",
+            self._local_ydb_command_result(("ydb",), jittered),
+            workload,
+            request,
+        )
+        self.assertEqual(result.measurement_window, (1787652001.0, 1787652003.0))
 
         short_request = replace(request, duration_seconds=1)
         with self.assertRaisesRegex(BenchmarkError, "duration of at least two seconds"):

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -765,6 +765,19 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(default_warmup.runs[0].parameters["local_ydb"]["measurement"]["warmup"], 10)
         definition = local_ydb_workloads.workload_definition("topic")
         self.assertEqual((definition.dataset_scope, definition.warmup_mode), ("sample", "inline"))
+        bounded = load_config(
+            self._config(
+                """
+                local-ydb:
+                  topic-bounded-output:
+                    workload: {type: topic, operation: full}
+                    load: {parameter: rate, values: [100]}
+                    measurement: {warmup: 1, duration: 3599, repetitions: 1}
+                """,
+                "topic-bounded-output.yaml",
+            )
+        )
+        self.assertEqual(bounded.runs[0].parameters["local_ydb"]["measurement"]["duration"], 3599)
 
         latency = (
             load_config(
@@ -853,6 +866,16 @@ class YdbBenchTest(unittest.TestCase):
                     measurement: {duration: 2}
                 """,
                 "percentile.*must be one of p99",
+            ),
+            (
+                """
+                local-ydb:
+                  invalid-topic:
+                    workload: {type: topic, operation: full}
+                    load: {parameter: rate, values: [10]}
+                    measurement: {warmup: 1, duration: 3600}
+                """,
+                "measurement.*warmup plus duration must not exceed 3600 seconds",
             ),
         )
         for index, (body, message) in enumerate(invalid_profiles):

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -125,6 +125,8 @@ class YdbBenchTest(unittest.TestCase):
         cleanup_action=None,
         cpu_metrics=None,
         lifecycle_actions=None,
+        extra_cluster_dynamic_nodes=(),
+        extra_cluster_start_error=None,
     ):
         def record(action, command=None):
             if lifecycle_actions is None:
@@ -189,6 +191,26 @@ class YdbBenchTest(unittest.TestCase):
             return command_result(command)
 
         cluster._run.side_effect = run_cluster_command
+        clusters = [cluster]
+        for dynamic_node_count in extra_cluster_dynamic_nodes:
+            extra_cluster = mock.Mock(
+                ydb_cli=Path("/tmp/ydb"),
+                client_endpoint="grpc://benchmark-host:2135",
+                database="/Root/bench",
+                dynamic_nodes=[{} for _index in range(dynamic_node_count)],
+                static_pids=(10,),
+                dynamic_pids=(20,),
+            )
+            extra_cluster.init_workload.side_effect = init_workload
+
+            def add_extra_dynamic_nodes(count, target=extra_cluster):
+                record("scale")
+                target.dynamic_nodes.extend({} for _index in range(count))
+
+            extra_cluster.add_dynamic_nodes.side_effect = add_extra_dynamic_nodes
+            extra_cluster._run.side_effect = run_cluster_command
+            extra_cluster.start.side_effect = extra_cluster_start_error
+            clusters.append(extra_cluster)
         monitor = mock.Mock(records=[])
         monitor.start.return_value = monitor
         monitor.stop.return_value = {
@@ -236,7 +258,10 @@ class YdbBenchTest(unittest.TestCase):
         events = []
         self.last_local_ydb_cluster = cluster
         self.last_local_ydb_monitor = monitor
-        with mock.patch.object(local_ydb, "LocalYdbCluster", return_value=cluster), mock.patch.object(
+        self.local_ydb_clusters = clusters
+        with mock.patch.object(
+            local_ydb, "LocalYdbCluster", side_effect=clusters
+        ) as cluster_constructor, mock.patch.object(
             local_ydb, "LinuxCpuMonitor", return_value=monitor
         ), mock.patch.object(
             local_ydb,
@@ -254,6 +279,7 @@ class YdbBenchTest(unittest.TestCase):
             "run_command",
             side_effect=lambda command, *_args, **_kwargs: next_measurement(command),
         ):
+            self.last_local_ydb_cluster_constructor = cluster_constructor
             manifest = local_ydb.run_local_ydb(
                 binaries,
                 configuration,
@@ -1803,6 +1829,129 @@ class YdbBenchTest(unittest.TestCase):
             ],
         )
 
+    def test_local_ydb_keeps_best_scaled_geometry_and_verifies_it_on_a_fresh_cluster(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              geometry-best:
+                workload: {type: kv, operation: upsert}
+                geometry: {preset: storage, static-nodes: 1, dynamic-nodes: 1, max-dynamic-nodes: 2}
+                load: {parameter: threads, values: [1]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1, verification-repetitions: 2}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        definition = replace(local_ydb_workloads.workload_definition("kv"), dataset_scope="geometry")
+        actions = []
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+            manifest, _output, events = self._run_mock_local_ydb(
+                configuration,
+                "geometry-best",
+                [
+                    {"throughput": 30},
+                    {"throughput": 20},
+                    {"throughput": 31},
+                    {"throughput": 33},
+                ],
+                cpu_metrics={"dynamic_cpu_mean": 100, "static_cpu_mean": 1},
+                lifecycle_actions=actions,
+                extra_cluster_dynamic_nodes=(1,),
+            )
+
+        self.assertEqual(len(manifest["searches"]), 2)
+        self.assertEqual(manifest["result"]["search_stage"], 1)
+        self.assertEqual(manifest["result"]["dynamic_nodes"], 1)
+        self.assertEqual(manifest["result"]["selected_metrics"]["throughput"], 30)
+        self.assertEqual(manifest["result"]["verified_metrics"]["throughput"], 32)
+        self.assertEqual(manifest["verification"]["cluster"], "fresh")
+        self.assertEqual(manifest["verification"]["dynamic_nodes"], 1)
+        self.assertEqual(self.last_local_ydb_cluster_constructor.call_count, 2)
+        verification_cluster = self.last_local_ydb_cluster_constructor.call_args_list[1]
+        self.assertEqual(verification_cluster.args[3], self.root / "geometry-best" / "verification-cluster")
+        self.assertEqual(verification_cluster.args[4]["dynamic_nodes"], 1)
+        self.assertEqual(verification_cluster.args[4]["max_dynamic_nodes"], 1)
+        self.assertEqual([len(cluster.dynamic_nodes) for cluster in self.local_ydb_clusters], [2, 1])
+        self.assertEqual([cluster.start.call_count for cluster in self.local_ydb_clusters], [1, 1])
+        self.assertEqual([cluster.stop.call_count for cluster in self.local_ydb_clusters], [1, 1])
+        self.assertEqual(
+            actions,
+            [
+                ("init", "ydb_bench_geometry_01"),
+                ("measure", "ydb_bench_geometry_01"),
+                ("clean", "ydb_bench_geometry_01"),
+                ("scale", None),
+                ("init", "ydb_bench_geometry_02"),
+                ("measure", "ydb_bench_geometry_02"),
+                ("clean", "ydb_bench_geometry_02"),
+                ("init", "ydb_bench_verify_geometry_01"),
+                ("measure", "ydb_bench_verify_geometry_01"),
+                ("measure", "ydb_bench_verify_geometry_01"),
+                ("clean", "ydb_bench_verify_geometry_01"),
+            ],
+        )
+        artifacts = next(event["artifacts"] for event in events if event["type"] == "step-artifacts")
+        self.assertIn("verification-cluster/cluster.yaml", artifacts)
+
+    def test_local_ydb_stops_both_clusters_when_fresh_geometry_start_fails(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              geometry-restart-failure:
+                workload: {type: kv, operation: upsert}
+                geometry: {preset: storage, static-nodes: 1, dynamic-nodes: 1, max-dynamic-nodes: 2}
+                load: {parameter: threads, values: [1]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1, verification-repetitions: 1}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        definition = replace(local_ydb_workloads.workload_definition("kv"), dataset_scope="geometry")
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+            with self.assertRaisesRegex(BenchmarkError, "verification cluster failed"):
+                self._run_mock_local_ydb(
+                    configuration,
+                    "geometry-restart-failure",
+                    [{"throughput": 30}, {"throughput": 20}],
+                    cpu_metrics={"dynamic_cpu_mean": 100, "static_cpu_mean": 1},
+                    extra_cluster_dynamic_nodes=(1,),
+                    extra_cluster_start_error=BenchmarkError("verification cluster failed"),
+                )
+
+        manifest = json.loads((self.root / "geometry-restart-failure" / "run.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["state"], "failed")
+        self.assertEqual(manifest["verification"]["status"], "failed")
+        self.assertIn("verification cluster failed", manifest["verification"]["error"])
+        self.assertEqual([cluster.start.call_count for cluster in self.local_ydb_clusters], [1, 1])
+        self.assertEqual([cluster.stop.call_count for cluster in self.local_ydb_clusters], [1, 1])
+
+    def test_local_ydb_stage_score_uses_load_for_latency_and_throughput_otherwise(self):
+        one_node = {"dynamic_nodes": 1, "selected_load": 10, "selected_metrics": {"throughput": 100}}
+        two_nodes = {"dynamic_nodes": 2, "selected_load": 20, "selected_metrics": {"throughput": 90}}
+        tied_load = {"dynamic_nodes": 2, "selected_load": 10, "selected_metrics": {"throughput": 200}}
+        latency = {"objective": {"type": "latency-slo"}}
+        throughput = {"objective": {"type": "maximize-throughput"}}
+        points = {}
+
+        self.assertGreater(
+            local_ydb._search_stage_score(latency, two_nodes),
+            local_ydb._search_stage_score(latency, one_node),
+        )
+        self.assertGreater(
+            local_ydb._search_stage_score(latency, one_node),
+            local_ydb._search_stage_score(latency, tied_load),
+        )
+        self.assertGreater(
+            local_ydb._search_stage_score(throughput, one_node),
+            local_ydb._search_stage_score(throughput, two_nodes),
+        )
+        tied_throughput = {"dynamic_nodes": 2, "selected_load": 5, "selected_metrics": {"throughput": 100}}
+        self.assertGreater(
+            local_ydb._search_stage_score(points, one_node),
+            local_ydb._search_stage_score(points, tied_throughput),
+        )
+        self.assertIsNone(local_ydb._search_stage_score(throughput, {"selected_metrics": None}))
+
     def test_local_ydb_geometry_cleanup_cancellation_prevents_scaling(self):
         configuration = load_config(self._config("""
             local-ydb:
@@ -1869,6 +2018,10 @@ class YdbBenchTest(unittest.TestCase):
             )
 
         self.assertEqual(manifest["verification"]["status"], "completed")
+        self.assertEqual(manifest["verification"]["cluster"], "search")
+        self.assertEqual(self.last_local_ydb_cluster_constructor.call_count, 1)
+        self.last_local_ydb_cluster.start.assert_called_once_with()
+        self.last_local_ydb_cluster.stop.assert_called_once_with()
         self.assertEqual(
             actions,
             [
@@ -8376,6 +8529,7 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"metrics_source==='verification'", script)
                 self.assertIn(b"verification-measuring", script)
                 self.assertIn(b"'verification-evaluating':'Evaluating verification'", script)
+                self.assertIn(b"'restarting-verification-cluster':'Restarting verification cluster'", script)
                 self.assertIn(b"Reported metrics come from the independent holdout", script)
                 self.assertIn(b"Incompatible metric source", script)
                 self.assertIn(b"function localElapsed(started,finished=null)", script)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Made local YDB measurements, load search, cleanup, charts, and Builder limits bounded and reproducible.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Caps UI data, cleanup, commands, search attempts, load values, and Topic measurement windows; aligns TPCC and Topic aggregation and warmup semantics; preserves the best geometry and exposes verification provenance.