### PR TITLE
ci: run PR checks for NBS branches

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'main'
       - 'stable-*'
+      - 'nbs-*'
       - 'prestable-*'
       - 'stream-nb-*'
       - 'dev-*'
@@ -18,6 +19,7 @@ on:
     branches:
       - 'main'
       - 'stable-*'
+      - 'nbs-*'
       - 'stream-nb-*'
     paths-ignore:
       - 'ydb/docs/**'


### PR DESCRIPTION
### Changelog entry

Not for changelog.

### Description for reviewers

Enable PR-check for nbs-* target branches on pull_request_target and push events.

This gives NBS release branches the same incremental relwithdebinfo and ASAN small/medium checks as stable branches, including checks_integrated for pull requests.