### PR TITLE
fix CODEOWNERS order (move fq specific rules down)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,59 @@
 /yql @ydb-platform/synced-dirs
 /yt @ydb-platform/synced-dirs
 
+/ydb/core/kqp/ @ydb-platform/qp
+/ydb/core/kqp/ut/olap/ @ydb-platform/cs
+/ydb/core/kqp/ut/indexes/ @ydb-platform/qp
+/ydb/core/kqp/ut/indexes/vector @ydb-platform/datashard
+/ydb/core/kqp/ut/indexes/prefixed_vector @ydb-platform/datashard
+/ydb/core/kqp/ut/indexes/fulltext @ydb-platform/datashard
+/ydb/core/kqp/ut/knn/ @ydb-platform/datashard
+/ydb/core/kqp/ut/tli/ @ydb-platform/datashard
+
+/ydb/docs/ @ydb-platform/docs
+
+/ydb/library/yql/ @ydb-platform/qp
+/ydb/library/yql/dq @ydb-platform/qp @ydb-platform/yt
+/ydb/library/yql/providers/dq @ydb-platform/yt
+/ydb/library/yql/udfs/common/knn @ydb-platform/datashard
+
+/ydb/core/http_proxy @ydb-platform/Topics
+/ydb/core/kafka_proxy @ydb-platform/Topics
+/ydb/core/persqueue @ydb-platform/Topics
+/ydb/library/persqueue @ydb-platform/Topics
+/ydb/services/datastreams @ydb-platform/Topics
+/ydb/services/deprecated/persqueue_v0 @ydb-platform/Topics
+/ydb/services/persqueue_v1 @ydb-platform/Topics
+/ydb/core/transfer @ydb-platform/Topics
+
+/ydb/core/change_exchange @ydb-platform/core
+/ydb/core/cms @ydb-platform/core
+/ydb/core/config @ydb-platform/core
+/ydb/core/health_check @ydb-platform/core
+/ydb/core/kesus @ydb-platform/core
+/ydb/core/mind/hive @ydb-platform/core
+/ydb/core/mind/node_broker* @ydb-platform/core
+/ydb/core/protos/counters_replication.proto @ydb-platform/core
+/ydb/core/protos/replication.proto @ydb-platform/core
+/ydb/core/quoter @ydb-platform/core
+/ydb/core/tx/replication @ydb-platform/core
+/ydb/tests/functional/backup_collection @ydb-platform/core
+/ydb/tests/functional/serverless @ydb-platform/core
+
+/ydb/core/viewer @ydb-platform/ui-backend
+/ydb/core/protos/node_whiteboard.proto @ydb-platform/ui-backend
+
+/ydb/core/protos/flat_scheme_op.proto @ydb-platform/schemeshard
+/ydb/core/protos/flat_tx_scheme.proto @ydb-platform/schemeshard
+/ydb/core/protos/counters_schemeshard.proto @ydb-platform/schemeshard
+/ydb/core/protos/schemeshard @ydb-platform/schemeshard
+/ydb/core/tx/scheme_board @ydb-platform/schemeshard
+/ydb/core/tx/schemeshard @ydb-platform/schemeshard
+/ydb/tests/functional/limits @ydb-platform/schemeshard
+/ydb/tests/functional/scheme_shard @ydb-platform/schemeshard
+/ydb/tests/functional/tenants/test_dynamic_tenants.py @ydb-platform/schemeshard
+/ydb/core/tx/tx_proxy/schemereq.cpp @ydb-platform/schemeshard
+
 /ydb/core/external_sources/ @ydb-platform/fq
 /ydb/core/fq/ @ydb-platform/fq
 /ydb/core/grpc_services/local_grpc/ @ydb-platform/fq
@@ -123,59 +176,6 @@
 /ydb/tests/tools/s3_recipe/ @ydb-platform/fq
 /ydb/tests/tools/token_accessor_mock/ @ydb-platform/fq
 /ydb/tests/workload_manager/ @ydb-platform/fq
