### PR TITLE
Split kafka_proxy protocol UTs and speed up slow tests.

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -16,7 +16,6 @@ ydb/core/kafka_proxy/ut TTopicOffsetsActor.MissingTopicIsSchemeError
 ydb/core/kafka_proxy/ut TTopicOffsetsActor.ParsesConsumerOffsetsAndSkipsErrors
 ydb/core/kafka_proxy/ut TTopicOffsetsActor.RetriesOnDeliveryProblem
 ydb/core/kafka_proxy/ut TTopicOffsetsActor.RetriesOnEmptyStatusResponse
-ydb/core/kafka_proxy/ut unittest.sole chunk
 ydb/core/kqp/ut/indexes/json KqpJsonIndexes.NoMultipleColumnsWithoutFeatureFlag
 ydb/core/kqp/ut/scheme KqpScheme.CreateDropTableMultipleTime
 ydb/core/tx/schemeshard/ut_compaction_reboots unittest.[*/*] chunk

--- a/ydb/core/kafka_proxy/ut/protocol/ya.make
+++ b/ydb/core/kafka_proxy/ut/protocol/ya.make
@@ -1,8 +1,12 @@
 UNITTEST_FOR(ydb/core/kafka_proxy)
 
 ADDINCL(
+    ydb/core/kafka_proxy/ut
     ydb/public/sdk/cpp
 )
+
+FORK_SUBTESTS()
+SPLIT_FACTOR(4)
 
 IF (SANITIZER_TYPE)
     SIZE(LARGE)
@@ -12,16 +16,12 @@ ELSE()
 ENDIF()
 
 SRCS(
-    actors_ut.cpp
-    metarequest_ut.cpp
-    topic_location_actor_ut.cpp
-    topic_offsets_actor_ut.cpp
-    ut_consumer_protocol.cpp
-    ut_kafka_functions.cpp
-    ut_produce_actor.cpp
-    ut_serialization.cpp
-    ut_transaction_actor.cpp
-    ut_transaction_coordinator.cpp
+    ../kafka_test_client.cpp
+    ../kafka_test_client.h
+    ../test_server.cpp
+    ../ut_auth.cpp
+    ../ut_authz.cpp
+    ../ut_protocol.cpp
 )
 
 PEERDIR(
@@ -42,7 +42,3 @@ YQL_LAST_ABI_VERSION()
 ENV(INSIDE_YDB="1")
 
 END()
-
-RECURSE_FOR_TESTS(
-    protocol
-)

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -5393,7 +5393,6 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         CreateTopic(pqClient, outputTopicName, 1, {consumerName});
 
         const ui64 txnTimeoutMs = 200;
-        const auto txnStartedAt = TInstant::Now();
         auto initProducerIdResp = kafkaClient.InitProducerId(transactionalId, txnTimeoutMs);
         UNIT_ASSERT_VALUES_EQUAL(initProducerIdResp->ErrorCode, EKafkaErrors::NONE_ERROR);
         TProducerInstanceId producerInstanceId = {initProducerIdResp->ProducerId, initProducerIdResp->ProducerEpoch};
@@ -5402,6 +5401,8 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         topicPartitionsToAddToTxn[outputTopicName] = std::vector<ui32>{0};
         auto addPartsResponse = kafkaClient.AddPartitionsToTxn(transactionalId, producerInstanceId, topicPartitionsToAddToTxn);
         UNIT_ASSERT_VALUES_EQUAL(addPartsResponse->Results[0].Results[0].ErrorCode, EKafkaErrors::NONE_ERROR);
+        // TTransactionActor starts TxnTimeoutMs from CreatedAt, which is set on this first txn request.
+        const auto txnStartedAt = TInstant::Now();
 
         auto out0ProduceResponse = kafkaClient.Produce({outputTopicName, 0}, {{"0", "123"}}, 0, producerInstanceId, transactionalId);
         UNIT_ASSERT_VALUES_EQUAL(out0ProduceResponse->Responses[0].PartitionResponses[0].ErrorCode, EKafkaErrors::NONE_ERROR);

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -2969,7 +2969,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
                 if (*lastStartOffset >= minStartOffset) {
                     return;
                 }
-                Sleep(TDuration::MilliSeconds(500));
+                Sleep(TDuration::MilliSeconds(100));
             }
             UNIT_ASSERT_C(
                 false,
@@ -2979,8 +2979,10 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
                                  << (lastStartOffset ? ToString(*lastStartOffset) : "n/a"));
         };
 
-        WriteMessagesWithKeys(writeSession, {{"key-1", 7_MB}}, 3);
-        WriteMessagesWithKeys(writeSession, {{"key-new", 100}}, 20);
+        // 7_MB exceeds LowWatermark (6MB), so each write becomes its own blob and retention/compaction
+        // can move startOffset. Two blobs plus a few small records are enough to form a gap.
+        WriteMessagesWithKeys(writeSession, {{"key-1", 7_MB}}, 2);
+        WriteMessagesWithKeys(writeSession, {{"key-new", 100}}, 3);
         waitStartOffsetAtLeast(1, TDuration::Seconds(60), "retention");
 
         auto msg = client.AlterConfigs(
@@ -2993,10 +2995,10 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         rSSettings.AppendTopics({topicFullPath});
         auto readSession = pqClient.CreateReadSession(rSSettings);
         bool seenMessage = false;
-        for (ui32 triesCount = 30; triesCount != 0 && !seenMessage; --triesCount) {
+        for (ui32 triesCount = 40; triesCount != 0 && !seenMessage; --triesCount) {
             auto results = Read(readSession, false);
             if (results.empty()) {
-                Sleep(TDuration::MilliSeconds(500));
+                Sleep(TDuration::MilliSeconds(50));
                 continue;
             }
             for (auto& dataEvent : results) {
@@ -4526,17 +4528,28 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         // CHECK ONE READER DEAD (NO HEARTBEAT)
 
-        Sleep(TDuration::Seconds(5));
+        Sleep(TDuration::Seconds(2));
 
         UNIT_ASSERT_VALUES_EQUAL(
             clientA.Heartbeat(joinRespA2->MemberId.value(), joinRespA2->GenerationId, groupId)->ErrorCode,
             static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR)
         );
 
-        Sleep(TDuration::Seconds(25));
         {
-            auto errorCode = clientA.Heartbeat(joinRespA2->MemberId.value(), joinRespA2->GenerationId, groupId)->ErrorCode;
-            UNIT_ASSERT(errorCode == static_cast<TKafkaInt16>(EKafkaErrors::REBALANCE_IN_PROGRESS) || errorCode == static_cast<TKafkaInt16>(EKafkaErrors::ILLEGAL_GENERATION));
+            const auto deadline = TInstant::Now() + TDuration::MilliSeconds(heartbeatTimeout * 2);
+            TKafkaInt16 errorCode = static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR);
+            while (TInstant::Now() < deadline) {
+                errorCode = clientA.Heartbeat(joinRespA2->MemberId.value(), joinRespA2->GenerationId, groupId)->ErrorCode;
+                if (errorCode == static_cast<TKafkaInt16>(EKafkaErrors::REBALANCE_IN_PROGRESS)
+                    || errorCode == static_cast<TKafkaInt16>(EKafkaErrors::ILLEGAL_GENERATION))
+                {
+                    break;
+                }
+                UNIT_ASSERT_VALUES_EQUAL(errorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+                Sleep(TDuration::MilliSeconds(200));
+            }
+            UNIT_ASSERT(errorCode == static_cast<TKafkaInt16>(EKafkaErrors::REBALANCE_IN_PROGRESS)
+                || errorCode == static_cast<TKafkaInt16>(EKafkaErrors::ILLEGAL_GENERATION));
         }
 
 
@@ -5377,41 +5390,32 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         TString transactionalId = TStringBuilder() << "my-tx-producer-" << TGUID::Create().AsUuidString();
         TString consumerName = "my-consumer";
 
-        // create input and output topics
-        CreateTopic(pqClient, outputTopicName, 3, {consumerName});
+        CreateTopic(pqClient, outputTopicName, 1, {consumerName});
 
-        // init producer id
-        ui64 txnTimeoutMs = 1000;
+        const ui64 txnTimeoutMs = 200;
+        const auto txnStartedAt = TInstant::Now();
         auto initProducerIdResp = kafkaClient.InitProducerId(transactionalId, txnTimeoutMs);
         UNIT_ASSERT_VALUES_EQUAL(initProducerIdResp->ErrorCode, EKafkaErrors::NONE_ERROR);
         TProducerInstanceId producerInstanceId = {initProducerIdResp->ProducerId, initProducerIdResp->ProducerEpoch};
 
-        // add partitions to txn
         std::unordered_map<TString, std::vector<ui32>> topicPartitionsToAddToTxn;
         topicPartitionsToAddToTxn[outputTopicName] = std::vector<ui32>{0};
         auto addPartsResponse = kafkaClient.AddPartitionsToTxn(transactionalId, producerInstanceId, topicPartitionsToAddToTxn);
         UNIT_ASSERT_VALUES_EQUAL(addPartsResponse->Results[0].Results[0].ErrorCode, EKafkaErrors::NONE_ERROR);
 
-        // produce data
-        // to part 0
         auto out0ProduceResponse = kafkaClient.Produce({outputTopicName, 0}, {{"0", "123"}}, 0, producerInstanceId, transactionalId);
         UNIT_ASSERT_VALUES_EQUAL(out0ProduceResponse->Responses[0].PartitionResponses[0].ErrorCode, EKafkaErrors::NONE_ERROR);
 
-        // init consumer
-        std::vector<TString> topicsToSubscribe{outputTopicName};
-        TString protocolName = "range";
-        auto consumerInfo = kafkaClient.JoinAndSyncGroupAndWaitPartitions(topicsToSubscribe, consumerName, 3, protocolName, 3, 15000);
-
         kafkaClient.ValidateNoDataInTopics({{outputTopicName, {0}}});
 
-        // move time forward after transaction timeout
-        Sleep(TDuration::MilliSeconds(txnTimeoutMs));
+        const auto expireAt = txnStartedAt + TDuration::MilliSeconds(txnTimeoutMs) + TDuration::MilliSeconds(50);
+        if (TInstant::Now() < expireAt) {
+            Sleep(expireAt - TInstant::Now());
+        }
 
-        // end txn
         auto endTxnResponse = kafkaClient.EndTxn(transactionalId, producerInstanceId, true);
         UNIT_ASSERT_VALUES_EQUAL(endTxnResponse->ErrorCode, EKafkaErrors::PRODUCER_FENCED);
 
-        // validate data is still not assessible in target topic
         auto fetchResponse1 = kafkaClient.Fetch({{outputTopicName, {0}}});
         UNIT_ASSERT_VALUES_EQUAL(fetchResponse1->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
         UNIT_ASSERT(!fetchResponse1->Responses[0].Partitions[0].Records.has_value());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

`ydb/core/kafka_proxy/ut` ran as one MEDIUM chunk (600s) without `FORK_SUBTESTS` / `SPLIT_FACTOR`. ~210 tests, ~100 of them each start a full `TKikimrWithGrpcAndRootSchema`. The suite was muted as `unittest.sole chunk`.

**Split**
- `ydb/core/kafka_proxy/ut` — actor/unit tests
- `ydb/core/kafka_proxy/ut/protocol` — cluster integration (`ut_protocol`, `ut_auth`, `ut_authz`) with `FORK_SUBTESTS()` and `SPLIT_FACTOR(4)`

**Speedups in `ut_protocol.cpp`**
- `NativeKafkaBalanceScenario`: poll Heartbeat instead of `Sleep(5s)+Sleep(25s)` for a dead member (session timeout stays 15s)
- `TopicsCompactionGapFromRetention`: less data before retention, faster poll
- `Commit_Transaction_After_timeout_should_return_producer_fenced`: drop unused JoinGroup, 1 partition, shorter txn timeout

Removed mute `ydb/core/kafka_proxy/ut unittest.sole chunk`. Individual `TTopicLocationActor` / `TTopicOffsetsActor` mutes are unchanged.
