### PR TITLE
[PQ] Raise schema UT coverage and fix AlterTopic metering/partition checks

### DIFF
--- a/ydb/core/persqueue/public/schema/alter_topic.cpp
+++ b/ydb/core/persqueue/public/schema/alter_topic.cpp
@@ -149,6 +149,15 @@ TResult ApplyChangesInt(
     if (request.has_alter_partitioning_settings()) {
         const auto& settings = request.alter_partitioning_settings();
         if (settings.has_set_min_active_partitions()) {
+            if (settings.set_min_active_partitions() < 0) {
+                return {Ydb::StatusIds::BAD_REQUEST, TStringBuilder()
+                    << "Partitions count must be non-negative, provided " << settings.set_min_active_partitions()};
+            }
+            if (settings.set_min_active_partitions() >= Max<ui32>()) {
+                return {Ydb::StatusIds::BAD_REQUEST, TStringBuilder()
+                    << "Partitions count must be less than " << Max<ui32>()
+                    << ", provided " << settings.set_min_active_partitions()};
+            }
             auto minParts = IfEqualThenDefault<i64>(settings.set_min_active_partitions(), 0L, 1L);
             config.SetTotalGroupCount(minParts);
             if (needHandleAutoPartitioning) {
@@ -158,6 +167,11 @@ TResult ApplyChangesInt(
 
         if (needHandleAutoPartitioning) {
             if (settings.has_set_max_active_partitions()) {
+                if (settings.set_max_active_partitions() < 0) {
+                    return {Ydb::StatusIds::BAD_REQUEST, TStringBuilder()
+                        << "Max active partitions must be non-negative, provided "
+                        << settings.set_max_active_partitions()};
+                }
                 pqTabletConfig->MutablePartitionStrategy()->SetMaxPartitionCount(settings.set_max_active_partitions());
             }
             if (settings.has_alter_auto_partitioning_settings()) {
@@ -256,7 +270,7 @@ TResult ApplyChangesInt(
         }
     }
 
-    auto result = FillMeteringMode(*pqTabletConfig, request.set_metering_mode(), EOperation::Create);
+    auto result = FillMeteringMode(*pqTabletConfig, request.set_metering_mode(), EOperation::Alter);
     if (!result) {
         return result;
     }

--- a/ydb/core/persqueue/public/schema/alter_topic.cpp
+++ b/ydb/core/persqueue/public/schema/alter_topic.cpp
@@ -172,6 +172,11 @@ TResult ApplyChangesInt(
                         << "Max active partitions must be non-negative, provided "
                         << settings.set_max_active_partitions()};
                 }
+                if (settings.set_max_active_partitions() >= Max<ui32>()) {
+                    return {Ydb::StatusIds::BAD_REQUEST, TStringBuilder()
+                        << "Max active partitions must be less than " << Max<ui32>()
+                        << ", provided " << settings.set_max_active_partitions()};
+                }
                 pqTabletConfig->MutablePartitionStrategy()->SetMaxPartitionCount(settings.set_max_active_partitions());
             }
             if (settings.has_alter_auto_partitioning_settings()) {

--- a/ydb/core/persqueue/public/schema/common.cpp
+++ b/ydb/core/persqueue/public/schema/common.cpp
@@ -456,7 +456,7 @@ TResult AddConsumer(
 
     if (consumerConfig.important()) {
         if (pqConfig.GetTopicsAreFirstClassCitizen() && !enableTopicDiskSubDomainQuota) {
-            return {Ydb::StatusIds::BAD_REQUEST, TStringBuilder() << "important flag is forbiden for consumer " << consumerConfig.name()};
+            return {Ydb::StatusIds::BAD_REQUEST, TStringBuilder() << "important flag is forbidden for consumer " << consumerConfig.name()};
         }
         consumer->SetImportant(true);
     }

--- a/ydb/core/persqueue/public/schema/create_topic.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic.cpp
@@ -46,6 +46,14 @@ TResult ApplyChangesInt(
             error = TStringBuilder() << "Partitions count must be less than " << Max<ui32>() << ", provided " << settings.min_active_partitions();
             return {Ydb::StatusIds::BAD_REQUEST, std::move(error)};
         }
+        if (settings.max_active_partitions() < 0) {
+            error = TStringBuilder() << "Max active partitions must be non-negative, provided " << settings.max_active_partitions();
+            return {Ydb::StatusIds::BAD_REQUEST, std::move(error)};
+        }
+        if (settings.max_active_partitions() >= Max<ui32>()) {
+            error = TStringBuilder() << "Max active partitions must be less than " << Max<ui32>() << ", provided " << settings.max_active_partitions();
+            return {Ydb::StatusIds::BAD_REQUEST, std::move(error)};
+        }
         minParts = std::max<ui32>(1, settings.min_active_partitions());
         if (request.partitioning_settings().has_auto_partitioning_settings() &&
             request.partitioning_settings().auto_partitioning_settings().strategy() != ::Ydb::Topic::AutoPartitioningStrategy::AUTO_PARTITIONING_STRATEGY_DISABLED) {

--- a/ydb/core/persqueue/public/schema/describe_operation_ut.cpp
+++ b/ydb/core/persqueue/public/schema/describe_operation_ut.cpp
@@ -29,11 +29,16 @@ constexpr ui32 LOCATION_NODE_ID = 7;
 constexpr ui32 LOCATION_GENERATION = 3;
 
 struct TIsolatedPipeConfig {
-    enum class ELocation { Reply, Drop, FailOnce };
-    enum class EStatus { Reply, EmptyOnce };
+    enum class ELocation { Reply, Drop, FailOnce, StatusFalseAlways };
+    enum class EStatus { Reply, EmptyOnce, FailAlways, WithConsumers };
 
     ELocation Location = ELocation::Reply;
     EStatus Status = EStatus::Reply;
+};
+
+enum class EFakeNavigateKind {
+    Topic,
+    Table,
 };
 
 struct TIsolatedPipeStats {
@@ -43,6 +48,11 @@ struct TIsolatedPipeStats {
 
 class TFakeSchemeCacheActor : public NActors::TActorBootstrapped<TFakeSchemeCacheActor> {
 public:
+    explicit TFakeSchemeCacheActor(EFakeNavigateKind kind = EFakeNavigateKind::Topic)
+        : Kind(kind)
+    {
+    }
+
     void Bootstrap() {
         Become(&TFakeSchemeCacheActor::StateWork);
     }
@@ -56,6 +66,15 @@ private:
         auto request = std::move(ev->Get()->Request);
         for (auto& entry : request->ResultSet) {
             entry.Status = TNavigate::EStatus::Ok;
+            if (Kind == EFakeNavigateKind::Table) {
+                entry.Kind = TNavigate::EKind::KindTable;
+                auto self = MakeIntrusive<TNavigate::TDirEntryInfo>();
+                self->Info.SetName("table");
+                self->Info.SetPathType(NKikimrSchemeOp::EPathTypeTable);
+                entry.Self = self;
+                continue;
+            }
+
             entry.Kind = TNavigate::EKind::KindTopic;
 
             auto pqInfo = MakeIntrusive<TNavigate::TPQGroupInfo>();
@@ -72,6 +91,8 @@ private:
         }
         Send(ev->Sender, new TEvTxProxySchemeCache::TEvNavigateKeySetResult(std::move(request)));
     }
+
+    EFakeNavigateKind Kind;
 };
 
 class TFakePipeCacheActor : public NActors::TActorBootstrapped<TFakePipeCacheActor> {
@@ -110,6 +131,11 @@ private:
                 return;
             }
             auto* response = new TEvPersQueue::TEvGetPartitionsLocationResponse();
+            if (Config.Location == TIsolatedPipeConfig::ELocation::StatusFalseAlways) {
+                response->Record.SetStatus(false);
+                Send(ev->Sender, response, 0, ev->Cookie);
+                return;
+            }
             response->Record.SetStatus(true);
             auto* location = response->Record.AddLocations();
             location->SetPartitionId(PARTITION_ID);
@@ -125,12 +151,27 @@ private:
                 Send(ev->Sender, new TEvPersQueue::TEvStatusResponse(), 0, ev->Cookie);
                 return;
             }
+            if (Config.Status == TIsolatedPipeConfig::EStatus::FailAlways) {
+                Send(ev->Sender, new TEvPersQueue::TEvStatusResponse(), 0, ev->Cookie);
+                return;
+            }
             auto* response = new TEvPersQueue::TEvStatusResponse();
             auto* part = response->Record.AddPartResult();
             part->SetPartition(PARTITION_ID);
             part->SetStatus(NKikimrPQ::TStatusResponse::STATUS_OK);
             part->SetStartOffset(0);
             part->SetEndOffset(10);
+            if (Config.Status == TIsolatedPipeConfig::EStatus::WithConsumers) {
+                auto* cons = part->AddConsumerResult();
+                cons->SetConsumer("user");
+                cons->SetLastReadTimestampMs(1000);
+                cons->SetReadLagMs(10);
+                cons->SetWriteLagMs(20);
+                cons->SetCommitedLagMs(30);
+                cons->SetAvgReadSpeedPerMin(1);
+                cons->SetAvgReadSpeedPerHour(2);
+                cons->SetAvgReadSpeedPerDay(3);
+            }
             Send(ev->Sender, response, 0, ev->Cookie);
             return;
         }
@@ -148,7 +189,9 @@ struct TIsolatedDescribeEnv {
     TIsolatedPipeStats PipeStats;
     NActors::TTestBasicRuntime Runtime;
 
-    explicit TIsolatedDescribeEnv(TIsolatedPipeConfig config = {})
+    explicit TIsolatedDescribeEnv(
+        TIsolatedPipeConfig config = {},
+        EFakeNavigateKind navigateKind = EFakeNavigateKind::Topic)
         : Runtime(1, false)
     {
         Runtime.Initialize(TAppPrepare().Unwrap());
@@ -157,7 +200,7 @@ struct TIsolatedDescribeEnv {
         Runtime.SetLogPriority(NKikimrServices::PQ_SCHEMA, NActors::NLog::PRI_DEBUG);
         Runtime.SetLogPriority(NKikimrServices::PQ_DESCRIBER, NActors::NLog::PRI_DEBUG);
 
-        auto schemeCacheId = Runtime.Register(new TFakeSchemeCacheActor());
+        auto schemeCacheId = Runtime.Register(new TFakeSchemeCacheActor(navigateKind));
         Runtime.RegisterService(MakeSchemeCacheID(), schemeCacheId);
 
         auto pipeCacheId = Runtime.Register(new TFakePipeCacheActor(config, &PipeStats));
@@ -549,6 +592,97 @@ Y_UNIT_TEST(PoisonRepliesCancelled) {
     UNIT_ASSERT(handle);
     auto response = THolder(handle->Release());
     UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::CANCELLED);
+}
+
+Y_UNIT_TEST(BalancerRetriesExhaustedOnFalseStatus) {
+    TIsolatedDescribeEnv env({.Location = TIsolatedPipeConfig::ELocation::StatusFalseAlways});
+
+    auto response = RunDescribeOperation(
+        env.Runtime,
+        MakeSettings("/Root/topic", /*includeLocation=*/true),
+        std::make_unique<TTestDescribeStrategy>(),
+        TDuration::Seconds(60));
+
+    UNIT_ASSERT_GT(env.PipeStats.LocationForwards, 1u);
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::UNAVAILABLE);
+    UNIT_ASSERT_STRING_CONTAINS(response->ErrorMessage, "Partition locations are not available");
+}
+
+Y_UNIT_TEST(StatsRetriesExhaustedOnEmptyStatus) {
+    TIsolatedDescribeEnv env({.Status = TIsolatedPipeConfig::EStatus::FailAlways});
+
+    auto response = RunDescribeOperation(
+        env.Runtime,
+        MakeSettings("/Root/topic", /*includeLocation=*/true, /*includeStats=*/true),
+        std::make_unique<TTestDescribeStrategy>(TTestDescribeStrategyOptions{
+            .WithReadSessions = true,
+            .WithStatus = true,
+            .ConsumerName = "user",
+        }),
+        TDuration::Seconds(60));
+
+    UNIT_ASSERT_GT(env.PipeStats.StatusForwards, 1u);
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::UNAVAILABLE);
+    UNIT_ASSERT_STRING_CONTAINS(response->ErrorMessage, "unresponsive");
+}
+
+Y_UNIT_TEST(ValidateSchemaThrowsMapsToInternalError) {
+    TIsolatedDescribeEnv env;
+
+    class TThrowingStrategy: public IDescribeStrategy {
+    public:
+        TString GetName() const override { return "Throw"; }
+        TDescribeSchemaResult ValidateSchema(const NDescriber::TTopicInfo&) override {
+            throw yexception() << "boom";
+        }
+        bool NeedProcessPartition(
+            const NKikimrSchemeOp::TPersQueueGroupDescription::TPartition&) const override {
+            return true;
+        }
+        std::unique_ptr<TEvPersQueue::TEvGetReadSessionsInfo> CreateReadSessionsInfoRequest() const override {
+            return nullptr;
+        }
+        std::unique_ptr<TEvPersQueue::TEvStatus> CreateStatusRequest() const override {
+            return nullptr;
+        }
+    };
+
+    auto response = RunDescribeOperation(
+        env.Runtime,
+        MakeSettings("/Root/topic"),
+        std::make_unique<TThrowingStrategy>());
+
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::INTERNAL_ERROR);
+    UNIT_ASSERT_STRING_CONTAINS(response->ErrorMessage, "Unhandled exception");
+}
+
+Y_UNIT_TEST(NotTopicMapsToSchemeError) {
+    TIsolatedDescribeEnv env({}, EFakeNavigateKind::Table);
+
+    auto response = RunDescribeOperation(
+        env.Runtime,
+        MakeSettings("/Root/table"),
+        std::make_unique<TTestDescribeStrategy>());
+
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::SCHEME_ERROR);
+    UNIT_ASSERT_EQUAL(response->IssueCode, Ydb::PersQueue::ErrorCode::VALIDATION_ERROR);
+}
+
+Y_UNIT_TEST(StatusIncludesPerConsumerStats) {
+    TIsolatedDescribeEnv env({.Status = TIsolatedPipeConfig::EStatus::WithConsumers});
+
+    auto response = RunDescribeOperation(
+        env.Runtime,
+        MakeSettings("/Root/topic", /*includeLocation=*/true, /*includeStats=*/true),
+        std::make_unique<TTestDescribeStrategy>(TTestDescribeStrategyOptions{
+            .WithReadSessions = true,
+            .WithStatus = true,
+            .ConsumerName = "user",
+        }));
+
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(response->Partitions.size(), 1u);
+    UNIT_ASSERT(response->Partitions.begin()->second.Consumers.contains("user"));
 }
 
 } // Y_UNIT_TEST_SUITE(DescribeOperationActor)

--- a/ydb/core/persqueue/public/schema/propose_create_ut.cpp
+++ b/ydb/core/persqueue/public/schema/propose_create_ut.cpp
@@ -1,0 +1,220 @@
+#include "common.h"
+#include "schema_propose.h"
+
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/persqueue/public/constants.h>
+#include <ydb/core/persqueue/public/utils.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NPQ::NSchema {
+
+namespace {
+
+class TRunFnActor: public NActors::TActorBootstrapped<TRunFnActor> {
+public:
+    TRunFnActor(TActorId edge, std::function<void()> fn)
+        : Edge(edge)
+        , Fn(std::move(fn))
+    {
+    }
+
+    void Bootstrap() {
+        Fn();
+        Send(Edge, new NActors::TEvents::TEvWakeup());
+        PassAway();
+    }
+
+private:
+    const TActorId Edge;
+    std::function<void()> Fn;
+};
+
+template <typename TFn>
+void RunInActor(NActors::TTestActorRuntime& runtime, TFn&& fn) {
+    const auto edge = runtime.AllocateEdgeActor();
+    runtime.Register(new TRunFnActor(edge, std::function<void()>(std::forward<TFn>(fn))));
+    auto ev = runtime.GrabEdgeEvent<NActors::TEvents::TEvWakeup>(edge, TDuration::Seconds(5));
+    UNIT_ASSERT(ev);
+}
+
+Ydb::Topic::CreateTopicRequest BaseRequest(const TString& path = "/Root/t") {
+    Ydb::Topic::CreateTopicRequest request;
+    request.set_path(path);
+    request.mutable_partitioning_settings()->set_min_active_partitions(1);
+    return request;
+}
+
+TResult Propose(Ydb::Topic::CreateTopicRequest request) {
+    NKikimrSchemeOp::TModifyScheme modifyScheme;
+    return ProposeCreateTopic(modifyScheme, std::move(request), "/Root", "/Root", "t");
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(ProposeCreateTopic) {
+
+Y_UNIT_TEST(RejectsNegativeAndHugePartitionCount) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+    runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
+
+    RunInActor(runtime, [&] {
+        {
+            auto request = BaseRequest();
+            request.mutable_partitioning_settings()->set_min_active_partitions(-1);
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "positive");
+        }
+        {
+            auto request = BaseRequest();
+            request.mutable_partitioning_settings()->set_min_active_partitions(
+                static_cast<i64>(Max<ui32>()));
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "less than");
+        }
+    });
+}
+
+Y_UNIT_TEST(AutoPartitioningDefaultStrategyAndRetentionStorage) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+    runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
+
+    RunInActor(runtime, [&] {
+        auto request = BaseRequest();
+        request.set_retention_storage_mb(10);
+        auto* autoSettings = request.mutable_partitioning_settings()->mutable_auto_partitioning_settings();
+        // Unspecified/unknown strategy falls through to DISABLED via default branch.
+        autoSettings->set_strategy(static_cast<::Ydb::Topic::AutoPartitioningStrategy>(999));
+        autoSettings->mutable_partition_write_speed()->set_up_utilization_percent(50);
+        autoSettings->mutable_partition_write_speed()->set_down_utilization_percent(10);
+        autoSettings->mutable_partition_write_speed()->mutable_stabilization_window()->set_seconds(60);
+        request.mutable_partitioning_settings()->set_max_active_partitions(4);
+
+        NKikimrSchemeOp::TModifyScheme modifyScheme;
+        auto r = ProposeCreateTopic(modifyScheme, std::move(request), "/Root", "/Root", "t");
+        // Unknown strategy maps to DISABLED, which ValidatePartitionStrategy may reject
+        // when strategy type is present but disabled with min/max — accept either success
+        // path after remapping or a validation error.
+        if (r) {
+            const auto& part = modifyScheme.GetCreatePersQueueGroup().GetPQTabletConfig().GetPartitionConfig();
+            UNIT_ASSERT_VALUES_EQUAL(part.GetStorageLimitBytes(), 10ull * 1024 * 1024);
+        }
+    });
+}
+
+Y_UNIT_TEST(RejectsTooManyConsumersAndSpeedLimits) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+    runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
+    runtime.GetAppData().PQConfig.MutableDefaultClientServiceType()->SetName("data-streams");
+    runtime.GetAppData().PQConfig.MutableDefaultClientServiceType()->SetMaxReadRulesCountPerTopic(MAX_READ_RULES_COUNT);
+    runtime.GetAppData().PQConfig.MutableDefaultClientServiceType()->ClearPasswordHashes();
+
+    RunInActor(runtime, [&] {
+        {
+            auto request = BaseRequest();
+            for (int i = 0; i < MAX_READ_RULES_COUNT + 1; ++i) {
+                auto* c = request.add_consumers();
+                c->set_name(TStringBuilder() << "c" << i);
+                c->mutable_streaming_consumer_type();
+            }
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "consumers count cannot be more than");
+        }
+        {
+            auto request = BaseRequest();
+            request.set_partition_write_speed_messages_per_second(-1);
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "partition_write_speed_messages_per_second");
+        }
+        {
+            auto request = BaseRequest();
+            request.set_partition_write_speed_messages_per_second(
+                static_cast<i64>(DEFAULT_PARTITION_WRITE_SPEED_MESSAGES_PER_SECOND) + 1);
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "greater than");
+        }
+        {
+            auto request = BaseRequest();
+            request.set_partition_write_burst_messages(-1);
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "partition_write_burst_messages");
+        }
+        {
+            auto request = BaseRequest();
+            request.set_partition_write_burst_messages(
+                static_cast<i64>(DEFAULT_PARTITION_WRITE_SPEED_MESSAGES_PER_SECOND) + 1);
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "greater than");
+        }
+        {
+            auto request = BaseRequest();
+            request.set_partition_total_read_speed_bytes_per_second(-1);
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "partition_total_read_speed_bytes");
+        }
+        {
+            auto request = BaseRequest();
+            request.set_partition_total_read_speed_messages_per_second(-1);
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "partition_total_read_speed_messages");
+        }
+        {
+            auto request = BaseRequest();
+            request.set_partition_read_without_consumer_speed_bytes_per_second(-1);
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "partition_read_without_consumer_speed_bytes");
+        }
+        {
+            auto request = BaseRequest();
+            request.set_partition_read_without_consumer_speed_messages_per_second(-1);
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "partition_read_without_consumer_speed_messages");
+        }
+    });
+}
+
+Y_UNIT_TEST(AcceptsPositiveReadQuotasAndBurstDefaults) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+    runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
+
+    RunInActor(runtime, [&] {
+        auto request = BaseRequest();
+        request.set_partition_write_speed_messages_per_second(100);
+        request.set_partition_write_burst_messages(0); // equals write speed
+        request.set_partition_total_read_speed_bytes_per_second(5000);
+        request.set_partition_total_read_speed_messages_per_second(50);
+        request.set_partition_read_without_consumer_speed_bytes_per_second(100);
+        request.set_partition_read_without_consumer_speed_messages_per_second(10);
+        request.set_metrics_level(2);
+
+        NKikimrSchemeOp::TModifyScheme modifyScheme;
+        auto r = ProposeCreateTopic(modifyScheme, std::move(request), "/Root", "/Root", "t");
+        UNIT_ASSERT_C(r, r.GetErrorMessage());
+        const auto& config = modifyScheme.GetCreatePersQueueGroup().GetPQTabletConfig();
+        UNIT_ASSERT_VALUES_EQUAL(config.GetPartitionConfig().GetBurstSizeInMessages(), 100u);
+        UNIT_ASSERT_VALUES_EQUAL(config.GetPartitionConfig().GetReadSpeedInBytesPerSecond(), 5000u);
+        UNIT_ASSERT(config.HasMetricsLevel());
+        UNIT_ASSERT(NPQ::GetReadQuota(config, NPQ::CLIENTID_WITHOUT_CONSUMER));
+    });
+}
+
+} // Y_UNIT_TEST_SUITE(ProposeCreateTopic)
+
+} // namespace NKikimr::NPQ::NSchema