-
-/ydb/core/kqp/ @ydb-platform/qp
-/ydb/core/kqp/ut/olap/ @ydb-platform/cs
-/ydb/core/kqp/ut/indexes/ @ydb-platform/qp
-/ydb/core/kqp/ut/indexes/vector @ydb-platform/datashard
-/ydb/core/kqp/ut/indexes/prefixed_vector @ydb-platform/datashard
-/ydb/core/kqp/ut/indexes/fulltext @ydb-platform/datashard
-/ydb/core/kqp/ut/knn/ @ydb-platform/datashard
-/ydb/core/kqp/ut/tli/ @ydb-platform/datashard
-
-/ydb/docs/ @ydb-platform/docs
-
-/ydb/library/yql/ @ydb-platform/qp
-/ydb/library/yql/dq @ydb-platform/qp @ydb-platform/yt
-/ydb/library/yql/providers/dq @ydb-platform/yt
-/ydb/library/yql/udfs/common/knn @ydb-platform/datashard
-
-/ydb/core/http_proxy @ydb-platform/Topics
-/ydb/core/kafka_proxy @ydb-platform/Topics
-/ydb/core/persqueue @ydb-platform/Topics
-/ydb/library/persqueue @ydb-platform/Topics
-/ydb/services/datastreams @ydb-platform/Topics
-/ydb/services/deprecated/persqueue_v0 @ydb-platform/Topics
-/ydb/services/persqueue_v1 @ydb-platform/Topics
-/ydb/core/transfer @ydb-platform/Topics
-
-/ydb/core/change_exchange @ydb-platform/core
-/ydb/core/cms @ydb-platform/core
-/ydb/core/config @ydb-platform/core
-/ydb/core/health_check @ydb-platform/core
-/ydb/core/kesus @ydb-platform/core
-/ydb/core/mind/hive @ydb-platform/core
-/ydb/core/mind/node_broker* @ydb-platform/core
-/ydb/core/protos/counters_replication.proto @ydb-platform/core
-/ydb/core/protos/replication.proto @ydb-platform/core
-/ydb/core/quoter @ydb-platform/core
-/ydb/core/tx/replication @ydb-platform/core
-/ydb/tests/functional/backup_collection @ydb-platform/core
-/ydb/tests/functional/serverless @ydb-platform/core
-
-/ydb/core/viewer @ydb-platform/ui-backend
-/ydb/core/protos/node_whiteboard.proto @ydb-platform/ui-backend
-
-/ydb/core/protos/flat_scheme_op.proto @ydb-platform/schemeshard
-/ydb/core/protos/flat_tx_scheme.proto @ydb-platform/schemeshard
-/ydb/core/protos/counters_schemeshard.proto @ydb-platform/schemeshard
-/ydb/core/protos/schemeshard @ydb-platform/schemeshard
-/ydb/core/tx/scheme_board @ydb-platform/schemeshard
-/ydb/core/tx/schemeshard @ydb-platform/schemeshard
-/ydb/tests/functional/limits @ydb-platform/schemeshard
-/ydb/tests/functional/scheme_shard @ydb-platform/schemeshard
-/ydb/tests/functional/tenants/test_dynamic_tenants.py @ydb-platform/schemeshard
-/ydb/core/tx/tx_proxy/schemereq.cpp @ydb-platform/schemeshard
 
 /ydb/core/scheme @ydb-platform/datashard
 /ydb/core/statistics @ydb-platform/datashard


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

regression by #51738

```perl
#!/usr/bin/perl -aln
BEGIN {
    %rules = ();
}
next unless scalar @F >= 2;
my $path = $F[0];
$path =~ s/\/$//;
my $owner = $F[1];
while(my($k, $v) = each %rules) {
   print "$path / $owner overrides $k / $v" if $path eq substr($k, 0, length($path)) and $v ne $owner;
}
$rules{$path}=$owner;
```

