### PR TITLE
Fix windows build: Guard DbsController dependency under YDB_EMBEDDED_NBS_ENABLED flag

### DIFF
--- a/ydb/core/mind/configured_tablet_bootstrapper.cpp
+++ b/ydb/core/mind/configured_tablet_bootstrapper.cpp
@@ -781,9 +781,11 @@ TIntrusivePtr<TTabletSetupInfo> MakeTabletSetupInfo(
     case TTabletTypes::Dummy:
         createFunc = &CreateSimpleTablet;
         break;
+#if defined(YDB_EMBEDDED_NBS_ENABLED)
     case TTabletTypes::DbsController:
         createFunc = &NYdb::NBS::NBlockStore::NStorage::NDbsController::CreateDbsControllerTablet;
         break;
+#endif
     default:
         return nullptr;
     }

--- a/ydb/core/mind/ya.make
+++ b/ydb/core/mind/ya.make
@@ -77,6 +77,18 @@ PEERDIR(
     ydb/core/tx/schemeshard
 )
 
+DEFAULT(YDB_EMBEDDED_NBS_ENABLED yes)
+
+IF (OS_LINUX AND YDB_EMBEDDED_NBS_ENABLED)
+    CFLAGS(
+        -DYDB_EMBEDDED_NBS_ENABLED
+    )
+
+    PEERDIR(
+        ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller
+    )
+ENDIF()
+
 END()
 
 RECURSE(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