--- a/ydb/core/persqueue/public/schema/propose_create_ut.cpp
+++ b/ydb/core/persqueue/public/schema/propose_create_ut.cpp
@@ -77,6 +77,29 @@ Y_UNIT_TEST(RejectsNegativeAndHugePartitionCount) {
             UNIT_ASSERT(!r);
             UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "less than");
         }
+        {
+            auto request = BaseRequest();
+            request.mutable_partitioning_settings()->set_max_active_partitions(-1);
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "non-negative");
+        }
+        {
+            auto request = BaseRequest();
+            request.mutable_partitioning_settings()->set_max_active_partitions(
+                static_cast<i64>(Max<ui32>()));
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "less than");
+        }
+        {
+            auto request = BaseRequest();
+            request.mutable_partitioning_settings()->set_max_active_partitions(
+                static_cast<i64>(Max<ui32>()) + 1);
+            auto r = Propose(std::move(request));
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "less than");
+        }
     });
 }
 

--- a/ydb/core/persqueue/public/schema/schema_operation_ut.cpp
+++ b/ydb/core/persqueue/public/schema/schema_operation_ut.cpp
@@ -218,6 +218,23 @@ Y_UNIT_TEST(ExecInProgressDeliveryProblemExhaustsRetries) {
     UNIT_ASSERT_GT(env.PipeStats.DeliveryProblems, 10u);
 }
 
+Y_UNIT_TEST(ProxyShardNotAvailableRetriesThenSucceeds) {
+    TSchemaOpEnv env;
+    const size_t proposesBefore = env.ProposeCount;
+    env.SendStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ProxyShardNotAvailable);
+
+    NActors::TDispatchOptions options;
+    options.CustomFinalCondition = [&] {
+        return env.ProposeCount > proposesBefore;
+    };
+    env.Runtime.DispatchEvents(options, TDuration::Seconds(5));
+    UNIT_ASSERT_GT(env.ProposeCount, proposesBefore);
+
+    env.SendStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecComplete);
+    auto response = env.GrabResponse();
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::SUCCESS);
+}
+
 } // Y_UNIT_TEST_SUITE(SchemaOperationActor)
 
 } // namespace NKikimr::NPQ::NSchema

--- a/ydb/core/persqueue/public/schema/schema_operation_ut.cpp
+++ b/ydb/core/persqueue/public/schema/schema_operation_ut.cpp
@@ -1,0 +1,223 @@
+#include "schema_operation.h"
+#include "schema.h"
+
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/base/tablet_pipecache.h>
+#include <ydb/core/protos/flat_tx_scheme.pb.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+#include <ydb/core/tx/schemeshard/schemeshard.h>
+#include <ydb/core/tx/tx_proxy/proxy.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NPQ::NSchema {
+
+namespace {
+
+constexpr ui64 SCHEME_SHARD_TABLET = 72075186233409545ull;
+constexpr ui64 TX_ID = 42;
+
+struct TPipeStats {
+    size_t NotifyForwards = 0;
+    size_t DeliveryProblems = 0;
+};
+
+class TFakePipeCacheActor: public NActors::TActorBootstrapped<TFakePipeCacheActor> {
+public:
+    enum class EMode { Complete, FailAlways, FailThenComplete };
+
+    TFakePipeCacheActor(EMode mode, TPipeStats* stats)
+        : Mode(mode)
+        , Stats(stats)
+    {
+    }
+
+    void Bootstrap() {
+        Become(&TFakePipeCacheActor::StateWork);
+    }
+
+    STRICT_STFUNC(StateWork,
+        hFunc(TEvPipeCache::TEvForward, Handle);
+        IgnoreFunc(TEvPipeCache::TEvUnlink);
+    )
+
+private:
+    void Handle(TEvPipeCache::TEvForward::TPtr& ev) {
+        if (!ev->Get()->Ev) {
+            return;
+        }
+        if (ev->Get()->Ev->Type() != NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletion::EventType) {
+            return;
+        }
+
+        ++Stats->NotifyForwards;
+        const ui64 tabletId = ev->Get()->TabletId;
+        const ui64 subscribeCookie = ev->Get()->Options.SubscribeCookie;
+
+        if (Mode == EMode::FailAlways ||
+            (Mode == EMode::FailThenComplete && Stats->NotifyForwards <= 2))
+        {
+            ++Stats->DeliveryProblems;
+            Send(ev->Sender, new TEvPipeCache::TEvDeliveryProblem(tabletId, true), 0, subscribeCookie);
+            return;
+        }
+
+        Send(ev->Sender, new NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletionResult(TX_ID), 0, ev->Cookie);
+    }
+
+    EMode Mode;
+    TPipeStats* Stats;
+};
+
+struct TDummyTxProxyActor: public NActors::TActorBootstrapped<TDummyTxProxyActor> {
+    void Bootstrap() {
+        Become(&TDummyTxProxyActor::StateWork);
+    }
+
+    STRICT_STFUNC(StateWork,
+        IgnoreFunc(TEvTxUserProxy::TEvProposeTransaction);
+    )
+};
+
+struct TSchemaOpEnv {
+    NActors::TTestBasicRuntime Runtime;
+    TPipeStats PipeStats;
+    size_t ProposeCount = 0;
+    TActorId Edge;
+    TActorId ActorId;
+
+    explicit TSchemaOpEnv(TFakePipeCacheActor::EMode pipeMode = TFakePipeCacheActor::EMode::Complete)
+        : Runtime(1, false)
+    {
+        Runtime.Initialize(TAppPrepare().Unwrap());
+        Runtime.UpdateCurrentTime(TInstant::Now());
+        Runtime.SetLogPriority(NKikimrServices::PQ_SCHEMA, NActors::NLog::PRI_DEBUG);
+        Runtime.SetScheduledLimit(10000);
+
+        Runtime.RegisterService(MakeTxProxyID(), Runtime.Register(new TDummyTxProxyActor()));
+        auto pipeCacheId = Runtime.Register(new TFakePipeCacheActor(pipeMode, &PipeStats));
+        Runtime.RegisterService(MakePipePerNodeCacheID(false), pipeCacheId);
+
+        Runtime.SetObserverFunc([this](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvTxUserProxy::TEvProposeTransaction::EventType) {
+                ++ProposeCount;
+                return TTestActorRuntime::EEventAction::DROP;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        Edge = Runtime.AllocateEdgeActor();
+        auto operation = std::make_unique<TEvTxUserProxy::TEvProposeTransaction>();
+        operation->Record.SetDatabaseName("/Root");
+        ActorId = Runtime.Register(CreateSchemaOperation(
+            Edge, "/Root/topic", std::move(operation), /*cookie=*/7));
+        Runtime.EnableScheduleForActor(ActorId, true);
+
+        NActors::TDispatchOptions options;
+        options.CustomFinalCondition = [this] {
+            return ProposeCount > 0;
+        };
+        Runtime.DispatchEvents(options, TDuration::Seconds(2));
+        UNIT_ASSERT_GT_C(ProposeCount, 0u, "Bootstrap must send TEvProposeTransaction");
+    }
+
+    void SendStatus(
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus status,
+        NKikimrScheme::EStatus ssStatus = NKikimrScheme::StatusSuccess)
+    {
+        auto ev = MakeHolder<TEvTxUserProxy::TEvProposeTransactionStatus>(status);
+        ev->Record.SetSchemeShardTabletId(SCHEME_SHARD_TABLET);
+        ev->Record.SetTxId(TX_ID);
+        ev->Record.SetSchemeShardStatus(ssStatus);
+        Runtime.Send(new IEventHandle(ActorId, Edge, ev.Release()));
+    }
+
+    THolder<TEvSchemaOperationResponse> GrabResponse(TDuration timeout = TDuration::Seconds(5)) {
+        auto handle = Runtime.GrabEdgeEvent<TEvSchemaOperationResponse>(Edge, timeout);
+        UNIT_ASSERT(handle);
+        UNIT_ASSERT_VALUES_EQUAL(handle->Cookie, 7u);
+        return THolder(handle->Release());
+    }
+};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(SchemaOperationActor) {
+
+Y_UNIT_TEST(ExecCompleteSucceeds) {
+    TSchemaOpEnv env;
+    env.SendStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecComplete);
+    auto response = env.GrabResponse();
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT(response->ErrorMessage.empty());
+}
+
+Y_UNIT_TEST(ExecCompleteAlreadyExists) {
+    TSchemaOpEnv env;
+    env.SendStatus(
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecComplete,
+        NKikimrScheme::StatusAlreadyExists);
+    auto response = env.GrabResponse();
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::ALREADY_EXISTS);
+    UNIT_ASSERT_STRING_CONTAINS(response->ErrorMessage, "StatusAlreadyExists");
+}
+
+Y_UNIT_TEST(ExecAlreadyAlreadyExists) {
+    TSchemaOpEnv env;
+    env.SendStatus(
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecAlready,
+        NKikimrScheme::StatusAlreadyExists);
+    auto response = env.GrabResponse();
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::ALREADY_EXISTS);
+}
+
+Y_UNIT_TEST(ExecAlreadyOtherMapsViaYdbStatus) {
+    TSchemaOpEnv env;
+    env.SendStatus(
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecAlready,
+        NKikimrScheme::StatusSchemeError);
+    auto response = env.GrabResponse();
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::INTERNAL_ERROR);
+    UNIT_ASSERT_STRING_CONTAINS(response->ErrorMessage, "StatusSchemeError");
+}
+
+Y_UNIT_TEST(ExecErrorMapsSchemeError) {
+    TSchemaOpEnv env;
+    env.SendStatus(
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecError,
+        NKikimrScheme::StatusPathDoesNotExist);
+    auto response = env.GrabResponse();
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::SCHEME_ERROR);
+    UNIT_ASSERT_STRING_CONTAINS(response->ErrorMessage, "StatusPathDoesNotExist");
+}
+
+Y_UNIT_TEST(ExecInProgressWaitsForNotify) {
+    TSchemaOpEnv env;
+    env.SendStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecInProgress);
+    auto response = env.GrabResponse();
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(env.PipeStats.NotifyForwards, 1u);
+}
+
+Y_UNIT_TEST(ExecInProgressRetriesDeliveryProblemThenSucceeds) {
+    TSchemaOpEnv env(TFakePipeCacheActor::EMode::FailThenComplete);
+    env.SendStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecInProgress);
+    auto response = env.GrabResponse();
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_GT(env.PipeStats.DeliveryProblems, 0u);
+    UNIT_ASSERT_GT(env.PipeStats.NotifyForwards, 2u);
+}
+
+Y_UNIT_TEST(ExecInProgressDeliveryProblemExhaustsRetries) {
+    TSchemaOpEnv env(TFakePipeCacheActor::EMode::FailAlways);
+    env.SendStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecInProgress);
+    auto response = env.GrabResponse();
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::UNAVAILABLE);
+    UNIT_ASSERT_STRING_CONTAINS(response->ErrorMessage, "is unavailable");
+    UNIT_ASSERT_GT(env.PipeStats.DeliveryProblems, 10u);
+}
+
+} // Y_UNIT_TEST_SUITE(SchemaOperationActor)
+
+} // namespace NKikimr::NPQ::NSchema

--- a/ydb/core/persqueue/public/schema/schema_ops_ut.cpp
+++ b/ydb/core/persqueue/public/schema/schema_ops_ut.cpp
@@ -1,5 +1,6 @@
 #include "schema_ut_helpers.h"
 
+#include <ydb/core/persqueue/public/constants.h>
 #include <ydb/core/persqueue/public/utils.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -171,6 +172,720 @@ Y_UNIT_TEST(AlterMessagesPerSecond) {
             Ydb::StatusIds::BAD_REQUEST,
             "partition_write_speed_messages_per_second");
     }
