### PR TITLE
Make string field in DB monpage in flat_executor_db_mon.cpp configurable via a cgi param (#32633)

### DIFF
--- a/ydb/core/tablet_flat/flat_executor_db_mon.cpp
+++ b/ydb/core/tablet_flat/flat_executor_db_mon.cpp
@@ -235,6 +235,8 @@ public:
                     rowOffset = Max<ssize_t>(rowOffset, 0);
                     ssize_t rowLimit = FromStringWithDefault<ssize_t>(cgi.Get("MaxRows"), 1000);
                     rowLimit = Max<ssize_t>(rowLimit, 1);
+                    ssize_t stringlimit = FromStringWithDefault<ssize_t>(cgi.Get("MaxString"), 1024);
+                    stringlimit = Max<ssize_t>(stringlimit, 1);
                     const ssize_t rowsEnd = rowLimit > Max<ssize_t>() - rowOffset
                         ? Max<ssize_t>()
                         : rowOffset + rowLimit;
@@ -345,7 +347,7 @@ public:
                                         case NScheme::NTypeIds::String:
                                         case NScheme::NTypeIds::String4k:
                                         case NScheme::NTypeIds::String2m:
-                                            row << EncodeHtmlPcdata(EscapeC(TStringBuf(static_cast<const char*>(data), Min(size, (ui32)1024))));
+                                            row << EncodeHtmlPcdata(EscapeC(TStringBuf(static_cast<const char*>(data), Min(size, (ui32)stringlimit))));
                                             break;
                                         case NScheme::NTypeIds::ActorId:
                                             row << *(TActorId*)data;


### PR DESCRIPTION
Monpage of a database was used by us as an alternative to using miniKQL. But since strings are cropped to 1024 chars, it renders this approach unusable sometimes

(cherry-picked from commit e72809d685b5927461353cb491caaec1442d41c4)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