```
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/common/events/script_executions.h / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/proxy_service/kqp_script_executions.h / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/ut/service/kqp_qs_scripts_ut.cpp / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/proxy_service/run_script_actor / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/proxy_service/kqp_script_executions.cpp / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/finalize_script_service / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/proxy_service/proto/result_set_meta.proto / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/common/kqp_script_executions.h / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/gateway/behaviour/external_data_source / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/gateway/behaviour/streaming_query / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/proxy_service/kqp_script_executions_impl.h / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/ut/federated_query / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/common/kqp_script_executions.cpp / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/federated_query / @ydb-platform/fq
/ydb/core/kqp / @ydb-platform/qp overrides /ydb/core/kqp/proxy_service/script_executions_utils / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/providers/common/http_gateway / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/dq/proto/dq_state_load_plan.proto / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/dq/runtime/streaming / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/udfs/common/clickhouse / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/providers/s3 / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/dq/actors/compute/dq_compute_actor_checkpoints.* / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/providers/common/token_accessor / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/providers/generic / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/tests/sql/suites/solomon / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/tools/solomon_emulator / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/providers/solomon / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/providers/pq / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/dq/opt/dq_opt_hopping.* / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/providers/common/pushdown / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/dq/actors/common / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/providers/common/db_id_async_resolver / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/dq/actors/compute/input_transforms / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/dq/actors/compute/dq_checkpoints* / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/providers/common/ut_helpers / @ydb-platform/fq
/ydb/library/yql / @ydb-platform/qp overrides /ydb/library/yql/dq/comp_nodes/dq_watermark_generator.* / @ydb-platform/fq
/ydb/library/yql/dq / @ydb-platform/qp overrides /ydb/library/yql/dq/actors/common / @ydb-platform/fq
/ydb/library/yql/dq / @ydb-platform/qp overrides /ydb/library/yql/dq/opt/dq_opt_hopping.* / @ydb-platform/fq
/ydb/library/yql/dq / @ydb-platform/qp overrides /ydb/library/yql/dq/comp_nodes/dq_watermark_generator.* / @ydb-platform/fq
/ydb/library/yql/dq / @ydb-platform/qp overrides /ydb/library/yql/dq/actors/compute/input_transforms / @ydb-platform/fq
/ydb/library/yql/dq / @ydb-platform/qp overrides /ydb/library/yql/dq/actors/compute/dq_checkpoints* / @ydb-platform/fq
/ydb/library/yql/dq / @ydb-platform/qp overrides /ydb/library/yql/dq/proto/dq_state_load_plan.proto / @ydb-platform/fq
/ydb/library/yql/dq / @ydb-platform/qp overrides /ydb/library/yql/dq/actors/compute/dq_compute_actor_checkpoints.* / @ydb-platform/fq
/ydb/library/yql/dq / @ydb-platform/qp overrides /ydb/library/yql/dq/runtime/streaming / @ydb-platform/fq
/ydb/core/tx/schemeshard / @ydb-platform/schemeshard overrides /ydb/core/tx/schemeshard/ut_external_data_source_reboots / @ydb-platform/fq
/ydb/core/tx/schemeshard / @ydb-platform/schemeshard overrides /ydb/core/tx/schemeshard/ut_resource_pool_reboots / @ydb-platform/fq
/ydb/core/tx/schemeshard / @ydb-platform/schemeshard overrides /ydb/core/tx/schemeshard/ut_streaming_query / @ydb-platform/fq
/ydb/core/tx/schemeshard / @ydb-platform/schemeshard overrides /ydb/core/tx/schemeshard/ut_external_table_reboots / @ydb-platform/fq
/ydb/core/tx/schemeshard / @ydb-platform/schemeshard overrides /ydb/core/tx/schemeshard/ut_streaming_query_reboots / @ydb-platform/fq
/ydb/core/tx/schemeshard / @ydb-platform/schemeshard overrides /ydb/core/tx/schemeshard/ut_external_table / @ydb-platform/fq
/ydb/core/tx/schemeshard / @ydb-platform/schemeshard overrides /ydb/core/tx/schemeshard/ut_external_data_source / @ydb-platform/fq
/ydb/core/tx/schemeshard / @ydb-platform/schemeshard overrides /ydb/core/tx/schemeshard/ut_resource_pool / @ydb-platform/fq
```