### PR TITLE
ci: use NBS release approvers for nbs-26-3-1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @ydb-platform/ReleaseApprovers
+* @ydb-platform/NbsReleaseApprovers
 /.github @ydb-platform/ci
 /.github/workflows/docs_* @ydb-platform/docs
 /.github/workflows/ydbdoc-* @ydb-platform/docs     


### PR DESCRIPTION
### Changelog entry

Not for changelog.

### Description for reviewers

Use @ydb-platform/NbsReleaseApprovers as the default code owner for NBS release branch