### PR TITLE
kqp: fix infinite SCHEME_CHANGED retry loop in InconsistentTx write actor

### DIFF
--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -1100,14 +1100,9 @@ public:
                 {"shardID", ev->Get()->Record.GetOrigin()},
                 {"sink", this->SelfId()},
                 {"issues", getIssues().ToOneLineString()});
-            // For InconsistentTx the schema version is baked into every
-            // TEvWrite at Open() time and is NOT refreshed by a successful
-            // TEvResolveKeySet round-trip.  Retrying only causes the
-            // datashard to return SCHEME_CHANGED again on the very next write,
-            // producing an infinite loop.  Surface the error so the session
-            // actor invalidates the compiled query and re-plans with the new
-            // schema.  The same RuntimeError path is already taken for the
-            // non-InconsistentTx case; unify both branches here.
+            // Schema version is baked into TEvWrite at Open() time and is not
+            // refreshed by resolve, so retrying InconsistentTx writes loops forever.
+            // Surface the error so the session actor recompiles.
             if (!InconsistentTx) {
                 UpdateStats(ev->Get()->Record.GetTxStats());
                 TxManager->SetError(ev->Get()->Record.GetOrigin());

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -1100,9 +1100,7 @@ public:
                 {"shardID", ev->Get()->Record.GetOrigin()},
                 {"sink", this->SelfId()},
                 {"issues", getIssues().ToOneLineString()});
-            // Schema version is baked into TEvWrite at Open() time and is not
-            // refreshed by resolve, so retrying InconsistentTx writes loops forever.
-            // Surface the error so the session actor recompiles.
+            // Resolve does not refresh the baked-in schema version: fail to recompile instead of retrying forever.
             if (!InconsistentTx) {
                 UpdateStats(ev->Get()->Record.GetTxStats());
                 TxManager->SetError(ev->Get()->Record.GetOrigin());

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -1100,19 +1100,24 @@ public:
                 {"shardID", ev->Get()->Record.GetOrigin()},
                 {"sink", this->SelfId()},
                 {"issues", getIssues().ToOneLineString()});
