### PR TITLE
Fix undefined symbol linkage error in dq_pq_write_actor.cpp

### DIFF
--- a/ydb/library/yql/providers/pq/async_io/dq_pq_write_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_write_actor.cpp
@@ -1055,7 +1055,7 @@ private:
             WriteSession.reset();
         }
 
-        Y_VALIDATE(!IsIn({NDqProto::StatusIds::SUCCESS, NDqProto::StatusIds::UNSPECIFIED}, status), "Invalid fail status: " << status);
+        Y_VALIDATE(!IsIn({NDqProto::StatusIds::SUCCESS, NDqProto::StatusIds::UNSPECIFIED}, status), "Invalid fail status: " << NDqProto::StatusIds::StatusCode_Name(status));
         SINK_LOG_W("Fail. Status: " << NDqProto::StatusIds::StatusCode_Name(status) << ". Issues: " << issues.ToOneLineString());
         Callbacks->OnAsyncOutputError(OutputIndex, issues, status);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

```
ld.lld: error: undefined symbol: void Out<NYql::NDqProto::StatusIds_StatusCode>(IOutputStream&, TTypeTraits<NYql::NDqProto::StatusIds_StatusCode>::TFuncParam)
>>> referenced by output.h:231 (/-S/util/stream/output.h:231)
>>>               dq_pq_write_actor.cpp.o:(void NPrivateException::yexception::Append<NYql::NDqProto::StatusIds_StatusCode>(NYql::NDqProto::StatusIds_StatusCode const&)) in archive ydb/library/yql/providers/pq/async_io/libproviders-pq-async_io.a
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
