### PR TITLE
Fix stuck MLP consumer request queue caused by a swallowed processing wakeup

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
@@ -172,7 +172,7 @@ TConsumerActor::TConsumerActor(
     , Config(config)
     , RetentionPeriod(retentionPeriod)
     , PartitionEndOffset(partitionEndOffset)
-    , Storage(std::make_unique<TStorage>(CreateDefaultTimeProvider(), StorageSettingsFromConfig(Config, GetPartitionConfig())))
+    , Storage(std::make_unique<TStorage>(AppData()->TimeProvider, StorageSettingsFromConfig(Config, GetPartitionConfig())))
     , DetailedMetricsRoot(detailedMetricsRoot) {
 }
 
@@ -550,9 +550,7 @@ void TConsumerActor::Handle(TEvPQ::TEvMLPConsumerUpdateConfig::TPtr& ev) {
     InitializeDetailedMetrics();
     UpdateLockedGroupsIdInChildPartitions(false);
 
-    if (CurrentStateFunc() == &TConsumerActor::StateWork) {
-        ScheduleProcessing();
-    }
+    ScheduleProcessing();
 }
 
 void TConsumerActor::HandleInit(TEvPQ::TEvEndOffsetChanged::TPtr& ev) {
@@ -666,7 +664,7 @@ STFUNC(TConsumerActor::StateWork) {
         hFunc(TEvPipeCache::TEvDeliveryProblem, Handle);
         hFunc(TEvPQ::TEvMLPErrorResponse, Handle);
         hFunc(TEvPQ::TEvMLPDLQMoverResponse, Handle);
-        hFunc(TEvents::TEvWakeup, HandleOnWork);
+        hFunc(TEvents::TEvWakeup, Handle);
         sFunc(TEvents::TEvPoison, PassAway);
         default:
             YDB_LOG_ERROR("Unexpected",
@@ -716,8 +714,12 @@ void TConsumerActor::Restart(TString&& error) {
     PassAway();
 }
 
+bool TConsumerActor::InStateWork() const {
+    return CurrentStateFunc() == &TConsumerActor::StateWork;
+}
+
 void TConsumerActor::ScheduleProcessing() {
-    if (ProcessingScheduled) {
+    if (ProcessingScheduled || !InStateWork()) {
         return;
     }
 
@@ -1117,41 +1119,11 @@ void TConsumerActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev) {
         LastTimeWithMessages = TAppData::TimeProvider->Now();
         NotifyPQRB();
     }
-    if (CurrentStateFunc() == &TConsumerActor::StateWork) {
-        ScheduleProcessing();
-    }
+    ScheduleProcessing();
 }
 
 void TConsumerActor::Handle(TEvPQ::TEvError::TPtr& ev) {
     Restart(TStringBuilder() << "Received error: " << ev->Get()->Error);
-}
-
-void TConsumerActor::HandleOnWork(TEvents::TEvWakeup::TPtr& ev) {
-    YDB_LOG_DEBUG("HandleOnWork TEvents::TEvWakeup",
-        {"logPrefix", NPQ_LOG_PREFIX},
-        {"tag", ev->Get()->Tag});
-    switch (ev->Get()->Tag) {
-        case EWakeUpTag::Regular: {
-            FetchMessagesIfNeeded();
-            if (!ProcessingScheduled) {
-                ProcessEventQueue();
-            }
-            NotifyPQRB(true);
-            UpdateMetrics();
-            ScheduleProcessing();
-            Schedule(WakeupInterval, new TEvents::TEvWakeup(EWakeUpTag::Regular));
-            break;
-        }
-        case EWakeUpTag::Processing: {
-            ProcessingScheduled = false;
-            ProcessEventQueue();
-            break;
-        }
-        case EWakeUpTag::UpdateChildPartitions: {
-            UpdateLockedGroupsIdInChildPartitions(false);
-            break;
-        }
-    }
 }
 
 void TConsumerActor::MoveToDLQIfPossible() {
@@ -1210,22 +1182,36 @@ void TConsumerActor::Handle(TEvPQ::TEvMLPDLQMoverResponse::TPtr& ev) {
         AFL_ENSURE(result)("o", offset)("s", seqNo);
     }
 
-    if (CurrentStateFunc() == &TConsumerActor::StateWork) {
-        ScheduleProcessing();
-    }
+    ScheduleProcessing();
 }
 
 void TConsumerActor::Handle(TEvents::TEvWakeup::TPtr& ev) {
     YDB_LOG_DEBUG("Handle TEvents::TEvWakeup",
         {"logPrefix", NPQ_LOG_PREFIX},
         {"tag", ev->Get()->Tag});
-    if (ev->Get()->Tag == EWakeUpTag::UpdateChildPartitions) {
-        UpdateLockedGroupsIdInChildPartitions(false);
-        return;
+    switch (ev->Get()->Tag) {
+        case EWakeUpTag::UpdateChildPartitions:
+            UpdateLockedGroupsIdInChildPartitions(false);
+            return;
+        case EWakeUpTag::Processing:
+            ProcessingScheduled = false;
+            if (!InStateWork()) {
+                return;
+            }
+            ProcessEventQueue();
+            return;
+        case EWakeUpTag::Regular:
+            if (InStateWork()) {
+                FetchMessagesIfNeeded();
+                ProcessingScheduled = false;
+                ProcessEventQueue();
+                ScheduleProcessing();
+            }
+            UpdateMetrics();
+            NotifyPQRB(true);
+            Schedule(WakeupInterval, new TEvents::TEvWakeup(EWakeUpTag::Regular));
+            return;
     }
-    UpdateMetrics();
-    NotifyPQRB(true);
-    Schedule(WakeupInterval, new TEvents::TEvWakeup(EWakeUpTag::Regular));
 }
 
 void TConsumerActor::SendToPQTablet(std::unique_ptr<IEventBase> ev) {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
@@ -172,7 +172,7 @@ TConsumerActor::TConsumerActor(
     , Config(config)
     , RetentionPeriod(retentionPeriod)
     , PartitionEndOffset(partitionEndOffset)
-    , Storage(std::make_unique<TStorage>(AppData()->TimeProvider, StorageSettingsFromConfig(Config, GetPartitionConfig())))
+    , Storage(std::make_unique<TStorage>(TAppData::TimeProvider, StorageSettingsFromConfig(Config, GetPartitionConfig())))
     , DetailedMetricsRoot(detailedMetricsRoot) {
 }
 
@@ -1194,6 +1194,8 @@ void TConsumerActor::Handle(TEvents::TEvWakeup::TPtr& ev) {
             UpdateLockedGroupsIdInChildPartitions(false);
             return;
         case EWakeUpTag::Processing:
+            // The flag is reset in any state: the scheduled wakeup is consumed here, so
+            // ScheduleProcessing() must be able to schedule a new one for later requests.
             ProcessingScheduled = false;
             if (!InStateWork()) {
                 return;
@@ -1203,8 +1205,9 @@ void TConsumerActor::Handle(TEvents::TEvWakeup::TPtr& ev) {
         case EWakeUpTag::Regular:
             if (InStateWork()) {
                 FetchMessagesIfNeeded();
-                ProcessingScheduled = false;
-                ProcessEventQueue();
+                if (!ProcessingScheduled) {
+                    ProcessEventQueue();
+                }
                 ScheduleProcessing();
             }
             UpdateMetrics();

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.h
@@ -70,8 +70,8 @@ private:
     void Handle(TEvPQ::TEvMLPErrorResponse::TPtr&);
     void RetryChildPartitionSync(ui32 partitionId);
 
-    void HandleOnWork(TEvents::TEvWakeup::TPtr&);
     void Handle(TEvents::TEvWakeup::TPtr&);
+    bool InStateWork() const;
 
     void Handle(TEvPQ::TEvMLPDLQMoverResponse::TPtr&);
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/ut/mlp_consumer_wakeup_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/ut/mlp_consumer_wakeup_ut.cpp
@@ -1,0 +1,469 @@
+#include "mlp.h"
+#include "mlp_storage.h"
+
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/base/tablet_pipecache.h>
+#include <ydb/core/keyvalue/keyvalue_events.h>
+#include <ydb/core/persqueue/events/global.h>
+#include <ydb/core/persqueue/events/internal.h>
+#include <ydb/core/protos/grpc_pq_old.pb.h>
+#include <ydb/core/protos/msgbus.pb.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/events.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NPQ::NMLP {
+
+namespace {
+
+constexpr ui64 kTabletId = 100;
+constexpr const char* kConsumer = "mlp-consumer";
+constexpr const char* kTopic = "topic";
+
+// Must match TConsumerActor::EWakeUpTag in mlp_consumer.cpp.
+constexpr ui64 kWakeupRegular = 1;
+constexpr ui64 kWakeupProcessing = 2;
+
+NKikimrPQ::TPQTabletConfig MakeTopicConfig() {
+    NKikimrPQ::TPQTabletConfig config;
+    config.SetTopicName(kTopic);
+    config.SetTopicPath("/Root/topic");
+
+    auto* partition = config.AddAllPartitions();
+    partition->SetPartitionId(0);
+    partition->SetTabletId(kTabletId);
+    partition->SetStatus(NKikimrPQ::ETopicPartitionStatus::Active);
+
+    auto* consumer = config.AddConsumers();
+    consumer->SetName(kConsumer);
+    consumer->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+    consumer->SetKeepMessageOrder(false);
+    consumer->SetGeneration(1);
+    return config;
+}
+
+NKikimrPQ::TPQTabletConfig::TConsumer MakeConsumerConfig() {
+    NKikimrPQ::TPQTabletConfig::TConsumer consumer;
+    consumer.SetName(kConsumer);
+    consumer.SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+    consumer.SetKeepMessageOrder(false);
+    consumer.SetGeneration(1);
+    return consumer;
+}
+
+THolder<TEvKeyValue::TEvResponse> MakeEmptySnapshotResponse(ui64 cookie) {
+    auto response = MakeHolder<TEvKeyValue::TEvResponse>();
+    response->Record.SetStatus(NMsgBusProxy::MSTATUS_OK);
+    response->Record.SetCookie(cookie);
+    response->Record.AddReadResult()->SetStatus(NKikimrProto::NODATA);
+    response->Record.AddReadRangeResult()->SetStatus(NKikimrProto::NODATA);
+    return response;
+}
+
+THolder<TEvKeyValue::TEvResponse> MakeKvWriteOk(ui64 cookie) {
+    auto response = MakeHolder<TEvKeyValue::TEvResponse>();
+    response->Record.SetStatus(NMsgBusProxy::MSTATUS_OK);
+    response->Record.SetCookie(cookie);
+    response->Record.AddWriteResult()->SetStatus(NKikimrProto::OK);
+    return response;
+}
+
+THolder<TEvPersQueue::TEvResponse> MakeFetchResponse(ui64 firstOffset, ui64 count, TInstant writeTimestamp) {
+    auto response = MakeHolder<TEvPersQueue::TEvResponse>();
+    response->Record.SetStatus(NMsgBusProxy::MSTATUS_OK);
+    response->Record.SetErrorCode(NPersQueue::NErrorCode::OK);
+
+    NKikimrPQClient::TDataChunk chunk;
+    chunk.SetChunkType(NKikimrPQClient::TDataChunk::REGULAR);
+    const auto data = chunk.SerializeAsString();
+
+    for (ui64 i = 0; i < count; ++i) {
+        auto* result = response->Record.MutablePartitionResponse()->MutableCmdReadResult()->AddResult();
+        result->SetOffset(firstOffset + i);
+        result->SetLogicalMessageCount(1);
+        result->SetWriteTimestampMS(writeTimestamp.MilliSeconds());
+        result->SetData(data);
+    }
+    return response;
+}
+
+class TIgnorePipeCacheActor : public TActorBootstrapped<TIgnorePipeCacheActor> {
+public:
+    void Bootstrap() {
+        Become(&TThis::StateWork);
+    }
+
+    STRICT_STFUNC(StateWork,
+        IgnoreFunc(TEvPipeCache::TEvForward);
+        IgnoreFunc(TEvPipeCache::TEvUnlink);
+    )
+};
+
+struct TConsumerEnv {
+    TTestBasicRuntime Runtime;
+    TActorId Tablet;
+    TActorId Partition;
+    TActorId Reader;
+    TActorId Consumer;
+    NMonitoring::TDynamicCounterPtr Counters;
+    ui32 RegularWakeupsAllowed = 0;
+    bool DropProcessingWakeups = false;
+
+    TConsumerEnv()
+        : Runtime(1, false)
+        , Counters(new NMonitoring::TDynamicCounters())
+    {
+        Runtime.Initialize(TAppPrepare().Unwrap());
+        Runtime.SetScheduledLimit(10000);
+        Runtime.SetLogPriority(NKikimrServices::PQ_MLP_CONSUMER, NLog::PRI_DEBUG);
+
+        auto pipeCache = Runtime.Register(new TIgnorePipeCacheActor());
+        Runtime.EnableScheduleForActor(pipeCache);
+        Runtime.RegisterService(MakePipePerNodeCacheID(false), pipeCache);
+
+        Tablet = Runtime.AllocateEdgeActor();
+        Partition = Runtime.AllocateEdgeActor();
+        Reader = Runtime.AllocateEdgeActor();
+
+        Runtime.SetObserverFunc([this](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvents::TEvWakeup::EventType) {
+                const auto* wakeup = ev->Get<TEvents::TEvWakeup>();
+                if (!wakeup) {
+                    return TTestActorRuntime::EEventAction::PROCESS;
+                }
+                if (wakeup->Tag == kWakeupRegular) {
+                    if (RegularWakeupsAllowed == 0) {
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                    --RegularWakeupsAllowed;
+                } else if (wakeup->Tag == kWakeupProcessing && DropProcessingWakeups) {
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        Consumer = Runtime.Register(CreateConsumerActor(
+            "/Root",
+            kTabletId,
+            Tablet,
+            0,
+            Partition,
+            1,
+            MakeTopicConfig(),
+            MakeConsumerConfig(),
+            std::nullopt,
+            0,
+            Counters
+        ));
+        Runtime.EnableScheduleForActor(Consumer);
+
+        auto kvReq = Runtime.GrabEdgeEvent<TEvKeyValue::TEvRequest>(TDuration::Seconds(5));
+        UNIT_ASSERT(kvReq);
+        Runtime.Send(new IEventHandle(Consumer, Tablet, MakeEmptySnapshotResponse(kvReq->Record.GetCookie()).Release()));
+    }
+
+    TInstant Now() {
+        return Runtime.GetTimeProvider()->Now();
+    }
+
+    void Pump() {
+        ui32 cycles = 0;
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&cycles] { return ++cycles >= 20; };
+        Runtime.DispatchEvents(options);
+    }
+
+    THolder<TEvKeyValue::TEvRequest> GrabKvRequest(TDuration timeout = TDuration::Seconds(5)) {
+        auto kvReq = Runtime.GrabEdgeEvent<TEvKeyValue::TEvRequest>(timeout);
+        UNIT_ASSERT(kvReq);
+        return kvReq;
+    }
+
+    void ReplyKv(const TEvKeyValue::TEvRequest& kvReq, bool pump = true) {
+        Runtime.Send(new IEventHandle(Consumer, Tablet, MakeKvWriteOk(kvReq.Record.GetCookie()).Release()));
+        if (pump) {
+            Pump();
+        }
+    }
+
+    void ReplyKvWrite() {
+        ReplyKv(*GrabKvRequest());
+    }
+
+    void FetchMessages(ui64 count, ui64 firstOffset = 0) {
+        Runtime.Send(new IEventHandle(Consumer, Tablet, new TEvPQ::TEvEndOffsetChanged(firstOffset + count)));
+        auto fetch = Runtime.GrabEdgeEvent<TEvPersQueue::TEvRequest>(TDuration::Seconds(5));
+        UNIT_ASSERT(fetch);
+        Runtime.Send(new IEventHandle(Consumer, Tablet, MakeFetchResponse(firstOffset, count, Now()).Release()));
+        ReplyKvWrite();
+    }
+
+    void FetchOneMessage() {
+        FetchMessages(1);
+    }
+
+    void SendRead(TDuration wait, TDuration processingTimeout) {
+        Runtime.Send(new IEventHandle(
+            Consumer,
+            Reader,
+            new TEvPQ::TEvMLPReadRequest(
+                kTopic,
+                kConsumer,
+                0,
+                Now() + wait,
+                processingTimeout,
+                1,
+                {})));
+    }
+
+    void SendCommit(ui64 offset) {
+        Runtime.Send(new IEventHandle(
+            Consumer,
+            Reader,
+            new TEvPQ::TEvMLPCommitRequest(kTopic, kConsumer, 0, {offset})));
+    }
+
+    void SendUnlock(ui64 offset) {
+        Runtime.Send(new IEventHandle(
+            Consumer,
+            Reader,
+            new TEvPQ::TEvMLPUnlockRequest(kTopic, kConsumer, 0, {offset})));
+    }
+
+    void SendWakeup(ui64 tag) {
+        Runtime.Send(new IEventHandle(Consumer, Consumer, new TEvents::TEvWakeup(tag)), 0, true);
+    }
+
+    void DeliverProcessing() {
+        SendWakeup(kWakeupProcessing);
+        Pump();
+    }
+
+    THolder<TEvPQ::TEvGetMLPConsumerStateResponse> GetState() {
+        Runtime.Send(new IEventHandle(Consumer, Reader, new TEvPQ::TEvGetMLPConsumerStateRequest(kTopic, kConsumer, 0)));
+        auto state = Runtime.GrabEdgeEvent<TEvPQ::TEvGetMLPConsumerStateResponse>(TDuration::Seconds(5));
+        UNIT_ASSERT(state);
+        return state;
+    }
+
+    void AssertStatus(ui64 offset, TStorage::EMessageStatus status) {
+        auto state = GetState();
+        for (const auto& message : state->Messages) {
+            if (message.Offset == offset) {
+                UNIT_ASSERT_VALUES_EQUAL(message.Status, static_cast<ui32>(status));
+                return;
+            }
+        }
+        // Persist() compact drops a committed prefix, so a successful commit may
+        // disappear from the in-memory iterator.
+        if (status == TStorage::EMessageStatus::Committed) {
+            return;
+        }
+        UNIT_FAIL("offset not found in consumer state");
+    }
+
+    THolder<TEvKeyValue::TEvRequest> ExpectPersist(const char* message) {
+        Runtime.SetDispatchTimeout(TDuration::Seconds(3));
+        auto kv = Runtime.GrabEdgeEvent<TEvKeyValue::TEvRequest>(TDuration::Seconds(2));
+        UNIT_ASSERT_C(kv, message);
+        return kv;
+    }
+
+    void AssertPersisted(ui64 offset, TStorage::EMessageStatus status, const char* message) {
+        auto kv = ExpectPersist(message);
+        AssertStatus(offset, status);
+        ReplyKv(*kv);
+    }
+
+    void AssertQueueStillProcessesAfterCommit(ui64 committedOffset, ui64 nextOffset) {
+        AssertPersisted(committedOffset, TStorage::EMessageStatus::Committed,
+            "queued commit must be applied");
+        DropProcessingWakeups = false;
+        SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+        AssertPersisted(nextOffset, TStorage::EMessageStatus::Locked,
+            "queue must still serve a later read");
+    }
+
+    void AssertQueueStillProcessesAfterUnlock(ui64 offset) {
+        AssertPersisted(offset, TStorage::EMessageStatus::Unprocessed,
+            "queued unlock must be applied");
+        DropProcessingWakeups = false;
+        SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+        AssertPersisted(offset, TStorage::EMessageStatus::Locked,
+            "queue must still lock the message after unlock");
+    }
+};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TMLPConsumerWakeupTests) {
+
+Y_UNIT_TEST(RegularPersistDoesNotStickProcessingScheduled) {
+    TConsumerEnv env;
+    env.FetchOneMessage();
+
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(1));
+    env.ReplyKvWrite();
+
+    // Leave a long-poll in ReadRequestsQueue so ScheduleProcessing() after Persist()
+    // does not early-return: one waiter takes the unlocked message, the other stays queued.
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    env.Pump();
+
+    // Storage uses wall-clock CreateDefaultTimeProvider(); wait for vacuum + visibility.
+    Sleep(TDuration::Seconds(3));
+
+    env.RegularWakeupsAllowed = 1;
+    env.DropProcessingWakeups = true;
+    env.SendWakeup(kWakeupRegular);
+
+    auto unlockKv = env.Runtime.GrabEdgeEvent<TEvKeyValue::TEvRequest>(TDuration::Seconds(5));
+    UNIT_ASSERT_C(unlockKv, "Regular wakeup must persist expired visibility locks");
+
+    env.DropProcessingWakeups = false;
+    env.DeliverProcessing();
+
+    env.ReplyKv(*unlockKv, false);
+
+    env.SendCommit(0);
+    env.AssertPersisted(0, TStorage::EMessageStatus::Committed,
+        "ProcessingScheduled stayed true after Processing wakeup in StateWrite; later requests never persist");
+
+    // Fetch does not persist by itself; the next Processing wakeup writes the new
+    // message together with the lock. Do not consume that KV before the assert.
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    env.Runtime.Send(new IEventHandle(env.Consumer, env.Tablet, new TEvPQ::TEvEndOffsetChanged(2)));
+    auto fetch = env.Runtime.GrabEdgeEvent<TEvPersQueue::TEvRequest>(TDuration::Seconds(5));
+    UNIT_ASSERT(fetch);
+    env.Runtime.Send(new IEventHandle(
+        env.Consumer,
+        env.Tablet,
+        MakeFetchResponse(1, 1, env.Now()).Release()));
+    env.AssertPersisted(1, TStorage::EMessageStatus::Locked,
+        "queue must still lock a later message after the stuck ProcessingScheduled race");
+}
+
+Y_UNIT_TEST(RegularDrainsQueueWhenProcessingWakeupIsDropped) {
+    TConsumerEnv env;
+    env.FetchMessages(2);
+
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    env.ReplyKvWrite();
+
+    env.DropProcessingWakeups = true;
+    env.SendCommit(0);
+    env.RegularWakeupsAllowed = 1;
+    env.SendWakeup(kWakeupRegular);
+
+    env.AssertQueueStillProcessesAfterCommit(0, 1);
+}
+
+Y_UNIT_TEST(DelayedProcessingAfterKvReplyPersistsQueuedCommit) {
+    TConsumerEnv env;
+    env.FetchMessages(2);
+
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    env.ReplyKvWrite();
+
+    env.DropProcessingWakeups = true;
+    env.SendCommit(0);
+    env.Pump();
+
+    env.DropProcessingWakeups = false;
+    env.SendWakeup(kWakeupProcessing);
+
+    env.AssertQueueStillProcessesAfterCommit(0, 1);
+}
+
+Y_UNIT_TEST(CommitQueuedDuringWriteIsPersistedAfterKv) {
+    TConsumerEnv env;
+    env.FetchMessages(2);
+
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    auto lockKv = env.GrabKvRequest();
+    env.SendCommit(0);
+    env.ReplyKv(*lockKv);
+
+    env.AssertQueueStillProcessesAfterCommit(0, 1);
+}
+
+Y_UNIT_TEST(UnlockQueuedDuringWriteIsPersistedAfterKv) {
+    TConsumerEnv env;
+    env.FetchOneMessage();
+
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    auto lockKv = env.GrabKvRequest();
+    env.SendUnlock(0);
+    env.ReplyKv(*lockKv);
+
+    env.AssertQueueStillProcessesAfterUnlock(0);
+}
+
+Y_UNIT_TEST(ReadQueuedDuringWriteLocksNextMessageAfterKv) {
+    TConsumerEnv env;
+    env.FetchMessages(3);
+
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    auto firstLockKv = env.GrabKvRequest();
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    env.ReplyKv(*firstLockKv);
+
+    env.AssertPersisted(1, TStorage::EMessageStatus::Locked,
+        "A read queued in StateWrite must lock the next message after KV completes");
+    env.AssertStatus(0, TStorage::EMessageStatus::Locked);
+
+    env.SendCommit(0);
+    env.AssertQueueStillProcessesAfterCommit(0, 1);
+}
+
+Y_UNIT_TEST(DelayedFetchServesAlreadyQueuedRead) {
+    TConsumerEnv env;
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    env.Pump();
+
+    env.FetchMessages(2);
+    env.AssertStatus(0, TStorage::EMessageStatus::Locked);
+
+    env.SendCommit(0);
+    env.AssertQueueStillProcessesAfterCommit(0, 1);
+}
+
+Y_UNIT_TEST(RegularDuringWriteDoesNotDropQueuedCommit) {
+    TConsumerEnv env;
+    env.FetchMessages(2);
+
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    auto lockKv = env.GrabKvRequest();
+    env.SendCommit(0);
+
+    env.RegularWakeupsAllowed = 1;
+    env.SendWakeup(kWakeupRegular);
+    env.Pump();
+
+    env.ReplyKv(*lockKv);
+
+    env.AssertQueueStillProcessesAfterCommit(0, 1);
+}
+
+Y_UNIT_TEST(StaleProcessingInWriteThenKvPersistsCommit) {
+    TConsumerEnv env;
+    env.FetchMessages(2);
+
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    auto lockKv = env.GrabKvRequest();
+    env.DeliverProcessing();
+    env.DeliverProcessing();
+    env.ReplyKv(*lockKv);
+
+    env.SendCommit(0);
+    env.AssertQueueStillProcessesAfterCommit(0, 1);
+}
+
+} // Y_UNIT_TEST_SUITE(TMLPConsumerWakeupTests)
+
+} // namespace NKikimr::NPQ::NMLP

--- a/ydb/core/persqueue/pqtablet/partition/mlp/ut/mlp_consumer_wakeup_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/ut/mlp_consumer_wakeup_ut.cpp
@@ -23,7 +23,7 @@ constexpr ui64 kTabletId = 100;
 constexpr const char* kConsumer = "mlp-consumer";
 constexpr const char* kTopic = "topic";
 
-// Must match TConsumerActor::EWakeUpTag in mlp_consumer.cpp.
+// Must match EWakeUpTag in mlp_consumer.cpp.
 constexpr ui64 kWakeupRegular = 1;
 constexpr ui64 kWakeupProcessing = 2;
 
@@ -315,8 +315,9 @@ Y_UNIT_TEST(RegularPersistDoesNotStickProcessingScheduled) {
     env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
     env.Pump();
 
-    // Storage uses wall-clock CreateDefaultTimeProvider(); wait for vacuum + visibility.
-    Sleep(TDuration::Seconds(3));
+    // Wait for the visibility timeout of the locked message and for the storage vacuum
+    // interval. Storage takes time from AppData, so simulated time is enough.
+    env.Runtime.SimulateSleep(TDuration::Seconds(3));
 
     env.RegularWakeupsAllowed = 1;
     env.DropProcessingWakeups = true;
@@ -348,19 +349,29 @@ Y_UNIT_TEST(RegularPersistDoesNotStickProcessingScheduled) {
         "queue must still lock a later message after the stuck ProcessingScheduled race");
 }
 
-Y_UNIT_TEST(RegularDrainsQueueWhenProcessingWakeupIsDropped) {
+Y_UNIT_TEST(RegularServesQueuedReadAfterVisibilityTimeout) {
     TConsumerEnv env;
-    env.FetchMessages(2);
+    env.FetchOneMessage();
 
-    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(1));
     env.ReplyKvWrite();
 
-    env.DropProcessingWakeups = true;
-    env.SendCommit(0);
+    // The message is locked, so the second read stays in ReadRequestsQueue. Nothing
+    // schedules a wakeup for the visibility timeout, so the Regular tick is the only
+    // event that unlocks the message and serves the waiting read.
+    env.SendRead(TDuration::Seconds(60), TDuration::Seconds(30));
+    env.Pump();
+
+    env.Runtime.SimulateSleep(TDuration::Seconds(3));
+
     env.RegularWakeupsAllowed = 1;
     env.SendWakeup(kWakeupRegular);
 
-    env.AssertQueueStillProcessesAfterCommit(0, 1);
+    env.AssertPersisted(0, TStorage::EMessageStatus::Locked,
+        "Regular wakeup must unlock the expired message and serve the queued read");
+
+    env.SendUnlock(0);
+    env.AssertQueueStillProcessesAfterUnlock(0);
 }
 
 Y_UNIT_TEST(DelayedProcessingAfterKvReplyPersistsQueuedCommit) {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/ut/ya.make
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/ut/ya.make
@@ -15,6 +15,7 @@ SRCS(
     mlp_consumer_order_ut.cpp
     mlp_consumer_split_ut.cpp
     mlp_consumer_ut.cpp
+    mlp_consumer_wakeup_ut.cpp
     mlp_counters_ut.cpp
     mlp_dlq_mover_ut.cpp
     mlp_message_enricher_ut.cpp

--- a/ydb/tests/stress/sqs_topic/tests/test_boto_stress.py
+++ b/ydb/tests/stress/sqs_topic/tests/test_boto_stress.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from ydb.tests.library.stress.fixtures import StressFixture
+from ydb.tests.stress.sqs_topic.workload.boto_stress import (
+    BotoStressWorkload,
+    DEFAULT_DURATION_SECONDS,
+    DEFAULT_WORKERS,
+)
+
+
+class TestSqsTopicBotoStress(StressFixture):
+    @pytest.fixture(autouse=True, scope="function")
+    def setup(self):
+        yield from self.setup_cluster(
+            extra_feature_flags={
+                "enable_topic_message_level_parallelism": True,
+            },
+            http_proxy_config={
+                "enabled": True,
+                "sqs_topic_enabled": True,
+                "ymq_enabled": False,
+                "yandex_cloud_service_region": ["ru-central1", "ru-test"],
+            },
+        )
+
+    def test_boto_write_read_commit_stress(self):
+        with BotoStressWorkload(
+            endpoint=self.endpoint,
+            database=self.database,
+            duration=DEFAULT_DURATION_SECONDS,
+            sqs_endpoint=self.http_proxy_endpoint + self.database,
+            workers=DEFAULT_WORKERS,
+        ) as workload:
+            workload.run()

--- a/ydb/tests/stress/sqs_topic/tests/test_boto_stress.py
+++ b/ydb/tests/stress/sqs_topic/tests/test_boto_stress.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 import pytest
+import yatest.common
 
+from ydb.tests.library.fixtures import ydb_database_ctx
+from ydb.tests.library.harness.kikimr_config import Erasure, KikimrConfigGenerator
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+from ydb.tests.library.harness.param_constants import kikimr_driver_path
 from ydb.tests.library.stress.fixtures import StressFixture
+from ydb.tests.oss.ydb_sdk_import import ydb
 from ydb.tests.stress.sqs_topic.workload.boto_stress import (
     BotoStressWorkload,
     DEFAULT_DURATION_SECONDS,
@@ -12,7 +18,10 @@ from ydb.tests.stress.sqs_topic.workload.boto_stress import (
 class TestSqsTopicBotoStress(StressFixture):
     @pytest.fixture(autouse=True, scope="function")
     def setup(self):
-        yield from self.setup_cluster(
+        erasure = Erasure.from_string(yatest.common.get_param('stress_default_erasure', default='NONE'))
+        self.config = KikimrConfigGenerator(
+            binary_paths=[kikimr_driver_path()],
+            erasure=erasure,
             extra_feature_flags={
                 "enable_topic_message_level_parallelism": True,
             },
@@ -23,6 +32,17 @@ class TestSqsTopicBotoStress(StressFixture):
                 "yandex_cloud_service_region": ["ru-central1", "ru-test"],
             },
         )
+        self.cluster = KiKiMR(self.config)
+        self.cluster.start()
+        with ydb_database_ctx(self.cluster, "/Root/SqsTopic", node_count=1) as db_path:
+            self.database = db_path
+            self.endpoint = "grpc://%s:%s" % ("localhost", self.cluster.nodes[1].port)
+            self.http_proxy_endpoint = f"http://localhost:{self.cluster.nodes[1].http_proxy_port}"
+            self.driver = ydb.Driver(ydb.DriverConfig(self.endpoint, self.database))
+            self.driver.wait(timeout=60)
+            yield
+            self.driver.stop()
+        self.cluster.stop()
 
     def test_boto_write_read_commit_stress(self):
         with BotoStressWorkload(

--- a/ydb/tests/stress/sqs_topic/tests/ya.make
+++ b/ydb/tests/stress/sqs_topic/tests/ya.make
@@ -7,11 +7,13 @@ ENV(YDB_TEST_PATH="ydb/tests/stress/sqs_topic/sqs_topic")
 
 TEST_SRCS(
     test_workload.py
+    test_boto_stress.py
 )
 
 REQUIREMENTS(ram:32 cpu:4)
 
-SIZE(MEDIUM)
+SIZE(LARGE)
+TAG(ya:fat)
 
 DEPENDS(
     ydb/apps/ydb
@@ -22,6 +24,8 @@ PEERDIR(
     ydb/tests/library
     ydb/tests/library/stress
     ydb/tests/stress/sqs_topic/workload
+    contrib/python/boto3
+    contrib/python/botocore
 )
 
 END()

--- a/ydb/tests/stress/sqs_topic/tests/ya.make
+++ b/ydb/tests/stress/sqs_topic/tests/ya.make
@@ -22,6 +22,7 @@ DEPENDS(
 
 PEERDIR(
     ydb/tests/library
+    ydb/tests/library/fixtures
     ydb/tests/library/stress
     ydb/tests/stress/sqs_topic/workload
     contrib/python/boto3

--- a/ydb/tests/stress/sqs_topic/workload/boto_stress.py
+++ b/ydb/tests/stress/sqs_topic/workload/boto_stress.py
@@ -2,6 +2,7 @@ import logging
 import threading
 import time
 import uuid
+from typing import NamedTuple
 
 import boto3
 import ydb
@@ -22,23 +23,51 @@ BOTO_CONFIG = Config(
 )
 
 
-def make_sqs_topic_queue_name(topic_name, consumer=DEFAULT_CONSUMER):
-    if consumer == DEFAULT_CONSUMER:
-        return topic_name
-    return f"{topic_name}@{consumer}"
+class PartitionState(NamedTuple):
+    partition_id: int
+    active: bool
+    partition_end: int
+    committed_offset: int
 
 
-def get_written_messages_count(driver, topic_name):
-    describe = driver.topic_client.describe_topic(topic_name, include_stats=True)
-    return sum(p.partition_stats.partition_end for p in describe.partitions)
-
-
-def get_committed_messages_count(driver, topic_name, consumer=DEFAULT_CONSUMER):
+def get_consumer_partition_states(driver, topic_name, consumer=DEFAULT_CONSUMER):
     describe = driver.topic_client.describe_consumer(topic_name, consumer, include_stats=True)
-    return sum(
-        p.partition_consumer_stats.committed_offset
-        for p in describe.partitions
-        if p.partition_consumer_stats is not None
+    states = {}
+    for partition in describe.partitions:
+        partition_end = 0
+        if partition.partition_stats is not None:
+            partition_end = partition.partition_stats.partition_end
+        committed_offset = 0
+        if partition.partition_consumer_stats is not None:
+            committed_offset = partition.partition_consumer_stats.committed_offset
+        states[partition.partition_id] = PartitionState(
+            partition_id=partition.partition_id,
+            active=partition.active,
+            partition_end=partition_end,
+            committed_offset=committed_offset,
+        )
+    return states
+
+
+def partition_needs_committed_progress(state: PartitionState) -> bool:
+    if state.partition_end <= state.committed_offset:
+        return False
+    if not state.active and state.committed_offset >= state.partition_end:
+        return False
+    return True
+
+
+def assert_partitions_committed_caught_up(states, sent):
+    stalled_partitions = []
+    for partition_id, state in sorted(states.items()):
+        if state.committed_offset < state.partition_end:
+            stalled_partitions.append(
+                f"partition={partition_id} active={state.active} "
+                f"end={state.partition_end} committed={state.committed_offset}"
+            )
+    assert not stalled_partitions, (
+        f"some partitions did not commit all written messages (sent={sent}): "
+        f"{'; '.join(stalled_partitions)}"
     )
 
 
@@ -58,8 +87,8 @@ class BotoStressWorkload:
         self.sqs_endpoint = sqs_endpoint
         self.workers = workers
         self.consumer = consumer
-        self.topic_name = f"boto_stress_{uuid.uuid4().hex}"
-        self.queue_name = make_sqs_topic_queue_name(self.topic_name, consumer)
+        self.queue_name = f"boto_stress_{uuid.uuid4().hex}"
+        self.topic_name = self.queue_name
         self._queue_url = None
         self._driver = ydb.Driver(ydb.DriverConfig(endpoint, database))
         self._driver.wait(timeout=60)
@@ -76,49 +105,31 @@ class BotoStressWorkload:
             config=BOTO_CONFIG,
         )
 
-    def create_topic(self):
-        with ydb.QuerySessionPool(self._driver) as session_pool:
-            session_pool.execute_with_retries(f"""
-                CREATE TOPIC `{self.topic_name}`
-                  (CONSUMER `{self.consumer}`
-                    WITH (
-                      type = 'shared',
-                      keep_messages_order = false,
-                      default_processing_timeout = Interval('PT30S')
-                    )
-                  );
-            """)
-
-    def drop_topic(self):
-        with ydb.QuerySessionPool(self._driver) as session_pool:
-            try:
-                session_pool.execute_with_retries(f"DROP TOPIC `{self.topic_name}`;")
-            except Exception as error:
-                logging.error("Failed to drop topic %s: %r", self.topic_name, error)
-
-    def resolve_queue_url(self):
+    def create_queue(self):
         client = self._make_boto_client()
         last_error = None
         for attempt in range(10):
             try:
-                self._queue_url = client.get_queue_url(QueueName=self.queue_name)["QueueUrl"]
+                self._queue_url = client.create_queue(QueueName=self.queue_name)["QueueUrl"]
                 return self._queue_url
             except Exception as error:
                 last_error = error
-                logging.warning("get_queue_url attempt %s failed: %r", attempt + 1, error)
+                logging.warning("create_queue attempt %s failed: %r", attempt + 1, error)
                 time.sleep(1)
                 client = self._make_boto_client()
-        raise AssertionError(f"get_queue_url failed for {self.queue_name}: {last_error!r}")
+        raise AssertionError(f"create_queue failed for {self.queue_name}: {last_error!r}")
 
-    @property
-    def queue_url(self):
+    def delete_queue(self):
         if self._queue_url is None:
-            return self.resolve_queue_url()
-        return self._queue_url
+            return
+        client = self._make_boto_client()
+        try:
+            client.delete_queue(QueueUrl=self._queue_url)
+        except Exception as error:
+            logging.error("Failed to delete queue %s: %r", self._queue_url, error)
 
     def run(self):
-        self.create_topic()
-        queue_url = self.resolve_queue_url()
+        queue_url = self.create_queue()
         stop_event = threading.Event()
         drain_event = threading.Event()
         lock = threading.Lock()
@@ -204,34 +215,58 @@ class BotoStressWorkload:
         def monitor_loop():
             monitor_driver = ydb.Driver(ydb.DriverConfig(self.endpoint, self.database))
             monitor_driver.wait(timeout=60)
-            last_committed = -1
-            last_progress_at = time.time()
+            last_committed_by_partition = {}
+            last_progress_at_by_partition = {}
+            monitor_started_at = time.time()
             try:
                 while not drain_event.is_set():
-                    written = get_written_messages_count(monitor_driver, self.topic_name)
-                    committed = get_committed_messages_count(
+                    partition_states = get_consumer_partition_states(
                         monitor_driver,
                         self.topic_name,
                         self.consumer,
                     )
                     with lock:
                         stats["describe_checks"] += 1
-                        committed_history.append((time.time(), written, committed, stats["sent"], stats["deleted"]))
+                        committed_history.append((
+                            time.time(),
+                            {
+                                partition_id: state._asdict()
+                                for partition_id, state in partition_states.items()
+                            },
+                            stats["sent"],
+                            stats["deleted"],
+                        ))
 
-                    if committed < last_committed:
-                        raise AssertionError(
-                            f"committed offset moved backwards: {last_committed} -> {committed}"
+                    now = time.time()
+                    for partition_id, state in partition_states.items():
+                        committed = state.committed_offset
+                        last_committed = last_committed_by_partition.get(partition_id, -1)
+
+                        if committed < last_committed:
+                            raise AssertionError(
+                                f"partition {partition_id} committed offset moved backwards: "
+                                f"{last_committed} -> {committed}"
+                            )
+                        if committed > last_committed:
+                            last_committed_by_partition[partition_id] = committed
+                            last_progress_at_by_partition[partition_id] = now
+
+                        if not partition_needs_committed_progress(state):
+                            continue
+
+                        last_progress_at = last_progress_at_by_partition.get(
+                            partition_id,
+                            monitor_started_at,
                         )
-                    if committed > last_committed:
-                        last_committed = committed
-                        last_progress_at = time.time()
-                    elif written > committed and time.time() - last_progress_at > COMMITTED_STALL_TIMEOUT_SECONDS:
-                        with lock:
-                            snapshot = dict(stats)
-                        raise AssertionError(
-                            "committed offset stalled while messages are still in the topic: "
-                            f"written={written} committed={committed} stats={snapshot}"
-                        )
+                        if now - last_progress_at > COMMITTED_STALL_TIMEOUT_SECONDS:
+                            with lock:
+                                snapshot = dict(stats)
+                            raise AssertionError(
+                                "partition committed offset stalled while messages are still in the topic: "
+                                f"partition={partition_id} active={state.active} "
+                                f"end={state.partition_end} committed={committed} stats={snapshot}"
+                            )
+
                     time.sleep(DESCRIBE_INTERVAL_SECONDS)
             finally:
                 monitor_driver.stop()
@@ -247,9 +282,9 @@ class BotoStressWorkload:
         monitor_thread = threading.Thread(target=monitor_loop, name="sqs-monitor", daemon=True)
 
         logging.info(
-            "Starting boto SQS stress for %s seconds: topic=%s workers=%s endpoint=%s",
+            "Starting boto SQS stress for %s seconds: queue=%s workers=%s endpoint=%s",
             self.duration,
-            self.topic_name,
+            self.queue_name,
             self.workers,
             self.sqs_endpoint,
         )
@@ -277,16 +312,24 @@ class BotoStressWorkload:
         monitor_thread.join(timeout=10)
 
         committed_deadline = time.time() + 30
-        committed = 0
+        partition_states = {}
         while time.time() < committed_deadline:
-            committed = get_committed_messages_count(self._driver, self.topic_name, self.consumer)
+            partition_states = get_consumer_partition_states(
+                self._driver,
+                self.topic_name,
+                self.consumer,
+            )
             with lock:
                 sent = stats["sent"]
-            if committed >= sent:
+            if sent > 0 and not any(
+                partition_needs_committed_progress(state)
+                for state in partition_states.values()
+            ):
                 break
             time.sleep(1)
 
-        written = get_written_messages_count(self._driver, self.topic_name)
+        written = sum(state.partition_end for state in partition_states.values())
+        committed = sum(state.committed_offset for state in partition_states.values())
 
         with lock:
             final_stats = dict(stats)
@@ -294,9 +337,11 @@ class BotoStressWorkload:
             history_tail = committed_history[-5:]
 
         logging.info(
-            "Boto SQS stress finished: written=%s committed=%s stats=%s history_tail=%s",
+            "Boto SQS stress finished: written=%s committed=%s partition_states=%s "
+            "stats=%s history_tail=%s",
             written,
             committed,
+            {pid: state._asdict() for pid, state in partition_states.items()},
             final_stats,
             history_tail,
         )
@@ -320,16 +365,14 @@ class BotoStressWorkload:
         assert final_stats["deleted"] == final_stats["sent"], (
             f"not all sent messages were read and committed: {final_stats}"
         )
-        assert committed >= final_stats["sent"], (
-            f"committed offset lagged behind sent messages: committed={committed} sent={final_stats['sent']}"
-        )
+        assert_partitions_committed_caught_up(partition_states, final_stats["sent"])
         assert written >= final_stats["sent"], (
             f"topic end offset lagged behind sent messages: written={written} sent={final_stats['sent']}"
         )
         assert not final_errors, f"worker errors: {final_errors[:10]}"
 
     def close(self):
-        self.drop_topic()
+        self.delete_queue()
         self._driver.stop()
 
     def __enter__(self):

--- a/ydb/tests/stress/sqs_topic/workload/boto_stress.py
+++ b/ydb/tests/stress/sqs_topic/workload/boto_stress.py
@@ -1,0 +1,339 @@
+import logging
+import threading
+import time
+import uuid
+
+import boto3
+import ydb
+from botocore.config import Config
+
+SQS_REGION = "ru-central1"
+SECURITY_TOKEN = "root@builtin"
+DEFAULT_CONSUMER = "ydb-sqs-consumer"
+DEFAULT_WORKERS = 20
+DEFAULT_DURATION_SECONDS = 5 * 60
+DESCRIBE_INTERVAL_SECONDS = 1
+COMMITTED_STALL_TIMEOUT_SECONDS = 10
+DRAIN_TIMEOUT_SECONDS = 120
+BOTO_CONFIG = Config(
+    connect_timeout=5,
+    read_timeout=20,
+    retries={"max_attempts": 3, "mode": "standard"},
+)
+
+
+def make_sqs_topic_queue_name(topic_name, consumer=DEFAULT_CONSUMER):
+    if consumer == DEFAULT_CONSUMER:
+        return topic_name
+    return f"{topic_name}@{consumer}"
+
+
+def get_written_messages_count(driver, topic_name):
+    describe = driver.topic_client.describe_topic(topic_name, include_stats=True)
+    return sum(p.partition_stats.partition_end for p in describe.partitions)
+
+
+def get_committed_messages_count(driver, topic_name, consumer=DEFAULT_CONSUMER):
+    describe = driver.topic_client.describe_consumer(topic_name, consumer, include_stats=True)
+    return sum(
+        p.partition_consumer_stats.committed_offset
+        for p in describe.partitions
+        if p.partition_consumer_stats is not None
+    )
+
+
+class BotoStressWorkload:
+    def __init__(
+        self,
+        endpoint,
+        database,
+        duration,
+        sqs_endpoint,
+        workers=DEFAULT_WORKERS,
+        consumer=DEFAULT_CONSUMER,
+    ):
+        self.endpoint = endpoint
+        self.database = database
+        self.duration = duration
+        self.sqs_endpoint = sqs_endpoint
+        self.workers = workers
+        self.consumer = consumer
+        self.topic_name = f"boto_stress_{uuid.uuid4().hex}"
+        self.queue_name = make_sqs_topic_queue_name(self.topic_name, consumer)
+        self._queue_url = None
+        self._driver = ydb.Driver(ydb.DriverConfig(endpoint, database))
+        self._driver.wait(timeout=60)
+
+    def _make_boto_client(self):
+        session = boto3.session.Session()
+        return session.client(
+            service_name="sqs",
+            aws_access_key_id="unused",
+            aws_secret_access_key="unused",
+            aws_session_token=SECURITY_TOKEN,
+            endpoint_url=self.sqs_endpoint,
+            region_name=SQS_REGION,
+            config=BOTO_CONFIG,
+        )
+
+    def create_topic(self):
+        with ydb.QuerySessionPool(self._driver) as session_pool:
+            session_pool.execute_with_retries(f"""
+                CREATE TOPIC `{self.topic_name}`
+                  (CONSUMER `{self.consumer}`
+                    WITH (
+                      type = 'shared',
+                      keep_messages_order = false,
+                      default_processing_timeout = Interval('PT30S')
+                    )
+                  );
+            """)
+
+    def drop_topic(self):
+        with ydb.QuerySessionPool(self._driver) as session_pool:
+            try:
+                session_pool.execute_with_retries(f"DROP TOPIC `{self.topic_name}`;")
+            except Exception as error:
+                logging.error("Failed to drop topic %s: %r", self.topic_name, error)
+
+    def resolve_queue_url(self):
+        client = self._make_boto_client()
+        last_error = None
+        for attempt in range(10):
+            try:
+                self._queue_url = client.get_queue_url(QueueName=self.queue_name)["QueueUrl"]
+                return self._queue_url
+            except Exception as error:
+                last_error = error
+                logging.warning("get_queue_url attempt %s failed: %r", attempt + 1, error)
+                time.sleep(1)
+                client = self._make_boto_client()
+        raise AssertionError(f"get_queue_url failed for {self.queue_name}: {last_error!r}")
+
+    @property
+    def queue_url(self):
+        if self._queue_url is None:
+            return self.resolve_queue_url()
+        return self._queue_url
+
+    def run(self):
+        self.create_topic()
+        queue_url = self.resolve_queue_url()
+        stop_event = threading.Event()
+        drain_event = threading.Event()
+        lock = threading.Lock()
+        stats = {
+            "sent": 0,
+            "deleted": 0,
+            "send_errors": 0,
+            "receive_errors": 0,
+            "delete_errors": 0,
+            "describe_checks": 0,
+        }
+        committed_history = []
+        errors = []
+
+        def record_error(where, error):
+            logging.exception("%s failed", where)
+            with lock:
+                errors.append(f"{where}: {error!r}")
+
+        def writer_loop(worker_id):
+            client = self._make_boto_client()
+            seq = 0
+            while not stop_event.is_set():
+                try:
+                    client.send_message(
+                        QueueUrl=queue_url,
+                        MessageBody=f"stress-{worker_id}-{seq}",
+                    )
+                    with lock:
+                        stats["sent"] += 1
+                    seq += 1
+                except Exception as error:
+                    with lock:
+                        stats["send_errors"] += 1
+                    record_error(f"writer-{worker_id}", error)
+                    client = self._make_boto_client()
+                    time.sleep(0.2)
+
+        def reader_loop(worker_id):
+            client = self._make_boto_client()
+            while True:
+                with lock:
+                    if stop_event.is_set() and stats["deleted"] >= stats["sent"]:
+                        return
+                try:
+                    response = client.receive_message(
+                        QueueUrl=queue_url,
+                        WaitTimeSeconds=1,
+                        MaxNumberOfMessages=10,
+                    )
+                    messages = response.get("Messages", [])
+                    if not messages:
+                        continue
+
+                    entries = []
+                    for index, message in enumerate(messages):
+                        entries.append({
+                            "Id": str(index),
+                            "ReceiptHandle": message["ReceiptHandle"],
+                        })
+                    delete_response = client.delete_message_batch(
+                        QueueUrl=queue_url,
+                        Entries=entries,
+                    )
+                    if delete_response.get("Failed"):
+                        with lock:
+                            stats["delete_errors"] += len(delete_response["Failed"])
+                        record_error(
+                            f"reader-{worker_id}",
+                            delete_response["Failed"],
+                        )
+                        continue
+
+                    with lock:
+                        stats["deleted"] += len(delete_response.get("Successful", []))
+                except Exception as error:
+                    with lock:
+                        stats["receive_errors"] += 1
+                    record_error(f"reader-{worker_id}", error)
+                    client = self._make_boto_client()
+                    time.sleep(0.2)
+
+        def monitor_loop():
+            monitor_driver = ydb.Driver(ydb.DriverConfig(self.endpoint, self.database))
+            monitor_driver.wait(timeout=60)
+            last_committed = -1
+            last_progress_at = time.time()
+            try:
+                while not drain_event.is_set():
+                    written = get_written_messages_count(monitor_driver, self.topic_name)
+                    committed = get_committed_messages_count(
+                        monitor_driver,
+                        self.topic_name,
+                        self.consumer,
+                    )
+                    with lock:
+                        stats["describe_checks"] += 1
+                        committed_history.append((time.time(), written, committed, stats["sent"], stats["deleted"]))
+
+                    if committed < last_committed:
+                        raise AssertionError(
+                            f"committed offset moved backwards: {last_committed} -> {committed}"
+                        )
+                    if committed > last_committed:
+                        last_committed = committed
+                        last_progress_at = time.time()
+                    elif written > committed and time.time() - last_progress_at > COMMITTED_STALL_TIMEOUT_SECONDS:
+                        with lock:
+                            snapshot = dict(stats)
+                        raise AssertionError(
+                            "committed offset stalled while messages are still in the topic: "
+                            f"written={written} committed={committed} stats={snapshot}"
+                        )
+                    time.sleep(DESCRIBE_INTERVAL_SECONDS)
+            finally:
+                monitor_driver.stop()
+
+        writer_threads = [
+            threading.Thread(target=writer_loop, args=(worker_id,), name=f"sqs-writer-{worker_id}", daemon=True)
+            for worker_id in range(self.workers)
+        ]
+        reader_threads = [
+            threading.Thread(target=reader_loop, args=(worker_id,), name=f"sqs-reader-{worker_id}", daemon=True)
+            for worker_id in range(self.workers)
+        ]
+        monitor_thread = threading.Thread(target=monitor_loop, name="sqs-monitor", daemon=True)
+
+        logging.info(
+            "Starting boto SQS stress for %s seconds: topic=%s workers=%s endpoint=%s",
+            self.duration,
+            self.topic_name,
+            self.workers,
+            self.sqs_endpoint,
+        )
+
+        for thread in writer_threads + reader_threads:
+            thread.start()
+        monitor_thread.start()
+
+        time.sleep(self.duration)
+        stop_event.set()
+
+        for thread in writer_threads:
+            thread.join(timeout=30)
+
+        drain_deadline = time.time() + DRAIN_TIMEOUT_SECONDS
+        while time.time() < drain_deadline:
+            with lock:
+                if stats["deleted"] >= stats["sent"] and stats["sent"] > 0:
+                    break
+            time.sleep(0.5)
+        drain_event.set()
+
+        for thread in reader_threads:
+            thread.join(timeout=30)
+        monitor_thread.join(timeout=10)
+
+        committed_deadline = time.time() + 30
+        committed = 0
+        while time.time() < committed_deadline:
+            committed = get_committed_messages_count(self._driver, self.topic_name, self.consumer)
+            with lock:
+                sent = stats["sent"]
+            if committed >= sent:
+                break
+            time.sleep(1)
+
+        written = get_written_messages_count(self._driver, self.topic_name)
+
+        with lock:
+            final_stats = dict(stats)
+            final_errors = list(errors)
+            history_tail = committed_history[-5:]
+
+        logging.info(
+            "Boto SQS stress finished: written=%s committed=%s stats=%s history_tail=%s",
+            written,
+            committed,
+            final_stats,
+            history_tail,
+        )
+
+        alive = [
+            thread.name
+            for thread in writer_threads + reader_threads + [monitor_thread]
+            if thread.is_alive()
+        ]
+        assert not alive, f"threads are still alive: {alive}"
+        assert final_stats["sent"] > 0, f"no messages were sent: {final_stats}"
+        assert final_stats["deleted"] > 0, f"no messages were deleted: {final_stats}"
+        assert final_stats["describe_checks"] > 0, f"topic was not described: {final_stats}"
+        assert final_stats["send_errors"] < final_stats["sent"], f"too many send errors: {final_stats}"
+        assert final_stats["receive_errors"] < final_stats["deleted"] + 100, (
+            f"too many receive errors: {final_stats}"
+        )
+        assert final_stats["delete_errors"] < final_stats["deleted"], (
+            f"too many delete errors: {final_stats}"
+        )
+        assert final_stats["deleted"] == final_stats["sent"], (
+            f"not all sent messages were read and committed: {final_stats}"
+        )
+        assert committed >= final_stats["sent"], (
+            f"committed offset lagged behind sent messages: committed={committed} sent={final_stats['sent']}"
+        )
+        assert written >= final_stats["sent"], (
+            f"topic end offset lagged behind sent messages: written={written} sent={final_stats['sent']}"
+        )
+        assert not final_errors, f"worker errors: {final_errors[:10]}"
+
+    def close(self):
+        self.drop_topic()
+        self._driver.stop()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/ydb/tests/stress/sqs_topic/workload/ya.make
+++ b/ydb/tests/stress/sqs_topic/workload/ya.make
@@ -2,6 +2,7 @@ PY3_LIBRARY()
 
 PY_SRCS(
     __init__.py
+    boto_stress.py
 )
 BUNDLE(
     ydb/apps/ydb NAME ydb_cli
@@ -10,6 +11,8 @@ RESOURCE(ydb_cli ydb_cli)
 PEERDIR(
     ydb/tests/stress/common
 
+    contrib/python/boto3
+    contrib/python/botocore
     library/python/monlib
     library/python/resource
     ydb/public/sdk/python


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed a bug where an MLP consumer partition could stop processing requests: reads and commits stayed in the internal queue until the client deadline (`RequestExpired` for SQS over topics), and the partition recovered only after a tablet restart.

### Description for reviewers <!-- (optional) description for those who read this PR -->

#### Problem

`ProcessingScheduled` guards the `Processing` wakeup, which is what calls `ProcessEventQueue()` and therefore the only way queued read/commit/unlock requests get applied. The flag was reset in `HandleOnWork` only, i.e. in `StateWork`. In `StateInit` and `StateWrite` `TEvWakeup` was routed to `Handle()`, which treated every tag as `Regular`: it did not reset the flag and, on top of that, scheduled one more `Regular` timer.

The usual sequence looked like this:

1. `Regular` wakeup → `ProcessEventQueue()` → `Persist()` → `Become(StateWrite)`;
2. `ScheduleProcessing()` in the same turn set the flag and scheduled a `Processing` wakeup;
3. that wakeup arrived while the consumer was still in `StateWrite` and was swallowed, so the flag stayed `true` forever;
4. every later `ScheduleProcessing()` became a no-op, so nothing ever drained the queue again.

From the outside the consumer looked healthy: the partition stayed in `StateWork`, reads piled up in `ReadRequestsQueue` and were answered only by the HTTP proxy 60s deadline, while the monitoring page still showed unprocessed messages because the lock is taken in `ProcessEventQueue()`.

#### Fix

* one `Handle(TEvents::TEvWakeup)` for all three states with an explicit branch per tag, `HandleOnWork` removed;
* the `Processing` branch always resets `ProcessingScheduled`, and drains the queue only in `StateWork`, so a wakeup consumed in a non-work state can no longer leave the flag set;
* `ScheduleProcessing()` returns early outside `StateWork`, so it never arms a wakeup that is going to be swallowed; the duplicated `if (CurrentStateFunc() == StateWork)` checks around the call sites are gone;
* `TStorage` takes `TAppData::TimeProvider` instead of its own `CreateDefaultTimeProvider()`, so storage deadlines (visibility timeout, vacuum, retention) use the same clock as the rest of the consumer and follow simulated time in tests.

#### Tests

New suite `TMLPConsumerWakeupTests` (`mlp_consumer_wakeup_ut.cpp`, 9 tests) reproduces the original race and covers requests queued during a KV write, delayed and stale `Processing` wakeups, a delayed fetch, and a `Regular` tick during a write. Every test additionally asserts that the queue keeps being processed afterwards: a later read or commit must still be applied and persisted.

Full run of `ydb/core/persqueue/pqtablet/partition/mlp` and `ydb/core/persqueue/public/mlp`: 343 tests, all GOOD.