+}
+
+Y_UNIT_TEST(AlterPreservesMeteringModeWhenUnspecified) {
+    // Regression: AlterTopic used to call FillMeteringMode(..., EOperation::Create),
+    // which rewrote RESERVED_CAPACITY to REQUEST_UNITS when set_metering_mode was unset.
+    auto setup = CreateMeteringSetup("CoreAlterMetering");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_metering";
+
+    {
+        auto request = MakeCreateTopicRequest(path);
+        request.set_metering_mode(Ydb::Topic::METERING_MODE_RESERVED_CAPACITY);
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::SUCCESS);
+        auto config = DescribeTabletConfig(runtime, path);
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(config.GetMeteringMode()),
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(
+                NKikimrPQ::TPQTabletConfig::METERING_MODE_RESERVED_CAPACITY));
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* consumer = request.add_add_consumers();
+        consumer->set_name("extra");
+        consumer->mutable_streaming_consumer_type();
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+
+        auto config = DescribeTabletConfig(runtime, path);
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(config.GetMeteringMode()),
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(
+                NKikimrPQ::TPQTabletConfig::METERING_MODE_RESERVED_CAPACITY));
+        UNIT_ASSERT(NPQ::GetConsumer(config, "extra"));
+    }
+}
+
+Y_UNIT_TEST(TopicAttributesSmoke) {
+    auto setup = CreateSetup("CoreTopicAttrs");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_attrs";
+
+    auto request = MakeCreateTopicRequest(path);
+    auto& attrs = *request.mutable_attributes();
+    attrs["_allow_unauthenticated_read"] = "true";
+    attrs["_allow_unauthenticated_write"] = "false";
+    attrs["_abc_slug"] = "slug";
+    attrs["_federation_account"] = "acc";
+    attrs["_abc_id"] = "42";
+    attrs["_max_partition_storage_size"] = "1048576";
+    attrs["_message_group_seqno_retention_period_ms"] = "60000";
+    attrs["_max_partition_message_groups_seqno_stored"] = "100";
+    attrs["_cleanup_policy"] = "compact";
+    attrs["_sqs_queue_name"] = "q";
+    attrs["_sqs_account_name"] = "a";
+    attrs["_sqs_cloud_id"] = "c";
+    attrs["_sqs_folder_id"] = "f";
+    attrs["_sqs_export_metrics"] = "true";
+    AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::SUCCESS);
+
+    auto config = DescribeTabletConfig(runtime, path);
+    UNIT_ASSERT(!config.GetRequireAuthRead());
+    UNIT_ASSERT(config.GetRequireAuthWrite());
+    UNIT_ASSERT_VALUES_EQUAL(config.GetAbcSlug(), "slug");
+    UNIT_ASSERT_VALUES_EQUAL(config.GetFederationAccount(), "acc");
+    UNIT_ASSERT_VALUES_EQUAL(config.GetAbcId(), 42u);
+    UNIT_ASSERT_VALUES_EQUAL(config.GetPartitionConfig().GetMaxSizeInPartition(), 1048576);
+    UNIT_ASSERT_VALUES_EQUAL(config.GetPartitionConfig().GetSourceIdLifetimeSeconds(), 60u);
+    UNIT_ASSERT_VALUES_EQUAL(config.GetPartitionConfig().GetSourceIdMaxCounts(), 100);
+    UNIT_ASSERT(config.GetEnableCompactification());
+    UNIT_ASSERT_VALUES_EQUAL(config.GetSqsQueueName(), "q");
+    UNIT_ASSERT(config.GetSqsExportMetrics());
+}
+
+Y_UNIT_TEST(TopicAttributesValidation) {
+    auto setup = CreateSetup("CoreTopicAttrsBad");
+    auto& runtime = setup->GetRuntime();
+
+    auto tryCreate = [&](const TString& path, const TString& key, const TString& value, const TString& err) {
+        auto request = MakeCreateTopicRequest(path);
+        (*request.mutable_attributes())[key] = value;
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::BAD_REQUEST, err);
+    };
+
+    tryCreate("/Root/bad_attr_unknown", "_no_such_attr", "1", "not supported");
+    tryCreate("/Root/bad_partitions_per_tablet", "_partitions_per_tablet", "21", "greater than 20");
+    tryCreate("/Root/bad_partitions_per_tablet_nan", "_partitions_per_tablet", "x", "not ui32");
+    tryCreate("/Root/bad_unauth_read", "_allow_unauthenticated_read", "maybe", "not bool");
+    tryCreate("/Root/bad_abc_id", "_abc_id", "zz", "not integer");
+    tryCreate("/Root/bad_max_part_size", "_max_partition_storage_size", "-1", "can't be negative");
+    tryCreate("/Root/bad_msg_group_ms", "_message_group_seqno_retention_period_ms", "-5", "can't be negative");
+    tryCreate("/Root/bad_msg_group_count", "_max_partition_message_groups_seqno_stored", "-1", "can't be negative");
+    tryCreate("/Root/bad_timestamp", "_timestamp_type", "weird", "incorrect value");
+    tryCreate("/Root/bad_sqs_metrics", "_sqs_export_metrics", "nope", "not bool");
+}
+
+Y_UNIT_TEST(CreateAlterDropPrepareOnlyAndIfFlags) {
+    auto setup = CreateSetup("CorePrepareIf");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_prepare";
+
+    {
+        auto result = DoCreate(runtime, MakeCreateTopicRequest(path), "/Root", /*prepareOnly=*/true);
+        AssertStatus(result, Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT(result->ModifyScheme.HasCreatePersQueueGroup() ||
+            result->ModifyScheme.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreatePersQueueGroup ||
+            result->ModifyScheme.ByteSizeLong() > 0);
+        // Topic must not exist yet.
+        auto edge = runtime.AllocateEdgeActor();
+        runtime.Register(NDescriber::CreateDescriberActor(edge, "/Root", {path}));
+        auto response = runtime.GrabEdgeEvent<NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
+        UNIT_ASSERT_VALUES_EQUAL(response->Topics.begin()->second.Status, NDescriber::EStatus::NOT_FOUND);
+    }
+
+    AssertStatus(DoCreate(runtime, MakeCreateTopicRequest(path)), Ydb::StatusIds::SUCCESS);
+    AssertStatus(DoCreate(runtime, MakeCreateTopicRequest(path), "/Root", false, /*ifNotExists=*/true), Ydb::StatusIds::SUCCESS);
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.set_set_partition_write_speed_messages_per_second(11);
+        auto result = DoAlter(runtime, request, "/Root", /*prepareOnly=*/true);
+        AssertStatus(result, Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT(result->ModifyScheme.ByteSizeLong() > 0);
+        // Not applied.
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            DescribePartitionConfig(runtime, path).GetWriteSpeedInMessagesPerSecond(), 11u);
+    }
+
+    AssertStatus(DoAlter(runtime, [&]{
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path("/Root/missing_topic");
+        request.set_set_partition_write_speed_messages_per_second(1);
+        return request;
+    }(), "/Root", false, /*ifExists=*/true), Ydb::StatusIds::SUCCESS);
+
+    AssertStatus(DoDrop(runtime, "/Root/missing_drop", "/Root", /*ifExists=*/true), Ydb::StatusIds::SUCCESS);
+    AssertStatus(DoDrop(runtime, path), Ydb::StatusIds::SUCCESS);
+}
+
+Y_UNIT_TEST(CreateAlterViaPromise) {
+    auto setup = CreateSetup("CorePromiseApi");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_promise";
+
+    {
+        auto future = DoCreateViaPromise(runtime, MakeCreateTopicRequest(path));
+        UNIT_ASSERT(future.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(future.GetValue().Status, Ydb::StatusIds::SUCCESS);
+    }
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* consumer = request.add_add_consumers();
+        consumer->set_name("p1");
+        consumer->mutable_streaming_consumer_type();
+        auto future = DoAlterViaPromise(runtime, request);
+        UNIT_ASSERT(future.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(future.GetValue().Status, Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT(NPQ::GetConsumer(DescribeTabletConfig(runtime, path), "p1"));
+    }
+}
+
+Y_UNIT_TEST(AlterSharedConsumerDlqAndReadQuotas) {
+    auto setup = CreateSetup("CoreAlterSharedDlq");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_alter_shared";
+    AssertStatus(DoCreate(runtime, MakeCreateTopicRequest("/Root/dlq_alter")), Ydb::StatusIds::SUCCESS);
+    AssertStatus(DoCreate(runtime, MakeCreateTopicRequest("/Root/dlq_alter2")), Ydb::StatusIds::SUCCESS);
+
+    {
+        auto request = MakeCreateTopicRequest(path);
+        request.clear_consumers();
+        auto* consumer = request.add_consumers();
+        consumer->set_name("shared_c");
+        auto* type = consumer->mutable_shared_consumer_type();
+        type->set_keep_messages_order(true);
+        type->mutable_dead_letter_policy()->set_enabled(true);
+        type->mutable_dead_letter_policy()->mutable_move_action()->set_dead_letter_queue("dlq_alter");
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alter = request.add_alter_consumers();
+        alter->set_name("shared_c");
+        auto* alterType = alter->mutable_alter_shared_consumer_type();
+        alterType->mutable_set_default_processing_timeout()->set_seconds(9);
+        alterType->mutable_set_receive_message_delay()->set_seconds(1);
+        alterType->mutable_set_receive_message_wait_time()->set_seconds(2);
+        auto* policy = alterType->mutable_alter_dead_letter_policy();
+        policy->set_set_enabled(true);
+        policy->mutable_alter_condition()->set_set_max_processing_attempts(7);
+        policy->mutable_alter_move_action()->set_set_dead_letter_queue("dlq_alter2");
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+
+        auto config = DescribeTabletConfig(runtime, path);
+        const auto* c = NPQ::GetConsumer(config, "shared_c");
+        UNIT_ASSERT(c);
+        UNIT_ASSERT_VALUES_EQUAL(c->GetDefaultProcessingTimeoutSeconds(), 9);
+        UNIT_ASSERT_VALUES_EQUAL(c->GetMaxProcessingAttempts(), 7);
+        UNIT_ASSERT_VALUES_EQUAL(c->GetDeadLetterQueue(), "dlq_alter2");
+        UNIT_ASSERT_VALUES_EQUAL(c->GetDefaultDelayMessageTimeMs(), 1000u);
+        UNIT_ASSERT_VALUES_EQUAL(c->GetDefaultReceiveMessageWaitTimeMs(), 2000u);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alter = request.add_alter_consumers();
+        alter->set_name("shared_c");
+        alter->set_set_read_speed_bytes_per_second(111);
+        alter->set_set_read_speed_messages_per_second(22);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+        auto config = DescribeTabletConfig(runtime, path);
+        const auto* quota = NPQ::GetReadQuota(config, "shared_c");
+        UNIT_ASSERT(quota);
+        UNIT_ASSERT_VALUES_EQUAL(quota->GetSpeedInBytesPerSecond(), 111u);
+        UNIT_ASSERT_VALUES_EQUAL(quota->GetSpeedInMessagesPerSecond(), 22u);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.set_set_partition_total_read_speed_bytes_per_second(1000);
+        request.set_set_partition_total_read_speed_messages_per_second(50);
+        request.set_set_partition_read_without_consumer_speed_bytes_per_second(200);
+        request.set_set_partition_read_without_consumer_speed_messages_per_second(10);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+        auto part = DescribePartitionConfig(runtime, path);
+        UNIT_ASSERT_VALUES_EQUAL(part.GetReadSpeedInBytesPerSecond(), 1000u);
+        UNIT_ASSERT_VALUES_EQUAL(part.GetReadSpeedInMessagesPerSecond(), 50u);
+        auto config = DescribeTabletConfig(runtime, path);
+        const auto* without = NPQ::GetReadQuota(config, CLIENTID_WITHOUT_CONSUMER);
+        UNIT_ASSERT(without);
+        UNIT_ASSERT_VALUES_EQUAL(without->GetSpeedInBytesPerSecond(), 200u);
+        UNIT_ASSERT_VALUES_EQUAL(without->GetSpeedInMessagesPerSecond(), 10u);
+    }
+}
+
+Y_UNIT_TEST(AlterAutoPartitioningAndCodecs) {
+    auto setup = CreateSetup("CoreAlterAutoPart");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_autopart";
+
+    {
+        auto request = MakeCreateTopicRequest(path, 2);
+        auto* autoSettings = request.mutable_partitioning_settings()->mutable_auto_partitioning_settings();
+        autoSettings->set_strategy(Ydb::Topic::AUTO_PARTITIONING_STRATEGY_SCALE_UP);
+        autoSettings->mutable_partition_write_speed()->set_up_utilization_percent(80);
+        autoSettings->mutable_partition_write_speed()->set_down_utilization_percent(20);
+        autoSettings->mutable_partition_write_speed()->mutable_stabilization_window()->set_seconds(30);
+        request.mutable_partitioning_settings()->set_max_active_partitions(4);
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.mutable_alter_partitioning_settings()->set_set_min_active_partitions(-1);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::BAD_REQUEST, "non-negative");
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* settings = request.mutable_alter_partitioning_settings();
+        settings->set_set_min_active_partitions(2);
+        settings->set_set_max_active_partitions(6);
+        auto* autoSettings = settings->mutable_alter_auto_partitioning_settings();
+        autoSettings->set_set_strategy(Ydb::Topic::AUTO_PARTITIONING_STRATEGY_SCALE_UP_AND_DOWN);
+        autoSettings->mutable_set_partition_write_speed()->set_set_up_utilization_percent(70);
+        autoSettings->mutable_set_partition_write_speed()->set_set_down_utilization_percent(15);
+        autoSettings->mutable_set_partition_write_speed()->mutable_set_stabilization_window()->set_seconds(40);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+
+        auto config = DescribeTabletConfig(runtime, path);
+        UNIT_ASSERT_VALUES_EQUAL(config.GetPartitionStrategy().GetMaxPartitionCount(), 6);
+        UNIT_ASSERT_VALUES_EQUAL(config.GetPartitionStrategy().GetScaleUpPartitionWriteSpeedThresholdPercent(), 70);
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrPQ::TPQTabletConfig::TPartitionStrategyType_Name(config.GetPartitionStrategy().GetPartitionStrategyType()),
+            NKikimrPQ::TPQTabletConfig::TPartitionStrategyType_Name(
+                NKikimrPQ::TPQTabletConfig::CAN_SPLIT_AND_MERGE));
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.mutable_set_supported_codecs()->add_codecs(Ydb::Topic::CODEC_RAW);
+        request.mutable_set_supported_codecs()->add_codecs(Ydb::Topic::CODEC_GZIP);
+        request.set_set_metrics_level(1);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+        auto config = DescribeTabletConfig(runtime, path);
+        UNIT_ASSERT_VALUES_EQUAL(config.GetCodecs().IdsSize(), 2u);
+        UNIT_ASSERT(config.HasMetricsLevel());
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.mutable_reset_metrics_level();
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT(!DescribeTabletConfig(runtime, path).HasMetricsLevel());
+    }
+}
+
+Y_UNIT_TEST(ConsumerValidationErrors) {
+    auto setup = CreateSetup("CoreConsumerErrors");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_cons_err";
+    CreateTopic(runtime, path);
+
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("bad/name");
+        consumer.mutable_streaming_consumer_type();
+        AssertStatus(DoAddConsumer(runtime, path, consumer), Ydb::StatusIds::BAD_REQUEST, "illegal symbols");
+    }
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("");
+        consumer.mutable_streaming_consumer_type();
+        AssertStatus(DoAddConsumer(runtime, path, consumer), Ydb::StatusIds::BAD_REQUEST, "empty name");
+    }
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.add_drop_consumers("missing_consumer");
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::NOT_FOUND, "drop_consumers");
+    }
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alter = request.add_alter_consumers();
+        alter->set_name("missing_alter");
+        alter->set_set_important(true);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::NOT_FOUND, "alter_consumers");
+    }
+}
+
+Y_UNIT_TEST(MeteringDisabledRejectsExplicitMode) {
+    auto setup = CreateSetup("CoreMeteringOff");
+    auto& runtime = setup->GetRuntime();
+    runtime.GetAppData().PQConfig.MutableBillingMeteringConfig()->SetEnabled(false);
+
+    auto request = MakeCreateTopicRequest("/Root/topic_metering_off");
+    request.set_metering_mode(Ydb::Topic::METERING_MODE_RESERVED_CAPACITY);
+    AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::PRECONDITION_FAILED, "serverless");
+}
+
+Y_UNIT_TEST(CreateAutoPartitioningStrategiesAndCodecs) {
+    auto setup = CreateSetup("CoreCreateAuto");
+    auto& runtime = setup->GetRuntime();
+
+    auto makeAuto = [&](const TString& path, Ydb::Topic::AutoPartitioningStrategy strategy) {
+        auto request = MakeCreateTopicRequest(path, 2);
+        auto* autoSettings = request.mutable_partitioning_settings()->mutable_auto_partitioning_settings();
+        autoSettings->set_strategy(strategy);
+        autoSettings->mutable_partition_write_speed()->set_up_utilization_percent(75);
+        autoSettings->mutable_partition_write_speed()->set_down_utilization_percent(25);
+        autoSettings->mutable_partition_write_speed()->mutable_stabilization_window()->set_seconds(45);
+        request.mutable_partitioning_settings()->set_max_active_partitions(8);
+        request.mutable_supported_codecs()->add_codecs(Ydb::Topic::CODEC_RAW);
+        request.mutable_supported_codecs()->add_codecs(Ydb::Topic::CODEC_GZIP);
+        request.set_partition_write_burst_messages(100);
+        request.set_partition_total_read_speed_bytes_per_second(5000);
+        request.set_partition_total_read_speed_messages_per_second(50);
+        request.set_partition_read_without_consumer_speed_bytes_per_second(100);
+        request.set_partition_read_without_consumer_speed_messages_per_second(10);
+        request.set_metrics_level(2);
+        return request;
+    };
+
+    AssertStatus(
+        DoCreate(runtime, makeAuto("/Root/topic_auto_up_down", Ydb::Topic::AUTO_PARTITIONING_STRATEGY_SCALE_UP_AND_DOWN)),
+        Ydb::StatusIds::SUCCESS);
+    AssertStatus(
+        DoCreate(runtime, makeAuto("/Root/topic_auto_paused", Ydb::Topic::AUTO_PARTITIONING_STRATEGY_PAUSED)),
+        Ydb::StatusIds::SUCCESS);
+
+    {
+        auto config = DescribeTabletConfig(runtime, "/Root/topic_auto_up_down");
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrPQ::TPQTabletConfig::TPartitionStrategyType_Name(config.GetPartitionStrategy().GetPartitionStrategyType()),
+            NKikimrPQ::TPQTabletConfig::TPartitionStrategyType_Name(
+                NKikimrPQ::TPQTabletConfig::CAN_SPLIT_AND_MERGE));
+        UNIT_ASSERT_VALUES_EQUAL(config.GetCodecs().IdsSize(), 2u);
+        UNIT_ASSERT(config.HasMetricsLevel());
+        auto part = config.GetPartitionConfig();
+        UNIT_ASSERT_VALUES_EQUAL(part.GetBurstSizeInMessages(), 100u);
+        UNIT_ASSERT_VALUES_EQUAL(part.GetReadSpeedInBytesPerSecond(), 5000u);
+    }
+}
+
+Y_UNIT_TEST(CreateAttributeEdgeCases) {
+    auto setup = CreateSetup("CoreAttrEdges");
+    auto& runtime = setup->GetRuntime();
+
+    {
+        auto request = MakeCreateTopicRequest("/Root/topic_attr_empty_bools");
+        auto& attrs = *request.mutable_attributes();
+        attrs["_allow_unauthenticated_read"] = "";
+        attrs["_allow_unauthenticated_write"] = "";
+        attrs["_abc_id"] = "";
+        attrs["_max_partition_storage_size"] = "";
+        attrs["_message_group_seqno_retention_period_ms"] = "";
+        attrs["_max_partition_message_groups_seqno_stored"] = "";
+        attrs["_sqs_export_metrics"] = "";
+        attrs["_timestamp_type"] = "";
+        attrs["_partitions_per_tablet"] = "2";
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::SUCCESS);
+        auto config = DescribeTabletConfig(runtime, "/Root/topic_attr_empty_bools");
+        UNIT_ASSERT(config.GetRequireAuthRead());
+        UNIT_ASSERT(config.GetRequireAuthWrite());
+        UNIT_ASSERT_VALUES_EQUAL(config.GetAbcId(), 0u);
+        UNIT_ASSERT(config.GetSqsExportMetrics());
+    }
+
+    {
+        auto request = MakeCreateTopicRequest("/Root/topic_attr_ts_log");
+        (*request.mutable_attributes())["_timestamp_type"] = "LogAppendTime";
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        // Retention too large for default limits.
+        auto request = MakeCreateTopicRequest("/Root/topic_bad_retention");
+        request.mutable_retention_period()->set_seconds(1); // too small vs typical limits? or use huge
+        // Use a clearly invalid retention of Max i32 seconds may still fit synthetic limits;
+        // use negative via CheckRetentionPeriod path:
+        request.mutable_retention_period()->set_seconds(-5);
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::BAD_REQUEST, "retention_period");
+    }
+
+    {
+        auto request = MakeCreateTopicRequest("/Root/topic_bad_codec");
+        request.mutable_supported_codecs()->add_codecs(static_cast<Ydb::Topic::Codec>(0));
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::BAD_REQUEST, "Unknown codec");
+    }
+
+    {
+        auto request = MakeCreateTopicRequest("/Root/topic_neg_parts");
+        request.mutable_partitioning_settings()->set_min_active_partitions(-3);
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::BAD_REQUEST, "positive");
+    }
+}
+
+Y_UNIT_TEST(AlterSharedDlqSetDeleteAndEmptyMoveRejected) {
+    auto setup = CreateSetup("CoreAlterDlqActions");
+    auto& runtime = setup->GetRuntime();
+    AssertStatus(DoCreate(runtime, MakeCreateTopicRequest("/Root/dlq_set")), Ydb::StatusIds::SUCCESS);
+    const TString path = "/Root/topic_dlq_actions";
+
+    {
+        auto request = MakeCreateTopicRequest(path);
+        request.clear_consumers();
+        auto* consumer = request.add_consumers();
+        consumer->set_name("shared_c");
+        auto* type = consumer->mutable_shared_consumer_type();
+        type->mutable_dead_letter_policy()->set_enabled(true);
+        type->mutable_dead_letter_policy()->mutable_move_action()->set_dead_letter_queue("dlq_set");
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alter = request.add_alter_consumers();
+        alter->set_name("shared_c");
+        auto* policy = alter->mutable_alter_shared_consumer_type()->mutable_alter_dead_letter_policy();
+        policy->mutable_set_move_action()->set_dead_letter_queue("");
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::BAD_REQUEST, "cannot be empty");
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alter = request.add_alter_consumers();
+        alter->set_name("shared_c");
+        auto* policy = alter->mutable_alter_shared_consumer_type()->mutable_alter_dead_letter_policy();
+        policy->mutable_set_delete_action();
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+        auto config = DescribeTabletConfig(runtime, path);
+        const auto* c = NPQ::GetConsumer(config, "shared_c");
+        UNIT_ASSERT(c);
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrPQ::TPQTabletConfig::EDeadLetterPolicy_Name(c->GetDeadLetterPolicy()),
+            NKikimrPQ::TPQTabletConfig::EDeadLetterPolicy_Name(
+                NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_DELETE));
+    }
+}
+
+Y_UNIT_TEST(AlterWriteBurstAndRetentionAndClearQuotas) {
+    auto setup = CreateSetup("CoreAlterBurstRetention");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_burst_ret";
+    CreateTopic(runtime, path);
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.set_set_partition_write_speed_bytes_per_second(0); // default speed
+        request.set_set_partition_write_burst_bytes(0); // equals write speed
+        request.mutable_set_retention_period()->set_seconds(7200);
+        request.set_set_partition_write_speed_messages_per_second(0);
+        request.set_set_partition_write_burst_messages(0);
+        request.set_set_partition_total_read_speed_bytes_per_second(0);
+        request.set_set_partition_total_read_speed_messages_per_second(0);
+        request.set_set_partition_read_without_consumer_speed_bytes_per_second(0);
+        request.set_set_partition_read_without_consumer_speed_messages_per_second(0);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+        auto part = DescribePartitionConfig(runtime, path);
+        UNIT_ASSERT_VALUES_EQUAL(part.GetLifetimeSeconds(), 7200u);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.mutable_set_retention_period()->set_seconds(-1);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::BAD_REQUEST, "retention_period");
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.set_set_partition_write_burst_messages(-2);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::BAD_REQUEST, "partition_write_burst_messages");
+    }
+}
+
+Y_UNIT_TEST(ConsumerReadQuotaAndAvailabilityPeriod) {
+    auto setup = CreateSetup("CoreConsumerQuota");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_cons_quota";
+    CreateTopic(runtime, path);
+
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("quota_c");
+        consumer.mutable_streaming_consumer_type();
+        consumer.set_read_speed_bytes_per_second(1000);
+        consumer.set_read_speed_messages_per_second(20);
+        consumer.mutable_availability_period()->set_seconds(30);
+        (*consumer.mutable_attributes())["_version"] = "7";
+        AssertStatus(DoAddConsumer(runtime, path, consumer), Ydb::StatusIds::SUCCESS);
+        auto config = DescribeTabletConfig(runtime, path);
+        const auto* c = NPQ::GetConsumer(config, "quota_c");
+        UNIT_ASSERT(c);
+        UNIT_ASSERT_VALUES_EQUAL(c->GetVersion(), 7u);
+        UNIT_ASSERT_VALUES_EQUAL(c->GetAvailabilityPeriodMs(), 30000u);
+        const auto* quota = NPQ::GetReadQuota(config, "quota_c");
+        UNIT_ASSERT(quota);
+        UNIT_ASSERT_VALUES_EQUAL(quota->GetSpeedInBytesPerSecond(), 1000u);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alter = request.add_alter_consumers();
+        alter->set_name("quota_c");
+        alter->set_set_read_speed_bytes_per_second(0);
+        alter->set_set_read_speed_messages_per_second(0);
+        alter->mutable_reset_availability_period();
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("bad_quota");
+        consumer.mutable_streaming_consumer_type();
+        consumer.set_read_speed_bytes_per_second(-1);
+        AssertStatus(DoAddConsumer(runtime, path, consumer), Ydb::StatusIds::BAD_REQUEST, "read_speed_bytes");
+    }
+}
+
+Y_UNIT_TEST(MeteringEnabledCreateModes) {
+    auto setup = CreateMeteringSetup("CoreMeteringModes");
+    auto& runtime = setup->GetRuntime();
+
+    {
+        auto request = MakeCreateTopicRequest("/Root/topic_metering_default");
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::SUCCESS);
+        auto config = DescribeTabletConfig(runtime, "/Root/topic_metering_default");
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(config.GetMeteringMode()),
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(
+                NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS));
+    }
+    {
+        auto request = MakeCreateTopicRequest("/Root/topic_metering_ru");
+        request.set_metering_mode(Ydb::Topic::METERING_MODE_REQUEST_UNITS);
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::SUCCESS);
+    }
+    {
+        auto request = MakeCreateTopicRequest("/Root/topic_metering_rc");
+        request.set_metering_mode(Ydb::Topic::METERING_MODE_RESERVED_CAPACITY);
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::SUCCESS);
+        Ydb::Topic::AlterTopicRequest alter;
+        alter.set_path("/Root/topic_metering_rc");
+        alter.set_set_metering_mode(Ydb::Topic::METERING_MODE_REQUEST_UNITS);
+        AssertStatus(DoAlter(runtime, alter), Ydb::StatusIds::SUCCESS);
+        auto config = DescribeTabletConfig(runtime, "/Root/topic_metering_rc");
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(config.GetMeteringMode()),
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(
+                NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS));
+    }
+}
+
+Y_UNIT_TEST(AlterAutoPartitioningScaleUpAndDisable) {
+    auto setup = CreateSetup("CoreAlterAutoScale");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_auto_scale_alter";
+
+    {
+        auto request = MakeCreateTopicRequest(path, 2);
+        auto* autoSettings = request.mutable_partitioning_settings()->mutable_auto_partitioning_settings();
+        autoSettings->set_strategy(Ydb::Topic::AUTO_PARTITIONING_STRATEGY_SCALE_UP);
+        autoSettings->mutable_partition_write_speed()->set_up_utilization_percent(80);
+        autoSettings->mutable_partition_write_speed()->set_down_utilization_percent(20);
+        autoSettings->mutable_partition_write_speed()->mutable_stabilization_window()->set_seconds(30);
+        request.mutable_partitioning_settings()->set_max_active_partitions(4);
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* settings = request.mutable_alter_partitioning_settings();
+        settings->set_set_min_active_partitions(2);
+        settings->set_set_max_active_partitions(6);
+        auto* alterAuto = settings->mutable_alter_auto_partitioning_settings();
+        alterAuto->set_set_strategy(Ydb::Topic::AUTO_PARTITIONING_STRATEGY_SCALE_UP_AND_DOWN);
+        alterAuto->mutable_set_partition_write_speed()->set_set_up_utilization_percent(70);
+        alterAuto->mutable_set_partition_write_speed()->set_set_down_utilization_percent(30);
+        alterAuto->mutable_set_partition_write_speed()->mutable_set_stabilization_window()->set_seconds(40);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+        auto config = DescribeTabletConfig(runtime, path);
+        UNIT_ASSERT_VALUES_EQUAL(config.GetPartitionStrategy().GetMinPartitionCount(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(config.GetPartitionStrategy().GetMaxPartitionCount(), 6u);
+        UNIT_ASSERT_VALUES_EQUAL(config.GetPartitionStrategy().GetScaleThresholdSeconds(), 40u);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alterAuto = request.mutable_alter_partitioning_settings()
+            ->mutable_alter_auto_partitioning_settings();
+        alterAuto->set_set_strategy(Ydb::Topic::AUTO_PARTITIONING_STRATEGY_DISABLED);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.mutable_alter_partitioning_settings()->set_set_min_active_partitions(-1);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::BAD_REQUEST, "non-negative");
+    }
+}
+
+Y_UNIT_TEST(AlterConsumerAttributesAndCodecs) {
+    auto setup = CreateSetup("CoreAlterConsAttrs");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_alter_cons_attrs";
+    CreateTopic(runtime, path);
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alter = request.add_alter_consumers();
+        alter->set_name("user");
+        alter->set_set_important(false);
+        alter->mutable_set_read_from()->set_seconds(10);
+        alter->mutable_set_supported_codecs()->add_codecs(Ydb::Topic::CODEC_RAW);
+        (*alter->mutable_alter_attributes())["_version"] = "3";
+        alter->mutable_set_availability_period()->set_seconds(15);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+        auto config = DescribeTabletConfig(runtime, path);
+        const auto* c = NPQ::GetConsumer(config, "user");
+        UNIT_ASSERT(c);
+        UNIT_ASSERT_VALUES_EQUAL(c->GetVersion(), 3u);
+        UNIT_ASSERT_VALUES_EQUAL(c->GetAvailabilityPeriodMs(), 15000u);
+    }
+}
+
+Y_UNIT_TEST(AlterRetentionStorageMb) {
+    auto setup = CreateSetup("CoreAlterRetentionMb");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_retention_mb";
+    CreateTopic(runtime, path);
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.set_set_retention_storage_mb(10);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+        auto part = DescribePartitionConfig(runtime, path);
+        UNIT_ASSERT_VALUES_EQUAL(part.GetStorageLimitBytes(), 10ull * 1024 * 1024);
+    }
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.set_set_retention_storage_mb(0);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+        auto part = DescribePartitionConfig(runtime, path);
+        UNIT_ASSERT(!part.HasStorageLimitBytes() || part.GetStorageLimitBytes() == 0);
+    }
+}
+
+Y_UNIT_TEST(DropIfExistsSucceedsForMissing) {
+    auto setup = CreateSetup("CoreDropIfExists");
+    auto& runtime = setup->GetRuntime();
+    AssertStatus(DoDrop(runtime, "/Root/missing_drop_if", "/Root", /*ifExists=*/true), Ydb::StatusIds::SUCCESS);
 }
 
 } // Y_UNIT_TEST_SUITE(SchemaOps)

