### PR TITLE
[HashJoin] pack fixed-width build rows directly into bucket pages

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/dq_block_hash_join.cpp
+++ b/ydb/library/yql/dq/comp_nodes/dq_block_hash_join.cpp
@@ -62,6 +62,57 @@ class TBlockPackedTupleSource : public NNonCopyable::TMoveOnly {
     }
 
     FetchResult<IBlockLayoutConverter::TPackResult> FetchRow() {
+        auto fetched = FetchColumns();
+        const auto status = AsStatus(fetched);
+        if (status != NYql::NUdf::EFetchStatus::Ok) {
+            if (status == NYql::NUdf::EFetchStatus::Finish) {
+                return Finish{};
+            }
+            return Yield{};
+        }
+
+        auto& block = GetPayload(fetched);
+        IBlockLayoutConverter::TPackResult result;
+        if (block.Columns.empty()) {
+            MKQL_ENSURE(Meta_->Kind == EJoinKind::Cross, "empty payload side is only allowed for Cross join");
+            const auto* layout = ArrowBlockToInternalConverter_->GetTupleLayout();
+            result.PackedTuples.resize(layout->TotalRowSize * block.NRows, 0);
+            result.NTuples = block.NRows;
+            return One{std::move(result)};
+        }
+
+        ArrowBlockToInternalConverter_->Pack(block.Columns, result);
+        return One{std::move(result)};
+    }
+
+    struct DirectBucketPack {};
+
+    template <TSpillerSettings S>
+    NYql::NUdf::EFetchStatus TryDirectPackInto(TBucketsSpiller<S>& spiller) {
+        auto fetched = FetchColumns();
+        const auto status = AsStatus(fetched);
+        if (status != NYql::NUdf::EFetchStatus::Ok) {
+            return status;
+        }
+        auto& block = GetPayload(fetched);
+        MKQL_ENSURE(!block.Columns.empty(), "direct bucket pack needs columns");
+        TPaddedPtr<TPackResult> pages(&spiller.GetBuckets()[0].BuildingPage, sizeof(TBucket));
+        const bool ok = ArrowBlockToInternalConverter_->PackIntoBucketPages(
+            block.Columns, pages, S.Buckets, S.BucketSizeBytes,
+            [&](ui32 bucket) {
+                spiller.GetBuckets()[bucket].template DetatchBuildingPageIfLimitReached<S.BucketSizeBytes>();
+            });
+        MKQL_ENSURE(ok, "direct bucket pack rejected a fixed-width layout");
+        return NYql::NUdf::EFetchStatus::Ok;
+    }
+
+  private:
+    struct TFetchedColumns {
+        TVector<arrow::Datum> Columns;
+        ui64 NRows = 0;
+    };
+
+    FetchResult<TFetchedColumns> FetchColumns() {
         if (Finished()) {
             return Finish{};
         }
@@ -74,15 +125,12 @@ class TBlockPackedTupleSource : public NNonCopyable::TMoveOnly {
             return Yield{};
         }
 
-        IBlockLayoutConverter::TPackResult result;
+        TFetchedColumns block;
         const size_t cols = UserDataCols();
         if (cols == 0) {
             MKQL_ENSURE(Meta_->Kind == EJoinKind::Cross, "empty payload side is only allowed for Cross join");
-            const auto* layout = ArrowBlockToInternalConverter_->GetTupleLayout();
-            const ui64 n = GetBlockCount(Buff_[0]);
-            result.PackedTuples.resize(layout->TotalRowSize * n, 0);
-            result.NTuples = n;
-            return One{std::move(result)};
+            block.NRows = GetBlockCount(Buff_[0]);
+            return One{std::move(block)};
         }
 
         TVector<arrow::Datum> columns = ArrowFromUV({Buff_.data(), cols});
@@ -94,11 +142,10 @@ class TBlockPackedTupleSource : public NNonCopyable::TMoveOnly {
             columns = std::move(permuted);
         }
         NormalizeScalarColumns(columns);
-        ArrowBlockToInternalConverter_->Pack(columns, result);
-        return One{std::move(result)};
+        block.Columns = std::move(columns);
+        block.NRows = block.Columns.front().array()->length;
+        return One{std::move(block)};
     }
