### PR TITLE
Pre-shard fulltext index tables during build

### DIFF
--- a/ydb/core/tx/schemeshard/index/build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index__progress.cpp
@@ -596,6 +596,20 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildFulltextPropose(
         std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&buildInfo.SpecializedIndexDescription),
         buildInfo.IndexType, prefixColumns, true);
 
+    // Set a low SizeToSplit so the build table quickly ramps up shard count during data upload.
+    auto& policy = *op.MutablePartitionConfig()->MutablePartitioningPolicy();
+    policy.SetSizeToSplit(100*1024*1024);
+    const auto maxShardsInPath = path.DomainInfo()->GetSchemeLimits().MaxShardsInPath;
+    ui32 fulltextShards = tableInfo->GetPartitionStore().size();
+    if (fulltextShards < buildInfo.MaxInProgressShards) {
+        fulltextShards = buildInfo.MaxInProgressShards;
+    }
+    if (fulltextShards > maxShardsInPath) {
+        fulltextShards = maxShardsInPath;
+    }
+    policy.SetMinPartitionsCount(fulltextShards);
+    policy.SetMaxPartitionsCount(fulltextShards);
+
     op.SetName(TString::Join(NTableIndex::ImplTable, NTableIndex::NKMeans::BuildSuffix0));
 
     InheritDetailedMetricsSettings(tableInfo, op);
@@ -632,6 +646,19 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildFulltextRowIdSrcP
     op = CalcFulltextRowIdSrcImplTableDesc(tableInfo, tableInfo->PartitionConfig(),
         dataColumns, buildInfo.IndexColumns, NKikimrSchemeOp::TTableDescription(),
         std::get<NKikimrSchemeOp::TFulltextIndexDescription>(buildInfo.SpecializedIndexDescription));
+    const auto maxShardsInPath = path.DomainInfo()->GetSchemeLimits().MaxShardsInPath;
+    ui32 fulltextShards = tableInfo->GetPartitionStore().size();
+    if (fulltextShards < buildInfo.MaxInProgressShards) {
+        fulltextShards = buildInfo.MaxInProgressShards;
+    }
+    if (fulltextShards > maxShardsInPath) {
+        fulltextShards = maxShardsInPath;
+    }
+    // rowid is bitreverse-sequential, so it uses the whole uint64 range, so we can use uniform partitioning
+    op.SetUniformPartitionsCount(fulltextShards);
+    auto& policy = *op.MutablePartitionConfig()->MutablePartitioningPolicy();
+    policy.SetMinPartitionsCount(fulltextShards);
+    policy.SetMaxPartitionsCount(fulltextShards);
 
     op.SetName(TString::Join(NTableIndex::ImplTable, NTableIndex::NFulltext::RowIdSrcBuildSuffix));
 
@@ -640,6 +667,55 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildFulltextRowIdSrcP
     LOG_NOTICE_S((TlsActivationContext->AsActorContext()), NKikimrServices::BUILD_INDEX,
         "CreateBuildFulltextRowIdSrcPropose " << buildInfo.Id << " " << buildInfo.State << " " << propose->Record.ShortDebugString());
 