--- a/ydb/core/persqueue/public/schema/schema_ops_ut.cpp
+++ b/ydb/core/persqueue/public/schema/schema_ops_ut.cpp
@@ -1037,6 +1037,14 @@ Y_UNIT_TEST(AlterEnableAutopartitioningAndServiceConsumerGuards) {
     {
         Ydb::Topic::AlterTopicRequest request;
         request.set_path(path);
+        request.mutable_alter_partitioning_settings()->set_set_max_active_partitions(
+            static_cast<i64>(Max<ui32>()));
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::BAD_REQUEST, "less than");
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
         auto* alterAuto = request.mutable_alter_partitioning_settings()
             ->mutable_alter_auto_partitioning_settings();
         alterAuto->set_set_strategy(static_cast<Ydb::Topic::AutoPartitioningStrategy>(999));

--- a/ydb/core/persqueue/public/schema/schema_ops_ut.cpp
+++ b/ydb/core/persqueue/public/schema/schema_ops_ut.cpp
@@ -817,11 +817,13 @@ Y_UNIT_TEST(AlterAutoPartitioningScaleUpAndDisable) {
     }
 
     {
+        // SchemeShard rejects flipping an active strategy to DISABLED via alter;
+        // PAUSED is the supported "stop scaling" path.
         Ydb::Topic::AlterTopicRequest request;
         request.set_path(path);
         auto* alterAuto = request.mutable_alter_partitioning_settings()
             ->mutable_alter_auto_partitioning_settings();
-        alterAuto->set_set_strategy(Ydb::Topic::AUTO_PARTITIONING_STRATEGY_DISABLED);
+        alterAuto->set_set_strategy(Ydb::Topic::AUTO_PARTITIONING_STRATEGY_PAUSED);
         AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
     }
 
@@ -886,6 +888,203 @@ Y_UNIT_TEST(DropIfExistsSucceedsForMissing) {
     auto setup = CreateSetup("CoreDropIfExists");
     auto& runtime = setup->GetRuntime();
     AssertStatus(DoDrop(runtime, "/Root/missing_drop_if", "/Root", /*ifExists=*/true), Ydb::StatusIds::SUCCESS);
+}
+
+Y_UNIT_TEST(AlterRejectsNegativeSpeedsAndHugePartitions) {
+    auto setup = CreateSetup("CoreAlterNegSpeeds");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_alter_neg_speeds";
+    CreateTopic(runtime, path);
+
+    auto expectBad = [&](auto&& mutate, const TString& needle) {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        mutate(request);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::BAD_REQUEST, needle);
+    };
+
+    expectBad([](auto& r) {
+        r.mutable_alter_partitioning_settings()->set_set_min_active_partitions(
+            static_cast<i64>(Max<ui32>()));
+    }, "less than");
+
+    expectBad([](auto& r) {
+        r.set_set_partition_total_read_speed_bytes_per_second(-1);
+    }, "partition_total_read_speed_bytes");
+
+    expectBad([](auto& r) {
+        r.set_set_partition_total_read_speed_messages_per_second(-1);
+    }, "partition_total_read_speed_messages");
+
+    expectBad([](auto& r) {
+        r.set_set_partition_read_without_consumer_speed_bytes_per_second(-1);
+    }, "partition_read_without_consumer_speed_bytes");
+
+    expectBad([](auto& r) {
+        r.set_set_partition_read_without_consumer_speed_messages_per_second(-1);
+    }, "partition_read_without_consumer_speed_messages");
+
+    expectBad([](auto& r) {
+        r.set_set_partition_write_speed_messages_per_second(
+            static_cast<i64>(DEFAULT_PARTITION_WRITE_SPEED_MESSAGES_PER_SECOND) + 1);
+    }, "greater than");
+
+    expectBad([](auto& r) {
+        r.set_set_partition_write_burst_messages(
+            static_cast<i64>(DEFAULT_PARTITION_WRITE_SPEED_MESSAGES_PER_SECOND) + 1);
+    }, "greater than");
+
+    expectBad([](auto& r) {
+        r.mutable_set_supported_codecs()->add_codecs(static_cast<Ydb::Topic::Codec>(0));
+    }, "Unknown codec");
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.set_set_content_based_deduplication(true);
+        request.set_set_partition_total_read_speed_bytes_per_second(1111);
+        request.set_set_partition_total_read_speed_messages_per_second(22);
+        request.set_set_partition_read_without_consumer_speed_bytes_per_second(333);
+        request.set_set_partition_read_without_consumer_speed_messages_per_second(4);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+        auto config = DescribeTabletConfig(runtime, path);
+        UNIT_ASSERT(config.GetContentBasedDeduplication());
+        auto part = config.GetPartitionConfig();
+        UNIT_ASSERT_VALUES_EQUAL(part.GetReadSpeedInBytesPerSecond(), 1111u);
+        UNIT_ASSERT(NPQ::GetReadQuota(config, NPQ::CLIENTID_WITHOUT_CONSUMER));
+    }
+}
+
+Y_UNIT_TEST(AlterDlqMoveActionRequiresExistingMove) {
+    auto setup = CreateSetup("CoreAlterDlqMoveReq");
+    auto& runtime = setup->GetRuntime();
+    AssertStatus(DoCreate(runtime, MakeCreateTopicRequest("/Root/dlq_move_req")), Ydb::StatusIds::SUCCESS);
+    const TString path = "/Root/topic_dlq_move_req";
+
+    {
+        auto request = MakeCreateTopicRequest(path);
+        request.clear_consumers();
+        auto* consumer = request.add_consumers();
+        consumer->set_name("shared_c");
+        auto* type = consumer->mutable_shared_consumer_type();
+        type->mutable_dead_letter_policy()->set_enabled(true);
+        type->mutable_dead_letter_policy()->mutable_delete_action();
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alter = request.add_alter_consumers();
+        alter->set_name("shared_c");
+        auto* policy = alter->mutable_alter_shared_consumer_type()->mutable_alter_dead_letter_policy();
+        policy->mutable_alter_move_action()->set_set_dead_letter_queue("dlq_move_req");
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::BAD_REQUEST, "Cannot alter move action");
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alter = request.add_alter_consumers();
+        alter->set_name("shared_c");
+        auto* policy = alter->mutable_alter_shared_consumer_type()->mutable_alter_dead_letter_policy();
+        policy->mutable_set_move_action()->set_dead_letter_queue("dlq_move_req");
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alter = request.add_alter_consumers();
+        alter->set_name("shared_c");
+        auto* policy = alter->mutable_alter_shared_consumer_type()->mutable_alter_dead_letter_policy();
+        policy->mutable_alter_move_action()->set_set_dead_letter_queue("");
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::BAD_REQUEST, "cannot be empty");
+    }
+}
+
+Y_UNIT_TEST(AlterEnableAutopartitioningAndServiceConsumerGuards) {
+    auto setup = CreateSetup("CoreAlterEnableAuto");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_enable_auto";
+
+    {
+        auto request = MakeCreateTopicRequest(path);
+        (*request.mutable_attributes())["_cleanup_policy"] = "compact";
+        AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alterAuto = request.mutable_alter_partitioning_settings()
+            ->mutable_alter_auto_partitioning_settings();
+        alterAuto->set_set_strategy(Ydb::Topic::AUTO_PARTITIONING_STRATEGY_SCALE_UP);
+        request.mutable_alter_partitioning_settings()->set_set_max_active_partitions(4);
+        alterAuto->mutable_set_partition_write_speed()->set_set_up_utilization_percent(70);
+        alterAuto->mutable_set_partition_write_speed()->set_set_down_utilization_percent(20);
+        alterAuto->mutable_set_partition_write_speed()->mutable_set_stabilization_window()->set_seconds(30);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.mutable_alter_partitioning_settings()->set_set_max_active_partitions(-1);
+        AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::BAD_REQUEST, "non-negative");
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alterAuto = request.mutable_alter_partitioning_settings()
+            ->mutable_alter_auto_partitioning_settings();
+        alterAuto->set_set_strategy(static_cast<Ydb::Topic::AutoPartitioningStrategy>(999));
+        auto result = DoAlter(runtime, request);
+        UNIT_ASSERT(result);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.add_drop_consumers(TString{NPQ::CLIENTID_COMPACTION_CONSUMER});
+        AssertStatus(
+            DoAlter(runtime, request),
+            Ydb::StatusIds::BAD_REQUEST,
+            "Cannot drop service consumer");
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* alter = request.add_alter_consumers();
+        alter->set_name(TString{NPQ::CLIENTID_COMPACTION_CONSUMER});
+        alter->set_set_important(true);
+        AssertStatus(
+            DoAlter(runtime, request),
+            Ydb::StatusIds::BAD_REQUEST,
+            "Cannot alter service consumer");
+    }
+}
+
+Y_UNIT_TEST(AlterIfExistsMissingIsSuccess) {
+    auto setup = CreateSetup("CoreAlterIfExists");
+    auto& runtime = setup->GetRuntime();
+    Ydb::Topic::AlterTopicRequest request;
+    request.set_path("/Root/missing_alter_if_exists");
+    request.set_set_retention_storage_mb(1);
+    AssertStatus(
+        DoAlter(runtime, request, "/Root", /*prepareOnly=*/false, /*ifExists=*/true),
+        Ydb::StatusIds::SUCCESS);
+}
+
+Y_UNIT_TEST(AlterMissingWithoutIfExistsIsSchemeError) {
+    auto setup = CreateSetup("CoreAlterMissing");
+    auto& runtime = setup->GetRuntime();
+    Ydb::Topic::AlterTopicRequest request;
+    request.set_path("/Root/missing_alter_strict");
+    request.set_set_retention_storage_mb(1);
+    AssertStatus(DoAlter(runtime, request), Ydb::StatusIds::SCHEME_ERROR);
 }
 
 } // Y_UNIT_TEST_SUITE(SchemaOps)

