### PR TITLE
[NEW RBO][PERF] Add QuickMatch to subplan handling rules

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_rbo.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo.cpp
@@ -109,7 +109,7 @@ void TRuleBasedStage::RunStage(TOpRoot& root, TRBOContext& ctx) {
         for (const auto& iter : root) {
             for (const auto& rule : Rules) {
                 auto op = iter.Current;
-                if (!rule->QuickMatch(op)) {
+                if (!rule->QuickMatch(op, root.PlanProps)) {
                     continue;
                 }
 

--- a/ydb/core/kqp/opt/rbo/kqp_rbo.h
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo.h
@@ -36,6 +36,9 @@ class IRule {
     virtual bool QuickMatch(const TIntrusivePtr<IOperator>&) const {
         return true;
     }
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input, const TPlanProps&) const {
+        return QuickMatch(input);
+    }
     virtual bool MatchAndApply(TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) = 0;
 
     virtual ~IRule() = default;

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_rules.h
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_rules.h
@@ -42,6 +42,7 @@ class TInlineScalarSubplanRule : public IRule {
   public:
     TInlineScalarSubplanRule() : IRule("Inline scalar subplan", ERuleProperties::RequireParents | ERuleProperties::RequireTypes) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input, const TPlanProps& props) const override;
     virtual bool MatchAndApply(TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -51,6 +52,7 @@ class TInlineSimpleInExistsSubplanRule : public ISimplifiedRule {
         : ISimplifiedRule("Inline simple in or exists subplan",
                           ERuleProperties::RequireParents | ERuleProperties::RequireOutputIUs | ERuleProperties::RequireTypes) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input, const TPlanProps& props) const override;
     virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
@@ -59,6 +61,7 @@ class TInlineGenericInExistsSubplanRule : public ISimplifiedRule {
   public:
     TInlineGenericInExistsSubplanRule() : ISimplifiedRule("Inline generic in or exists subplan", ERuleProperties::RequireParents | ERuleProperties::RequireTypes | ERuleProperties::RequireMetadata) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input, const TPlanProps& props) const override;
     virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };

--- a/ydb/core/kqp/opt/rbo/rules/expand_distinct_aggregation.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/expand_distinct_aggregation.cpp
@@ -278,7 +278,7 @@ TIntrusivePtr<IOperator> ExpandMultiDistinct(const TIntrusivePtr<TOpAggregate>& 
 } // anonymous namespace
 
 bool TExpandDistinctAggregationRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
-    return input->Kind == EOperator::Aggregate;
+    return IsSuitableToExpandDistinctAggregation(input);
 }
 
 TIntrusivePtr<IOperator> TExpandDistinctAggregationRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& rboCtx, TPlanProps& props) {

--- a/ydb/core/kqp/opt/rbo/rules/inline_generic_in_exists_subplan.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/inline_generic_in_exists_subplan.cpp
@@ -26,6 +26,21 @@ void AddDomainColumn(TVector<TInfoUnit>& domain, const TInfoUnit& iu) {
 namespace NKikimr {
 namespace NKqp {
 
+bool TInlineGenericInExistsSubplanRule::QuickMatch(const TIntrusivePtr<IOperator>& input, const TPlanProps& props) const {
+    if (input->Kind != EOperator::Filter || props.Subplans.Empty()) {
+        return false;
+    }
+
+    for (const auto& iu : input->GetSubplanIUs(props.Subplans)) {
+        const auto type = props.Subplans.At(iu).Type;
+        if (type == ESubplanType::IN_SUBPLAN || type == ESubplanType::EXISTS) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool TInlineGenericInExistsSubplanRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
     return input->Kind == EOperator::Filter;
 }

--- a/ydb/core/kqp/opt/rbo/rules/inline_scalar_subplan.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/inline_scalar_subplan.cpp
@@ -41,6 +41,20 @@ std::pair<TIntrusivePtr<IOperator>, TInfoUnit> MakeAtMostOneRowPerGroup(const TI
 
 } // anonymous namespace
 
+bool TInlineScalarSubplanRule::QuickMatch(const TIntrusivePtr<IOperator>& input, const TPlanProps& props) const {
+    if (props.Subplans.Empty()) {
+        return false;
+    }
+
+    for (const auto& iu : input->GetSubplanIUs(props.Subplans)) {
+        if (props.Subplans.At(iu).Type == ESubplanType::EXPR) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 // Rewrite a single scalar subplan into a cross-join for uncorrelated queries
 // or into a left join for correlated (assuming at most one tuple in the output of each subquery)
 // FIXME: Need to do correct general case decorellation in the future

--- a/ydb/core/kqp/opt/rbo/rules/inline_simple_in_exists_subplan.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/inline_simple_in_exists_subplan.cpp
@@ -6,6 +6,21 @@
 namespace NKikimr {
 namespace NKqp {
 
+bool TInlineSimpleInExistsSubplanRule::QuickMatch(const TIntrusivePtr<IOperator>& input, const TPlanProps& props) const {
+    if (input->Kind != EOperator::Filter || props.Subplans.Empty()) {
+        return false;
+    }
+
+    for (const auto& iu : input->GetSubplanIUs(props.Subplans)) {
+        const auto type = props.Subplans.At(iu).Type;
+        if (type == ESubplanType::IN_SUBPLAN || type == ESubplanType::EXISTS) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool TInlineSimpleInExistsSubplanRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
     return input->Kind == EOperator::Filter;
 }


### PR DESCRIPTION
Subplan handling rules require types, which makes them expensive. We should only check if it's reasonable, this PR does exactly that: we extend QuickMatch to check for existence of relevant subplans before recomputing properties.