+    return propose;
+}
+
+// Copy compact fulltext index table partition boundaries from the 0build table
+THolder<TEvSchemeShard::TEvModifySchemeTransaction> AlterIndexPartitioningPropose(
+    TSchemeShard* ss, const TIndexBuildInfo& buildInfo)
+{
+    Y_ENSURE(buildInfo.IsBuildFulltextCompact(), "Unknown operation kind while building AlterIndexPartitioningPropose");
+
+    auto implPath = GetBuildPath(ss, buildInfo, NTableIndex::ImplTable);
+    TTableInfo::TPtr implTable = ss->Tables.at(implPath->PathId);
+    auto buildPath = GetBuildPath(ss, buildInfo, TString::Join(NTableIndex::ImplTable, NTableIndex::NKMeans::BuildSuffix0));
+    TTableInfo::TPtr buildTable = ss->Tables.at(buildPath->PathId);
+
+    if (implTable->GetPartitions().size() > 1 ||
+        buildTable->GetPartitions().size() <= 1) {
+        return nullptr;
+    }
+
+    auto implShardIdx = implTable->GetPartitions()[0]->ShardIdx;
+    auto implTabletId = ss->ShardInfos.at(implShardIdx).TabletID;
+
+    if (!implTable->GetStats().PartitionStats.contains(implShardIdx) ||
+        implTable->GetStats().PartitionStats.at(implShardIdx).ShardState != NKikimrTxDataShard::Ready) {
+        // implTable shard is not Ready - the index is likely so small that
+        // the datashard didn't even have time to report its first PeriodicTableStats
+        // just skip pre-sharding in this case too
+        return nullptr;
+    }
+
+    auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.ApplyTxId), ss->TabletID());
+    propose->Record.SetFailOnExist(true);
+
+    NKikimrSchemeOp::TModifyScheme& modifyScheme = *propose->Record.AddTransaction();
+
+    modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpSplitMergeTablePartitions);
+    modifyScheme.SetInternal(true);
+
+    auto& splitMerge = *modifyScheme.MutableSplitMergeTablePartitions();
+    splitMerge.SetTablePath(implPath.PathString());
+    splitMerge.AddSourceTabletId(ui64(implTabletId));
+
+    const auto& parts = buildTable->GetPartitions();
+    for (size_t i = 0; i < parts.size() - 1; i++) {
+        splitMerge.AddSplitBoundary()->SetSerializedKeyPrefix(parts[i]->EndOfRange);
+    }
+
+    LOG_NOTICE_S((TlsActivationContext->AsActorContext()), NKikimrServices::BUILD_INDEX,
+        "AlterIndexPartitioningPropose " << buildInfo.Id << " " << propose->Record.ShortDebugString());
     return propose;
 }
 
@@ -2828,6 +2904,35 @@ public:
                 Progress(BuildId);
             }
             break;
+        case TIndexBuildInfo::EState::AlterIndexTable: {
+            Y_ENSURE(buildInfo.IsBuildFulltextCompact());
+            if (buildInfo.ApplyTxId == InvalidTxId) {
+                AllocateTxId(BuildId);
+                break;
+            } else if (buildInfo.ApplyTxStatus == NKikimrScheme::StatusSuccess) {
+                auto ev = AlterIndexPartitioningPropose(Self, buildInfo);
+                if (ev) {
+                    buildInfo.ApplyTxStatus = NKikimrScheme::StatusAccepted;
+                    Send(Self->SelfId(), std::move(ev), 0, ui64(BuildId));
+                    break;
+                }
+            } else if (!buildInfo.ApplyTxDone) {
+                Send(Self->SelfId(), MakeHolder<TEvSchemeShard::TEvNotifyTxCompletion>(ui64(buildInfo.ApplyTxId)));
+                break;
+            }
+
+            buildInfo.ApplyTxId = {};
+            buildInfo.ApplyTxStatus = NKikimrScheme::StatusSuccess;
+            buildInfo.ApplyTxDone = false;
+
+            NIceDb::TNiceDb db(txc.DB);
+            Self->PersistBuildIndexApplyTx(db, buildInfo);
+
+            // Next step is FulltextDictionary, previous was LockBuild
+            ChangeState(BuildId, TIndexBuildInfo::EState::Filling);
+            Progress(BuildId);
+            break;
+        }
         case TIndexBuildInfo::EState::ProvisioningRowIdColumn: {
             if (!buildInfo.RowIdColumnBuildId) {
                 // Mint the child build id (assigned + child created in the AllocateResult handler).
@@ -3050,7 +3155,11 @@ public:
                 NIceDb::TNiceDb db(txc.DB);
                 Self->PersistBuildIndexApplyTx(db, buildInfo);
 
-                ChangeState(BuildId, TIndexBuildInfo::EState::Filling);
+                if (buildInfo.IsBuildFulltextCompact()) {
+                    ChangeState(BuildId, TIndexBuildInfo::EState::AlterIndexTable);
+                } else {
+                    ChangeState(BuildId, TIndexBuildInfo::EState::Filling);
+                }
                 Progress(BuildId);
             }
             break;
@@ -4117,6 +4226,7 @@ public:
         case TIndexBuildInfo::EState::CreateBuild:
         case TIndexBuildInfo::EState::LockBuild:
         case TIndexBuildInfo::EState::AlterSequence:
+        case TIndexBuildInfo::EState::AlterIndexTable:
         case TIndexBuildInfo::EState::PrepareValidation:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Cancellation_Applying:
@@ -4330,13 +4440,31 @@ public:
             }
             break;
         }