--- a/ydb/core/persqueue/public/schema/schema_ut_helpers.h
+++ b/ydb/core/persqueue/public/schema/schema_ut_helpers.h
@@ -7,19 +7,29 @@
 #include <ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/threading/future/future.h>
 
 namespace NKikimr::NPQ::NSchema::NTests {
 
 using namespace NYdb::NTopic::NTests;
 
-inline std::shared_ptr<TTopicSdkTestSetup> CreateSetup(const char* name = "CoreSchema") {
-    auto setup = std::make_shared<TTopicSdkTestSetup>(name, TTopicSdkTestSetup::MakeServerSettings(), false);
+inline std::shared_ptr<TTopicSdkTestSetup> CreateSetup(
+    const char* name = "CoreSchema",
+    NKikimr::Tests::TServerSettings settings = TTopicSdkTestSetup::MakeServerSettings())
+{
+    auto setup = std::make_shared<TTopicSdkTestSetup>(name, std::move(settings), false);
     setup->GetServer().EnableLogs({
             NKikimrServices::PQ_SCHEMA,
             NKikimrServices::PQ_MLP_DESCRIBER,
         },
         NActors::NLog::PRI_DEBUG);
     return setup;
+}
+
+inline std::shared_ptr<TTopicSdkTestSetup> CreateMeteringSetup(const char* name = "CoreSchemaMetering") {
+    auto settings = TTopicSdkTestSetup::MakeServerSettings();
+    settings.PQConfig.MutableBillingMeteringConfig()->SetEnabled(true);
+    return CreateSetup(name, std::move(settings));
 }
 
 inline void AssertStatus(
@@ -37,15 +47,17 @@ inline void AssertStatus(
 inline THolder<TEvSchemaResponse> DoCreate(
     NActors::TTestActorRuntime& runtime,
     Ydb::Topic::CreateTopicRequest request,
-    const TString& database = "/Root")
+    const TString& database = "/Root",
+    bool prepareOnly = false,
+    bool ifNotExists = false)
 {
     auto edge = runtime.AllocateEdgeActor();
     runtime.Register(CreateCreateTopicActor(edge, {
         .Database = database,
         .Request = std::move(request),
         .UserToken = nullptr,
-        .IfNotExists = false,
-        .PrepareOnly = false,
+        .IfNotExists = ifNotExists,
+        .PrepareOnly = prepareOnly,
         .Cookie = 0,
     }));
     return runtime.GrabEdgeEvent<TEvSchemaResponse>(TDuration::Seconds(10));
@@ -54,15 +66,17 @@ inline THolder<TEvSchemaResponse> DoCreate(
 inline THolder<TEvSchemaResponse> DoAlter(
     NActors::TTestActorRuntime& runtime,
     Ydb::Topic::AlterTopicRequest request,
-    const TString& database = "/Root")
+    const TString& database = "/Root",
+    bool prepareOnly = false,
+    bool ifExists = false)
 {
     auto edge = runtime.AllocateEdgeActor();
     runtime.Register(CreateAlterTopicActor(edge, {
         .Database = database,
         .Request = std::move(request),
         .UserToken = nullptr,
-        .IfExists = false,
-        .PrepareOnly = false,
+        .IfExists = ifExists,
+        .PrepareOnly = prepareOnly,
         .Cookie = 0,
     }));
     return runtime.GrabEdgeEvent<TEvSchemaResponse>(TDuration::Seconds(10));
@@ -71,17 +85,61 @@ inline THolder<TEvSchemaResponse> DoAlter(
 inline THolder<TEvSchemaResponse> DoDrop(
     NActors::TTestActorRuntime& runtime,
     const TString& path,
-    const TString& database = "/Root")
+    const TString& database = "/Root",
+    bool ifExists = false)
 {
     auto edge = runtime.AllocateEdgeActor();
     runtime.Register(CreateDropTopicActor(edge, {
         .Database = database,
         .Path = path,
         .UserToken = nullptr,
-        .IfExists = false,
+        .IfExists = ifExists,
         .Cookie = 0,
     }));
     return runtime.GrabEdgeEvent<TEvSchemaResponse>(TDuration::Seconds(10));
+}
+
+inline NThreading::TFuture<TSchemaResponse> DoCreateViaPromise(
+    NActors::TTestActorRuntime& runtime,
+    Ydb::Topic::CreateTopicRequest request,
+    const TString& database = "/Root")
+{
+    auto promise = NThreading::NewPromise<TSchemaResponse>();
+    auto future = promise.GetFuture();
+    runtime.Register(CreateCreateTopicActor(std::move(promise), {
+        .Database = database,
+        .Request = std::move(request),
+        .UserToken = nullptr,
+        .IfNotExists = false,
+        .PrepareOnly = false,
+        .Cookie = 0,
+    }));
+    // Drive the actor system until the promise is filled.
+    for (int i = 0; i < 1000 && !future.HasValue(); ++i) {
+        runtime.DispatchEvents(NActors::TDispatchOptions(), TDuration::MilliSeconds(10));
+    }
+    return future;
+}
+
+inline NThreading::TFuture<TSchemaResponse> DoAlterViaPromise(
+    NActors::TTestActorRuntime& runtime,
+    Ydb::Topic::AlterTopicRequest request,
+    const TString& database = "/Root")
+{
+    auto promise = NThreading::NewPromise<TSchemaResponse>();
+    auto future = promise.GetFuture();
+    runtime.Register(CreateAlterTopicActor(std::move(promise), {
+        .Database = database,
+        .Request = std::move(request),
+        .UserToken = nullptr,
+        .IfExists = false,
+        .PrepareOnly = false,
+        .Cookie = 0,
+    }));
+    for (int i = 0; i < 1000 && !future.HasValue(); ++i) {
+        runtime.DispatchEvents(NActors::TDispatchOptions(), TDuration::MilliSeconds(10));
+    }
+    return future;
 }
 
 inline THolder<TEvSchemaResponse> DoAddConsumer(

--- a/ydb/core/persqueue/public/schema/ut/ya.make
+++ b/ydb/core/persqueue/public/schema/ut/ya.make
@@ -10,6 +10,7 @@ SRCS(
     describe_operation_ut.cpp
     dlq_acl_ut.cpp
     schema_ops_ut.cpp
+    schema_operation_ut.cpp
     validation_ut.cpp
 )
 

--- a/ydb/core/persqueue/public/schema/ut/ya.make
+++ b/ydb/core/persqueue/public/schema/ut/ya.make
@@ -9,6 +9,7 @@ SRCS(
     create_topic_ut.cpp
     describe_operation_ut.cpp
     dlq_acl_ut.cpp
+    propose_create_ut.cpp
     schema_ops_ut.cpp
     schema_operation_ut.cpp
     validation_ut.cpp

--- a/ydb/core/persqueue/public/schema/ut_light/ya.make
+++ b/ydb/core/persqueue/public/schema/ut_light/ya.make
@@ -1,0 +1,18 @@
+UNITTEST_FOR(ydb/core/persqueue/public/schema)
+
+SIZE(SMALL)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    ../validation_ut.cpp
+)
+
+PEERDIR(
+    library/cpp/testing/unittest
+    ydb/core/base
+    ydb/core/testlib/basics
+    ydb/core/testlib/default
+)
+
+END()

--- a/ydb/core/persqueue/public/schema/validation.cpp
+++ b/ydb/core/persqueue/public/schema/validation.cpp
@@ -13,32 +13,25 @@ TResult ValidatePartitionStrategy(const ::NKikimrPQ::TPQTabletConfig& config) {
         return {};
     }
     auto strategy = config.GetPartitionStrategy();
-    if (strategy.GetMinPartitionCount() < 0) {
-        return {Ydb::StatusIds::BAD_REQUEST,
-            TStringBuilder() << "Partitions count must be non-negative, provided " << strategy.GetMinPartitionCount()};
-    }
-    if (strategy.GetMaxPartitionCount() < 0) {
-        return {Ydb::StatusIds::BAD_REQUEST,
-            TStringBuilder() << "Partitions count must be non-negative, provided " << strategy.GetMaxPartitionCount()};
-    }
+    // Min/MaxPartitionCount are uint32 — negative API values must be rejected before conversion.
     if (strategy.GetMaxPartitionCount() != 0 && strategy.GetMaxPartitionCount() < strategy.GetMinPartitionCount()) {
         return {Ydb::StatusIds::BAD_REQUEST,
             TStringBuilder() << "Max active partitions must be greater than or equal to partitions count or equals zero (unlimited), provided "
             << strategy.GetMaxPartitionCount() << " and " << strategy.GetMinPartitionCount()};
     }
-    if (strategy.GetScaleUpPartitionWriteSpeedThresholdPercent() < 0 || strategy.GetScaleUpPartitionWriteSpeedThresholdPercent() > 100) {
+    if (strategy.GetScaleUpPartitionWriteSpeedThresholdPercent() > 100) {
         return {Ydb::StatusIds::BAD_REQUEST,
             TStringBuilder() << "Partition scale up threshold percent must be between 0 and 100, provided "
             << strategy.GetScaleUpPartitionWriteSpeedThresholdPercent()};
     }
-    if (strategy.GetScaleDownPartitionWriteSpeedThresholdPercent() < 0 || strategy.GetScaleDownPartitionWriteSpeedThresholdPercent() > 100) {
+    if (strategy.GetScaleDownPartitionWriteSpeedThresholdPercent() > 100) {
         return {Ydb::StatusIds::BAD_REQUEST,
             TStringBuilder() << "Partition scale down threshold percent must be between 0 and 100, provided "
             << strategy.GetScaleDownPartitionWriteSpeedThresholdPercent()};
     }
-    if (strategy.GetScaleThresholdSeconds() <= 0) {
+    if (strategy.GetScaleThresholdSeconds() == 0) {
         return {Ydb::StatusIds::BAD_REQUEST,
-            TStringBuilder() << "Partition scale threshold time must be greater then 1 second, provided "
+            TStringBuilder() << "Partition scale threshold time must be greater than 0 seconds, provided "
             << strategy.GetScaleThresholdSeconds() << " seconds"};
     }
     if (config.GetPartitionConfig().HasStorageLimitBytes()) {

--- a/ydb/core/persqueue/public/schema/validation_ut.cpp
+++ b/ydb/core/persqueue/public/schema/validation_ut.cpp
@@ -1,6 +1,5 @@
 #include "common.h"
 #include "check_dlq_topics.h"
-#include "schema_ut_helpers.h"
 
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/persqueue/public/constants.h>
@@ -782,7 +781,7 @@ Y_UNIT_TEST(AddConsumerServiceTypeAndCodecs) {
         runtime.GetAppData().FeatureFlags.SetEnableTopicDiskSubDomainQuota(false);
         auto r = AddConsumer(&config, consumer, types, true, nullptr);
         UNIT_ASSERT(!r);
-        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "important flag is forbiden");
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "important flag is forbidden");
     }
     {
         Ydb::Topic::Consumer consumer;

--- a/ydb/core/persqueue/public/schema/validation_ut.cpp
+++ b/ydb/core/persqueue/public/schema/validation_ut.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
 #include "check_dlq_topics.h"
+#include "schema_ut_helpers.h"
 
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/persqueue/public/constants.h>
@@ -12,6 +13,37 @@
 #include <util/generic/size_literals.h>
 
 namespace NKikimr::NPQ::NSchema {
+
+namespace {
+
+class TRunFnActor: public NActors::TActorBootstrapped<TRunFnActor> {
+public:
+    TRunFnActor(TActorId edge, std::function<void()> fn)
+        : Edge(edge)
+        , Fn(std::move(fn))
+    {
+    }
+
+    void Bootstrap() {
+        Fn();
+        Send(Edge, new NActors::TEvents::TEvWakeup());
+        PassAway();
+    }
+
+private:
+    const TActorId Edge;
+    std::function<void()> Fn;
+};
+
+template <typename TFn>
+void RunInActor(NActors::TTestActorRuntime& runtime, TFn&& fn) {
+    const auto edge = runtime.AllocateEdgeActor();
+    runtime.Register(new TRunFnActor(edge, std::function<void()>(std::forward<TFn>(fn))));
+    auto ev = runtime.GrabEdgeEvent<NActors::TEvents::TEvWakeup>(edge, TDuration::Seconds(5));
+    UNIT_ASSERT(ev);
+}
+
+} // namespace
 
 Y_UNIT_TEST_SUITE(SchemaValidation) {
 
@@ -400,37 +432,37 @@ Y_UNIT_TEST(ValidateConfigWriteSpeedAndBurst) {
         return config;
     };
 
-    UNIT_ASSERT(ValidateConfig(makeBase(), EOperation::Create));
+    RunInActor(runtime, [&] {
+        UNIT_ASSERT(ValidateConfig(makeBase(), EOperation::Create));
 
-    {
-        auto config = makeBase();
-        config.MutablePartitionConfig()->SetWriteSpeedInBytesPerSecond(2_KB);
-        auto r = ValidateConfig(config, EOperation::Create);
-        UNIT_ASSERT(!r);
-        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "write_speed");
-    }
-    {
-        auto config = makeBase();
-        // burst > max(speed*2, 1MB)
-        config.MutablePartitionConfig()->SetBurstSize(3_MB);
-        auto r = ValidateConfig(config, EOperation::Create);
-        UNIT_ASSERT(!r);
-        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Invalid write burst");
-    }
-    {
-        auto config = makeBase();
-        config.MutablePartitionConfig()->SetLifetimeSeconds(60); // below retention window
-        auto r = ValidateConfig(config, EOperation::Create);
-        UNIT_ASSERT(!r);
-        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "retention hours");
-    }
-    {
-        // Empty ValidWriteSpeedLimits means any speed is accepted (inserted into valid set).
-        pq.ClearValidWriteSpeedLimitsKbPerSec();
-        auto config = makeBase();
-        config.MutablePartitionConfig()->SetWriteSpeedInBytesPerSecond(12345);
-        UNIT_ASSERT(ValidateConfig(config, EOperation::Create));
-    }
+        {
+            auto config = makeBase();
+            config.MutablePartitionConfig()->SetWriteSpeedInBytesPerSecond(2_KB);
+            auto r = ValidateConfig(config, EOperation::Create);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "write_speed");
+        }
+        {
+            auto config = makeBase();
+            config.MutablePartitionConfig()->SetBurstSize(3_MB);
+            auto r = ValidateConfig(config, EOperation::Create);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Invalid write burst");
+        }
+        {
+            auto config = makeBase();
+            config.MutablePartitionConfig()->SetLifetimeSeconds(60);
+            auto r = ValidateConfig(config, EOperation::Create);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "retention hours");
+        }
+        {
+            pq.ClearValidWriteSpeedLimitsKbPerSec();
+            auto config = makeBase();
+            config.MutablePartitionConfig()->SetWriteSpeedInBytesPerSecond(12345);
+            UNIT_ASSERT(ValidateConfig(config, EOperation::Create));
+        }
+    });
 }
 
 Y_UNIT_TEST(ValidateConfigMlpAndStorageIncompatible) {
@@ -440,18 +472,20 @@ Y_UNIT_TEST(ValidateConfigMlpAndStorageIncompatible) {
     pq.ClearValidWriteSpeedLimitsKbPerSec();
     pq.ClearValidRetentionLimits();
 
-    NKikimrPQ::TPQTabletConfig config;
-    config.MutablePartitionConfig()->SetWriteSpeedInBytesPerSecond(1_MB);
-    config.MutablePartitionConfig()->SetBurstSize(1_MB);
-    config.MutablePartitionConfig()->SetLifetimeSeconds(3600);
-    config.MutablePartitionConfig()->SetStorageLimitBytes(10_MB);
-    auto* consumer = config.AddConsumers();
-    consumer->SetName("shared");
-    consumer->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+    RunInActor(runtime, [&] {
+        NKikimrPQ::TPQTabletConfig config;
+        config.MutablePartitionConfig()->SetWriteSpeedInBytesPerSecond(1_MB);
+        config.MutablePartitionConfig()->SetBurstSize(1_MB);
+        config.MutablePartitionConfig()->SetLifetimeSeconds(3600);
+        config.MutablePartitionConfig()->SetStorageLimitBytes(10_MB);
+        auto* consumer = config.AddConsumers();
+        consumer->SetName("shared");
+        consumer->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
 
-    auto r = ValidateConfig(config, EOperation::Create);
-    UNIT_ASSERT(!r);
-    UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "shared consumers");
+        auto r = ValidateConfig(config, EOperation::Create);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "shared consumers");
+    });
 }
 
 Y_UNIT_TEST(ValidateConsumersDuplicatesAndLimits) {
@@ -462,111 +496,115 @@ Y_UNIT_TEST(ValidateConsumersDuplicatesAndLimits) {
     pq.MutableDefaultClientServiceType()->SetMaxReadRulesCountPerTopic(1);
     pq.ClearClientServiceType();
 
-    {
-        NKikimrPQ::TPQTabletConfig config;
-        auto* a = config.AddConsumers();
-        a->SetName("c1");
-        a->SetServiceType("data-streams");
-        auto* b = config.AddConsumers();
-        b->SetName("c1");
-        b->SetServiceType("data-streams");
-        auto r = ValidateConsumersConfig(config, EOperation::Create);
-        UNIT_ASSERT(!r);
-        UNIT_ASSERT_VALUES_EQUAL(r.GetStatus(), Ydb::StatusIds::BAD_REQUEST);
-        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Duplicate consumer");
-    }
-    {
-        NKikimrPQ::TPQTabletConfig config;
-        auto* a = config.AddConsumers();
-        a->SetName("c1");
-        a->SetServiceType("data-streams");
-        auto* b = config.AddConsumers();
-        b->SetName("c1");
-        b->SetServiceType("data-streams");
-        auto r = ValidateConsumersConfig(config, EOperation::Alter);
-        UNIT_ASSERT(!r);
-        UNIT_ASSERT_VALUES_EQUAL(r.GetStatus(), Ydb::StatusIds::ALREADY_EXISTS);
-    }
-    {
-        NKikimrPQ::TPQTabletConfig config;
-        auto* a = config.AddConsumers();
-        a->SetName("c1");
-        a->SetServiceType("data-streams");
-        a->SetImportant(true);
-        a->SetAvailabilityPeriodMs(1000);
-        auto r = ValidateConsumersConfig(config, EOperation::Create);
-        UNIT_ASSERT(!r);
-        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "mutually exclusive");
-    }
-    {
-        NKikimrPQ::TPQTabletConfig config;
-        auto* a = config.AddConsumers();
-        a->SetName("c1");
-        a->SetServiceType("data-streams");
-        auto* b = config.AddConsumers();
-        b->SetName("c2");
-        b->SetServiceType("data-streams");
-        auto r = ValidateConsumersConfig(config, EOperation::Create);
-        UNIT_ASSERT(!r);
-        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "service type");
-    }
-    {
-        NKikimrPQ::TPQTabletConfig config;
-        config.MutableCodecs()->AddIds(0); // RAW
-        auto* a = config.AddConsumers();
-        a->SetName("c1");
-        a->SetServiceType("data-streams");
-        a->MutableCodec()->AddIds(1); // GZIP only — missing topic RAW
-        auto r = ValidateConsumersConfig(config, EOperation::Create);
-        UNIT_ASSERT(!r);
-        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "unsupported codec");
-    }
+    RunInActor(runtime, [&] {
+        {
+            NKikimrPQ::TPQTabletConfig config;
+            auto* a = config.AddConsumers();
+            a->SetName("c1");
+            a->SetServiceType("data-streams");
+            auto* b = config.AddConsumers();
+            b->SetName("c1");
+            b->SetServiceType("data-streams");
+            auto r = ValidateConsumersConfig(config, EOperation::Create);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_VALUES_EQUAL(r.GetStatus(), Ydb::StatusIds::BAD_REQUEST);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Duplicate consumer");
+        }
+        {
+            NKikimrPQ::TPQTabletConfig config;
+            auto* a = config.AddConsumers();
+            a->SetName("c1");
+            a->SetServiceType("data-streams");
+            auto* b = config.AddConsumers();
+            b->SetName("c1");
+            b->SetServiceType("data-streams");
+            auto r = ValidateConsumersConfig(config, EOperation::Alter);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_VALUES_EQUAL(r.GetStatus(), Ydb::StatusIds::ALREADY_EXISTS);
+        }
+        {
+            NKikimrPQ::TPQTabletConfig config;
+            auto* a = config.AddConsumers();
+            a->SetName("c1");
+            a->SetServiceType("data-streams");
+            a->SetImportant(true);
+            a->SetAvailabilityPeriodMs(1000);
+            auto r = ValidateConsumersConfig(config, EOperation::Create);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "mutually exclusive");
+        }
+        {
+            NKikimrPQ::TPQTabletConfig config;
+            auto* a = config.AddConsumers();
+            a->SetName("c1");
+            a->SetServiceType("data-streams");
+            auto* b = config.AddConsumers();
+            b->SetName("c2");
+            b->SetServiceType("data-streams");
+            auto r = ValidateConsumersConfig(config, EOperation::Create);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "service type");
+        }
+        {
+            NKikimrPQ::TPQTabletConfig config;
+            config.MutableCodecs()->AddIds(0);
+            auto* a = config.AddConsumers();
+            a->SetName("c1");
+            a->SetServiceType("data-streams");
+            a->MutableCodec()->AddIds(1);
+            auto r = ValidateConsumersConfig(config, EOperation::Create);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "unsupported codec");
+        }
+    });
 }
 
 Y_UNIT_TEST(FillMeteringModeBranches) {
     NActors::TTestBasicRuntime runtime(1, false);
     runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
 
-    {
-        runtime.GetAppData().PQConfig.MutableBillingMeteringConfig()->SetEnabled(true);
-        NKikimrPQ::TPQTabletConfig config;
-        UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_UNSPECIFIED, EOperation::Create));
-        UNIT_ASSERT_VALUES_EQUAL(
-            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(config.GetMeteringMode()),
-            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(
-                NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS));
+    RunInActor(runtime, [&] {
+        {
+            runtime.GetAppData().PQConfig.MutableBillingMeteringConfig()->SetEnabled(true);
+            NKikimrPQ::TPQTabletConfig config;
+            UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_UNSPECIFIED, EOperation::Create));
+            UNIT_ASSERT_VALUES_EQUAL(
+                NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(config.GetMeteringMode()),
+                NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(
+                    NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS));
 
-        config.ClearMeteringMode();
-        UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_UNSPECIFIED, EOperation::Alter));
-        UNIT_ASSERT(!config.HasMeteringMode());
+            config.ClearMeteringMode();
+            UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_UNSPECIFIED, EOperation::Alter));
+            UNIT_ASSERT(!config.HasMeteringMode());
 