-
-  private:
     TVector<arrow::Datum> ArrowFromUV(std::span<const NYql::NUdf::TUnboxedValue> UVs) {
         TVector<arrow::Datum> arrow;
         for (const auto& uv : UVs) {

--- a/ydb/library/yql/dq/comp_nodes/dq_join_common.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_join_common.h
@@ -641,6 +641,30 @@ template <typename Source, TSpillerSettings Settings, TPhysicalJoin Join> class 
             State_ = FetchingBuild{*this};
         } else if (auto* s = std::get_if<FetchingBuild>(&State_)) {
             FetchingBuild& state = *s;
+            if constexpr (requires { typename Source::DirectBucketPack; }) {
+                if (!IsGrid && Layouts_.Build->SupportsDirectBucketPack()) {
+                    ESpillResult res = state.Spiller.SpillWhile(notEnoughMemory);
+                    switch (res) {
+                    case Spilling:
+                        return WaitWhileSpilling();
+                    case FinishedSpilling:
+                        break;
+                    case DontHavePages:
+                        break;
+                    }
+                    NYql::NUdf::EFetchStatus status = state.Build.TryDirectPackInto(state.Spiller);
+                    if (status == NYql::NUdf::EFetchStatus::Yield) {
+                        return EFetchResult::Yield;
+                    }
+                    if (status == NYql::NUdf::EFetchStatus::Finish) {
+                        MKQL_ENSURE(state.Build.Finished(), "sanity check");
+                        State_ = BuildingInMemoryTable{*this, std::move(state.Spiller)};
+                    } else {
+                        MKQL_ENSURE(status == NYql::NUdf::EFetchStatus::Ok, "unhandled status");
+                    }
+                    return EFetchResult::One;
+                }
+            }
             if (!state.Pack.has_value()) {
                 FetchResult<TPackResult> var = state.Build.FetchRow();
                 NYql::NUdf::EFetchStatus status = AsStatus(var);

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.cpp
@@ -763,6 +763,25 @@ public:
         }
     }
 
+    bool PackIntoBucketPages(const TVector<arrow::Datum>& columns, TPaddedPtr<TPackResult> pages,
+                             ui32 nBuckets, ui32 pageSizeBytes,
+                             const std::function<void(ui32)>& onPageFull) override {
+        if (!TupleLayout_->SupportsDirectBucketPack()) {
+            return false;
+        }
+        if (columns.empty()) {
+            return false;
+        }
+
+        TVector<std::shared_ptr<arrow::Buffer>> nullBitmapRelocationBuffer;
+        auto [columnsData, columnsNullBitmap] = GetColumns_(columns, nullBitmapRelocationBuffer);
+        const ui32 tuplesToPack = columns.front().array()->length;
+        TupleLayout_->PackIntoBucketPages(
+            columnsData.data(), columnsNullBitmap.data(),
+            0, tuplesToPack, pages, nBuckets, pageSizeBytes, onPageFull);
+        return true;
+    }
+
     void Unpack(const TPackResult& packed, TVector<arrow::Datum>& columns) override {
         columns.resize(Extractors_.size());
         if (columns.empty()) {

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.h
@@ -5,6 +5,8 @@
 
 #include <arrow/type.h>
 
+#include <functional>
+
 #include <ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h>
 #include <ydb/library/yql/dq/comp_nodes/hash_join_utils/layout_converter_common.h>
 
@@ -21,6 +23,9 @@ public:
     // Can be called multiple times to accumulate packed data in one storage
     virtual void Pack(const TVector<arrow::Datum>& columns, TPackResult& packed) = 0;
     virtual void BucketPack(const TVector<arrow::Datum>& columns, TPaddedPtr<TPackResult> packs, ui32 bucketsLogNum) = 0;
+    virtual bool PackIntoBucketPages(const TVector<arrow::Datum>& columns, TPaddedPtr<TPackResult> pages,
+                                     ui32 nBuckets, ui32 pageSizeBytes,
+                                     const std::function<void(ui32)>& onPageFull) = 0;
     // Can not be called multiple times due to immutability of arrow arrays
     virtual void Unpack(const TPackResult& packed, TVector<arrow::Datum>& columns) = 0;
     // virtual void UnpackApply(const TPackResult& packed, std::function<void(const char*)>);

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
@@ -1,6 +1,7 @@
 #include "tuple.h"
 
 #include <algorithm>
+#include <cstring>
 #include <vector>
 #include <queue>
 
@@ -8,6 +9,7 @@
 #include <yql/essentials/public/udf/udf_data_type.h>
 #include <yql/essentials/public/udf/udf_types.h>
 #include <yql/essentials/public/udf/udf_value.h>
+#include <yql/essentials/utils/prefetch.h>
 
 #include <util/generic/bitops.h>
 #include <util/generic/buffer.h>
@@ -17,6 +19,7 @@
 #include "layout_converter_common.h"
 #include "hashes_calc.h"
 #include "packing.h"
+#include "better_mkql_ensure.h"
 
 namespace NKikimr {
 namespace NMiniKQL {
@@ -90,6 +93,18 @@ Y_FORCE_INLINE ui64 transposeBitmatrix(ui64 x) {
         *dst[ind] = x;
         x >>= 8;
     }
+}
+
+ui32 Crc32Packed(const ui8 *data, ui32 size, ui32 hash = 0) {
+#ifdef USE_X86_SIMD
+    if (NX86::HaveAVX2()) {
+        return CalculateCRC32<NSimd::TSimdAVX2Traits>(data, size, hash);
+    }
+    if (NX86::HaveSSE42()) {
+        return CalculateCRC32<NSimd::TSimdSSE42Traits>(data, size, hash);
+    }
+#endif
+    return CalculateCRC32<NSimd::TSimdFallbackTraits>(data, size, hash);
 }
 
 } // namespace
@@ -1724,6 +1739,230 @@ void TTupleLayout::Concat(
             }
         }
 
+    }
+}
+
+ui32 TTupleLayout::HashFixedRow(const ui8 **columns, ui32 row) const {
+    MKQL_ENSURE(VariableColumns.empty(), "HashFixedRow is fixed-width only");
+    const ui32 keyBytes = KeyColumnsFixedEnd - KeyColumnsOffset;
+    ui8 stack[512];
+    std::vector<ui8> heap;
+    ui8 *buf = stack;
+    if (keyBytes > sizeof(stack)) {
+        heap.resize(keyBytes);
+        buf = heap.data();
+    }
+    for (ui32 i = 0; i < KeyColumnsFixedNum; ++i) {
+        const auto &col = KeyColumns[i];
+        if (col.DataSize == 0) {
+            continue;
+        }
+        std::memcpy(buf + col.Offset - KeyColumnsOffset,
+                    columns[col.OriginalIndex] + static_cast<size_t>(row) * col.DataSize,
+                    col.DataSize);
+    }
+    return Crc32Packed(buf, keyBytes);
+}
+
+void TTupleLayout::PackSelected(const ui8 **columns, const ui8 **isValidBitmask,
+                                TArrayRef<const ui32> rowIndexes, TPackResult &dst) const {
+    MKQL_ENSURE(VariableColumns.empty(), "PackSelected is fixed-width only");
+    const ui32 n = rowIndexes.size();
+    if (n == 0) {
+        return;
+    }
+
+    const size_t oldSize = dst.PackedTuples.size();
+    dst.PackedTuples.resize(oldSize + static_cast<size_t>(n) * TotalRowSize, 0);
+    ui8 *res = dst.PackedTuples.data() + oldSize;
+
+    for (ui32 i = 0; i < n; ++i, res += TotalRowSize) {
+        const ui32 row = rowIndexes[i];
+
+        for (const auto &col : Columns) {
+            if (col.DataSize == 0) {
+                continue;
+            }
+            std::memcpy(res + col.Offset,
+                        columns[col.OriginalIndex] + static_cast<size_t>(row) * col.DataSize,
+                        col.DataSize);
+        }
+
+        std::memset(res + BitmaskOffset, 0xFF, BitmaskSize);
+        for (ui32 j = 0; j < Columns.size(); ++j) {
+            const ui8 *bm = isValidBitmask[Columns[j].OriginalIndex];
+            const bool valid = !bm || ((bm[row / 8] >> (row % 8)) & 1u);
+            const ui32 byte = j / 8;
+            const ui8 bit = ui8(1u << (j % 8));
+            if (valid) {
+                res[BitmaskOffset + byte] |= bit;
+            } else {
+                res[BitmaskOffset + byte] &= ~bit;
+            }
+        }
+
+        const ui32 hash = Crc32Packed(res + KeyColumnsOffset,
+                                      KeyColumnsFixedEnd - KeyColumnsOffset);
+        WriteUnaligned<ui32>(res, hash);
+    }
+
+    dst.NTuples += n;
+}
+
+void TTupleLayout::PackIntoBucketPages(const ui8 **columns, const ui8 **isValidBitmask,
+                                       ui32 start, ui32 count, TPaddedPtr<TPackResult> pages,
+                                       ui32 nBuckets, ui32 pageSizeBytes,
+                                       const std::function<void(ui32)> &onPageFull) const {
+    MKQL_ENSURE(VariableColumns.empty(), "PackIntoBucketPages is fixed-width only");
+    MKQL_ENSURE(nBuckets > 0 && (nBuckets & (nBuckets - 1)) == 0, "nBuckets must be a power of two");
+    if (count == 0) {
+        return;
+    }
+
+    const ui32 mask = nBuckets - 1;
+    const ui32 rowSize = TotalRowSize;
+
+    const auto flushIfFull = [&](ui32 bucket) {
+        if (pages[bucket].AllocatedBytes() > pageSizeBytes) {
+            onPageFull(bucket);
+        }
+    };
+
+    const auto maxRowsThisPage = [&](const TPackResult &page, ui32 remaining) -> ui32 {
+        if (remaining == 0) {
+            return 0;
+        }
+        const ui64 allocated = page.AllocatedBytes();
+        if (allocated > pageSizeBytes) {
+            return 0;
+        }
+        const ui64 room = (pageSizeBytes - allocated) / rowSize + 1;
+        return std::min<ui32>(remaining, room);
+    };
+
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+
+    if (nBuckets == 1) {
+        ui32 packed = 0;
+        while (packed < count) {
+            if (pages[0].AllocatedBytes() > pageSizeBytes) {
+                onPageFull(0);
+            }
+            const ui32 toCopy = maxRowsThisPage(pages[0], count - packed);
+            if (toCopy == 0) {
+                onPageFull(0);
+                continue;
+            }
+            const size_t old = pages[0].PackedTuples.size();
+            pages[0].PackedTuples.resize(old + static_cast<size_t>(toCopy) * rowSize, 0);
+            Pack(columns, isValidBitmask, pages[0].PackedTuples.data() + old, overflow,
+                 start + packed, toCopy);
+            pages[0].NTuples += toCopy;
+            packed += toCopy;
+            flushIfFull(0);
+        }
+        MKQL_ENSURE(overflow.empty(), "fixed-width pack must not write overflow");
+        return;
+    }
+
+    const auto appendFromTile = [&](TPackResult &page, const ui8 *tile, const ui32 *idx, ui32 n) {
+        const size_t old = page.PackedTuples.size();
+        page.PackedTuples.resize_uninitialized(old + static_cast<size_t>(n) * rowSize);
+        ui8 *dst = page.PackedTuples.data() + old;
+        for (ui32 i = 0; i < n; ++i) {
+            if (i + 8 < n) {
+                NYql::PrefetchForRead(tile + static_cast<size_t>(idx[i + 8]) * rowSize);
+            }
+            std::memcpy(dst + static_cast<size_t>(i) * rowSize,
+                        tile + static_cast<size_t>(idx[i]) * rowSize, rowSize);
+        }
+        page.NTuples += n;
+    };
+
+    const ui32 tileCap = rowSize <= 64 ? DirectPackTile : DirectPackTile / 2;
+    std::vector<ui8, TMKQLAllocator<ui8>> tileBuf(static_cast<size_t>(tileCap) * rowSize);
+    ui32 buckets[DirectPackTile];
+    ui32 selected[DirectPackTile];
+    std::vector<ui32> counts(nBuckets);
+    std::vector<ui8 *> dstPtr(nBuckets);
+
+    for (ui32 tileStart = start; tileStart < start + count;) {
+        const ui32 tile = std::min<ui32>(tileCap, start + count - tileStart);
+        std::memset(tileBuf.data(), 0, static_cast<size_t>(tile) * rowSize);
+        Pack(columns, isValidBitmask, tileBuf.data(), overflow, tileStart, tile);
+        MKQL_ENSURE(overflow.empty(), "fixed-width pack must not write overflow");
+
+        std::fill(counts.begin(), counts.end(), 0);
+        const ui8 *row = tileBuf.data();
+        for (ui32 i = 0; i < tile; ++i, row += rowSize) {
+            buckets[i] = ReadUnaligned<ui32>(row) & mask;
+            ++counts[buckets[i]];
+        }
+
+        bool allFit = true;
+        for (ui32 b = 0; b < nBuckets; ++b) {
+            if (counts[b] != 0 && maxRowsThisPage(pages[b], counts[b]) < counts[b]) {
+                allFit = false;
+                break;
+            }
+        }
+
+        if (allFit) {
+            for (ui32 b = 0; b < nBuckets; ++b) {
+                const ui32 n = counts[b];
+                if (n == 0) {
+                    dstPtr[b] = nullptr;
+                    continue;
+                }
+                auto &page = pages[b];
+                const size_t old = page.PackedTuples.size();
+                page.PackedTuples.resize_uninitialized(old + static_cast<size_t>(n) * rowSize);
+                dstPtr[b] = page.PackedTuples.data() + old;
+                page.NTuples += n;
+            }
+            row = tileBuf.data();
+            for (ui32 i = 0; i < tile; ++i, row += rowSize) {
+                ui8 *dst = dstPtr[buckets[i]];
+                std::memcpy(dst, row, rowSize);
+                dstPtr[buckets[i]] = dst + rowSize;
+            }
+            for (ui32 b = 0; b < nBuckets; ++b) {
+                if (counts[b] != 0) {
+                    flushIfFull(b);
+                }
+            }
+        } else {
+            std::vector<ui32> offsets(nBuckets);
+            ui32 acc = 0;
+            for (ui32 b = 0; b < nBuckets; ++b) {
+                offsets[b] = acc;
+                acc += counts[b];
+            }
+            for (ui32 i = 0; i < tile; ++i) {
+                selected[offsets[buckets[i]]++] = i;
+            }
+            ui32 begin = 0;
+            for (ui32 b = 0; b < nBuckets; ++b) {
+                const ui32 n = counts[b];
+                ui32 packed = 0;
+                while (packed < n) {
+                    if (pages[b].AllocatedBytes() > pageSizeBytes) {
+                        onPageFull(b);
+                    }
+                    const ui32 toCopy = maxRowsThisPage(pages[b], n - packed);
+                    if (toCopy == 0) {
+                        onPageFull(b);
+                        continue;
+                    }
+                    appendFromTile(pages[b], tileBuf.data(), selected + begin + packed, toCopy);
+                    packed += toCopy;
+                    flushIfFull(b);
+                }
+                begin += n;
+            }
+        }
+
+        tileStart += tile;
     }
 }
 

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h
@@ -4,10 +4,12 @@
 #include <yql/essentials/public/udf/udf_data_type.h>
 #include <yql/essentials/public/udf/udf_types.h>
 