-            if (InconsistentTx) {
-                ResetShardRetries(ev->Get()->Record.GetOrigin(), ev->Cookie);
-                RetryResolve();
-            } else {
+            // For InconsistentTx the schema version is baked into every
+            // TEvWrite at Open() time and is NOT refreshed by a successful
+            // TEvResolveKeySet round-trip.  Retrying only causes the
+            // datashard to return SCHEME_CHANGED again on the very next write,
+            // producing an infinite loop.  Surface the error so the session
+            // actor invalidates the compiled query and re-plans with the new
+            // schema.  The same RuntimeError path is already taken for the
+            // non-InconsistentTx case; unify both branches here.
+            if (!InconsistentTx) {
                 UpdateStats(ev->Get()->Record.GetTxStats());
                 TxManager->SetError(ev->Get()->Record.GetOrigin());
-                RuntimeError(
-                    NYql::NDqProto::StatusIds::SCHEME_ERROR,
-                    NYql::TIssuesIds::KIKIMR_SCHEME_MISMATCH,
-                    TStringBuilder() << "Scheme changed. Table: `"
-                        << TablePath << "`.",
-                    getIssues());
             }
+            RuntimeError(
+                NYql::NDqProto::StatusIds::SCHEME_ERROR,
+                NYql::TIssuesIds::KIKIMR_SCHEME_MISMATCH,
+                TStringBuilder() << "Scheme changed. Table: `"
+                    << TablePath << "`.",
+                getIssues());
             return;
         }
         case NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN: {

--- a/ydb/core/kqp/ut/tx/kqp_sink_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_sink_tx_ut.cpp
@@ -708,27 +708,11 @@ Y_UNIT_TEST_SUITE(KqpSinkTx) {
         tester.Execute();
     }
 
-    // Regression test for the SCHEME_CHANGED infinite-retry bug (InconsistentTx path).
-    //
-    // Streaming/YQ writes use InconsistentTx=true, set when the optimizer sees
-    // IsStreamingQuery=true in the user request context.  With the bug, a
-    // concurrent ALTER TABLE caused an infinite loop:
-    //
-    //   datashard returns STATUS_SCHEME_CHANGED
-    //   → InconsistentTx branch calls RetryResolve()
-    //   → TEvResolveKeySetResult SUCCESS: Prepare() resets ResolveAttempts=0
-    //   → next TEvWrite carries the same stale schema version (baked at Open()
-    //     time, not refreshed by resolve)
-    //   → datashard returns SCHEME_CHANGED again → …
-    //
-    // The fix unifies both branches so that SCHEME_CHANGED always calls
-    // RuntimeError(SCHEME_ERROR, KIKIMR_SCHEME_MISMATCH), letting the session
-    // actor invalidate and re-plan with the new schema.
-    //
-    // To drive InconsistentTx=true through the standard KQP stack we inject
-    // IsStreamingQuery=true into the TUserRequestContext of the query request
-    // inside the observer.  The optimizer then adds AllowInconsistentWrites to
-    // the write sink, which maps to InconsistentTx=true in the write actor.
+    // Regression test: InconsistentTx (streaming) writes looped forever on
+    // STATUS_SCHEME_CHANGED after a concurrent ALTER TABLE, because the stale
+    // schema version baked into TEvWrite is never refreshed by resolve.
+    // IsStreamingQuery=true is injected into the request context so the sink
+    // compiles with InconsistentTx=true.
     class TSchemeChangedDuringInconsistentWrite : public TTableDataModificationTester {
     protected:
         void DoExecute() override {

--- a/ydb/core/kqp/ut/tx/kqp_sink_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_sink_tx_ut.cpp
@@ -728,10 +728,7 @@ Y_UNIT_TEST_SUITE(KqpSinkTx) {
             bool queryRequestPatched = false;
 
             auto grab = [&](TAutoPtr<IEventHandle>& ev) -> TTestActorRuntime::EEventAction {
-                // Patch the first TEvQueryRequest to inject IsStreamingQuery=true.
-                // This causes the optimizer to emit AllowInconsistentWrites in the
-                // write sink settings, which maps to InconsistentTx=true in the
-                // write actor — the exact path where the bug lived.
+                // IsStreamingQuery=true makes the sink compile with InconsistentTx=true.
                 if (!queryRequestPatched &&
                     ev->GetTypeRewrite() == TEvKqp::TEvQueryRequest::EventType)
                 {

--- a/ydb/core/kqp/ut/tx/kqp_sink_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_sink_tx_ut.cpp
@@ -5,6 +5,9 @@
 #include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
 #include <ydb/core/tx/columnshard/hooks/testing/controller.h>
 #include <ydb/core/tx/datashard/datashard.h>
+#include <ydb/core/tx/data_events/events.h>
+#include <ydb/core/kqp/common/events/events.h>
+#include <ydb/core/kqp/common/kqp_user_request_context.h>
 
 namespace NKikimr {
 namespace NKqp {
@@ -701,6 +704,132 @@ Y_UNIT_TEST_SUITE(KqpSinkTx) {
     Y_UNIT_TEST(UncommittedWriteSeqNumAnsweredTwice) {
         TUncommittedWriteSeqNumAnsweredTwice tester;
         tester.SetIsOlap(false);
+        tester.SetUseRealThreads(false);
+        tester.Execute();
+    }
+
+    // Regression test for the SCHEME_CHANGED infinite-retry bug (InconsistentTx path).
+    //
+    // Streaming/YQ writes use InconsistentTx=true, set when the optimizer sees
+    // IsStreamingQuery=true in the user request context.  With the bug, a
+    // concurrent ALTER TABLE caused an infinite loop:
+    //
+    //   datashard returns STATUS_SCHEME_CHANGED
+    //   → InconsistentTx branch calls RetryResolve()
+    //   → TEvResolveKeySetResult SUCCESS: Prepare() resets ResolveAttempts=0
+    //   → next TEvWrite carries the same stale schema version (baked at Open()
+    //     time, not refreshed by resolve)
+    //   → datashard returns SCHEME_CHANGED again → …
+    //
+    // The fix unifies both branches so that SCHEME_CHANGED always calls
+    // RuntimeError(SCHEME_ERROR, KIKIMR_SCHEME_MISMATCH), letting the session
+    // actor invalidate and re-plan with the new schema.
+    //
+    // To drive InconsistentTx=true through the standard KQP stack we inject
+    // IsStreamingQuery=true into the TUserRequestContext of the query request
+    // inside the observer.  The optimizer then adds AllowInconsistentWrites to
+    // the write sink, which maps to InconsistentTx=true in the write actor.
+    class TSchemeChangedDuringInconsistentWrite : public TTableDataModificationTester {
+    protected:
+        void DoExecute() override {
+            auto& runtime = *Kikimr->GetTestServer().GetRuntime();
+            auto client = Kikimr->GetQueryClient();
+
+            // UseRealThreads=false requires GetSession() through RunCall.
+            auto session1 = Kikimr->RunCall([&] {
+                return client.GetSession().GetValueSync().GetSession();
+            });
+            auto session2 = Kikimr->RunCall([&] {
+                return client.GetSession().GetValueSync().GetSession();
+            });
+
+            std::atomic<size_t> evWriteCount{0};
+            std::vector<std::unique_ptr<IEventHandle>> held;
+            bool queryRequestPatched = false;
+
+            auto grab = [&](TAutoPtr<IEventHandle>& ev) -> TTestActorRuntime::EEventAction {
+                // Patch the first TEvQueryRequest to inject IsStreamingQuery=true.
+                // This causes the optimizer to emit AllowInconsistentWrites in the
+                // write sink settings, which maps to InconsistentTx=true in the
+                // write actor — the exact path where the bug lived.
+                if (!queryRequestPatched &&
+                    ev->GetTypeRewrite() == TEvKqp::TEvQueryRequest::EventType)
+                {
+                    queryRequestPatched = true;
+                    auto* req = ev->Get<TEvKqp::TEvQueryRequest>();
+                    auto userCtx = MakeIntrusive<TUserRequestContext>("", "/Root", "");
+                    userCtx->IsStreamingQuery = true;
+                    req->SetUserRequestContext(std::move(userCtx));
+                    return TTestActorRuntime::EEventAction::PROCESS;
+                }
+                // Hold TEvWrite events so we can ALTER TABLE before the write lands.
+                if (ev->GetTypeRewrite() == NKikimr::NEvents::TDataEvents::TEvWrite::EventType) {
+                    ++evWriteCount;
+                    held.emplace_back(ev.Release());
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+                return TTestActorRuntime::EEventAction::PROCESS;
+            };
+
+            auto savedObserver = runtime.SetObserverFunc(grab);
+            Y_DEFER { runtime.SetObserverFunc(savedObserver); };
+
+            // Start the write in the background; it will block once TEvWrite
+            // is intercepted.
+            auto future = Kikimr->RunInThreadPool([&] {
+                return session1.ExecuteQuery(
+                    Q_(R"(UPSERT INTO `/Root/KV` (Key, Value) VALUES (42u, "test");)"),
+                    TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()
+                ).ExtractValueSync();
+            });
+
+            // Wait until at least one TEvWrite is in our hands.
+            {
+                TDispatchOptions opts;
+                opts.FinalEvents.emplace_back([&](IEventHandle&) {
+                    return evWriteCount > 0;
+                });
+                runtime.DispatchEvents(opts);
+                UNIT_ASSERT_C(evWriteCount > 0, "TEvWrite was not intercepted");
+            }
+
+            // Alter the table while the write is held.  This bumps the schema
+            // version on the datashard so the stale write will get SCHEME_CHANGED.
+            auto alterResult = Kikimr->RunCall([&] {
+                return session2.ExecuteQuery(
+                    Q_(R"(ALTER TABLE `/Root/KV` ADD COLUMN Extra String;)"),
+                    TTxControl::NoTx()
+                ).ExtractValueSync();
+            });
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                alterResult.GetStatus(), EStatus::SUCCESS,
+                alterResult.GetIssues().ToString());
+
+            // Release all held writes.  The datashard sees a stale schema version
+            // and returns STATUS_SCHEME_CHANGED.
+            for (auto& ev : held) {
+                runtime.Send(ev.release());
+            }
+            held.clear();
+
+            // After the fix: RuntimeError(SCHEME_ERROR, KIKIMR_SCHEME_MISMATCH)
+            // is called; session actor converts it to ABORTED.
+            // Before the fix: RetryResolve() → infinite loop → test would hang.
+            auto result = runtime.WaitFuture(future, TDuration::Seconds(30));
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                result.GetStatus(), EStatus::ABORTED,
+                result.GetIssues().ToString());
+            UNIT_ASSERT_C(
+                result.GetIssues().ToString().contains("Scheme changed"),
+                TStringBuilder() << "Expected scheme-mismatch issue, got: "
+                    << result.GetIssues().ToString());
+        }
+    };
+
+    Y_UNIT_TEST(SchemeChangedDuringInconsistentWrite) {
+        TSchemeChangedDuringInconsistentWrite tester;
+        tester.SetIsOlap(false);
+        tester.SetFillTables(false);
         tester.SetUseRealThreads(false);
         tester.Execute();
     }

--- a/ydb/core/kqp/ut/tx/kqp_sink_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_sink_tx_ut.cpp
@@ -739,7 +739,6 @@ Y_UNIT_TEST_SUITE(KqpSinkTx) {
                     req->SetUserRequestContext(std::move(userCtx));
                     return TTestActorRuntime::EEventAction::PROCESS;
                 }
-                // Hold TEvWrite events so we can ALTER TABLE before the write lands.
                 if (ev->GetTypeRewrite() == NKikimr::NEvents::TDataEvents::TEvWrite::EventType) {
                     ++evWriteCount;
                     held.emplace_back(ev.Release());
@@ -751,8 +750,6 @@ Y_UNIT_TEST_SUITE(KqpSinkTx) {
             auto savedObserver = runtime.SetObserverFunc(grab);
             Y_DEFER { runtime.SetObserverFunc(savedObserver); };
 
-            // Start the write in the background; it will block once TEvWrite
-            // is intercepted.
             auto future = Kikimr->RunInThreadPool([&] {
                 return session1.ExecuteQuery(
                     Q_(R"(UPSERT INTO `/Root/KV` (Key, Value) VALUES (42u, "test");)"),
@@ -760,7 +757,6 @@ Y_UNIT_TEST_SUITE(KqpSinkTx) {
                 ).ExtractValueSync();
             });
 
-            // Wait until at least one TEvWrite is in our hands.
             {
                 TDispatchOptions opts;
                 opts.FinalEvents.emplace_back([&](IEventHandle&) {
@@ -770,8 +766,6 @@ Y_UNIT_TEST_SUITE(KqpSinkTx) {
                 UNIT_ASSERT_C(evWriteCount > 0, "TEvWrite was not intercepted");
             }
 
-            // Alter the table while the write is held.  This bumps the schema
-            // version on the datashard so the stale write will get SCHEME_CHANGED.
             auto alterResult = Kikimr->RunCall([&] {
                 return session2.ExecuteQuery(
                     Q_(R"(ALTER TABLE `/Root/KV` ADD COLUMN Extra String;)"),
@@ -782,16 +776,11 @@ Y_UNIT_TEST_SUITE(KqpSinkTx) {
                 alterResult.GetStatus(), EStatus::SUCCESS,
                 alterResult.GetIssues().ToString());
 
-            // Release all held writes.  The datashard sees a stale schema version
-            // and returns STATUS_SCHEME_CHANGED.
             for (auto& ev : held) {
                 runtime.Send(ev.release());
             }
             held.clear();
 
-            // After the fix: RuntimeError(SCHEME_ERROR, KIKIMR_SCHEME_MISMATCH)
-            // is called; session actor converts it to ABORTED.
-            // Before the fix: RetryResolve() → infinite loop → test would hang.
             auto result = runtime.WaitFuture(future, TDuration::Seconds(30));
             UNIT_ASSERT_VALUES_EQUAL_C(
                 result.GetStatus(), EStatus::ABORTED,

--- a/ydb/core/kqp/ut/tx/kqp_sink_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_sink_tx_ut.cpp
@@ -708,11 +708,7 @@ Y_UNIT_TEST_SUITE(KqpSinkTx) {
         tester.Execute();
     }
 
-    // Regression test: InconsistentTx (streaming) writes looped forever on
-    // STATUS_SCHEME_CHANGED after a concurrent ALTER TABLE, because the stale
-    // schema version baked into TEvWrite is never refreshed by resolve.
-    // IsStreamingQuery=true is injected into the request context so the sink
-    // compiles with InconsistentTx=true.
+    // ALTER TABLE during an in-flight InconsistentTx write must fail the query, not retry forever.
     class TSchemeChangedDuringInconsistentWrite : public TTableDataModificationTester {
     protected:
         void DoExecute() override {


### PR DESCRIPTION
Issue YQ-5669

### Changelog category

* Bugfix

### Description for reviewers

Fixes an infinite retry loop in the KQP write actor for `InconsistentTx` (streaming/YQ) writes after a schema operation in the database.

- (-) **Unify `STATUS_SCHEME_CHANGED` handling**: the `InconsistentTx` branch called `RetryResolve()`, but the schema version is baked into every `TEvWrite` at `Open()` time and is not refreshed by resolve — the datashard rejected the next write again, forever, and no error ever reached the session actor. Both branches now surface `RuntimeError(SCHEME_ERROR, KIKIMR_SCHEME_MISMATCH)`, so the session actor invalidates the plan and the retried execution recompiles against the new schema.
- (-) The trigger is not limited to the sink table: any scheme operation in the database invalidates scheme caches broadly. Observed on a 3-node cluster — `DROP TABLE` of an unrelated, abandoned table stopped all 77 running streaming queries writing to a different table. In `.sys/streaming_queries` they stay `RUNNING` with `RetryCount` frozen and `Issues` empty, while no new rows reach the target table and the Logbroker consumer shows no reads. Recovery requires dropping and recreating every query.
- (=) Shard splits/merges are unaffected: they emit `STATUS_WRONG_SHARD_STATE` (not `SCHEME_CHANGED`) and keep the resolve/retry path.
- (=) Complements b63a7a27ce9 (YQ-5172), which capped only the resolve-error path (dropped table); the case where resolve succeeds with a stale version is the one fixed here.

Test in `kqp/ut/tx/kqp_sink_tx_ut.cpp`: `SchemeChangedDuringWrite` — drives a genuine `InconsistentTx=true` write (injects `IsStreamingQuery=true` into the request context), ALTERs the table around an intercepted `TEvWrite`, asserts bounded `ABORTED` + "Scheme changed" instead of a hang. Verified to fail (bounded) with the actor change reverted and pass with it applied.