+        case TIndexBuildInfo::EState::AlterIndexTable: {
+            Y_ENSURE(txId == buildInfo.ApplyTxId, state);
+
+            if (record.GetStatus() != NKikimrScheme::StatusAccepted &&
+                record.GetStatus() != NKikimrScheme::StatusAlreadyExists) {
+                // Failure to pre-shard the final index table is non-critical, we just proceed as is
+                buildInfo.ApplyTxStatus = NKikimrScheme::StatusAccepted;
+                buildInfo.ApplyTxDone = true;
+                Self->PersistBuildIndexAddIssue(db, buildInfo, TStringBuilder()
+                    << "At " << state << " state got unsuccess propose result"
+                    << ", status: " << NKikimrScheme::EStatus_Name(record.GetStatus())
+                    << ", reason: " << record.GetReason());
+            } else {
+                buildInfo.ApplyTxStatus = record.GetStatus();
+            }
+            Self->PersistBuildIndexApplyTx(db, buildInfo);
+            break;
+        }
         case TIndexBuildInfo::EState::DropBuild:
         case TIndexBuildInfo::EState::CreateBuild:
         case TIndexBuildInfo::EState::LockBuild:
         case TIndexBuildInfo::EState::AlterSequence:
         case TIndexBuildInfo::EState::PrepareValidation:
         {
-            Y_ENSURE(txId == buildInfo.ApplyTxId);
+            Y_ENSURE(txId == buildInfo.ApplyTxId, state);
 
             if (shouldRetry()) {
                 buildInfo.ApplyTxId = InvalidTxId;
@@ -4596,6 +4724,7 @@ public:
         case TIndexBuildInfo::EState::CreateBuild:
         case TIndexBuildInfo::EState::LockBuild:
         case TIndexBuildInfo::EState::AlterSequence:
+        case TIndexBuildInfo::EState::AlterIndexTable:
         case TIndexBuildInfo::EState::PrepareValidation:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Cancellation_Applying:

--- a/ydb/core/tx/schemeshard/index/build_index_tx_base.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index_tx_base.cpp
@@ -259,6 +259,7 @@ void TSchemeShard::TIndexBuilder::TTxBase::Fill(NKikimrIndexBuilder::TIndexBuild
     case TIndexBuildInfo::EState::CreateBuild:
     case TIndexBuildInfo::EState::LockBuild:
     case TIndexBuildInfo::EState::AlterSequence:
+    case TIndexBuildInfo::EState::AlterIndexTable:
     case TIndexBuildInfo::EState::PrepareValidation:
         index.SetState(Ydb::Table::IndexBuildState::STATE_TRANSFERING_DATA);
         index.SetProgress(indexInfo.CalcProgressPercent());

--- a/ydb/core/tx/schemeshard/index/index_build_info.cpp
+++ b/ydb/core/tx/schemeshard/index/index_build_info.cpp
@@ -338,6 +338,7 @@ bool TIndexBuildInfo::IsValidState(EState value)
         case EState::Applying:
         case EState::Unlocking:
         case EState::AlterSequence:
+        case EState::AlterIndexTable:
         case EState::PrepareValidation:
         case EState::Done:
         case EState::Cancellation_Applying:

--- a/ydb/core/tx/schemeshard/index/index_build_info.h
+++ b/ydb/core/tx/schemeshard/index/index_build_info.h
@@ -92,6 +92,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         Unlocking = 60,
         AlterSequence = 61,
         PrepareValidation = 62,
+        AlterIndexTable = 63,
         Done = 200,
 
         Cancellation_Applying = 350,

--- a/ydb/core/tx/schemeshard/index/operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/index/operation_create_build_index.cpp
@@ -304,6 +304,16 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
             auto implTableDesc = CalcFulltextCompactImplTableDesc(tableInfo, tableInfo->PartitionConfig(),
                 indexTableDesc, &indexDesc.GetFulltextIndexDescription(), indexType, prefixColumns, false);
             implTableDesc.MutablePartitionConfig()->MutableCompactionPolicy()->SetKeepEraseMarkers(true);
+            // Set index table partitions to at least the same number of partitions at the main table
+            if (!indexTableDesc.GetPartitionConfig().HasPartitioningPolicy()) {
+                auto& policy = *implTableDesc.MutablePartitionConfig()->MutablePartitioningPolicy();
+                const auto maxShardsInPath = table.DomainInfo()->GetSchemeLimits().MaxShardsInPath;
+                ui32 fulltextShards = tableInfo->GetPartitionStore().size();
+                if (fulltextShards > maxShardsInPath) {
+                    fulltextShards = maxShardsInPath;
+                }
+                policy.SetMinPartitionsCount(fulltextShards);
+            }
             result.push_back(createImplTable(std::move(implTableDesc),
                 THashSet<TString>{NTableIndex::NFulltext::GenSequence}));
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_fulltext_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_fulltext_build.cpp
@@ -685,24 +685,38 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTest) {
     // Helpers for the auto-provisioning tests below: a table with a custom (Utf8) PK and NO __ydb_row_id
     // column / unique index - the schemeshard provisions both when the fulltext index is built.
 
-    void DoCreateCustomPkTextTable(TTestBasicRuntime& runtime, TTestEnv& env, ui64& txId) {
-        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+    void DoCreateCustomPkTextTable(TTestBasicRuntime& runtime, TTestEnv& env, ui64& txId, bool split = false) {
+        TestCreateTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
             Name: "texts"
             Columns { Name: "pk" Type: "Utf8" NotNull: true }
             Columns { Name: "text" Type: "String" }
             Columns { Name: "data" Type: "String" }
             KeyColumnNames: ["pk"]
-        )");
+            %s
+        )", split ? R"(SplitBoundary { KeyPrefix { Tuple { Optional { Bytes: "ptw" } } } })" : ""));
         env.TestWaitNotification(runtime, txId);
     }
 
     void DoWriteRowsCustomPk(TTestBasicRuntime& runtime) {
         auto tableDesc = DescribePath(runtime, "/MyRoot/texts", /*returnPartitioning*/ true, /*returnBoundaries*/ true);
         const auto& tablePartitions = tableDesc.GetPathDescription().GetTablePartitions();
-        UNIT_ASSERT(!tablePartitions.empty());
-        const ui64 textsTabletId = tablePartitions[0].GetDatashardId();
+        UNIT_ASSERT(tablePartitions.size() > 0);
+        TVector<TString> boundary;
+        for (auto& part: tablePartitions) {
+            if (part.GetEndOfRangeKeyPrefix().empty()) {
+                boundary.emplace_back();
+            } else {
+                TSerializedCellVec key(part.GetEndOfRangeKeyPrefix());
+                boundary.emplace_back(key.GetCells().at(0).AsBuf());
+            }
+        }
 
-        auto fnWriteRow = [&] (TString pk, TString text, TString data) {
+        auto fnWriteRow = [&](TString pk, TString text, TString data) {
+            size_t part;
+            for (part = 0; part < boundary.size()-1 && pk >= boundary[part]; part++) {
+            }
+            const ui64 textsTabletId = tablePartitions[part].GetDatashardId();
+
             TString writeQuery = Sprintf(R"(
                 (
                     (let key   '( '('pk     (Utf8 '%s) ) ) )
@@ -1184,5 +1198,98 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTest) {
         TestDescribeResult(DescribePrivatePath(runtime, RowIdSrcTablePath("/MyRoot/texts/fulltext_idx")), {
             NLs::PathNotExist,
         });
+    }
+
+    Y_UNIT_TEST(BuildPartitioning) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableCompactFulltextIndex(true).DataShardStatsReportIntervalSeconds(1).DisableStatsBatching(true));
+        ui64 txId = 100;
+
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        DoCreateCustomPkTextTable(runtime, env, txId, true);
+        DoWriteRowsCustomPk(runtime);
+
+        TBlockEvents<TEvDataShard::TEvBuildIndexCreateRequest> prepassBlocker(runtime, [](const auto& ev) {
+            return ev->Get()->Record.GetTargetName().EndsWith(NTableIndex::NFulltext::RowIdSrcBuildSuffix);
+        });
+
+        const ui64 buildIndexTx = ++txId;
+        {
+            Ydb::Table::TableIndex index = FulltextIndexConfig(/*relevance*/ false);
+            NKikimrIndexBuilder::TIndexBuildSettings settings;
+            settings.set_source_path("/MyRoot/texts");
+            settings.MutableScanSettings()->SetMaxBatchRows(1);
+            settings.set_max_shards_in_flight(4);
+            *settings.mutable_index() = index;
+            auto request = new TEvIndexBuilder::TEvCreateRequest(buildIndexTx, "/MyRoot", std::move(settings));
+            auto sender = runtime.AllocateEdgeActor();
+            ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, request);
+        }
+
+        runtime.WaitFor("row-id source prepass scan request", [&]{ return prepassBlocker.size() > 0; });
+
+        // Check rowidsrc partitioning - 4 partitions (same as max_shards_in_flight)
+        {
+            auto tableDesc = DescribePath(runtime, "/MyRoot/texts/fulltext_idx/indexImplTablerowidsrc", /*returnPartitioning*/ true, /*returnBoundaries*/ true);
+            const auto& tablePartitions = tableDesc.GetPathDescription().GetTablePartitions();
+            UNIT_ASSERT_VALUES_EQUAL(tablePartitions.size(), 4);
+        }
+
+        // Check indexImplTable partitioning - minParts = 2 (same as the main table) but actually 1 partition
+        ui64 implTabletId = 0;
+        {
+            auto tableDesc = DescribePath(runtime, "/MyRoot/texts/fulltext_idx/indexImplTable", /*returnPartitioning*/ true, /*returnBoundaries*/ true);
+            const auto& tablePartitions = tableDesc.GetPathDescription().GetTablePartitions();
+            UNIT_ASSERT_VALUES_EQUAL(tablePartitions.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(tableDesc.GetPathDescription().GetTable().GetPartitionConfig().GetPartitioningPolicy().GetMinPartitionsCount(), 2);
+            implTabletId = tablePartitions[0].GetDatashardId();
+        }
+
+        // Wait for the first PeriodicTableStats so schemeshard records Ready state
+        TBlockEvents<TEvDataShard::TEvPeriodicTableStats> periodicStatsBlocker(runtime, [implTabletId](const auto& ev) {
+            if (ev->Get()->Record.GetDatashardId() == implTabletId) {
+                return true;
+            }
+            return false;
+        });
+        runtime.SimulateSleep(TDuration::Seconds(6));
+        runtime.WaitFor("indexImplTable periodic stats", [&]{ return periodicStatsBlocker.size() > 0; });
+        periodicStatsBlocker.Stop().Unblock();
+
+        TBlockEvents<TEvDataShard::TEvBuildFulltextIndexRequest> fulltextBlocker(runtime, [](const auto&) {
+            return true;
+        });
+        prepassBlocker.Stop().Unblock();
+        runtime.WaitFor("fill 0build request", [&]{ return fulltextBlocker.size() > 0; });
+
+        // Check indexImplTable0build partitioning policy - size to split = 100 MB, max parts = 4 (same as max_shards_in_flight)
+        {
+            auto buildTable = "/MyRoot/texts/fulltext_idx/indexImplTable0build";
+            auto tableDesc = DescribePath(runtime, buildTable, /*returnPartitioning*/ true, /*returnBoundaries*/ true);
+            const auto& tablePartitions = tableDesc.GetPathDescription().GetTablePartitions();
+            UNIT_ASSERT_VALUES_EQUAL(tablePartitions.size(), 1);
+            const auto& policy = tableDesc.GetPathDescription().GetTable().GetPartitionConfig().GetPartitioningPolicy();
+            UNIT_ASSERT_VALUES_EQUAL(policy.GetMaxPartitionsCount(), 4);
+            UNIT_ASSERT_VALUES_EQUAL(policy.GetSizeToSplit(), 100 * 1024 * 1024);
+
+            // Re-partition it manually (100 MB isn't enough for auto-partitioning during the test)
+            TestSplitTable(runtime, ++txId, buildTable, Sprintf(R"(
+                SourceTabletId: %lu
+                SplitBoundary { KeyPrefix { Tuple { Optional: { Bytes: "ptw" } } } }
+            )", tablePartitions[0].GetDatashardId()));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        fulltextBlocker.Stop().Unblock();
+
+        env.TestWaitNotification(runtime, buildIndexTx);
+
+        // Check final indexImplTable partitioning
+        {
+            auto tableDesc = DescribePath(runtime, "/MyRoot/texts/fulltext_idx/indexImplTable", /*returnPartitioning*/ true, /*returnBoundaries*/ true);
+            const auto& tablePartitions = tableDesc.GetPathDescription().GetTablePartitions();
+            UNIT_ASSERT_VALUES_EQUAL(tablePartitions.size(), 2);
+        }
     }
 }


### PR DESCRIPTION
### Description for reviewers

Извращения вокруг статистики в тесте связаны с принуждением SchemeShard к получению и своевременной обработке статистики от даташарда, потому что без этого он не проставляет ему статус Ready и Split/Merge не работает.

Причём, вообще говоря, это можно было бы поправить на стороне даташарда - сейчас довольно глупо выходит, что вновь созданные шарды ещё чего-то ждут перед тем, как отправить первую статистику в Schemeshard. То есть даже не так: после старта они её отправляют сразу, но она пустая, потому что там ещё таблица не создана. А после создания таблицы, при переходе в Ready, они сразу ничего и не отправляют...