### PR TITLE
Speed up statistics aggregator tests

### DIFF
--- a/ydb/core/statistics/aggregator/ut/ut_analyze.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_analyze.cpp
@@ -793,7 +793,7 @@ Y_UNIT_TEST_SUITE(AnalyzeStatistics) {
                     PRIMARY KEY (key)
                 )
                 PARTITION BY HASH(key)
-                WITH (STORE = COLUMN);
+                WITH (STORE = COLUMN, AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 4);
             )");
         } else {
             ExecuteYqlScript(env, R"(

--- a/ydb/core/statistics/aggregator/ut/ut_traverse.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_traverse.cpp
@@ -18,17 +18,18 @@ namespace {
 
 TTestEnv CreateTestEnv() {
     return TTestEnv(1, 1, false, [](Tests::TServerSettings& settings) {
-        settings.AppConfig->MutableStatisticsConfig()
-            ->SetEnableBackgroundColumnStatsCollection(true);
+        auto* stats = settings.AppConfig->MutableStatisticsConfig();
+        stats->SetEnableBackgroundColumnStatsCollection(true);
+        stats->SetBaseStatsSendInitialDelaySeconds(3);
     });
 }
 
 TTestEnv CreateTestEnv(ui32 changeRatioThresholdPercent) {
     return TTestEnv(1, 1, false, [changeRatioThresholdPercent](Tests::TServerSettings& settings) {
-        settings.AppConfig->MutableStatisticsConfig()
-            ->SetEnableBackgroundColumnStatsCollection(true);
-        settings.AppConfig->MutableStatisticsConfig()
-            ->SetBackgroundAnalyzeChangeRatioThresholdPercent(changeRatioThresholdPercent);
+        auto* stats = settings.AppConfig->MutableStatisticsConfig();
+        stats->SetEnableBackgroundColumnStatsCollection(true);
+        stats->SetBackgroundAnalyzeChangeRatioThresholdPercent(changeRatioThresholdPercent);
+        stats->SetBaseStatsSendInitialDelaySeconds(3);
     });
 }
 
@@ -313,6 +314,7 @@ Y_UNIT_TEST_SUITE(TraverseStatistics) {
             auto* stats = settings.AppConfig->MutableStatisticsConfig();
             stats->SetEnableBackgroundColumnStatsCollection(true);
             stats->SetBaseStatsSendIntervalSecondsDedicated(1);
+            stats->SetBaseStatsSendInitialDelaySeconds(3);
         });
         auto& runtime = *env.GetServer().GetRuntime();
 
@@ -465,14 +467,10 @@ Y_UNIT_TEST_SUITE(TraverseStatistics) {
     // re-trigger ANALYZE. A later above-threshold change still must.
     Y_UNIT_TEST_TWIN(SchemeShardRestartWithoutPersistentStats, ColumnShard) {
         TTestEnv env(1, 1, false, [](Tests::TServerSettings& settings) {
-            settings.AppConfig->MutableStatisticsConfig()
-                ->SetEnableBackgroundColumnStatsCollection(true);
-            settings.AppConfig->MutableStatisticsConfig()
-                ->SetBackgroundAnalyzeChangeRatioThresholdPercent(20);
-            // After reboot SS waits 30s before the first SendBaseStatsToSA; keep
-            // the subsequent interval short so recovery is observable quickly.
-            settings.AppConfig->MutableStatisticsConfig()
-                ->SetBaseStatsSendIntervalSecondsDedicated(3);
+            auto* stats = settings.AppConfig->MutableStatisticsConfig();
+            stats->SetEnableBackgroundColumnStatsCollection(true);
+            stats->SetBackgroundAnalyzeChangeRatioThresholdPercent(20);
+            stats->SetBaseStatsSendInitialDelaySeconds(3);
             settings.FeatureFlags.SetEnablePersistentPartitionStats(false);
         });
         auto& runtime = *env.GetServer().GetRuntime();

--- a/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
@@ -381,7 +381,8 @@ Y_UNIT_TEST_SUITE(BasicStatistics) {
             return describe.GetPathDescription().GetTableStats().GetRowCount();
         };
 
-        runtime.SimulateSleep(TDuration::Seconds(100));
+        WaitForSchemeShardStatsUpdate(runtime, ssTabletId, /*requireFull=*/true);
+        WaitForRowCount(runtime, nodeIdx, pathId1, 1000, /*timeoutSec=*/30);
         UNIT_ASSERT_EQUAL(getDescribeRowCount(path1), 1000);
         UNIT_ASSERT_VALUES_EQUAL(GetRowCount(runtime, nodeIdx, pathId1), 1000);
 
@@ -393,7 +394,9 @@ Y_UNIT_TEST_SUITE(BasicStatistics) {
         PrepareColumnTable(env, dbName, table2, 4);
         auto pathId2 = ResolvePathId(runtime, path2, nullptr, &saTabletId);
 
-        runtime.SimulateSleep(TDuration::Seconds(100));
+        WaitForSchemeShardStatsUpdate(runtime, ssTabletId, /*requireFull=*/true);
+        WaitForRowCount(runtime, nodeIdx, pathId1, 1000, /*timeoutSec=*/30);
+        WaitForRowCount(runtime, nodeIdx, pathId2, 1000, /*timeoutSec=*/30);
         UNIT_ASSERT_EQUAL(getDescribeRowCount(path1), 1000);
         UNIT_ASSERT_EQUAL(getDescribeRowCount(path2), 1000);
         UNIT_ASSERT_VALUES_EQUAL(GetRowCount(runtime, nodeIdx, pathId1), 1000);
@@ -404,7 +407,10 @@ Y_UNIT_TEST_SUITE(BasicStatistics) {
         PrepareColumnTable(env, dbName, table3, 4);
         auto pathId3 = ResolvePathId(runtime, path3, nullptr, &saTabletId);
 
-        runtime.SimulateSleep(TDuration::Seconds(140));
+        WaitForSchemeShardStatsUpdate(runtime, ssTabletId, /*requireFull=*/true);
+        WaitForRowCount(runtime, nodeIdx, pathId1, 1000, /*timeoutSec=*/30);
+        WaitForRowCount(runtime, nodeIdx, pathId2, 1000, /*timeoutSec=*/30);
+        WaitForRowCount(runtime, nodeIdx, pathId3, 1000, /*timeoutSec=*/30);
         UNIT_ASSERT_EQUAL(getDescribeRowCount(path1), 1000);
         UNIT_ASSERT_EQUAL(getDescribeRowCount(path2), 1000);
         UNIT_ASSERT_EQUAL(getDescribeRowCount(path3), 1000);
@@ -439,8 +445,9 @@ Y_UNIT_TEST_SUITE(BasicStatistics) {
     Y_UNIT_TEST(ServerlessTimeIntervals) {
         // Test that time intervals set in config for the serverless environment are honored.
         auto modifyConfig = [](Tests::TServerSettings& settings) {
-            settings.AppConfig->MutableStatisticsConfig()->SetBaseStatsSendIntervalSecondsServerless(30);
-            settings.AppConfig->MutableStatisticsConfig()->SetBaseStatsPropagateIntervalSecondsServerless(30);
+            settings.AppConfig->MutableStatisticsConfig()->SetBaseStatsSendInitialDelaySeconds(5);
+            settings.AppConfig->MutableStatisticsConfig()->SetBaseStatsSendIntervalSecondsServerless(5);
+            settings.AppConfig->MutableStatisticsConfig()->SetBaseStatsPropagateIntervalSecondsServerless(5);
         };
         TTestEnv env(1, 1, false, modifyConfig);
 
@@ -450,25 +457,15 @@ Y_UNIT_TEST_SUITE(BasicStatistics) {
         CreateTable(env, "Serverless1", "Table1", 5);
         CreateTable(env, "Serverless2", "Table2", 6);
 
-        // Wait until reported row counts are correct.
         auto& runtime = *env.GetServer().GetRuntime();
         auto pathId1 = ResolvePathId(runtime, "/Root/Serverless1/Table1");
         auto pathId2 = ResolvePathId(runtime, "/Root/Serverless2/Table2");
-        ValidateRowCount(runtime, 1, pathId1, 5);
-        ValidateRowCount(runtime, 1, pathId2, 6);
 
-        // Subsequent events renewing base statistics should not be sent out for a long time.
-
-        size_t sendCount = 0;
+        THashMap<ui64, TVector<TInstant>> sendTimesBySs;
         auto sendObserver = runtime.AddObserver<TEvStatistics::TEvSchemeShardStats>([&](auto& ev){
-            // Count only events from serverless schemeshards.
-            NKikimrStat::TSchemeShardStats stats;
-            UNIT_ASSERT(stats.ParseFromString(ev->Get()->Record.GetStats()));
-            if (stats.GetEntries().size() == 1) {
-                auto ownerId = stats.GetEntries()[0].GetPathId().GetOwnerId();
-                if (ownerId == pathId1.OwnerId || ownerId == pathId2.OwnerId) {
-                    ++sendCount;
-                }
+            auto ssId = ev->Get()->Record.GetSchemeShardId();
+            if (ssId == pathId1.OwnerId || ssId == pathId2.OwnerId) {
+                sendTimesBySs[ssId].push_back(runtime.GetCurrentTime());
             }
         });
 
@@ -477,13 +474,37 @@ Y_UNIT_TEST_SUITE(BasicStatistics) {
             ++propagateCount;
         });
 
-        runtime.SimulateSleep(TDuration::Seconds(15));
-        UNIT_ASSERT_VALUES_EQUAL(sendCount, 0);
-        UNIT_ASSERT_VALUES_EQUAL(propagateCount, 0);
+        ValidateRowCount(runtime, 1, pathId1, 5);
+        ValidateRowCount(runtime, 1, pathId2, 6);
 
-        runtime.SimulateSleep(TDuration::Seconds(20));
-        UNIT_ASSERT_VALUES_EQUAL(sendCount, 2); // events from 2 serverless schemeshards
-        UNIT_ASSERT_VALUES_EQUAL(propagateCount, 2); // SA -> node1 and node1 -> node2
+        auto enoughSamples = [&] {
+            if (sendTimesBySs.size() != 2) {
+                return false;
+            }
+            for (const auto& [_, times] : sendTimesBySs) {
+                if (times.size() < 2) {
+                    return false;
+                }
+            }
+            return true;
+        };
+        for (int i = 0; i < 20 && !enoughSamples(); ++i) {
+            runtime.SimulateSleep(TDuration::Seconds(1));
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(sendTimesBySs.size(), 2);
+        for (const auto& [ssId, times] : sendTimesBySs) {
+            UNIT_ASSERT_C(times.size() >= 2,
+                "schemeshard " << ssId << " sent only " << times.size() << " time(s)");
+            for (size_t i = 1; i < times.size(); ++i) {
+                const auto gap = times[i] - times[i - 1];
+                UNIT_ASSERT_C(gap >= TDuration::Seconds(3),
+                    "schemeshard " << ssId << " gap " << gap << " is below serverless min jitter");
+                UNIT_ASSERT_C(gap <= TDuration::Seconds(7),
+                    "schemeshard " << ssId << " gap " << gap << " is above serverless max interval");
+            }
+        }
+        UNIT_ASSERT_GE(propagateCount, 2);
     }
 
     Y_UNIT_TEST(PersistenceWithStorageFailuresAndReboots) {

--- a/ydb/core/statistics/service/ut/ut_column_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_column_statistics.cpp
@@ -402,9 +402,8 @@ Y_UNIT_TEST_SUITE(ColumnStatistics) {
     }
 
     Y_UNIT_TEST(ManyColumns) {
-        constexpr size_t columnCount = 25;
         std::vector<TColumnDesc> columns;
-        for (size_t i = 0; i < columnCount; ++i) {
+        for (size_t i = 0; i < 100; ++i) {
             columns.push_back({
                 .Name = std::format("V_{}", i),
                 .TypeId = NScheme::NTypeIds::Int64,
@@ -414,16 +413,15 @@ Y_UNIT_TEST_SUITE(ColumnStatistics) {
             });
         }
 
-        TTestEnv env(1, 1);
+        TTestEnv env(1, 3);
         auto& runtime = *env.GetServer().GetRuntime();
 
-        CreateDatabase(env, "Database");
-        const auto tableInfo = PrepareTable(env, "Database", "Table1", columns, /*shardCount=*/1);
+        CreateDatabase(env, "Database", 3);
+        const auto tableInfo = PrepareTable(env, "Database", "Table1", columns);
         Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
 
         auto responses = GetStatistics(
-            runtime, tableInfo.PathId, EStatType::COUNT_MIN_SKETCH,
-            {GetTag(std::format("V_{}", columnCount - 1), columns)});
+            runtime, tableInfo.PathId, EStatType::COUNT_MIN_SKETCH, {GetTag("V_99", columns)});
         UNIT_ASSERT_VALUES_EQUAL(responses.size(), 1);
         const auto& resp = responses.at(0);
         UNIT_ASSERT(resp.Success);

--- a/ydb/core/statistics/service/ut/ut_column_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_column_statistics.cpp
@@ -402,8 +402,9 @@ Y_UNIT_TEST_SUITE(ColumnStatistics) {
     }
 
     Y_UNIT_TEST(ManyColumns) {
+        constexpr size_t columnCount = 25;
         std::vector<TColumnDesc> columns;
-        for (size_t i = 0; i < 100; ++i) {
+        for (size_t i = 0; i < columnCount; ++i) {
             columns.push_back({
                 .Name = std::format("V_{}", i),
                 .TypeId = NScheme::NTypeIds::Int64,
@@ -413,15 +414,16 @@ Y_UNIT_TEST_SUITE(ColumnStatistics) {
             });
         }
 
-        TTestEnv env(1, 3);
+        TTestEnv env(1, 1);
         auto& runtime = *env.GetServer().GetRuntime();
 
-        CreateDatabase(env, "Database", 3);
-        const auto tableInfo = PrepareTable(env, "Database", "Table1", columns);
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareTable(env, "Database", "Table1", columns, /*shardCount=*/1);
         Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
 
         auto responses = GetStatistics(
-            runtime, tableInfo.PathId, EStatType::COUNT_MIN_SKETCH, {GetTag("V_99", columns)});
+            runtime, tableInfo.PathId, EStatType::COUNT_MIN_SKETCH,
+            {GetTag(std::format("V_{}", columnCount - 1), columns)});
         UNIT_ASSERT_VALUES_EQUAL(responses.size(), 1);
         const auto& resp = responses.at(0);
         UNIT_ASSERT(resp.Success);

--- a/ydb/core/statistics/ut_common/ut_common.cpp
+++ b/ydb/core/statistics/ut_common/ut_common.cpp
@@ -54,7 +54,7 @@ TTestEnv::TTestEnv(ui32 staticNodes, ui32 dynamicNodes, bool useRealThreads,
     Settings->AddStoragePoolType("hdd2");
     Settings->SetColumnShardAlterObjectEnabled(true);
     auto* stats = Settings->AppConfig->MutableStatisticsConfig();
-    stats->SetBaseStatsSendInitialDelaySeconds(3);
+    stats->SetBaseStatsSendInitialDelaySeconds(1);
     stats->SetBaseStatsSendIntervalSecondsDedicated(1);
     stats->SetBaseStatsSendIntervalSecondsServerless(1);
     stats->SetBaseStatsPropagateIntervalSecondsDedicated(1);
@@ -509,7 +509,6 @@ void InsertDataIntoTable(
     UNIT_ASSERT_VALUES_EQUAL_C(
         response.operation().status(), Ydb::StatusIds::SUCCESS,
         GetIssuesString(response.operation()));
-    env.GetController()->WaitActualization(TDuration::Seconds(1));
 }
 
 TTableInfo PrepareColumnTable(TTestEnv& env, const TString& databaseName, const TString& tableName,
@@ -548,8 +547,6 @@ TTableInfo PrepareColumnTableWithIndexes(TTestEnv& env, const TString& databaseN
     runtime.SimulateSleep(TDuration::MilliSeconds(200));
 
     InsertDataIntoTable(env, databaseName, tableName, ColumnTableRowsNumber);
-
-    env.GetController()->WaitActualization(TDuration::Seconds(1));
 
     return info;
 }

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -9547,7 +9547,7 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
         LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::STATISTICS,
             "SendBaseStatsToSA() No tables to send"
             << ", at schemeshard: " << TabletID());
-        return TDuration::Seconds(30);
+        return TDuration::Seconds(Max<ui32>(1, AppData()->StatisticsConfig.GetBaseStatsSendInitialDelaySeconds()));
     }
 
     record.SetAreAllStatsFull(incompleteCount == 0);


### PR DESCRIPTION
* Retry empty SchemeShard base-stats send at the configured initial delay, shorten that delay in tests
*  Drop dead waits / a 64-shard table / a stale 3s interval override.