### PR TITLE
Fix SQS peer address extraction from X-Forwarded-For

### DIFF
--- a/ydb/core/http_proxy/http_req.cpp
+++ b/ydb/core/http_proxy/http_req.cpp
@@ -194,7 +194,9 @@ namespace NKikimr::NHttpProxy {
             } else if (AsciiEqualsIgnoreCase(header.first, REQUEST_ID_HEADER)) {
                 sourceReqId = header.second;
             } else if (AsciiEqualsIgnoreCase(header.first, REQUEST_FORWARDED_FOR)) {
-                SourceAddress = header.second;
+                if (TString sourceAddress = NKikimr::NNet::ExtractFirstForwardedForAddress(header.second)) {
+                    SourceAddress = std::move(sourceAddress);
+                }
             } else if (AsciiEqualsIgnoreCase(header.first, REQUEST_TARGET_HEADER)) {
                 TString requestTarget = TString(header.second);
                 TVector<TString> parts = SplitString(requestTarget, ".");

--- a/ydb/core/http_proxy/ut/ymq_ut.cpp
+++ b/ydb/core/http_proxy/ut/ymq_ut.cpp
@@ -1214,11 +1214,13 @@ Y_UNIT_TEST_SUITE(TestYmqHttpProxy) {
         } restoreAuthFactory{appData, previousAuthFactory};
 
         const TString sourceAddress = "203.0.113.42";
+        const TString forwardedFor = TStringBuilder()
+            << "  " << sourceAddress << " , 10.0.0.10, 10.0.0.11";
         auto createQueueReq = CreateSqsCreateQueueRequest();
         createQueueReq["QueueName"] = "HttpProxySourceAddressQueue";
         const TString authorization = TStringBuilder()
             << "X-YaCloud-SubjectToken: proxy_sa@builtin"
-            << "\r\nX-Forwarded-For:" << sourceAddress;
+            << "\r\nX-Forwarded-For:" << forwardedFor;
 
         auto createQueueRes = SendHttpRequest("/Root", "AmazonSQS.CreateQueue", std::move(createQueueReq), authorization);
         UNIT_ASSERT_VALUES_EQUAL_C(createQueueRes.HttpCode, 200, createQueueRes.Body);

--- a/ydb/core/ymq/http/http.cpp
+++ b/ydb/core/ymq/http/http.cpp
@@ -353,7 +353,7 @@ void THttpRequest::ParseHeaders(const THttpInput& input) {
         } else if (AsciiEqualsIgnoreCase(header.Name(), IAM_TOKEN_HEADER)) {
             IamToken_ = header.Value();
         } else if (AsciiEqualsIgnoreCase(header.Name(), FORWARDED_IP_HEADER)) {
-            SourceAddress_ = header.Value();
+            SourceAddress_ = NKikimr::NNet::ExtractFirstForwardedForAddress(header.Value());
         } else if (AsciiEqualsIgnoreCase(header.Name(), REQUEST_ID_HEADER)) {
             sourceReqId = header.Value();
         }

--- a/ydb/library/net/source_address.cpp
+++ b/ydb/library/net/source_address.cpp
@@ -2,8 +2,13 @@
 
 #include <util/generic/yexception.h>
 #include <util/network/address.h>
+#include <util/string/strip.h>
 
 namespace NKikimr::NNet {
+
+    TString ExtractFirstForwardedForAddress(TStringBuf forwardedFor) {
+        return TString(StripString(forwardedFor.Before(',')));
+    }
 
     TString FormatSourceAddress(const sockaddr* addr) {
         if (!addr) {

--- a/ydb/library/net/source_address.h
+++ b/ydb/library/net/source_address.h
@@ -5,6 +5,10 @@
 
 namespace NKikimr::NNet {
 
+    // X-Forwarded-For lists the original client first, followed by proxy hops.
+    // Return the first value without surrounding whitespace.
+    TString ExtractFirstForwardedForAddress(TStringBuf forwardedFor);
+
     // Peer IP without port via NAddr::PrintHost. AF_INET -> "192.0.2.1",
     // AF_INET6 -> "2001:db8::1" or "::1". nullptr, unsupported family, or
     // PrintHost failure -> "unknown".

--- a/ydb/library/net/ut/source_address_ut.cpp
+++ b/ydb/library/net/ut/source_address_ut.cpp
@@ -86,6 +86,22 @@ TEST(FormatSourceAddress, UnknownFamilyIsUnknown) {
     EXPECT_EQ(FormatSourceAddress(&addr), "unknown");
 }
 
+TEST(ExtractFirstForwardedForAddress, IPv4Chain) {
+    EXPECT_EQ(
+        ExtractFirstForwardedForAddress("203.0.113.42, 10.0.0.10, 10.0.0.11"),
+        "203.0.113.42");
+}
+
+TEST(ExtractFirstForwardedForAddress, IPv6Chain) {
+    EXPECT_EQ(
+        ExtractFirstForwardedForAddress(" 2001:db8::42 , 2001:db8::10, 2001:db8::11"),
+        "2001:db8::42");
+}
+
+TEST(ExtractFirstForwardedForAddress, EmptyValue) {
+    EXPECT_TRUE(ExtractFirstForwardedForAddress("   ").empty());
+}
+
 TEST(PeerSourceAddressFromSocket, IPv4Loopback) {
     EXPECT_EQ((PeerAddressAfterConnect<TSockAddrInet, TInetStreamSocket>("127.0.0.1")), "127.0.0.1");
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

SQS HTTP endpoints copied the complete `X-Forwarded-For` header into `SourceAddress`. When a request passed through multiple proxies, the header contained a comma-separated address chain:

```text
client-ip, proxy-ip, ingress-ip
```

This value was propagated to TEvAuthorizeTicket::PeerName. TicketParser expects a single IP address or peer name, so it reported invalid peer name format. The same malformed value could also be sent to Access Service through the x-user-ip header.

Changes:
- Added a shared helper that extracts the first address from X-Forwarded-For and removes surrounding whitespace.
- Applied the helper in both the current HTTP proxy and the legacy SQS HTTP endpoint.
- Preserved the socket-derived source address when the forwarded header is empty.
- Added unit tests covering IPv4 and IPv6 proxy chains, whitespace, and an empty header.
- Extended the HTTP proxy integration test to verify that only the original client address is propagated to the authentication flow.

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://nda.ya.ru/t/4D9Vk9xM7pXvCy
