### PR TITLE
ci: add scheduled NBS stable sync

### DIFF
--- a/.github/workflows/nbs_sync.yml
+++ b/.github/workflows/nbs_sync.yml
@@ -2,7 +2,7 @@ name: NBS stable sync
 
 on:
   schedule:
-    - cron: "30 6 * * *"   # At 06:30 UTC / 09:30 MSK
+    - cron: "0 20 * * *"   # At 20:00 UTC / 23:00 MSK
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/nbs_sync.yml
+++ b/.github/workflows/nbs_sync.yml
@@ -1,0 +1,44 @@
+name: NBS stable sync
+
+on:
+  schedule:
+    - cron: "30 6 * * *"   # At 06:30 UTC / 09:30 MSK
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  GH_TOKEN: ${{ secrets.YDBOT_TOKEN }}
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branches:
+          - base: nbs-26-2-1
+            head: stable-26-2-1
+          - base: nbs-26-3-1
+            head: stable-26-3-1
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          sparse-checkout: |
+            .github
+            ydb/ci/
+
+      - uses: ./.github/actions/rightlib_sync
+        with:
+          base_branch: ${{ matrix.branches.base }}
+          head_branch: ${{ matrix.branches.head }}
+          label: sync-nbs
+          repository: ${{ github.repository }}
+          gh_personal_access_token: ${{ env.GH_TOKEN }}


### PR DESCRIPTION
### Changelog entry

Not for changelog.

### Description for reviewers

Add daily branch syncs using the existing rightlib_sync action:

- stable-26-2-1 to nbs-26-2-1
- stable-26-3-1 to nbs-26-3-1

The workflow also supports manual dispatch and runs daily at 20:00 UTC (23:00 MSK).