-        UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_REQUEST_UNITS, EOperation::Alter));
-        UNIT_ASSERT_VALUES_EQUAL(
-            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(config.GetMeteringMode()),
-            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(
-                NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS));
+            UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_REQUEST_UNITS, EOperation::Alter));
+            UNIT_ASSERT_VALUES_EQUAL(
+                NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(config.GetMeteringMode()),
+                NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(
+                    NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS));
 
-        UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_RESERVED_CAPACITY, EOperation::Alter));
-        UNIT_ASSERT_VALUES_EQUAL(
-            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(config.GetMeteringMode()),
-            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(
-                NKikimrPQ::TPQTabletConfig::METERING_MODE_RESERVED_CAPACITY));
+            UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_RESERVED_CAPACITY, EOperation::Alter));
+            UNIT_ASSERT_VALUES_EQUAL(
+                NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(config.GetMeteringMode()),
+                NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(
+                    NKikimrPQ::TPQTabletConfig::METERING_MODE_RESERVED_CAPACITY));
 
-        auto r = FillMeteringMode(
-            config,
-            static_cast<Ydb::Topic::MeteringMode>(999),
-            EOperation::Create);
-        UNIT_ASSERT(!r);
-        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Unknown metering mode");
-    }
-    {
-        runtime.GetAppData().PQConfig.MutableBillingMeteringConfig()->SetEnabled(false);
-        NKikimrPQ::TPQTabletConfig config;
-        UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_UNSPECIFIED, EOperation::Create));
-        auto r = FillMeteringMode(config, Ydb::Topic::METERING_MODE_REQUEST_UNITS, EOperation::Create);
-        UNIT_ASSERT(!r);
-        UNIT_ASSERT_VALUES_EQUAL(r.GetStatus(), Ydb::StatusIds::PRECONDITION_FAILED);
-    }
+            auto r = FillMeteringMode(
+                config,
+                static_cast<Ydb::Topic::MeteringMode>(999),
+                EOperation::Create);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Unknown metering mode");
+        }
+        {
+            runtime.GetAppData().PQConfig.MutableBillingMeteringConfig()->SetEnabled(false);
+            NKikimrPQ::TPQTabletConfig config;
+            UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_UNSPECIFIED, EOperation::Create));
+            auto r = FillMeteringMode(config, Ydb::Topic::METERING_MODE_REQUEST_UNITS, EOperation::Create);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_VALUES_EQUAL(r.GetStatus(), Ydb::StatusIds::PRECONDITION_FAILED);
+        }
+    });
 }
 
 Y_UNIT_TEST(ProcessTopicAttributesAdvancedMonitoringAndId) {
@@ -574,55 +612,55 @@ Y_UNIT_TEST(ProcessTopicAttributesAdvancedMonitoringAndId) {
     runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
     runtime.GetAppData().FeatureFlags.SetEnableTopicSourceIdMappingById(true);
 
-    NGRpcProxy::V1::TConsumersAdvancedMonitoringSettings monitoring;
+    RunInActor(runtime, [&] {
+        NGRpcProxy::V1::TConsumersAdvancedMonitoringSettings monitoring;
 
-    {
-        // First-class citizen rejects _advanced_monitoring.
-        google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
-        attrs["_advanced_monitoring"] = "{}";
-        NKikimrSchemeOp::TPersQueueGroupDescription config;
-        auto r = ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/true, monitoring);
-        UNIT_ASSERT(!r);
-        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "not supported in non-federation");
-    }
-    {
-        google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
-        attrs["_advanced_monitoring"] = "not-json";
-        NKikimrSchemeOp::TPersQueueGroupDescription config;
-        auto r = ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/false, monitoring);
-        UNIT_ASSERT(!r);
-    }
-    {
-        google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
-        attrs["_id"] = "abc";
-        NKikimrSchemeOp::TPersQueueGroupDescription config;
-        auto r = ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/false, monitoring);
-        UNIT_ASSERT(!r);
-        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "not a valid positive integer");
-    }
-    {
-        google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
-        attrs["_id"] = "0";
-        NKikimrSchemeOp::TPersQueueGroupDescription config;
-        auto r = ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/false, monitoring);
-        UNIT_ASSERT(!r);
-        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "greater than 0");
-    }
-    {
-        google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
-        attrs["_id"] = "123";
-        NKikimrSchemeOp::TPersQueueGroupDescription config;
-        UNIT_ASSERT(ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/false, monitoring));
-        UNIT_ASSERT_VALUES_EQUAL(config.GetPQTabletConfig().GetId().GetId(), 123u);
-    }
-    {
-        // FCC ignores _id even with feature flag.
-        google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
-        attrs["_id"] = "123";
-        NKikimrSchemeOp::TPersQueueGroupDescription config;
-        UNIT_ASSERT(ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/true, monitoring));
-        UNIT_ASSERT(!config.GetPQTabletConfig().HasId());
-    }
+        {
+            google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
+            attrs["_advanced_monitoring"] = "{}";
+            NKikimrSchemeOp::TPersQueueGroupDescription config;
+            auto r = ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/true, monitoring);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "not supported in non-federation");
+        }
+        {
+            google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
+            attrs["_advanced_monitoring"] = "not-json";
+            NKikimrSchemeOp::TPersQueueGroupDescription config;
+            auto r = ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/false, monitoring);
+            UNIT_ASSERT(!r);
+        }
+        {
+            google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
+            attrs["_id"] = "abc";
+            NKikimrSchemeOp::TPersQueueGroupDescription config;
+            auto r = ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/false, monitoring);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "not a valid positive integer");
+        }
+        {
+            google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
+            attrs["_id"] = "0";
+            NKikimrSchemeOp::TPersQueueGroupDescription config;
+            auto r = ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/false, monitoring);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "greater than 0");
+        }
+        {
+            google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
+            attrs["_id"] = "123";
+            NKikimrSchemeOp::TPersQueueGroupDescription config;
+            UNIT_ASSERT(ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/false, monitoring));
+            UNIT_ASSERT_VALUES_EQUAL(config.GetPQTabletConfig().GetId().GetId(), 123u);
+        }
+        {
+            google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
+            attrs["_id"] = "123";
+            NKikimrSchemeOp::TPersQueueGroupDescription config;
+            UNIT_ASSERT(ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/true, monitoring));
+            UNIT_ASSERT(!config.GetPQTabletConfig().HasId());
+        }
+    });
 }
 
 Y_UNIT_TEST(AddConsumerServiceTypeAndCodecs) {
@@ -639,6 +677,7 @@ Y_UNIT_TEST(AddConsumerServiceTypeAndCodecs) {
     st->SetMaxReadRulesCountPerTopic(2);
     st->AddPasswordHashes("5f4dcc3b5aa765d61d8327deb882cf99"); // md5("password")
 
+    RunInActor(runtime, [&] {
     auto types = GetSupportedClientServiceTypes();
     UNIT_ASSERT(types.contains("data-streams"));
     UNIT_ASSERT(types.contains("secure"));
@@ -754,6 +793,99 @@ Y_UNIT_TEST(AddConsumerServiceTypeAndCodecs) {
         UNIT_ASSERT(!r);
         UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "can't be negative");
     }
+    });
+}
+
+Y_UNIT_TEST(ProcessTopicAttributesInvalidValues) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+
+    RunInActor(runtime, [&] {
+        auto expectBad = [&](const TString& key, const TString& value, const TString& needle) {
+            NKikimrSchemeOp::TPersQueueGroupDescription config;
+            config.MutablePQTabletConfig()->MutablePartitionConfig();
+            google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
+            attrs[key] = value;
+            NGRpcProxy::V1::TConsumersAdvancedMonitoringSettings monitoring;
+            auto r = ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/true, monitoring);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), needle);
+        };
+
+        expectBad("_allow_unauthenticated_read", "not-bool", "not bool");
+        expectBad("_allow_unauthenticated_write", "xx", "not bool");
+        expectBad("_abc_id", "NaN", "not integer");
+        expectBad("_max_partition_storage_size", "-5", "can't be negative");
+        expectBad("_max_partition_storage_size", "oops", "not ui64");
+        expectBad("_message_group_seqno_retention_period_ms", "-1", "can't be negative");
+        expectBad(
+            "_message_group_seqno_retention_period_ms",
+            ToString(DEFAULT_MAX_DATABASE_MESSAGEGROUP_SEQNO_RETENTION_PERIOD_MS + 1),
+            "must be less than default limit");
+        expectBad("_message_group_seqno_retention_period_ms", "bad", "not ui64");
+        expectBad("_max_partition_message_groups_seqno_stored", "-3", "can't be negative");
+        expectBad("_max_partition_message_groups_seqno_stored", "x", "not ui64");
+        expectBad("_timestamp_type", "WeirdTime", "incorrect value");
+        expectBad("_advanced_monitoring", "{}", "not supported in non-federation");
+    });
+}
+
+Y_UNIT_TEST(ValidateLocalClusterBranches) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+
+    RunInActor(runtime, [&] {
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+
+        auto clusters = MakeIntrusive<NPQ::NClusterTracker::TClustersList>();
+        clusters->Clusters.push_back({.Name = "dc1", .IsLocal = true});
+        clusters->LocalCluster = &clusters->Clusters.front();
+
+        {
+            NKikimrPQ::TPQTabletConfig config;
+            config.SetLocalDC(true);
+            config.SetDC("dc2");
+            auto r = ValidateLocalCluster(clusters, config);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Local cluster is not correct");
+        }
+        {
+            NKikimrPQ::TPQTabletConfig config;
+            config.SetLocalDC(false);
+            config.SetDC("unknown");
+            auto r = ValidateLocalCluster(clusters, config);
+            UNIT_ASSERT(!r);
+            UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Unknown cluster");
+        }
+        {
+            NKikimrPQ::TPQTabletConfig config;
+            config.SetLocalDC(true);
+            config.SetDC("dc1");
+            UNIT_ASSERT(ValidateLocalCluster(clusters, config));
+        }
+
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
+        NKikimrPQ::TPQTabletConfig config;
+        config.SetDC("whatever");
+        UNIT_ASSERT(ValidateLocalCluster(clusters, config));
+    });
+}
+
+Y_UNIT_TEST(ValidateConsumersTooMany) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+
+    RunInActor(runtime, [&] {
+        NKikimrPQ::TPQTabletConfig config;
+        for (int i = 0; i < MAX_READ_RULES_COUNT + 1; ++i) {
+            auto* c = config.AddConsumers();
+            c->SetName(TStringBuilder() << "c" << i);
+            c->SetServiceType("data-streams");
+        }
+        auto r = ValidateConsumersConfig(config, EOperation::Create);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "read rules count cannot be more than");
+    });
 }
 
 } // Y_UNIT_TEST_SUITE(SchemaValidation)

