### PR TITLE
fix reporting outdated dead tablets to whiteboard

### DIFF
--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -58,10 +58,11 @@ void TTablet::SendFollowerAttach(const TActorId& leader) {
 
 void TTablet::ReportTabletStateChange(ETabletState state) {
     const TActorId tabletStateServiceId = NNodeWhiteboard::MakeNodeWhiteboardServiceId(SelfId().NodeId());
+    const ui32 generation = ActualGeneration ? ActualGeneration : SuggestedGeneration;
     if (state == TTabletStateInfo::Created || state == TTabletStateInfo::ResolveLeader) {
-        Send(tabletStateServiceId, new NNodeWhiteboard::TEvWhiteboard::TEvTabletStateUpdate(TabletID(), FollowerId, state, Info, StateStorageInfo.KnownGeneration, Leader));
+        Send(tabletStateServiceId, new NNodeWhiteboard::TEvWhiteboard::TEvTabletStateUpdate(TabletID(), FollowerId, state, Info, generation, Leader));
     } else {
-        Send(tabletStateServiceId, new NNodeWhiteboard::TEvWhiteboard::TEvTabletStateUpdate(TabletID(), FollowerId, state, StateStorageInfo.KnownGeneration));
+        Send(tabletStateServiceId, new NNodeWhiteboard::TEvWhiteboard::TEvTabletStateUpdate(TabletID(), FollowerId, state, generation));
     }
 }
 
@@ -976,6 +977,7 @@ void TTablet::HandleStateStorageInfoUpgrade(TEvStateStorage::TEvInfo::TPtr &ev) 
         { // ok, we marked ourselves as generation owner
             NeedCleanupOnLockedPath = false;
             StateStorageInfo.Update(msg);
+            ActualGeneration = StateStorageInfo.KnownGeneration;
             for (const auto& followerInfo : msg->Followers) {
                 if (followerInfo.Follower == SelfId())
                     continue;
@@ -2504,6 +2506,7 @@ TTablet::TTablet(const TActorId &launcher, TTabletStorageInfo *info, TTabletSetu
     , Info(info)
     , SetupInfo(setupInfo)
     , SuggestedGeneration(suggestedGeneration)
+    , ActualGeneration(0)
     , NeedCleanupOnLockedPath(false)
     , GcCounter(0)
     , PipeConnectAcceptor(NTabletPipe::CreateConnectAcceptor(info->TabletID))

--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -1,4 +1,6 @@
 
+#include "tablet_sys.h"
+
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/hive.h>
 #include <ydb/core/base/tablet_pipecache.h>
@@ -2103,7 +2105,8 @@ bool TTablet::StopTablet(
                 FollowerStStGuardian = { };
             }
 
-            ReportTabletStateChange(TTabletStateInfo::Terminating, ActualGeneration);
+            const ui32 reportGeneration = ActualGeneration ? ActualGeneration : SuggestedGeneration;
+            ReportTabletStateChange(TTabletStateInfo::Terminating, reportGeneration);
             SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::StateTerminating);
         }
 

--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -1,5 +1,3 @@
-#include "tablet_sys.h"
-#include "tablet_tracing_signals.h"
 
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/hive.h>
@@ -56,9 +54,8 @@ void TTablet::SendFollowerAttach(const TActorId& leader) {
     }
 }
 
-void TTablet::ReportTabletStateChange(ETabletState state) {
+void TTablet::ReportTabletStateChange(ETabletState state, ui32 generation) {
     const TActorId tabletStateServiceId = NNodeWhiteboard::MakeNodeWhiteboardServiceId(SelfId().NodeId());
-    const ui32 generation = ActualGeneration ? ActualGeneration : SuggestedGeneration;
     if (state == TTabletStateInfo::Created || state == TTabletStateInfo::ResolveLeader) {
         Send(tabletStateServiceId, new NNodeWhiteboard::TEvWhiteboard::TEvTabletStateUpdate(TabletID(), FollowerId, state, Info, generation, Leader));
     } else {
@@ -88,7 +85,7 @@ void TTablet::PromoteToCandidate(ui32 gen) {
     Send(StateStorageInfo.ProxyID, new TEvStateStorage::TEvUpdate(TabletID(), 0, SelfId(), UserTablet, StateStorageInfo.KnownGeneration, 0, StateStorageInfo.Signature, TEvStateStorage::TProxyOptions::SigAsync));
 
     Become(&TThis::StateBecomeCandidate);
-    ReportTabletStateChange(TTabletStateInfo::Candidate);
+    ReportTabletStateChange(TTabletStateInfo::Candidate, StateStorageInfo.KnownGeneration);
 }
 
 void TTablet::TabletBlockBlobStorage() {
@@ -102,7 +99,7 @@ void TTablet::TabletBlockBlobStorage() {
     }
 
     Become(&TThis::StateBlockBlobStorage);
-    ReportTabletStateChange(TTabletStateInfo::BlockBlobStorage);
+    ReportTabletStateChange(TTabletStateInfo::BlockBlobStorage, StateStorageInfo.KnownGeneration);
 }
 
 void TTablet::TabletRebuildGraph() {
@@ -122,7 +119,7 @@ void TTablet::TabletRebuildGraph() {
     }
 
     Become(&TThis::StateRebuildGraph);
-    ReportTabletStateChange(TTabletStateInfo::RebuildGraph);
+    ReportTabletStateChange(TTabletStateInfo::RebuildGraph, StateStorageInfo.KnownGeneration);
 }
 
 void TTablet::WriteZeroEntry(TEvTablet::TDependencyGraph *graph) {
@@ -233,7 +230,7 @@ void TTablet::WriteZeroEntry(TEvTablet::TDependencyGraph *graph) {
         {"marker", "TSYS01"});
 
     Become(&TThis::StateWriteZeroEntry);
-    ReportTabletStateChange(TTabletStateInfo::WriteZeroEntry);
+    ReportTabletStateChange(TTabletStateInfo::WriteZeroEntry, StateStorageInfo.KnownGeneration);
 }
 
 void TTablet::StartActivePhase() {
@@ -244,7 +241,7 @@ void TTablet::StartActivePhase() {
     Send(UserTablet, new TEvTablet::TEvRestored(TabletID(), StateStorageInfo.KnownGeneration, UserTablet, false));
 
     Become(&TThis::StateActivePhase);
-    ReportTabletStateChange(TTabletStateInfo::Restored);
+    ReportTabletStateChange(TTabletStateInfo::Restored, StateStorageInfo.KnownGeneration);
 
     StateStorageGuardian = Register(CreateStateStorageTabletGuardian(TabletID(), SelfId(), UserTablet, StateStorageInfo.KnownGeneration));
 
@@ -953,7 +950,7 @@ void TTablet::HandleStateStorageInfoLock(TEvStateStorage::TEvInfo::TPtr &ev) {
 
             Register(CreateTabletFindLastEntry(SelfId(), false, Info.Get(), 0, Leader));
             Become(&TThis::StateDiscover);
-            ReportTabletStateChange(TTabletStateInfo::Discover);
+            ReportTabletStateChange(TTabletStateInfo::Discover, StateStorageInfo.KnownGeneration);
         }
         return;
     case NKikimrProto::ERROR:
@@ -1140,7 +1137,7 @@ void TTablet::Handle(TEvTablet::TEvPing::TPtr &ev) {
 void TTablet::HandleByLeader(TEvTablet::TEvTabletActive::TPtr &ev) {
     auto *msg = ev->Get();
     TabletVersionInfo = std::move(msg->VersionInfo);
-    ReportTabletStateChange(TTabletStateInfo::Active);
+    ReportTabletStateChange(TTabletStateInfo::Active, StateStorageInfo.KnownGeneration);
     Send(Launcher, new TEvTablet::TEvReady(TabletID(), StateStorageInfo.KnownGeneration, UserTablet));
     ActivateTime = AppData()->TimeProvider->Now();
     YDB_LOG_INFO("TTablet::Activate: tablet became active",
@@ -1164,7 +1161,7 @@ void TTablet::HandleByFollower(TEvTablet::TEvTabletActive::TPtr &ev) {
     PipeConnectAcceptor->Activate(SelfId(), UserTablet, false, StateStorageInfo.KnownGeneration, TabletVersionInfo);
 
     Send(FollowerStStGuardian, new TEvTablet::TEvFollowerUpdateState(false, SelfId(), UserTablet));
-    ReportTabletStateChange(TTabletStateInfo::Active);
+    ReportTabletStateChange(TTabletStateInfo::Active, StateStorageInfo.KnownGeneration);
     SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::StateActive);
 }
 
@@ -2106,7 +2103,7 @@ bool TTablet::StopTablet(
                 FollowerStStGuardian = { };
             }
 
-            ReportTabletStateChange(TTabletStateInfo::Terminating);
+            ReportTabletStateChange(TTabletStateInfo::Terminating, ActualGeneration);
             SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::StateTerminating);
         }
 
@@ -2212,7 +2209,7 @@ void TTablet::CancelTablet(TEvTablet::TEvTabletDead::EReason reason, const TStri
     if (NeedCleanupOnLockedPath)
         Send(StateStorageInfo.ProxyID, new TEvStateStorage::TEvCleanup(TabletID(), SelfId()));
 
-    ReportTabletStateChange(TTabletStateInfo::Dead);
+    ReportTabletStateChange(TTabletStateInfo::Dead, reportedGeneration);
     SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::StateDead);
     TabletStateSubscribers.clear();
 
@@ -2407,14 +2404,14 @@ void TTablet::LockedInitializationPath() {
 
     NeedCleanupOnLockedPath = true;
     Become(&TThis::StateLock);
-    ReportTabletStateChange(TTabletStateInfo::Lock);
+    ReportTabletStateChange(TTabletStateInfo::Lock, StateStorageInfo.KnownGeneration);
 }
 
 void TTablet::StartRecovery() {
     Become(&TThis::StateRecovery);
     PipeConnectAcceptor->Activate(SelfId(), UserTablet, true, StateStorageInfo.KnownGeneration, TabletVersionInfo);
 
-    ReportTabletStateChange(TTabletStateInfo::Active);
+    ReportTabletStateChange(TTabletStateInfo::Active, StateStorageInfo.KnownGeneration);
     SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::StateActive);
 }
 
@@ -2437,7 +2434,7 @@ void TTablet::Handle(TEvTablet::TEvCompleteRecoveryBoot::TPtr& ev) {
         Register(CreateTabletReqWriteLog(SelfId(), logid, entry.Release(), refs, TEvBlobStorage::TEvPut::TacticMinLatency,
             Info.Get(), Relevance, /*isZeroEntry=*/ false));
 
-        ReportTabletStateChange(TTabletStateInfo::WriteZeroEntry);
+        ReportTabletStateChange(TTabletStateInfo::WriteZeroEntry, StateStorageInfo.KnownGeneration);
 
         // Boot tablet with empty graph
         auto graph = MakeIntrusive<TEvTablet::TDependencyGraph>(std::pair<ui32, ui32>(0, 0));
@@ -2540,7 +2537,7 @@ TAutoPtr<IEventHandle> TTablet::AfterRegister(const TActorId &self, const TActor
 
 void TTablet::RetryFollowerBootstrapOrWait() {
     if (FollowerInfo.RetryRound) {
-        ReportTabletStateChange(TTabletStateInfo::ResolveLeader);
+        ReportTabletStateChange(TTabletStateInfo::ResolveLeader, Max(SuggestedGeneration, StateStorageInfo.KnownGeneration));
 
         TActivationContext::Schedule(TDuration::MilliSeconds(2000), new IEventHandle(
             SelfId(), SelfId(),
@@ -2574,7 +2571,7 @@ void TTablet::BootstrapFollower() {
     }
 
     Become(&TThis::StateResolveLeader);
-    ReportTabletStateChange(TTabletStateInfo::ResolveLeader);
+    ReportTabletStateChange(TTabletStateInfo::ResolveLeader, SuggestedGeneration);
 }
 
 void TTablet::Bootstrap() {
@@ -2585,7 +2582,7 @@ void TTablet::Bootstrap() {
     if (enInt) {
         IntrospectionTrace.Reset(NTracing::CreateTrace(NTracing::ITrace::TypeSysTabletBootstrap));
     }
-    ReportTabletStateChange(TTabletStateInfo::Created); // useless?
+    ReportTabletStateChange(TTabletStateInfo::Created, SuggestedGeneration); // useless?
     StateStorageInfo.ProxyID = MakeStateStorageProxyID();
     Send(StateStorageInfo.ProxyID, new TEvStateStorage::TEvLookup(TabletID(), 0, TEvStateStorage::TProxyOptions(TEvStateStorage::TProxyOptions::SigAsync)));
     if (IntrospectionTrace) {
@@ -2595,7 +2592,7 @@ void TTablet::Bootstrap() {
     PipeConnectAcceptor->Detach(SelfId());
     SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::StateBooting);
     Become(&TThis::StateResolveStateStorage);
-    ReportTabletStateChange(TTabletStateInfo::ResolveStateStorage);
+    ReportTabletStateChange(TTabletStateInfo::ResolveStateStorage, SuggestedGeneration);
 }
 
 void TTablet::ExternalWriteZeroEntry(TTabletStorageInfo *info, ui32 gen, TActorIdentity owner, TMessageRelevanceWatcher relevance) {

--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -1,5 +1,5 @@
-
 #include "tablet_sys.h"
+#include "tablet_tracing_signals.h"
 
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/hive.h>
@@ -321,6 +321,7 @@ void TTablet::HandleStateStorageLeaderResolve(TEvStateStorage::TEvInfo::TPtr &ev
     StateStorageInfo.KnownStep = msg->CurrentStep;
 
     if (msg->Status == NKikimrProto::OK && msg->CurrentLeader) {
+        ActualGeneration = msg->CurrentGeneration;
         SendFollowerAttach(msg->CurrentLeader);
 
         Become(&TThis::StateFollowerSubscribe);
@@ -2574,7 +2575,7 @@ void TTablet::BootstrapFollower() {
     }
 
     Become(&TThis::StateResolveLeader);
-    ReportTabletStateChange(TTabletStateInfo::ResolveLeader, SuggestedGeneration);
+    ReportTabletStateChange(TTabletStateInfo::ResolveLeader, Max(ActualGeneration, SuggestedGeneration));
 }
 
 void TTablet::Bootstrap() {

--- a/ydb/core/tablet/tablet_sys.h
+++ b/ydb/core/tablet/tablet_sys.h
@@ -223,6 +223,7 @@ class TTablet : public TActor<TTablet> {
     TIntrusivePtr<TTabletStorageInfo> Info;
     TIntrusivePtr<TTabletSetupInfo> SetupInfo;
     ui32 SuggestedGeneration;
+    ui32 ActualGeneration;
     bool NeedCleanupOnLockedPath;
     ui32 GcCounter;
     THolder<NTabletPipe::IConnectAcceptor> PipeConnectAcceptor;

--- a/ydb/core/tablet/tablet_sys.h
+++ b/ydb/core/tablet/tablet_sys.h
@@ -322,7 +322,7 @@ class TTablet : public TActor<TTablet> {
 
     ui64 TabletID() const;
 
-    void ReportTabletStateChange(ETabletState state);
+    void ReportTabletStateChange(ETabletState state, ui32 generation);
     void PromoteToCandidate(ui32 gen);
     void TabletBlockBlobStorage();
     void TabletRebuildGraph();

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -37,6 +37,9 @@
 #include <ydb/public/lib/deprecated/kicli/kicli.h>
 
 #include <ydb/core/node_whiteboard/node_whiteboard.h>
+#include <ydb/core/tablet/simple_tablet.h>
+#include <ydb/core/tablet/tablet_setup.h>
+#include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/library/actors/core/interconnect.h>
 #include <util/string/builder.h>
 #include <regex>
@@ -1395,6 +1398,97 @@ Y_UNIT_TEST_SUITE(Viewer) {
         const auto& vdiskMap = vdisks[0].GetMap();
         UNIT_ASSERT_C(vdiskMap.contains("VDiskState"), NJson::WriteJson(vdisks[0], false));
         UNIT_ASSERT_VALUES_EQUAL_C(vdiskMap.at("VDiskState").GetString(), "LocalRecoveryError", NJson::WriteJson(vdisks[0], false));
+    }
+
+    NJson::TJsonValue GetTabletInfo(TTestActorRuntime& runtime, const TActorId& sender) {
+        auto endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
+        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest(
+            "GET /viewer/tabletinfo?enums=true&direct=1 HTTP/1.1\r\n\r\n", endpoint, {});
+
+        TAutoPtr<IEventHandle> handle;
+        runtime.Send(new IEventHandle(NKikimr::NViewer::MakeViewerID(0), sender,
+            new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(request), 0));
+        auto* result = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+
+        NJson::TJsonValue json;
+        NJson::ReadJsonTree(result->Response->Body, &json, true);
+        return json;
+    }
+
+    std::optional<NJson::TJsonValue> FindTabletInfo(const NJson::TJsonValue& json, ui64 tabletId) {
+        const NJson::TJsonValue* tablets = nullptr;
+        if (!json.GetValuePointer("TabletStateInfo", &tablets) || !tablets->IsArray()) {
+            return std::nullopt;
+        }
+        for (const auto& tablet : tablets->GetArray()) {
+            if (tablet["TabletId"].GetStringRobust() == ToString(tabletId)) {
+                return tablet;
+            }
+        }
+        return std::nullopt;
+    }
+
+    NJson::TJsonValue WaitTabletInfoActive(TTestActorRuntime& runtime, const TActorId& sender, ui64 tabletId) {
+        NJson::TJsonValue json;
+        for (int i = 0; i < 60; ++i) {
+            json = GetTabletInfo(runtime, sender);
+            auto tablet = FindTabletInfo(json, tabletId);
+            if (tablet && (*tablet)["State"].GetStringRobust() == "Active") {
+                return *tablet;
+            }
+            runtime.SimulateSleep(TDuration::MilliSeconds(100));
+        }
+        UNIT_FAIL("Tablet " << tabletId << " never became active: " << NJson::WriteJson(json, false));
+        return {};
+    }
+
+    void RunOutdatedBootAttempt(TTestActorRuntime& runtime, ui64 tabletId) {
+        auto launcher = runtime.AllocateEdgeActor(0);
+        auto setup = MakeIntrusive<TTabletSetupInfo>(&CreateSimpleTablet,
+            TMailboxType::Simple, ui32(0), TMailboxType::Simple, ui32(0));
+
+        runtime.Register(CreateTablet(launcher,
+                CreateTestTabletInfo(tabletId, TTabletTypes::Hive),
+                setup.Get(), /* suggestedGeneration */ 1),
+            0);
+
+        auto dead = runtime.GrabEdgeEvent<TEvTablet::TEvTabletDead>(launcher);
+        UNIT_ASSERT_VALUES_EQUAL(dead->Get()->TabletID, tabletId);
+        UNIT_ASSERT_VALUES_EQUAL(dead->Get()->Reason, TEvTablet::TEvTabletDead::ReasonBootSuggestOutdated);
+
+        // wait for whiteboard update
+        runtime.SimulateSleep(TDuration::MilliSeconds(100));
+    }
+
+    Y_UNIT_TEST(TestTabletInfoAfterOutdatedBoot)
+    {
+        TPortManager tp;
+        ui16 port = tp.GetPort(2134);
+        ui16 grpcPort = tp.GetPort(2135);
+        auto settings = TServerSettings(port)
+                .SetNodeCount(2)
+                .SetUseRealThreads(false)
+                .SetDomainName("Root")
+                .SetUseSectorMap(true)
+                .InitKikimrRunConfig();
+        TServer server(settings);
+        server.EnableGRpc(grpcPort);
+
+        TClient client(settings);
+        TTestActorRuntime& runtime = *server.GetRuntime();
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        ui64 tabletId = runtime.GetAppData().DomainsInfo->GetHive();
+        auto running = WaitTabletInfoActive(runtime, sender, tabletId);
+
+        RunOutdatedBootAttempt(runtime, tabletId);
+
+        auto current = FindTabletInfo(GetTabletInfo(runtime, sender), tabletId);
+        UNIT_ASSERT(current);
+        UNIT_ASSERT_VALUES_EQUAL_C((*current)["State"].GetStringRobust(), "Active",
+            NJson::WriteJson(*current, false));
+        UNIT_ASSERT_VALUES_EQUAL_C((*current)["Generation"].GetStringRobust(),
+            running["Generation"].GetStringRobust(), NJson::WriteJson(*current, false));
     }
 
     Y_UNIT_TEST(ServerlessWithExclusiveNodes)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

Таблетка, умирая, репортит в вайтборд себя под KnownGeneration. В частности, если таблетка попыталась подняться в поколении 95, но узнала, что уже есть поколение 96, то она репортит "мёртвая таблетка в поколении 96". И ui видит это как актуальный статус таблетки.
