### PR TITLE
testlib: preserve EnableScheduleForActor propagation in TTabletScheduledEventsGuard

### DIFF
--- a/ydb/core/testlib/tablet_helpers.cpp
+++ b/ydb/core/testlib/tablet_helpers.cpp
@@ -1024,6 +1024,24 @@ namespace NKikimr {
             PrevRegistrationObserverFunc = Runtime.SetRegistrationObserverFunc(
                 [&](TTestActorRuntimeBase& runtime, const TActorId& parentId, const TActorId& actorId) {
                 TabletTracer.OnRegistration(AsKikimrRuntime(runtime), parentId, actorId);
+                // Chain to the previous observer (normally
+                // TTestActorRuntimeBase::DefaultRegistrationObserver) so that
+                // the EnableScheduleForActor whitelist keeps being propagated
+                // from parent actors to their children while the guard is
+                // active.
+                //
+                // A tablet rebooted under the guard is respawned by
+                // its bootstrapper and without this propagation the new tablet
+                // instance is never whitelisted, and once the guard is destroyed
+                // all the events the tablet schedules for itself are silently
+                // dropped by TTestActorRuntime::DefaultScheduledFilterFunc.
+                //
+                // The problem was originally reproduced in a test that reboots
+                // Hive. The test was hanging because some events Hive scheduled
+                // to itself were never answered
+                if (PrevRegistrationObserverFunc) {
+                    PrevRegistrationObserverFunc(runtime, parentId, actorId);
+                }
             });
 
             PrevScheduledFilterFunc = Runtime.SetScheduledEventFilter([&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event,


### PR DESCRIPTION
## Problem

`TTabletScheduledEventsGuard` (created via `NKikimr::CreateTabletScheduledEventsGuard`, typically around `NKikimr::RebootTablet` calls) replaces the test runtime's registration observer with one that only feeds its internal `TTabletTracer`:

```cpp
PrevRegistrationObserverFunc = Runtime.SetRegistrationObserverFunc(
    [&](TTestActorRuntimeBase& runtime, const TActorId& parentId, const TActorId& actorId) {
    TabletTracer.OnRegistration(AsKikimrRuntime(runtime), parentId, actorId);
});
```

Unlike `TTestActorRuntimeBase::DefaultRegistrationObserver`, this observer does **not** propagate the `EnableScheduleForActor` whitelist from parent actors to their children:

```cpp
void TTestActorRuntimeBase::DefaultRegistrationObserver(...) {
    if (runtime.ScheduleWhiteList.find(parentId) != runtime.ScheduleWhiteList.end()) {
        runtime.ScheduleWhiteList.insert(actorId);
        runtime.ScheduleWhiteListParent[actorId] = parentId;
    }
}
```

The whitelist propagation is exactly what makes tablets work in the test runtime in the first place: `CreateTestBootstrapper` is registered with `EnableScheduleForActor`, and every actor it spawns (sys tablet -> user tablet -> executor, etc.) inherits whitelist membership through the default registration observer, so the events these actors `Schedule()` for themselves are delivered.

When a tablet is rebooted **under the guard**, the sequence is:

1. The guard is constructed and replaces the registration observer.
2. `RebootTablet` poisons the tablet, the (whitelisted) bootstrapper respawns it. All actors of the new tablet instance are registered *while the guard's non-propagating observer is active*, so none of them enter the schedule whitelist.
3. During the guard's lifetime this is masked, because the guard's scheduled filter also admits events for traced tablet actors.
4. The guard is destroyed, restoring `TTestActorRuntime::DefaultScheduledFilterFunc` - which silently drops every scheduled event whose recipient is not whitelisted (except a short hardcoded list of pipe/BS retry events).

From that point on, the rebooted tablet never receives anything it schedules for itself.

## How this was found

A downstream test in ydb-platform/nbs (`TStorageServiceTest.ShouldReassignTablet`, cloud/filestore) reboots Hive via `CreateTabletScheduledEventsGuard` + `RebootTablet` to force Hive to re-read group occupancy from BSC, then performs a channel reassignment. After updating the vendored ydb to 25.1, the test started hanging: the FileStore tablet is restarted shortly after the Hive reboot, its re-boot lands on a postponed boot-queue path, the postpone wakeup is dropped, the tablet never comes back, and the test dies with `TSchedulingLimitReachedException: TestActorRuntime Processed over 100000 events` while pipe connects fail with `ERROR` for the rest of simulated time. With older Hive versions the post-restart path happened not to need any timer, which is why the bug stayed latent.

`ydb/core/mind/hive/hive_ut.cpp` uses the same guard around Hive restarts, so upstream tests are exposed to the same trap whenever a Hive code path after restart depends on a scheduled event.
