### PR TITLE
Fix dstool cluster balance logging issues

### DIFF
--- a/ydb/apps/dstool/lib/common.py
+++ b/ydb/apps/dstool/lib/common.py
@@ -1409,11 +1409,15 @@ def print_result(format: str, status: str, description: str = None, file=None):
         file = sys.stderr
     if format == 'json':
         print_json_result(status, description)
+        sys.stdout.flush()
+        return
+    if description is not None:
+        print('{0}, {1}'.format(status, description), file=file)
     else:
-        if description is not None:
-            print('{0}, {1}'.format(status, description), file=file)
-        else:
-            print(status, file=file)
+        print(status, file=file)
+    # Flush immediately so that messages do not interleave with unbuffered
+    # stderr output (e.g. 'INFO: using random hosts') when streams are merged.
+    file.flush()
 
 
 def print_request_result(args, request, response):

--- a/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
@@ -308,8 +308,8 @@ class BalancingStrategy(IBalancingStrategy):
             if pdisk_usage_w_donors[pdisk_to] + weight_to > pdisk_map[pdisk_to].ExpectedSlotCount:
                 common.print_if_not_quiet(
                     self.args,
-                    'NOTICE: Attempted to reassign vdisk from pdisk [%d:%d] to pdisk [%d:%d] with slot usage %d and slot limit %d on latter',
-                    *pdisk_from, *pdisk_to, pdisk_usage_w_donors[pdisk_to], pdisk_map[pdisk_to].ExpectedSlotCount)
+                    'NOTICE: Attempted to reassign vdisk from pdisk [%d:%d] to pdisk [%d:%d] with slot usage %d and slot limit %d on latter' %
+                    (*pdisk_from, *pdisk_to, pdisk_usage_w_donors[pdisk_to], pdisk_map[pdisk_to].ExpectedSlotCount), file=sys.stdout)
                 return False
 
             if not try_blocking:
@@ -685,7 +685,8 @@ def do(args):
             break
         common.print_if_not_quiet(args, f"\nStart balancing iteration {iteration_number}", file=sys.stdout)
         if groups_info.unhealthy_groups:
-            common.print_if_verbose(args, f'Skipping vdisks from unhealthy groups: {groups_info.unhealthy_groups}', file=sys.stdout)
+            common.print_if_not_quiet(args, f'Skipping vdisks from {len(groups_info.unhealthy_groups)} unhealthy groups', file=sys.stdout)
+            common.print_if_verbose(args, f'Unhealthy group ids: {", ".join(str(group_id) for group_id in sorted(groups_info.unhealthy_groups))}', file=sys.stdout)
 
         strategy = strategy_factory(args, cluster_info, groups_info)
         balancing_result = balance_iteration(args, strategy, iteration_number)

--- a/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
@@ -308,7 +308,7 @@ class BalancingStrategy(IBalancingStrategy):
             if pdisk_usage_w_donors[pdisk_to] + weight_to > pdisk_map[pdisk_to].ExpectedSlotCount:
                 common.print_if_not_quiet(
                     self.args,
-                    'NOTICE: Attempted to reassign vdisk from pdisk [%d:%d] to pdisk [%d:%d] with slot usage %d and slot limit %d on latter' %
+                    'NOTICE: Attempted to reassign vdisk from pdisk [%d:%d] to pdisk [%d:%d] with slot usage %d and slot limit %d on the latter' %
                     (*pdisk_from, *pdisk_to, pdisk_usage_w_donors[pdisk_to], pdisk_map[pdisk_to].ExpectedSlotCount), file=sys.stdout)
                 return False
 

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_skips_not_bsc_ready/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_skips_not_bsc_ready/results.txt
@@ -3,7 +3,8 @@ Exit Status: 0
 ===== stdout =====
 
 Start balancing iteration 1
-Skipping vdisks from unhealthy groups: {2147483649}
+Skipping vdisks from 1 unhealthy groups
+Unhealthy group ids: 2147483649
 Number of used slots -> number pdisks: 0=>1 2=>1
 Found 1 candidate vslots, 1 groups to reassign
 Checking to relocate vdisk from vslot (1, 1001, 1001) on pdisk (1, 1001) with slot usage 2, try_blocking=False


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

```
  File "ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py", line 309, in reassign_vslot
    common.print_if_not_quiet(
    ~~~~~~~~~~~~~~~~~~~~~~~~~^
        self.args,
        ^^^^^^^^^^
        'NOTICE: Attempted to reassign vdisk from pdisk [%d:%d] to pdisk [%d:%d] with slot usage %d and slot limit %d on latter',
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        *pdisk_from, *pdisk_to, pdisk_usage_w_donors[pdisk_to], pdisk_map[pdisk_to].ExpectedSlotCount) 
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
TypeError: print_if_not_quiet() takes from 2 to 3 positional arguments but 8 were given
```

Also:
- Reduce verbosity
- Fix stdout/stderr mess