+#include <util/generic/array_ref.h>
 #include <util/generic/buffer.h>
 
 #include <ydb/library/yql/dq/comp_nodes/hash_join_utils/simd/simd.h>
 
+#include <functional>
 #include <string>
 
 namespace NKikimr {
@@ -195,6 +197,23 @@ struct TTupleLayout {
                  TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
                  TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows,
                  ui32 start, ui32 count, ui32 bucketsLogNum) const = 0;
+
+    bool SupportsDirectBucketPack() const {
+        return VariableColumns.empty();
+    }
+
+    ui32 HashFixedRow(const ui8 **columns, ui32 row) const;
+
+    void PackSelected(const ui8 **columns, const ui8 **isValidBitmask,
+                      TArrayRef<const ui32> rowIndexes, TPackResult &dst) const;
+
+    static constexpr ui32 DirectPackTile = 2048;
+
+    void PackIntoBucketPages(const ui8 **columns, const ui8 **isValidBitmask,
+                             ui32 start, ui32 count,
+                             TPaddedPtr<TPackResult> pages, ui32 nBuckets,
+                             ui32 pageSizeBytes,
+                             const std::function<void(ui32)> &onPageFull) const;
 
     // Takes packed rows,
     // outputs vector of column sizes in bytes

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/block_layout_converter_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/block_layout_converter_ut.cpp
@@ -11,6 +11,13 @@
 #include <yql/essentials/minikql/mkql_program_builder.h>
 #include <yql/essentials/minikql/invoke_builtins/mkql_builtins.h>
 
+#include <util/system/unaligned_mem.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <limits>
+
 using namespace NYql::NUdf;
 using namespace NKikimr;
 using namespace NKikimr::NMiniKQL;
@@ -680,5 +687,164 @@ Y_UNIT_TEST_SUITE(TBlockLayoutConverterTest) {
             }
         }
         UNIT_ASSERT_EQUAL(hashsum, bhashsum);