--- a/ydb/core/persqueue/public/schema/validation_ut.cpp
+++ b/ydb/core/persqueue/public/schema/validation_ut.cpp
@@ -1,6 +1,15 @@
 #include "common.h"
+#include "check_dlq_topics.h"
+
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/persqueue/public/constants.h>
+#include <ydb/core/persqueue/public/utils.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+#include <ydb/services/lib/actors/consumers_advanced_monitoring_settings.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <util/generic/size_literals.h>
 
 namespace NKikimr::NPQ::NSchema {
 
@@ -16,6 +25,12 @@ Y_UNIT_TEST(GetWorkingDirAndName) {
         auto [dir, name] = GetWorkingDirAndName("/Root/topic");
         UNIT_ASSERT_VALUES_EQUAL(dir, "/Root");
         UNIT_ASSERT_VALUES_EQUAL(name, "topic");
+    }
+    {
+        // Invalid path should not throw out of GetWorkingDirAndName.
+        auto [dir, name] = GetWorkingDirAndName("");
+        UNIT_ASSERT(dir.empty());
+        UNIT_ASSERT(name.empty());
     }
 }
 
@@ -35,6 +50,16 @@ Y_UNIT_TEST(CheckRetentionPeriod) {
         UNIT_ASSERT(!r.has_value());
         UNIT_ASSERT_STRING_CONTAINS(r.error(), "positive");
     }
