### PR TITLE
[NEW RBO][PERF] Prune columns early to speedup TypeAnn during subplan handling

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_rbo_transformer.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_transformer.cpp
@@ -443,6 +443,14 @@ void TKqpNewRBOTransformer::InitializeRBOOptimizationStages() {
         rules.emplace_back(std::make_unique<TPruneDeadAggregateTraitsRule>());
     };
 
+    // Prune unused outputs before any rules that require type information.
+    TVector<std::unique_ptr<IRule>> earlyPruningRules;
+    earlyPruningRules.emplace_back(std::make_unique<TPruneDeadMapElementsRule>(/*pruneKeyColumns=*/true));
+    earlyPruningRules.emplace_back(std::make_unique<TPruneDeadAggregateTraitsRule>());
+    earlyPruningRules.emplace_back(std::make_unique<TPruneDeadUnionAllColumnsRule>());
+    earlyPruningRules.emplace_back(std::make_unique<TPruneDeadReadColumnsRule>(/*pruneKeyColumns=*/true));
+    RBO.AddStage(std::make_unique<TRuleBasedStage>("Early pruning", std::move(earlyPruningRules)));
+
     // Initial stages.
     // Expand aggregation.
     TVector<std::unique_ptr<IRule>> expandAggregationRules;


### PR DESCRIPTION
Type annotation seems to slowdown massively on queries with many columns. Most subplan handling rules require types, which, given the amount of columns, makes them unbearably slow.

This PR introduces additional pruning stage at the start to prevent type annotation from being launched of 1000s of unused columns slowing everything down.