+    }
+
+    struct TBucketPages {
+        static constexpr ui32 NBuckets = 64;
+        static constexpr ui32 PageSizeBytes = 1 << 16;
+
+        std::array<TPackResult, NBuckets> Building;
+        std::array<std::vector<TPackResult>, NBuckets> Closed;
+
+        void OnFull(ui32 bucket) {
+            Closed[bucket].push_back(std::move(Building[bucket]));
+            Building[bucket] = TPackResult{};
+        }
+
+        TPaddedPtr<TPackResult> Pages() {
+            return TPaddedPtr<TPackResult>(Building.data());
+        }
+
+        void AddRowBaseline(TSingleTuple tuple, const NPackedTuple::TTupleLayout* layout) {
+            const ui32 bucket = NPackedTuple::Hash(tuple.PackedData) & (NBuckets - 1);
+            Building[bucket].AppendTuple(tuple, layout);
+            if (Building[bucket].AllocatedBytes() > PageSizeBytes) {
+                OnFull(bucket);
+            }
+        }
+    };
+
+    void AssertBucketPagesEqual(TBucketPages& lhs, TBucketPages& rhs) {
+        for (ui32 b = 0; b < TBucketPages::NBuckets; ++b) {
+            UNIT_ASSERT_VALUES_EQUAL_C(lhs.Closed[b].size(), rhs.Closed[b].size(), "bucket " << b);
+            for (size_t p = 0; p < lhs.Closed[b].size(); ++p) {
+                UNIT_ASSERT_VALUES_EQUAL(lhs.Closed[b][p].NTuples, rhs.Closed[b][p].NTuples);
+                UNIT_ASSERT_EQUAL(lhs.Closed[b][p].PackedTuples, rhs.Closed[b][p].PackedTuples);
+                UNIT_ASSERT_EQUAL(lhs.Closed[b][p].Overflow, rhs.Closed[b][p].Overflow);
+            }
+            UNIT_ASSERT_VALUES_EQUAL(lhs.Building[b].NTuples, rhs.Building[b].NTuples);
+            UNIT_ASSERT_EQUAL(lhs.Building[b].PackedTuples, rhs.Building[b].PackedTuples);
+            UNIT_ASSERT_EQUAL(lhs.Building[b].Overflow, rhs.Building[b].Overflow);
+        }
+    }
+
+    TVector<arrow::Datum> MakeInt32Columns(TBlockLayoutConverterTestData& data, ui32 nCols, ui32 nRows, bool withNulls) {
+        const auto type = data.PgmBuilder.NewDataType(NUdf::EDataSlot::Int32, true);
+        size_t itemSize = nCols * NMiniKQL::CalcMaxBlockItemSize(type);
+        size_t blockLen = std::max<size_t>(NMiniKQL::CalcBlockLen(itemSize), nRows);
+
+        TVector<arrow::Datum> columns;
+        columns.reserve(nCols);
+        for (ui32 c = 0; c < nCols; ++c) {
+            auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), type, *data.ArrowPool, blockLen, nullptr);
+            for (ui32 r = 0; r < nRows; ++r) {
+                if (withNulls && ((r + c) % 17 == 0)) {
+                    builder->Add(TBlockItem());
+                } else {
+                    builder->Add(TBlockItem(i32(c * 100000 + r)));
+                }
+            }
+            columns.emplace_back(builder->Build(true));
+        }
+        return columns;
+    }
+
+    IBlockLayoutConverter::TPtr MakeInt32Converter(TBlockLayoutConverterTestData& data, ui32 nCols) {
+        const auto type = data.PgmBuilder.NewDataType(NUdf::EDataSlot::Int32, true);
+        TVector<NKikimr::NMiniKQL::TType*> types(nCols, type);
+        TVector<NPackedTuple::EColumnRole> roles(nCols, NPackedTuple::EColumnRole::Payload);
+        roles[0] = NPackedTuple::EColumnRole::Key;
+        return MakeBlockLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.ArrowPool);
+    }
+
+    Y_UNIT_TEST(TestPackSelectedMatchesPackInt32) {
+        TBlockLayoutConverterTestData data;
+        constexpr ui32 nRows = 384;
+        auto converter = MakeInt32Converter(data, 1);
+        auto columns = MakeInt32Columns(data, 1, nRows, true);
+
+        TPackResult packed;
+        converter->Pack(columns, packed);
+        UNIT_ASSERT_VALUES_EQUAL(packed.NTuples, nRows);
+        UNIT_ASSERT(converter->GetTupleLayout()->SupportsDirectBucketPack());
+
+        TPackResult gathered;
+        UNIT_ASSERT(converter->PackIntoBucketPages(
+            columns, TPaddedPtr<TPackResult>(&gathered), 1,
+            std::numeric_limits<ui32>::max(), [](ui32) {}));
+        UNIT_ASSERT_VALUES_EQUAL(gathered.NTuples, nRows);
+        UNIT_ASSERT_EQUAL(gathered.PackedTuples, packed.PackedTuples);
+        UNIT_ASSERT_EQUAL(gathered.Overflow, packed.Overflow);
+    }
+
+    void RunDirectVsAddRow(ui32 nCols, ui32 nRows, bool withNulls, bool bench) {
+        TBlockLayoutConverterTestData data;
+        auto converter = MakeInt32Converter(data, nCols);
+        auto columns = MakeInt32Columns(data, nCols, nRows, withNulls);
+        const auto* layout = converter->GetTupleLayout();
+        UNIT_ASSERT(layout->SupportsDirectBucketPack());
+
+        auto baseline = [&] {
+            TBucketPages pages;
+            TPackResult packed;
+            converter->Pack(columns, packed);
+            for (TSingleTuple tuple : packed) {
+                pages.AddRowBaseline(tuple, layout);
+            }
+            return pages;
+        };
+
+        auto direct = [&] {
+            TBucketPages pages;
+            UNIT_ASSERT(converter->PackIntoBucketPages(
+                columns, pages.Pages(), TBucketPages::NBuckets, TBucketPages::PageSizeBytes,
+                [&](ui32 b) { pages.OnFull(b); }));
+            return pages;
+        };
+
+        if (bench) {
+            auto expected = baseline();
+            auto got = direct();
+            AssertBucketPagesEqual(expected, got);
+
+            constexpr int kIters = 7;
+            i64 baseUs = std::numeric_limits<i64>::max();
+            i64 directUs = std::numeric_limits<i64>::max();
+            for (int i = 0; i < kIters; ++i) {
+                auto t0 = std::chrono::steady_clock::now();
+                Y_UNUSED(baseline());
+                auto t1 = std::chrono::steady_clock::now();
+                Y_UNUSED(direct());
+                auto t2 = std::chrono::steady_clock::now();
+                baseUs = std::min(baseUs, (i64)std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count());
+                directUs = std::min(directUs, (i64)std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count());
+            }
+            i64 packedBytes = 0;
+            for (ui32 b = 0; b < TBucketPages::NBuckets; ++b) {
+                packedBytes += got.Building[b].AllocatedBytes();
+                for (const auto& page : got.Closed[b]) {
+                    packedBytes += page.AllocatedBytes();
+                }
+            }
+            Cerr << "DirectArrowBucketPack cols=" << nCols << " rows=" << nRows
+                 << " packedBytes=" << packedBytes
+                 << " baselineUs=" << baseUs
+                 << " directUs=" << directUs
+                 << Endl;
+        } else {
+            auto expected = baseline();
+            auto got = direct();
+            AssertBucketPagesEqual(expected, got);
+        }
+    }
+
+    Y_UNIT_TEST(TestDirectBucketPackInt32) {
+        RunDirectVsAddRow(1, 384, true, false);
+        RunDirectVsAddRow(1, 65536, false, true);
+    }
+
+    Y_UNIT_TEST(TestDirectBucketPackWide64) {
+        RunDirectVsAddRow(64, 1024, true, false);
+        RunDirectVsAddRow(64, 65536, false, true);
     }
 }

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/packed_tuple_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/packed_tuple_ut.cpp
@@ -1,6 +1,8 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <chrono>
+#include <cstring>
+#include <numeric>
 #include <string>
 #include <vector>
 #include <random>
