### PR TITLE
TOwningFacilityCredentialsProvider: always forward GetAuthInfoAsync

### DIFF
--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/credentials/credentials.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/credentials/credentials.h
@@ -38,11 +38,9 @@ using TCredentialsProviderCreator = std::function<TCredentialsProviderPtr()>;
 class TOwningFacilityCredentialsProvider final : public ICredentialsProvider {
 public:
     TOwningFacilityCredentialsProvider(std::shared_ptr<ICoreFacility> facility,
-                                       TCredentialsProviderPtr inner,
-                                       bool forwardAsync = false)
+                                       TCredentialsProviderPtr inner)
         : Facility_(std::move(facility))
         , Inner_(std::move(inner))
-        , ForwardAsync_(forwardAsync)
     {}
 
     std::string GetAuthInfo() const override {
@@ -50,7 +48,7 @@ public:
     }
 
     NThreading::TFuture<std::string> GetAuthInfoAsync() const override {
-        return ForwardAsync_ ? Inner_->GetAuthInfoAsync() : ICredentialsProvider::GetAuthInfoAsync();
+        return Inner_->GetAuthInfoAsync();
     }
 
     bool IsValid() const override {
@@ -61,7 +59,6 @@ private:
     // Reverse destruction keeps Facility_ alive while Inner_ stops.
     std::shared_ptr<ICoreFacility> Facility_;
     TCredentialsProviderPtr Inner_;
-    const bool ForwardAsync_;
 };
 
 // Process-wide weak cache for no-argument factory paths whose providers own their facilities.

--- a/ydb/public/sdk/cpp/src/client/iam_private/common/iam.h
+++ b/ydb/public/sdk/cpp/src/client/iam_private/common/iam.h
@@ -47,10 +47,10 @@ public:
             GetClientIdentity(),
             [this] {
                 auto authProvider = NCredentials::NDetail::GetOrCreateCachedProvider(
-                    "async:" + Params_.SystemServiceAccountCredentials->GetClientIdentity(), [this] {
+                    Params_.SystemServiceAccountCredentials->GetClientIdentity(), [this] {
                         auto facility = CreateSimpleCoreFacility();
                         return std::make_shared<TOwningFacilityCredentialsProvider>(facility,
-                            Params_.SystemServiceAccountCredentials->CreateProvider(facility), true);
+                            Params_.SystemServiceAccountCredentials->CreateProvider(facility));
                     });
                 auto facility = CreateSimpleCoreFacility();
                 auto serviceProvider = std::make_shared<TCredentialsProvider>(

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/grpc_iam_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/grpc_iam_ut.cpp
@@ -130,9 +130,8 @@ TEST(GrpcIamCredentialsProviderFactory, NoArgProvidersAreCachedAcrossFactoryInst
 }
 
 TEST(GrpcIamCredentialsProviderFactory, ReadyCallbackCanReleaseNoArgProvider) {
-    TIamTokenServiceStub iamStub;
-    iamStub.SetResponseToken("unit-test-iam-token");
-    TIamGrpcServer server(&iamStub);
+    TBlockingIamTokenService iamService;
+    TIamGrpcServer server(&iamService);
     ASSERT_TRUE(server.Start());
 
     auto provider = std::make_shared<TIamOAuthCredentialsProviderFactory<
@@ -140,12 +139,13 @@ TEST(GrpcIamCredentialsProviderFactory, ReadyCallbackCanReleaseNoArgProvider) {
             MakeOAuthParams(server.Endpoint()))->CreateProvider();
     auto released = std::make_shared<std::promise<void>>();
     auto authInfo = provider->GetAuthInfoAsync();
-    ASSERT_TRUE(authInfo.IsReady());
+    ASSERT_FALSE(authInfo.IsReady());
     authInfo.Subscribe(
         [provider = std::move(provider), released](const auto&) mutable {
             provider.reset();
             released->set_value();
         });
+    iamService.Release();
 
     ASSERT_EQ(released->get_future().wait_for(std::chrono::seconds(10)), std::future_status::ready);
     server.Stop();

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/grpc_iam_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/grpc_iam_ut.cpp
@@ -68,6 +68,8 @@ TEST(GrpcIamCredentialsProvider, TeardownWhileIamCreatePendingCompletesViaFactor
         CreateIamTokenRequest, CreateIamTokenResponse, IamTokenService>>(params);
 
     auto provider = factory->CreateProvider();
+    auto authInfo = provider->GetAuthInfoAsync();
+    ASSERT_FALSE(authInfo.IsReady());
 
     ASSERT_TRUE(iamService.WaitUntilRpcEntered(std::chrono::seconds(5)))
         << "server should have accepted the IAM Create call";
@@ -126,28 +128,6 @@ TEST(GrpcIamCredentialsProviderFactory, NoArgProvidersAreCachedAcrossFactoryInst
     EXPECT_EQ(differentOAuthProvider->GetAuthInfo(), "unit-test-iam-token");
     EXPECT_EQ(iamStub.GetRequestCount(), 3);
 
-    server.Stop();
-}
-
-TEST(GrpcIamCredentialsProviderFactory, ReadyCallbackCanReleaseNoArgProvider) {
-    TBlockingIamTokenService iamService;
-    TIamGrpcServer server(&iamService);
-    ASSERT_TRUE(server.Start());
-
-    auto provider = std::make_shared<TIamOAuthCredentialsProviderFactory<
-        CreateIamTokenRequest, CreateIamTokenResponse, IamTokenService>>(
-            MakeOAuthParams(server.Endpoint()))->CreateProvider();
-    auto released = std::make_shared<std::promise<void>>();
-    auto authInfo = provider->GetAuthInfoAsync();
-    ASSERT_FALSE(authInfo.IsReady());
-    authInfo.Subscribe(
-        [provider = std::move(provider), released](const auto&) mutable {
-            provider.reset();
-            released->set_value();
-        });
-    iamService.Release();
-
-    ASSERT_EQ(released->get_future().wait_for(std::chrono::seconds(10)), std::future_status::ready);
     server.Stop();
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

Must be meged only after #52087
See YQ-5670
Note: may be incorrect approach, I'd like to run CI tests and see
~~UPD: Indeed, this does not work (and result in exactly same terminate-on-self-join error we've started with)
UPDv2: The test failure is not indicative of the bug, since it captures the last provider reference and is a misuse example.~~