### PR TITLE
[http_proxy] Use SigV4 service from the request instead of hardcoded kinesis

### DIFF
--- a/ydb/core/http_proxy/auth_actors.cpp
+++ b/ydb/core/http_proxy/auth_actors.cpp
@@ -187,7 +187,7 @@ namespace NKikimr::NHttpProxy {
                     signature.AccessKeyId = Signature->GetAccessKeyId();
                     signature.StringToSign = Signature->GetStringToSign();
                     signature.Signature = Signature->GetParsedSignature();
-                    signature.Service = "kinesis";
+                    signature.Service = Signature->GetService();
                     signature.Region = Signature->GetRegion();
                     signature.SignedAt = signedAt;
 
@@ -213,7 +213,7 @@ namespace NKikimr::NHttpProxy {
                 signature.set_signature(Signature->GetParsedSignature());
 
                 auto& v4params = *signature.mutable_v4_parameters();
-                v4params.set_service("kinesis");
+                v4params.set_service(Signature->GetService());
                 v4params.set_region(Signature->GetRegion());
 
                 const ui64 nanos = signedAt.NanoSeconds();

--- a/ydb/core/http_proxy/auth_actors.cpp
+++ b/ydb/core/http_proxy/auth_actors.cpp
@@ -178,6 +178,12 @@ namespace NKikimr::NHttpProxy {
                                           "Access key id should be provided",
                                           NYds::EErrorCodes::MISSING_AUTHENTICATION_TOKEN);
                 }
+
+                if (Signature->GetService().empty()) {
+                    return ReplyWithError(ctx, NYdb::EStatus::UNAUTHORIZED,
+                                          "Service name should be provided",
+                                          NYds::EErrorCodes::INCOMPLETE_SIGNATURE);
+                }
             }
 
             if (Authorize) {

--- a/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.cpp
+++ b/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.cpp
@@ -32,13 +32,13 @@ void THttpProxyTestMock::InitAll(const TInitParameters initParameters) {
     InitHttpServer(initParameters.YandexCloudMode, initParameters.EnableSqsTopic, initParameters.EnableAccessServiceV2Interface);
 }
 
-TString THttpProxyTestMock::FormAuthorizationStr(const TString& region) const {
+TString THttpProxyTestMock::FormAuthorizationStr(const TString& region, const TString& service) const {
     if (!SendAuthorizationStr) {
         return "";
     }
     return TStringBuilder() <<
         "Authorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/" << region <<
-        "/service/aws4_request, SignedHeaders=host;x-amz-date, Signature="
+        "/" << service << "/aws4_request, SignedHeaders=host;x-amz-date, Signature="
         "5da7c1a2acd57cee7505fc6676e4e544621c30862966e37dddb68e92efbe5d6b)__";
 }
 
@@ -956,6 +956,8 @@ void THttpProxyTestMock::InitAccessServiceService(bool enableAccessServiceV2Inte
     const auto setupAccessServiceMock = [&](auto& asMock) {
         asMock.AuthenticateData["kinesis"].Response.mutable_subject()->mutable_service_account()->set_id("Service1_id");
         asMock.AuthenticateData["kinesis"].Response.mutable_subject()->mutable_service_account()->set_folder_id("folder4");
+        asMock.AuthenticateData["service"].Response.mutable_subject()->mutable_service_account()->set_id("Service1_id");
+        asMock.AuthenticateData["service"].Response.mutable_subject()->mutable_service_account()->set_folder_id("folder4");
         asMock.AuthenticateData["proxy_sa@builtin"].Response.mutable_subject()->mutable_service_account()->set_id("Service1_id");
         asMock.AuthenticateData["proxy_sa@builtin"].Response.mutable_subject()->mutable_service_account()->set_folder_id("folder4");
         asMock.AuthenticateData["user@builtin"].Response.mutable_subject()->mutable_user_account()->set_id("user1_id");

--- a/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.h
+++ b/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.h
@@ -82,7 +82,7 @@ public:
 
     void InitAll(const TInitParameters initParameters);
 
-    TString FormAuthorizationStr(const TString& region) const;
+    TString FormAuthorizationStr(const TString& region, const TString& service = "kinesis") const;
 
     void EnableAuthorization();
     void DisableAuthorization();

--- a/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
@@ -104,6 +104,19 @@ namespace {
         return GetPathFromFullQueueUrl(url);
     }
 
+    TString GetCapturedAuthenticateService(THttpProxyTestMock& fixture) {
+        TString capturedService;
+        with_lock (fixture.AccessServiceMock.MetadataMutex) {
+            capturedService = fixture.AccessServiceMock.CapturedAuthenticateService;
+        }
+        if (capturedService.empty()) {
+            with_lock (fixture.AccessServiceMockV2.MetadataMutex) {
+                capturedService = fixture.AccessServiceMockV2.CapturedAuthenticateService;
+            }
+        }
+        return capturedService;
+    }
+
     NJson::TJsonMap SendSqsJsonWithHost(
         THttpProxyTestMock& fixture,
         const TString& host,
@@ -2887,17 +2900,34 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
             NJson::TJsonMap{},
             FormAuthorizationStr("ru-central1", "sqs"));
         UNIT_ASSERT_VALUES_EQUAL_C(res.HttpCode, 200, res.Body);
+        UNIT_ASSERT_VALUES_EQUAL(GetCapturedAuthenticateService(*this), "sqs");
+    }
 
-        TString capturedService;
-        with_lock (AccessServiceMock.MetadataMutex) {
-            capturedService = AccessServiceMock.CapturedAuthenticateService;
-        }
-        if (capturedService.empty()) {
-            with_lock (AccessServiceMockV2.MetadataMutex) {
-                capturedService = AccessServiceMockV2.CapturedAuthenticateService;
-            }
-        }
-        UNIT_ASSERT_VALUES_EQUAL(capturedService, "sqs");
+    Y_UNIT_TEST_F(TestSqsSigV4EmptyServiceIsRejected, TFixture) {
+        const TString authorization =
+            "Authorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/ru-central1, "
+            "SignedHeaders=host;x-amz-date, Signature="
+            "5da7c1a2acd57cee7505fc6676e4e544621c30862966e37dddb68e92efbe5d6b)__";
+        auto res = SendHttpRequest(
+            "/Root",
+            "AmazonSQS.ListQueues",
+            NJson::TJsonMap{},
+            authorization);
+        UNIT_ASSERT_VALUES_EQUAL_C(res.HttpCode, 400, res.Body);
+        NJson::TJsonMap json;
+        UNIT_ASSERT(NJson::ReadJsonTree(res.Body, &json, true));
+        UNIT_ASSERT_VALUES_EQUAL(GetByPath<TString>(json, "__type"), "IncompleteSignature");
+        UNIT_ASSERT_VALUES_EQUAL(GetByPath<TString>(json, "message"), "Service name should be provided");
+    }
+
+    Y_UNIT_TEST_F(TestKinesisSigV4ServiceIsForwardedToAccessService, TFixture) {
+        auto res = SendHttpRequest(
+            "/Root",
+            "kinesisApi.ListStreams",
+            NJson::TJsonMap{},
+            FormAuthorizationStr("ru-central1", "kinesis"));
+        UNIT_ASSERT_VALUES_EQUAL_C(res.HttpCode, 200, res.Body);
+        UNIT_ASSERT_VALUES_EQUAL(GetCapturedAuthenticateService(*this), "kinesis");
     }
 
     Y_UNIT_TEST_F(TestCreateQueueSetsDefaultTopicMessageRateLimit, TFixture) {

--- a/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
@@ -2880,6 +2880,26 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
         }
     }
 
+    Y_UNIT_TEST_F(TestSqsSigV4ServiceIsForwardedToAccessService, TFixture) {
+        auto res = SendHttpRequest(
+            "/Root",
+            "AmazonSQS.ListQueues",
+            NJson::TJsonMap{},
+            FormAuthorizationStr("ru-central1", "sqs"));
+        UNIT_ASSERT_VALUES_EQUAL_C(res.HttpCode, 200, res.Body);
+
+        TString capturedService;
+        with_lock (AccessServiceMock.MetadataMutex) {
+            capturedService = AccessServiceMock.CapturedAuthenticateService;
+        }
+        if (capturedService.empty()) {
+            with_lock (AccessServiceMockV2.MetadataMutex) {
+                capturedService = AccessServiceMockV2.CapturedAuthenticateService;
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL(capturedService, "sqs");
+    }
+
     Y_UNIT_TEST_F(TestCreateQueueSetsDefaultTopicMessageRateLimit, TFixture) {
         const TString queueName = "CreateQueueDefaultRateLimit";
 

--- a/ydb/library/http_proxy/authorization/signature.cpp
+++ b/ydb/library/http_proxy/authorization/signature.cpp
@@ -113,6 +113,10 @@ const TString& TAwsRequestSignV4::GetRegion() const {
     return AwsRegion_;
 }
 
+const TString& TAwsRequestSignV4::GetService() const {
+    return AwsService_;
+}
+
 const TString& TAwsRequestSignV4::GetAccessKeyId() const {
     return AccessKeyId_;
 }

--- a/ydb/library/http_proxy/authorization/signature.h
+++ b/ydb/library/http_proxy/authorization/signature.h
@@ -25,6 +25,8 @@ public:
 
     const TString& GetRegion() const;
 
+    const TString& GetService() const;
+
     const TString& GetAccessKeyId() const;
 
     TString CalcSignature(const TString& secretKey) const;

--- a/ydb/library/http_proxy/authorization/ut/signature_ut.cpp
+++ b/ydb/library/http_proxy/authorization/ut/signature_ut.cpp
@@ -52,6 +52,19 @@ Authorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/ru-central1/sqs/
         UNIT_ASSERT_EQUAL("AKIDEXAMPLE", signature.GetAccessKeyId());
     }
 
+    Y_UNIT_TEST(TestParsesEmptyServiceFromIncompleteCredential) {
+        const TString request = \
+R"__(POST / HTTP/1.1
+Host:example.amazonaws.com
+X-Amz-Date:20150830T123600Z
+Authorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/ru-central1, SignedHeaders=host;x-amz-date, Signature=5da7c1a2acd57cee7505fc6676e4e544621c30862966e37dddb68e92efbe5d6b)__";
+
+        TAwsRequestSignV4 signature(request);
+        UNIT_ASSERT_EQUAL("AKIDEXAMPLE", signature.GetAccessKeyId());
+        UNIT_ASSERT_EQUAL("ru-central1", signature.GetRegion());
+        UNIT_ASSERT(signature.GetService().empty());
+    }
+
     Y_UNIT_TEST(TestPostVanilla) {
         const TString request = \
 R"__(POST / HTTP/1.1

--- a/ydb/library/http_proxy/authorization/ut/signature_ut.cpp
+++ b/ydb/library/http_proxy/authorization/ut/signature_ut.cpp
@@ -35,7 +35,21 @@ bb579772317eb040ac9ed261061d46c1f17a8133879d6129b6e1c25292927e63)__";
         UNIT_ASSERT_EQUAL(canonicalizedRequest, signature.GetCanonicalRequest());
         UNIT_ASSERT_EQUAL(stringToSign, signature.GetStringToSign());
         UNIT_ASSERT_EQUAL("us-east-1", signature.GetRegion());
+        UNIT_ASSERT_EQUAL("service", signature.GetService());
         UNIT_ASSERT_EQUAL("5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31", signature.CalcSignature(superSecretAmazonKey));
+    }
+
+    Y_UNIT_TEST(TestParsesSqsServiceFromCredential) {
+        const TString request = \
+R"__(POST / HTTP/1.1
+Host:example.amazonaws.com
+X-Amz-Date:20150830T123600Z
+Authorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/ru-central1/sqs/aws4_request, SignedHeaders=host;x-amz-date, Signature=5da7c1a2acd57cee7505fc6676e4e544621c30862966e37dddb68e92efbe5d6b)__";
+
+        TAwsRequestSignV4 signature(request);
+        UNIT_ASSERT_EQUAL("ru-central1", signature.GetRegion());
+        UNIT_ASSERT_EQUAL("sqs", signature.GetService());
+        UNIT_ASSERT_EQUAL("AKIDEXAMPLE", signature.GetAccessKeyId());
     }
 
     Y_UNIT_TEST(TestPostVanilla) {

--- a/ydb/library/testlib/service_mocks/access_service_mock.h
+++ b/ydb/library/testlib/service_mocks/access_service_mock.h
@@ -45,6 +45,7 @@ public:
     TMutex MetadataMutex;
     TString CapturedXUserIP;
     TString CapturedUserAgent;
+    TString CapturedAuthenticateService;
 
     template <class TResponseProto>
     void CheckRequestId(grpc::ServerContext* ctx, const TResponse<TResponseProto>& resp, const TString& token) {
@@ -61,15 +62,15 @@ public:
         const yandex::cloud::priv::servicecontrol::v1::AuthenticateRequest* request,
         yandex::cloud::priv::servicecontrol::v1::AuthenticateResponse* response) override
     {
+        TString key;
         with_lock (MetadataMutex) {
             CapturedUserAgent = NTestUtils::CaptureUserAgent(ctx);
-        }
-
-        TString key;
-        if (request->has_signature()) {
-            key = request->signature().v4_parameters().service();
-        } else {
-            key = request->iam_token();
+            if (request->has_signature()) {
+                CapturedAuthenticateService = request->signature().v4_parameters().service();
+                key = CapturedAuthenticateService;
+            } else {
+                key = request->iam_token();
+            }
         }
 
         auto it = AuthenticateData.find(key);
@@ -124,6 +125,7 @@ public:
     TMutex MetadataMutex;
     TString CapturedXUserIP;
     TString CapturedUserAgent;
+    TString CapturedAuthenticateService;
 
     template <class TResponseProto>
     void CheckRequestId(grpc::ServerContext* ctx, const TResponse<TResponseProto>& resp, const TString& token) {
@@ -140,15 +142,15 @@ public:
         const yandex::cloud::priv::accessservice::v2::AuthenticateRequest* request,
         yandex::cloud::priv::accessservice::v2::AuthenticateResponse* response) override
     {
+        TString key;
         with_lock (MetadataMutex) {
             CapturedUserAgent = NTestUtils::CaptureUserAgent(ctx);
-        }
-
-        TString key;
-        if (request->has_signature()) {
-            key = request->signature().v4_parameters().service();
-        } else {
-            key = request->iam_token();
+            if (request->has_signature()) {
+                CapturedAuthenticateService = request->signature().v4_parameters().service();
+                key = CapturedAuthenticateService;
+            } else {
+                key = request->iam_token();
+            }
         }
 
         auto it = AuthenticateData.find(key);
@@ -195,6 +197,9 @@ public:
         with_lock (MetadataMutex) {
             CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
             CapturedUserAgent = NTestUtils::CaptureUserAgent(ctx);
+            if (request->has_signature()) {
+                CapturedAuthenticateService = request->signature().v4_parameters().service();
+            }
         }
 
         for (const auto& action : request->actions().items()) {

--- a/ydb/library/testlib/service_mocks/access_service_mock.h
+++ b/ydb/library/testlib/service_mocks/access_service_mock.h
@@ -65,6 +65,7 @@ public:
         TString key;
         with_lock (MetadataMutex) {
             CapturedUserAgent = NTestUtils::CaptureUserAgent(ctx);
+            CapturedAuthenticateService.clear();
             if (request->has_signature()) {
                 CapturedAuthenticateService = request->signature().v4_parameters().service();
                 key = CapturedAuthenticateService;
@@ -145,6 +146,7 @@ public:
         TString key;
         with_lock (MetadataMutex) {
             CapturedUserAgent = NTestUtils::CaptureUserAgent(ctx);
+            CapturedAuthenticateService.clear();
             if (request->has_signature()) {
                 CapturedAuthenticateService = request->signature().v4_parameters().service();
                 key = CapturedAuthenticateService;
@@ -197,6 +199,7 @@ public:
         with_lock (MetadataMutex) {
             CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
             CapturedUserAgent = NTestUtils::CaptureUserAgent(ctx);
+            CapturedAuthenticateService.clear();
             if (request->has_signature()) {
                 CapturedAuthenticateService = request->signature().v4_parameters().service();
             }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed SQS authentication through HTTP proxy: AWS SigV4 requests signed with service `sqs` were rejected with `The signature is invalid`, because the proxy always sent `kinesis` to Access Service.

### Description for reviewers <!-- (optional) description for those who read this PR -->

HTTP proxy auth hardcoded `service = "kinesis"` for every SigV4 request, including SQS. AWS CLI signs SQS with credential scope `.../sqs/aws4_request`, so Access Service (and TicketParser) rejected the signature. Kinesis kept working because the hardcoded value matched.

Native YMQ already sends `service = "sqs"`. This change takes the service name from the parsed SigV4 credential (`TAwsRequestSignV4::GetService()`) for both TicketParser and Access Service authenticate paths.

`TestSqsSigV4ServiceIsForwardedToAccessService` reproduces the bug: `ListQueues` signed as `sqs` used to arrive at Access Service as `kinesis`.