@@ -11,6 +13,7 @@
 #include <util/system/mem_info.h>
 
 #include <ydb/library/yql/dq/comp_nodes/hash_join_utils/hashes_calc.h>
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/layout_converter_common.h>
 #include <ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h>
 
 #include <yql/essentials/minikql/comp_nodes/mkql_rh_hash.h>
@@ -99,6 +102,52 @@ Y_UNIT_TEST(CreateLayout) {
 
     auto tl = TTupleLayout::Create(columns);
     UNIT_ASSERT(tl->TotalRowSize == 45);
+}
+
+Y_UNIT_TEST(PackSelectedMatchesPack) {
+    TScopedAlloc alloc(__LOCATION__);
+
+    TColumnDesc key;
+    key.Role = EColumnRole::Key;
+    key.DataSize = 4;
+    auto tl = TTupleLayout::Create({key});
+    UNIT_ASSERT(tl->SupportsDirectBucketPack());
+
+    constexpr ui32 n = 300;
+    std::vector<ui32> values(n);
+    std::vector<ui8> valid((n + 7) / 8, 0xFF);
+    for (ui32 i = 0; i < n; ++i) {
+        values[i] = i * 17 + 3;
+        if (i % 11 == 0) {
+            valid[i / 8] &= ~ui8(1u << (i % 8));
+        }
+    }
+    const ui8* cols[] = {reinterpret_cast<const ui8*>(values.data())};
+    const ui8* bits[] = {valid.data()};
+
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+    std::vector<ui8> packed(tl->TotalRowSize * n, 0);
+    tl->Pack(cols, bits, packed.data(), overflow, 0, n);
+
+    TPackResult selected;
+    std::vector<ui32> indexes(n);
+    std::iota(indexes.begin(), indexes.end(), 0);
+    tl->PackSelected(cols, bits, indexes, selected);
+    UNIT_ASSERT_VALUES_EQUAL(selected.NTuples, n);
+    UNIT_ASSERT_EQUAL(std::vector<ui8>(selected.PackedTuples.begin(), selected.PackedTuples.end()), packed);
+
+    TPackResult evenRows;
+    std::vector<ui32> evens;
+    for (ui32 i = 0; i < n; i += 2) {
+        evens.push_back(i);
+    }
+    tl->PackSelected(cols, bits, evens, evenRows);
+    UNIT_ASSERT_VALUES_EQUAL(evenRows.NTuples, evens.size());
+    for (ui32 i = 0; i < evens.size(); ++i) {
+        const ui8* expected = packed.data() + evens[i] * tl->TotalRowSize;
+        const ui8* got = evenRows.PackedTuples.data() + i * tl->TotalRowSize;
+        UNIT_ASSERT(std::memcmp(expected, got, tl->TotalRowSize) == 0);
+    }
 }
 
 // A row of 4-byte and 1-byte columns that is short enough for the small-tuple


### PR DESCRIPTION
Skip the temporary packed buffer and AddRow copy on the build side by packing tiles and scattering them into 64KiB bucket pages.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
