### PR TITLE
Add deadline to DQ job stop requests

### DIFF
--- a/ydb/library/yql/providers/dq/api/protos/dqs.proto
+++ b/ydb/library/yql/providers/dq/api/protos/dqs.proto
@@ -96,6 +96,8 @@ message TEvJobStop {
 }
 
 message TEvJobStopResponse {
+    string Error = 1;
+    bool Retryable = 2;
 }
 
 message TEvClusterStatus {

--- a/ydb/library/yql/providers/dq/api/protos/service.proto
+++ b/ydb/library/yql/providers/dq/api/protos/service.proto
@@ -223,6 +223,12 @@ message JobStopRequest {
     repeated TAttribute Attribute = 4;
     bool Force = 5;
     bool NegativeRevision = 6;
+    // Absolute ISO-8601 deadline for a non-forced stop filter,
+    // e.g. "2026-09-02T14:30:00Z". Ignored when Force = true.
+    // Malformed values are rejected; values beyond 10 minutes from server
+    // processing time are clamped. A past deadline is already expired.
+    // Empty keeps the legacy TTL: 600 seconds since the filter's last match.
+    string Deadline = 7;
 }
 
 message JobStopResponse {

--- a/ydb/library/yql/providers/dq/worker_manager/interface/events.cpp
+++ b/ydb/library/yql/providers/dq/worker_manager/interface/events.cpp
@@ -95,6 +95,11 @@ namespace NYql::NDqs {
         Record.SetIsForwarded(false);
     }
 
+    TEvJobStopResponse::TEvJobStopResponse(const TString& error, bool retryable) {
+        Record.SetError(error);
+        Record.SetRetryable(retryable);
+    }
+
     TEvOperationStop::TEvOperationStop(const Yql::DqsProto::OperationStopRequest& request) {
         *Record.MutableRequest() = request;
         Record.SetIsForwarded(false);

--- a/ydb/library/yql/providers/dq/worker_manager/interface/events.h
+++ b/ydb/library/yql/providers/dq/worker_manager/interface/events.h
@@ -64,6 +64,16 @@ using TDqResManEvents = NDq::TBaseDqResManEvents<NActors::TEvents::EEventSpace::
         TEvJobStop(const Yql::DqsProto::JobStopRequest& request);
     };
 
+    struct TEvJobStopResponse
+        : NActors::TEventPB<
+            TEvJobStopResponse,
+            NYql::NDqProto::TEvJobStopResponse,
+            TDqResManEvents::ES_JOB_STOP_RESPONSE> {
+
+        TEvJobStopResponse() = default;
+        explicit TEvJobStopResponse(const TString& error, bool retryable = false);
+    };
+
     struct TEvOperationStop
         : NActors::TEventPB<TEvOperationStop, NYql::NDqProto::TEvOperationStop, TDqResManEvents::ES_OPERATION_STOP> {
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add an optional deadline to DQ job stop requests.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Expose an optional absolute ISO-8601 `Deadline` in the shared `JobStopRequest` protobuf. The field is intended for non-forced stop filters; its comment documents the accepted format, server-side 10-minute clamp, expired-deadline semantics, and backward-compatible behavior for an empty value.

Add an internal `TEvJobStopResponse` wrapper with error text and a retryability flag, allowing callers to distinguish invalid requests from temporary service unavailability.

Validated in the Arcadia integration: DQ global worker manager unit tests pass (46 tests), and the DQ gRPC service builds successfully.
