### PR TITLE
ci: stop installing ANTLR3

### DIFF
--- a/.github/actions/prepare_vm/action.yaml
+++ b/.github/actions/prepare_vm/action.yaml
@@ -29,7 +29,7 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get -y install --no-install-recommends \
-          python-is-python3 git cmake python3-pip ninja-build antlr3 m4 \
+          python-is-python3 git cmake python3-pip ninja-build m4 \
           clang-14 lld-14 llvm-14 libidn11-dev libaio1 libaio-dev parallel s3cmd make postgresql-client
         sudo pip3 install conan==1.59 pytest==7.1.3 pytest-timeout pytest-xdist==3.3.1 setproctitle==1.3.2 grpcio grpcio-tools PyHamcrest tornado xmltodict pyarrow boto3 moto[server] psutil pygithub==1.59.1
     - name: install ccache

--- a/ydb/ci/gh-runner-image/image.pkr.hcl
+++ b/ydb/ci/gh-runner-image/image.pkr.hcl
@@ -55,7 +55,7 @@ curl -sL https://apt.kitware.com/kitware-archive.sh | bash
 apt-get -y install --no-install-recommends \
   gcc clang-12 clang-14 clang-16 clang-18 \
   lld-14 llvm-14 llvm-16 lld-16 llvm-18 lld-18 \
-  antlr3 cmake docker.io git jq libaio-dev libaio1 libicu70 libidn11-dev libkrb5-3 \
+  cmake docker.io git jq libaio-dev libaio1 libicu70 libidn11-dev libkrb5-3 \
   liblttng-ust1 m4 make ninja-build parallel postgresql-client postgresql-client \
   python-is-python3 python3-pip s3cmd s3cmd zlib1g linux-tools-common linux-tools-generic \
   ibverbs-providers rdma-core libibverbs1 ibverbs-utils


### PR DESCRIPTION
Removes the unused `antlr3` Ubuntu package from the legacy VM preparation action and the GitHub runner image.

The YQL JSONPath parser was migrated to ANTLR4 and the ANTLR3 generator/runtime were removed in #52154, so CI no longer needs this package.

This is a housekeeping follow-up and does not block closing KIKIMR-26999.

Testing: not run (package-list-only change); `git diff --check` passed.