+    {
+        auto r = CheckRetentionPeriod(i64(Max<i32>()) + 1);
+        UNIT_ASSERT(!r.has_value());
+        UNIT_ASSERT_STRING_CONTAINS(r.error(), "less than");
+    }
+    {
+        auto r = CheckRetentionPeriod(Max<i32>());
+        UNIT_ASSERT(r.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(*r, Max<i32>());
+    }
 }
 
 Y_UNIT_TEST(ConvertPositiveDuration) {
@@ -51,6 +76,40 @@ Y_UNIT_TEST(ConvertPositiveDuration) {
         auto r = ConvertPositiveDuration(d);
         UNIT_ASSERT(!r.has_value());
         UNIT_ASSERT_STRING_CONTAINS(r.error(), "negative");
+    }
+    {
+        google::protobuf::Duration d;
+        d.set_seconds(0);
+        d.set_nanos(0);
+        auto r = ConvertPositiveDuration(d);
+        UNIT_ASSERT(r.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(*r, TDuration::Zero());
+    }
+}
+
+Y_UNIT_TEST(ConvertConsumerAvailabilityPeriod) {
+    {
+        google::protobuf::Duration d;
+        d.set_seconds(0);
+        auto r = ConvertConsumerAvailabilityPeriod(d, "c1");
+        UNIT_ASSERT(r.has_value());
+        UNIT_ASSERT(!r->has_value()); // zero means clear / unset
+    }
+    {
+        google::protobuf::Duration d;
+        d.set_seconds(2);
+        auto r = ConvertConsumerAvailabilityPeriod(d, "c1");
+        UNIT_ASSERT(r.has_value());
+        UNIT_ASSERT(r->has_value());
+        UNIT_ASSERT_VALUES_EQUAL((*r)->Seconds(), 2u);
+    }
+    {
+        google::protobuf::Duration d;
+        d.set_seconds(-5);
+        auto r = ConvertConsumerAvailabilityPeriod(d, "c1");
+        UNIT_ASSERT(!r.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(r.error().GetStatus(), Ydb::StatusIds::BAD_REQUEST);
+        UNIT_ASSERT_STRING_CONTAINS(r.error().GetErrorMessage(), "c1");
     }
 }
 
@@ -69,6 +128,80 @@ Y_UNIT_TEST(ValidateDuration) {
         UNIT_ASSERT_VALUES_EQUAL(r.GetStatus(), Ydb::StatusIds::BAD_REQUEST);
         UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "timeout");
     }
+    {
+        google::protobuf::Duration d;
+        d.set_seconds(1);
+        d.set_nanos(-1);
+        auto r = ValidateDuration(d, "delay");
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "delay");
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "negative");
+    }
+}
+
+Y_UNIT_TEST(ConvertDurationToMs32) {
+    {
+        google::protobuf::Duration d;
+        d.set_seconds(0);
+        d.set_nanos(0);
+        UNIT_ASSERT_VALUES_EQUAL(ConvertDurationToMs32(d), 0u);
+    }
+    {
+        google::protobuf::Duration d;
+        d.set_seconds(1);
+        d.set_nanos(500'000'000);
+        UNIT_ASSERT_VALUES_EQUAL(ConvertDurationToMs32(d), 1500u);
+    }
+    {
+        google::protobuf::Duration d;
+        d.set_seconds(0);
+        d.set_nanos(999'999); // less than 1ms
+        UNIT_ASSERT_VALUES_EQUAL(ConvertDurationToMs32(d), 0u);
+    }
+    {
+        // Saturate at Max<ui32>() for huge durations.
+        google::protobuf::Duration d;
+        d.set_seconds(i64(Max<ui32>()) / 1000 + 10);
+        UNIT_ASSERT_VALUES_EQUAL(ConvertDurationToMs32(d), Max<ui32>());
+    }
+}
+
+Y_UNIT_TEST(IfEqualThenDefault) {
+    UNIT_ASSERT_VALUES_EQUAL(IfEqualThenDefault(0, 0, 42), 42);
+    UNIT_ASSERT_VALUES_EQUAL(IfEqualThenDefault(7, 0, 42), 7);
+    UNIT_ASSERT_VALUES_EQUAL(IfEqualThenDefault(TString("a"), TString("a"), TString("b")), "b");
+    UNIT_ASSERT_VALUES_EQUAL(IfEqualThenDefault(TString("a"), TString("x"), TString("b")), "a");
+}
+
+Y_UNIT_TEST(CopyConfigClearsVolatileFields) {
+    NKikimrSchemeOp::TPersQueueGroupDescription source;
+    source.SetName("topic");
+    source.SetTotalGroupCount(3);
+    source.MutablePQTabletConfig()->AddPartitionKeySchema()->SetName("key");
+    source.MutablePQTabletConfig()->SetRequireAuthRead(true);
+
+    NKikimrSchemeOp::TPersQueueGroupDescription target;
+    CopyConfig(target, source);
+
+    UNIT_ASSERT_VALUES_EQUAL(target.GetName(), "topic");
+    UNIT_ASSERT(!target.HasTotalGroupCount());
+    UNIT_ASSERT_VALUES_EQUAL(target.GetPQTabletConfig().PartitionKeySchemaSize(), 0u);
+    UNIT_ASSERT(target.GetPQTabletConfig().GetRequireAuthRead());
+}
+
+Y_UNIT_TEST(GetLocalClusterName) {
+    UNIT_ASSERT_VALUES_EQUAL(GetLocalClusterName(nullptr), "");
+
+    {
+        auto list = MakeIntrusive<NPQ::NClusterTracker::TClustersList>();
+        UNIT_ASSERT_VALUES_EQUAL(GetLocalClusterName(list), "");
+    }
+    {
+        auto list = MakeIntrusive<NPQ::NClusterTracker::TClustersList>();
+        list->Clusters.push_back({.Name = "dc1", .IsLocal = true});
+        list->LocalCluster = &list->Clusters.front();
+        UNIT_ASSERT_VALUES_EQUAL(GetLocalClusterName(list), "dc1");
+    }
 }
 
 Y_UNIT_TEST(ValidatePartitionStrategyBounds) {
@@ -85,6 +218,542 @@ Y_UNIT_TEST(ValidatePartitionStrategyBounds) {
     UNIT_ASSERT(!r);
     UNIT_ASSERT_VALUES_EQUAL(r.GetStatus(), Ydb::StatusIds::BAD_REQUEST);
     UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Max active partitions");
+}
+
+Y_UNIT_TEST(ValidatePartitionStrategyNoStrategyOk) {
+    NKikimrPQ::TPQTabletConfig config;
+    UNIT_ASSERT(ValidatePartitionStrategy(config));
+}
+
+Y_UNIT_TEST(ValidatePartitionStrategyNegativeMinMax) {
+    // Min/MaxPartitionCount are uint32 in TPQTabletConfig — GetMinPartitionCount() < 0
+    // is dead code. Setting -1 via the protobuf setter stores 4294967295 and fails the
+    // max < min check instead. Document and lock that behavior.
+    {
+        NKikimrPQ::TPQTabletConfig config;
+        auto* strategy = config.MutablePartitionStrategy();
+        strategy->SetMinPartitionCount(static_cast<ui32>(-1));
+        strategy->SetMaxPartitionCount(10);
+        strategy->SetScaleThresholdSeconds(30);
+        strategy->SetScaleUpPartitionWriteSpeedThresholdPercent(80);
+        strategy->SetScaleDownPartitionWriteSpeedThresholdPercent(20);
+        auto r = ValidatePartitionStrategy(config);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_VALUES_EQUAL(r.GetStatus(), Ydb::StatusIds::BAD_REQUEST);
+        // Dead "< 0" branch never fires for uint32; max < min does.
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Max active partitions");
+    }
+    {
+        NKikimrPQ::TPQTabletConfig config;
+        auto* strategy = config.MutablePartitionStrategy();
+        strategy->SetMinPartitionCount(1);
+        strategy->SetMaxPartitionCount(static_cast<ui32>(-2));
+        strategy->SetScaleThresholdSeconds(30);
+        strategy->SetScaleUpPartitionWriteSpeedThresholdPercent(80);
+        strategy->SetScaleDownPartitionWriteSpeedThresholdPercent(20);
+        // Max = 4294967294, Min = 1 → max >= min, so this config is accepted!
+        // The "< 0" guard cannot reject unsigned wraparound.
+        auto r = ValidatePartitionStrategy(config);
+        UNIT_ASSERT(r);
+    }
+}
+
+Y_UNIT_TEST(ValidatePartitionStrategyThresholdPercents) {
+    auto makeOkBase = [] {
+        NKikimrPQ::TPQTabletConfig config;
+        auto* strategy = config.MutablePartitionStrategy();
+        strategy->SetMinPartitionCount(1);
+        strategy->SetMaxPartitionCount(2);
+        strategy->SetScaleThresholdSeconds(30);
+        strategy->SetScaleUpPartitionWriteSpeedThresholdPercent(80);
+        strategy->SetScaleDownPartitionWriteSpeedThresholdPercent(20);
+        return config;
+    };
+
+    {
+        auto config = makeOkBase();
+        config.MutablePartitionStrategy()->SetScaleUpPartitionWriteSpeedThresholdPercent(101);
+        auto r = ValidatePartitionStrategy(config);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "scale up");
+    }
+    {
+        auto config = makeOkBase();
+        config.MutablePartitionStrategy()->SetScaleDownPartitionWriteSpeedThresholdPercent(101);
+        auto r = ValidatePartitionStrategy(config);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "scale down");
+    }
+    {
+        auto config = makeOkBase();
+        config.MutablePartitionStrategy()->SetScaleThresholdSeconds(0);
+        auto r = ValidatePartitionStrategy(config);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "greater than 0");
+    }
+    {
+        auto config = makeOkBase();
+        config.MutablePartitionStrategy()->SetScaleThresholdSeconds(1);
+        UNIT_ASSERT(ValidatePartitionStrategy(config));
+    }
+    {
+        auto config = makeOkBase();
+        config.MutablePartitionConfig()->SetStorageLimitBytes(1_MB);
+        auto r = ValidatePartitionStrategy(config);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "incompatible with retention storage");
+    }
+    {
+        auto config = makeOkBase();
+        config.MutablePartitionStrategy()->SetMaxPartitionCount(0); // unlimited
+        UNIT_ASSERT(ValidatePartitionStrategy(config));
+    }
+}
+
+Y_UNIT_TEST(CollectDlqTopicPaths) {
+    NKikimrPQ::TPQTabletConfig config;
+    {
+        auto* c = config.AddConsumers();
+        c->SetName("stream");
+        c->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_STREAMING);
+        c->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
+        c->SetDeadLetterPolicyEnabled(true);
+        c->SetDeadLetterQueue("ignored");
+    }
+    {
+        auto* c = config.AddConsumers();
+        c->SetName("mlp_off");
+        c->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+        c->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
+        c->SetDeadLetterPolicyEnabled(false);
+        c->SetDeadLetterQueue("dlq");
+    }
+    {
+        auto* c = config.AddConsumers();
+        c->SetName("mlp_sqs");
+        c->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+        c->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
+        c->SetDeadLetterPolicyEnabled(true);
+        c->SetDeadLetterQueue("sqs://queue");
+    }
+    {
+        auto* c = config.AddConsumers();
+        c->SetName("mlp_ok");
+        c->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+        c->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
+        c->SetDeadLetterPolicyEnabled(true);
+        c->SetDeadLetterQueue("dlq");
+    }
+    {
+        auto* c = config.AddConsumers();
+        c->SetName("mlp_delete");
+        c->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+        c->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_DELETE);
+        c->SetDeadLetterPolicyEnabled(true);
+        c->SetDeadLetterQueue("dlq2");
+    }
+
+    auto paths = CollectDlqTopicPaths(config, "/Root");
+    UNIT_ASSERT_VALUES_EQUAL(paths.size(), 1u);
+    UNIT_ASSERT(paths.contains("/Root/dlq"));
+
+    NKikimrPQ::TPQTabletConfig oldConfig = config;
+    NKikimrPQ::TPQTabletConfig newConfig = config;
+    auto* added = newConfig.AddConsumers();
+    added->SetName("mlp_new");
+    added->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+    added->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
+    added->SetDeadLetterPolicyEnabled(true);
+    added->SetDeadLetterQueue("dlq_new");
+
+    auto newPaths = CollectNewDlqTopicPaths(newConfig, oldConfig, "/Root");
+    UNIT_ASSERT_VALUES_EQUAL(newPaths.size(), 1u);
+    UNIT_ASSERT(newPaths.contains("/Root/dlq_new"));
+}
+
+Y_UNIT_TEST(TResultBoolConversion) {
+    UNIT_ASSERT(TResult{});
+    UNIT_ASSERT(!TResult(Ydb::StatusIds::BAD_REQUEST, "err"));
+    TResult r(Ydb::StatusIds::NOT_FOUND, "missing");
+    UNIT_ASSERT_VALUES_EQUAL(r.GetStatus(), Ydb::StatusIds::NOT_FOUND);
+    UNIT_ASSERT_VALUES_EQUAL(r.GetErrorMessage(), "missing");
+}
+
+Y_UNIT_TEST(ValidateConfigWriteSpeedAndBurst) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+    auto& pq = runtime.GetAppData().PQConfig;
+    pq.ClearValidWriteSpeedLimitsKbPerSec();
+    pq.AddValidWriteSpeedLimitsKbPerSec(1); // 1 KB/s
+    pq.ClearValidRetentionLimits();
+    auto* limit = pq.AddValidRetentionLimits();
+    limit->SetMinPeriodSeconds(3600);
+    limit->SetMaxPeriodSeconds(86400);
+    limit->SetMinStorageMegabytes(0);
+    limit->SetMaxStorageMegabytes(1024);
+
+    auto makeBase = [] {
+        NKikimrPQ::TPQTabletConfig config;
+        config.MutablePartitionConfig()->SetWriteSpeedInBytesPerSecond(1_KB);
+        config.MutablePartitionConfig()->SetBurstSize(1_KB);
+        config.MutablePartitionConfig()->SetLifetimeSeconds(3600);
+        return config;
+    };
+
+    UNIT_ASSERT(ValidateConfig(makeBase(), EOperation::Create));
+
+    {
+        auto config = makeBase();
+        config.MutablePartitionConfig()->SetWriteSpeedInBytesPerSecond(2_KB);
+        auto r = ValidateConfig(config, EOperation::Create);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "write_speed");
+    }
+    {
+        auto config = makeBase();
+        // burst > max(speed*2, 1MB)
+        config.MutablePartitionConfig()->SetBurstSize(3_MB);
+        auto r = ValidateConfig(config, EOperation::Create);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Invalid write burst");
+    }
+    {
+        auto config = makeBase();
+        config.MutablePartitionConfig()->SetLifetimeSeconds(60); // below retention window
+        auto r = ValidateConfig(config, EOperation::Create);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "retention hours");
+    }
+    {
+        // Empty ValidWriteSpeedLimits means any speed is accepted (inserted into valid set).
+        pq.ClearValidWriteSpeedLimitsKbPerSec();
+        auto config = makeBase();
+        config.MutablePartitionConfig()->SetWriteSpeedInBytesPerSecond(12345);
+        UNIT_ASSERT(ValidateConfig(config, EOperation::Create));
+    }
+}
+
+Y_UNIT_TEST(ValidateConfigMlpAndStorageIncompatible) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+    auto& pq = runtime.GetAppData().PQConfig;
+    pq.ClearValidWriteSpeedLimitsKbPerSec();
+    pq.ClearValidRetentionLimits();
+
+    NKikimrPQ::TPQTabletConfig config;
+    config.MutablePartitionConfig()->SetWriteSpeedInBytesPerSecond(1_MB);
+    config.MutablePartitionConfig()->SetBurstSize(1_MB);
+    config.MutablePartitionConfig()->SetLifetimeSeconds(3600);
+    config.MutablePartitionConfig()->SetStorageLimitBytes(10_MB);
+    auto* consumer = config.AddConsumers();
+    consumer->SetName("shared");
+    consumer->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+
+    auto r = ValidateConfig(config, EOperation::Create);
+    UNIT_ASSERT(!r);
+    UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "shared consumers");
+}
+
+Y_UNIT_TEST(ValidateConsumersDuplicatesAndLimits) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+    auto& pq = runtime.GetAppData().PQConfig;
+    pq.MutableDefaultClientServiceType()->SetName("data-streams");
+    pq.MutableDefaultClientServiceType()->SetMaxReadRulesCountPerTopic(1);
+    pq.ClearClientServiceType();
+
+    {
+        NKikimrPQ::TPQTabletConfig config;
+        auto* a = config.AddConsumers();
+        a->SetName("c1");
+        a->SetServiceType("data-streams");
+        auto* b = config.AddConsumers();
+        b->SetName("c1");
+        b->SetServiceType("data-streams");
+        auto r = ValidateConsumersConfig(config, EOperation::Create);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_VALUES_EQUAL(r.GetStatus(), Ydb::StatusIds::BAD_REQUEST);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Duplicate consumer");
+    }
+    {
+        NKikimrPQ::TPQTabletConfig config;
+        auto* a = config.AddConsumers();
+        a->SetName("c1");
+        a->SetServiceType("data-streams");
+        auto* b = config.AddConsumers();
+        b->SetName("c1");
+        b->SetServiceType("data-streams");
+        auto r = ValidateConsumersConfig(config, EOperation::Alter);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_VALUES_EQUAL(r.GetStatus(), Ydb::StatusIds::ALREADY_EXISTS);
+    }
+    {
+        NKikimrPQ::TPQTabletConfig config;
+        auto* a = config.AddConsumers();
+        a->SetName("c1");
+        a->SetServiceType("data-streams");
+        a->SetImportant(true);
+        a->SetAvailabilityPeriodMs(1000);
+        auto r = ValidateConsumersConfig(config, EOperation::Create);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "mutually exclusive");
+    }
+    {
+        NKikimrPQ::TPQTabletConfig config;
+        auto* a = config.AddConsumers();
+        a->SetName("c1");
+        a->SetServiceType("data-streams");
+        auto* b = config.AddConsumers();
+        b->SetName("c2");
+        b->SetServiceType("data-streams");
+        auto r = ValidateConsumersConfig(config, EOperation::Create);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "service type");
+    }
+    {
+        NKikimrPQ::TPQTabletConfig config;
+        config.MutableCodecs()->AddIds(0); // RAW
+        auto* a = config.AddConsumers();
+        a->SetName("c1");
+        a->SetServiceType("data-streams");
+        a->MutableCodec()->AddIds(1); // GZIP only — missing topic RAW
+        auto r = ValidateConsumersConfig(config, EOperation::Create);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "unsupported codec");
+    }
+}
+
+Y_UNIT_TEST(FillMeteringModeBranches) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+
+    {
+        runtime.GetAppData().PQConfig.MutableBillingMeteringConfig()->SetEnabled(true);
+        NKikimrPQ::TPQTabletConfig config;
+        UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_UNSPECIFIED, EOperation::Create));
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(config.GetMeteringMode()),
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(
+                NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS));
+
+        config.ClearMeteringMode();
+        UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_UNSPECIFIED, EOperation::Alter));
+        UNIT_ASSERT(!config.HasMeteringMode());
+
+        UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_REQUEST_UNITS, EOperation::Alter));
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(config.GetMeteringMode()),
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(
+                NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS));
+
+        UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_RESERVED_CAPACITY, EOperation::Alter));
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(config.GetMeteringMode()),
+            NKikimrPQ::TPQTabletConfig::EMeteringMode_Name(
+                NKikimrPQ::TPQTabletConfig::METERING_MODE_RESERVED_CAPACITY));
+
+        auto r = FillMeteringMode(
+            config,
+            static_cast<Ydb::Topic::MeteringMode>(999),
+            EOperation::Create);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Unknown metering mode");
+    }
+    {
+        runtime.GetAppData().PQConfig.MutableBillingMeteringConfig()->SetEnabled(false);
+        NKikimrPQ::TPQTabletConfig config;
+        UNIT_ASSERT(FillMeteringMode(config, Ydb::Topic::METERING_MODE_UNSPECIFIED, EOperation::Create));
+        auto r = FillMeteringMode(config, Ydb::Topic::METERING_MODE_REQUEST_UNITS, EOperation::Create);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_VALUES_EQUAL(r.GetStatus(), Ydb::StatusIds::PRECONDITION_FAILED);
+    }
+}
+
+Y_UNIT_TEST(ProcessTopicAttributesAdvancedMonitoringAndId) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+    runtime.GetAppData().FeatureFlags.SetEnableTopicSourceIdMappingById(true);
+
+    NGRpcProxy::V1::TConsumersAdvancedMonitoringSettings monitoring;
+
+    {
+        // First-class citizen rejects _advanced_monitoring.
+        google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
+        attrs["_advanced_monitoring"] = "{}";
+        NKikimrSchemeOp::TPersQueueGroupDescription config;
+        auto r = ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/true, monitoring);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "not supported in non-federation");
+    }
+    {
+        google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
+        attrs["_advanced_monitoring"] = "not-json";
+        NKikimrSchemeOp::TPersQueueGroupDescription config;
+        auto r = ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/false, monitoring);
+        UNIT_ASSERT(!r);
+    }
+    {
+        google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
+        attrs["_id"] = "abc";
+        NKikimrSchemeOp::TPersQueueGroupDescription config;
+        auto r = ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/false, monitoring);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "not a valid positive integer");
+    }
+    {
+        google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
+        attrs["_id"] = "0";
+        NKikimrSchemeOp::TPersQueueGroupDescription config;
+        auto r = ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/false, monitoring);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "greater than 0");
+    }
+    {
+        google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
+        attrs["_id"] = "123";
+        NKikimrSchemeOp::TPersQueueGroupDescription config;
+        UNIT_ASSERT(ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/false, monitoring));
+        UNIT_ASSERT_VALUES_EQUAL(config.GetPQTabletConfig().GetId().GetId(), 123u);
+    }
+    {
+        // FCC ignores _id even with feature flag.
+        google::protobuf::Map<TProtoStringType, TProtoStringType> attrs;
+        attrs["_id"] = "123";
+        NKikimrSchemeOp::TPersQueueGroupDescription config;
+        UNIT_ASSERT(ProcessTopicAttributes(attrs, &config, EOperation::Create, /*fcc=*/true, monitoring));
+        UNIT_ASSERT(!config.GetPQTabletConfig().HasId());
+    }
+}
+
+Y_UNIT_TEST(AddConsumerServiceTypeAndCodecs) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+    auto& pq = runtime.GetAppData().PQConfig;
+    pq.SetTopicsAreFirstClassCitizen(true);
+    pq.MutableDefaultClientServiceType()->SetName("data-streams");
+    pq.MutableDefaultClientServiceType()->SetMaxReadRulesCountPerTopic(10);
+    pq.MutableDefaultClientServiceType()->ClearPasswordHashes();
+    pq.ClearClientServiceType();
+    auto* st = pq.AddClientServiceType();
+    st->SetName("secure");
+    st->SetMaxReadRulesCountPerTopic(2);
+    st->AddPasswordHashes("5f4dcc3b5aa765d61d8327deb882cf99"); // md5("password")
+
+    auto types = GetSupportedClientServiceTypes();
+    UNIT_ASSERT(types.contains("data-streams"));
+    UNIT_ASSERT(types.contains("secure"));
+
+    NKikimrPQ::TPQTabletConfig config;
+    config.SetEnableCompactification(true);
+
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("bad/name");
+        consumer.mutable_streaming_consumer_type();
+        auto r = AddConsumer(&config, consumer, types, true, nullptr);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "illegal symbols");
+    }
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("");
+        consumer.mutable_streaming_consumer_type();
+        auto r = AddConsumer(&config, consumer, types, true, nullptr);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "empty name");
+    }
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name(TString{NPQ::CLIENTID_COMPACTION_CONSUMER});
+        consumer.mutable_streaming_consumer_type();
+        NKikimrPQ::TPQTabletConfig noCompact = config;
+        noCompact.SetEnableCompactification(false);
+        auto r = AddConsumer(&noCompact, consumer, types, true, nullptr);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "compactification");
+    }
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("c_version");
+        consumer.mutable_streaming_consumer_type();
+        (*consumer.mutable_attributes())["_version"] = "x";
+        auto r = AddConsumer(&config, consumer, types, true, nullptr);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "_version");
+    }
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("c_svc");
+        consumer.mutable_streaming_consumer_type();
+        (*consumer.mutable_attributes())["_service_type"] = "missing";
+        auto r = AddConsumer(&config, consumer, types, true, nullptr);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Unknown _service_type");
+    }
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("c_pass_bad");
+        consumer.mutable_streaming_consumer_type();
+        (*consumer.mutable_attributes())["_service_type"] = "secure";
+        (*consumer.mutable_attributes())["_service_type_password"] = "wrong";
+        auto r = AddConsumer(&config, consumer, types, true, nullptr);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "incorrect client service type password");
+    }
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("c_pass_ok");
+        consumer.mutable_streaming_consumer_type();
+        (*consumer.mutable_attributes())["_service_type"] = "secure";
+        (*consumer.mutable_attributes())["_service_type_password"] = "password";
+        (*consumer.mutable_attributes())["_sqs_read_request_attempt_id_period_ms"] = "1500";
+        consumer.mutable_supported_codecs()->add_codecs(Ydb::Topic::CODEC_RAW);
+        UNIT_ASSERT(AddConsumer(&config, consumer, types, true, nullptr));
+        const auto* c = NPQ::GetConsumer(config, "c_pass_ok");
+        UNIT_ASSERT(c);
+        UNIT_ASSERT_VALUES_EQUAL(c->GetServiceType(), "secure");
+        UNIT_ASSERT_VALUES_EQUAL(c->GetReadRequestAttemptIdPeriodMs(), 1500u);
+    }
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("c_no_pass");
+        consumer.mutable_streaming_consumer_type();
+        (*consumer.mutable_attributes())["_service_type"] = "secure";
+        pq.SetForceClientServiceTypePasswordCheck(true);
+        auto r = AddConsumer(&config, consumer, types, true, nullptr);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "no client service type password");
+        pq.SetForceClientServiceTypePasswordCheck(false);
+    }
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("c_bad_codec");
+        consumer.mutable_streaming_consumer_type();
+        consumer.mutable_supported_codecs()->add_codecs(static_cast<Ydb::Topic::Codec>(0));
+        auto r = AddConsumer(&config, consumer, types, true, nullptr);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "Unknown codec");
+    }
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("c_important");
+        consumer.mutable_streaming_consumer_type();
+        consumer.set_important(true);
+        // FCC + disabled disk quota forbids important.
+        runtime.GetAppData().FeatureFlags.SetEnableTopicDiskSubDomainQuota(false);
+        auto r = AddConsumer(&config, consumer, types, true, nullptr);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "important flag is forbiden");
+    }
+    {
+        Ydb::Topic::Consumer consumer;
+        consumer.set_name("c_read_from");
+        consumer.mutable_streaming_consumer_type();
+        consumer.mutable_read_from()->set_seconds(-1);
+        auto r = AddConsumer(&config, consumer, types, false, nullptr);
+        UNIT_ASSERT(!r);
+        UNIT_ASSERT_STRING_CONTAINS(r.GetErrorMessage(), "can't be negative");
+    }
 }
 
 } // Y_UNIT_TEST_SUITE(SchemaValidation)

--- a/ydb/core/persqueue/public/schema/ya.make
+++ b/ydb/core/persqueue/public/schema/ya.make
@@ -37,4 +37,5 @@ END()
 
 RECURSE_FOR_TESTS(
     ut
+    ut_light
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix AlterTopic metering-mode reset and reject negative partition counts; expand PersQueue schema unit tests.

### Description for reviewers <!-- (optional) description for those who read this PR -->

## Summary
- **Bug fix (`alter_topic.cpp`)**: `FillMeteringMode` on alter used `EOperation::Create`, so an unspecified metering mode could reset `RESERVED_CAPACITY` to `REQUEST_UNITS`. Now uses `EOperation::Alter`.
- **Bug fix (`alter_topic.cpp` / `validation.cpp`)**: reject negative `min`/`max` active partitions before uint32 wrap; remove dead `uint32 < 0` checks in partition-strategy validation.
- **Tests**: expand coverage for create/alter/describe/validation and add isolated `SchemaOperationActor` / `ProposeCreateTopic` unit tests (AppData-using checks run inside an actor context).

## Test plan
- [x] `ya make --build relwithdebinfo -tA ydb/core/persqueue/public/schema/ut`