### PR TITLE
Fix subcolumn compaction remapping. Compaction could take data from "a" subcolumn and place it under "a.b" if "a.b" went to Separated and "a" to Others.

### DIFF
--- a/ydb/core/formats/arrow/accessor/sub_columns/accessor.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/accessor.h
@@ -117,6 +117,9 @@ public:
         if (columnsResult.IsFail()) {
             return columnsResult;
         }
+        if (columnsResult.GetResult()->IsValid() && columnsResult.GetResult()->GetRemainingPath().empty()) {
+            return columnsResult;
+        }
         auto othersResult = OthersData.GetPathAccessor(svPath, recordsCount);
         if (othersResult.IsFail()) {
             return othersResult;

--- a/ydb/core/formats/arrow/accessor/sub_columns/accessor.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/accessor.h
@@ -113,11 +113,15 @@ public:
     }
 
     TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> GetPathAccessor(const std::string_view svPath, const ui32 recordsCount) const {
-        auto accResult = ColumnsData.GetPathAccessor(svPath);
-        if (accResult.IsFail() || accResult.GetResult()->IsValid()) {
-            return accResult;
+        auto columnsResult = ColumnsData.GetPathAccessor(svPath);
+        if (columnsResult.IsFail()) {
+            return columnsResult;
         }
-        return OthersData.GetPathAccessor(svPath, recordsCount);
+        auto othersResult = OthersData.GetPathAccessor(svPath, recordsCount);
+        if (othersResult.IsFail()) {
+            return othersResult;
+        }
+        return NSubColumns::TJsonPathAccessor::SelectBestMatch(columnsResult.DetachResult(), othersResult.DetachResult());
     }
 };
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
@@ -122,7 +122,7 @@ TString ToSubcolumnName(TStringBuf path) {
 }
 
 TJsonPathAccessor::TJsonPathAccessor(std::shared_ptr<IChunkedArray> accessor, TString remainingPath, const EValueType valueType,
-    const std::optional<ui64>& cookie)
+    const std::optional<ui32>& cookie)
     : ChunkedArrayAccessor(std::move(accessor))
     , RemainingPath(std::move(remainingPath))
     , ValueType(valueType)
@@ -203,7 +203,7 @@ void TJsonPathAccessor::VisitValues(const TValuesVisitor& visitor) const {
 }
 
 TConclusionStatus TJsonPathAccessorTrie::Insert(TJsonPathBuf jsonPath, std::shared_ptr<IChunkedArray> accessor, const EValueType valueType,
-    const std::optional<ui64>& cookie) {
+    const std::optional<ui32>& cookie) {
     auto splittedPathResult = NSubColumns::SplitJsonPath(jsonPath, NSubColumns::TJsonPathSplitSettings{.FillTypes = true, .FillStartPositions = false});
     if (!splittedPathResult.IsSuccess()) {
         return splittedPathResult;

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
@@ -50,14 +50,14 @@ class TJsonPathAccessor {
     YDB_READONLY_DEF(std::shared_ptr<IChunkedArray>, ChunkedArrayAccessor);
     YDB_READONLY_DEF(TString, RemainingPath);
     YDB_READONLY(EValueType, ValueType, EValueType::BinaryJson);
-    YDB_READONLY_DEF(std::optional<ui64>, Cookie);
+    YDB_READONLY_DEF(std::optional<ui32>, Cookie);
     NYql::NJsonPath::TJsonPathPtr RemainingPathPtr;
 
 public:
     using TValuesVisitor = std::function<void(const std::optional<TStringBuf>& value)>;
 
     TJsonPathAccessor(std::shared_ptr<IChunkedArray> accessor, TString remainingPath, const EValueType valueType,
-        const std::optional<ui64>& cookie = std::nullopt);
+        const std::optional<ui32>& cookie = std::nullopt);
 
     std::shared_ptr<IChunkedArray> GetNativeStringArray() const;
     void VisitValues(const TValuesVisitor& visitor) const;
@@ -87,14 +87,14 @@ class TJsonPathAccessorTrie {
         TMap<TString, std::unique_ptr<TrieNode>> Children;
         std::shared_ptr<IChunkedArray> Accessor;
         EValueType ValueType = EValueType::BinaryJson;
-        std::optional<ui64> Cookie;
+        std::optional<ui32> Cookie;
     };
 
     TrieNode Root;
 
 public:
     TConclusionStatus Insert(TJsonPathBuf jsonPath, std::shared_ptr<IChunkedArray> accessor, const EValueType valueType,
-        const std::optional<ui64>& cookie = std::nullopt);
+        const std::optional<ui32>& cookie = std::nullopt);
     TConclusion<std::shared_ptr<TJsonPathAccessor>> GetAccessor(TJsonPathBuf jsonPath) const;
 };
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
@@ -68,6 +68,9 @@ public:
 
     static std::shared_ptr<TJsonPathAccessor> SelectBestMatch(
         const std::shared_ptr<TJsonPathAccessor>& first, const std::shared_ptr<TJsonPathAccessor>& second) {
+        if (!first) {
+            return second;
+        }
         if (!second || !second->IsValid() || (first->IsValid() && first->RemainingPath.size() <= second->RemainingPath.size())) {
             return first;
         }

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
@@ -66,6 +66,14 @@ public:
         return ChunkedArrayAccessor != nullptr || Cookie.has_value();
     }
 
+    static std::shared_ptr<TJsonPathAccessor> SelectBestMatch(
+        const std::shared_ptr<TJsonPathAccessor>& first, const std::shared_ptr<TJsonPathAccessor>& second) {
+        if (!second || !second->IsValid() || (first->IsValid() && first->RemainingPath.size() <= second->RemainingPath.size())) {
+            return first;
+        }
+        return second;
+    }
+
     ui64 GetRecordsCount() const {
         return ChunkedArrayAccessor ? ChunkedArrayAccessor->GetRecordsCount() : 0;
     }

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
@@ -1,10 +1,6 @@
 #include "constructor.h"
 #include "partial.h"
 
-#include <ydb/core/formats/arrow/accessor/plain/accessor.h>
-
-#include <ydb/library/formats/arrow/simple_arrays_cache.h>
-
 namespace NKikimr::NArrow::NAccessor {
 
 void TSubColumnsPartialArray::InitOthers(const TString& blob, const TChunkConstructionData& externalInfo,
@@ -29,19 +25,21 @@ TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> TSubColumnsPartialA
         }
     }
 
-    auto accessorResult = jsonPathAccessorTrie->GetAccessor(svPath);
-    if (accessorResult.IsSuccess() && accessorResult.GetResult()->IsValid()) {
-        return accessorResult;
+    auto columnsResult = jsonPathAccessorTrie->GetAccessor(svPath);
+    if (columnsResult.IsFail()) {
+        return columnsResult;
     }
 
-    if (OthersData) {
-        return OthersData->GetPathAccessor(svPath, recordsCount);
+    if (!OthersData) {
+        // The fetch stage must have loaded Others if it has the best match.
+        AFL_VERIFY(!GetBestPathSource(NSubColumns::ToSubcolumnName(svPath)).IsOther);
+        return columnsResult;
     }
-
-    AFL_VERIFY(!Header.GetOtherStats().GetKeyIndexOptional(svPath));
-    return std::make_shared<NSubColumns::TJsonPathAccessor>(
-        std::make_shared<TTrivialArray>(TThreadSimpleArraysCache::GetNull(arrow::binary(), recordsCount)), TString{},
-        NSubColumns::EValueType::BinaryJson);
+    auto othersResult = OthersData->GetPathAccessor(svPath, recordsCount);
+    if (othersResult.IsFail()) {
+        return othersResult;
+    }
+    return NSubColumns::TJsonPathAccessor::SelectBestMatch(columnsResult.DetachResult(), othersResult.DetachResult());
 }
 
 }   // namespace NKikimr::NArrow::NAccessor

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.h
@@ -97,6 +97,11 @@ protected:
     }
 
 public:
+    struct TPathSource {
+        std::optional<ui32> ColumnIndex;
+        bool IsOther = false;
+    };
+
     TSubColumnsPartialArray(TSubColumnsHeader&& header, const ui32 recordsCount, const std::shared_ptr<arrow::DataType>& dataType,
         const NSubColumns::TSettings& settings)
         : TBase(recordsCount, EType::SubColumnsPartialArray, dataType)
@@ -131,13 +136,21 @@ public:
 
     TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> GetPathAccessor(const std::string_view svPath, const ui32 recordsCount) const;
 
-    bool NeedFetch(const std::string_view colName) const {
-        if (auto idx = Header.GetColumnStats().GetKeyIndexOptional(colName)) {
-            return !PartialColumnsData.HasColumn(*idx);
-        } else if (auto idx = Header.GetOtherStats().GetKeyIndexOptional(colName)) {
-            return !OthersData;
+    TPathSource GetBestPathSource(const std::string_view colName) const {
+        const auto columnsAccessor = Header.GetColumnStats().GetPathAccessor(colName);
+        const auto othersAccessor = Header.GetOtherStats().GetPathAccessor(colName);
+        if (NSubColumns::TJsonPathAccessor::SelectBestMatch(columnsAccessor, othersAccessor) == columnsAccessor) {
+            return { columnsAccessor->GetCookie(), false };
         }
-        return false;
+        return { std::nullopt, true };
+    }
+
+    bool NeedFetch(const std::string_view colName) const {
+        const auto source = GetBestPathSource(colName);
+        if (source.ColumnIndex) {
+            return !PartialColumnsData.HasColumn(*source.ColumnIndex);
+        }
+        return source.IsOther && !OthersData;
     }
 
     void AddColumn(const TString& columnName, const std::shared_ptr<IChunkedArray>& arr) {
@@ -150,10 +163,6 @@ public:
 
     void InitOthers(const TString& blob, const TChunkConstructionData& externalInfo, const std::shared_ptr<NArrow::TColumnFilter>& applyFilter,
         const bool deserialize);
-
-    bool IsOtherColumn(const TString& colName) const {
-        return !!Header.GetOtherStats().GetKeyIndexOptional(std::string_view(colName.data(), colName.size()));
-    }
 
     NSubColumns::TReadRange GetColumnReadRange(const ui32 colIndex) const {
         return Header.GetColumnReadRange(colIndex);

--- a/ydb/core/formats/arrow/accessor/sub_columns/stats.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/stats.h
@@ -69,12 +69,15 @@ public:
         CachedJsonPathAccessorTrie = GenerateJsonPathAccessorTrie();
     }
 
-    std::optional<ui32> GetKeyIndexOptional(const std::string_view keyName) const {
+    std::shared_ptr<TJsonPathAccessor> GetPathAccessor(const std::string_view keyName) const {
         auto accessorResult = CachedJsonPathAccessorTrie ? CachedJsonPathAccessorTrie->GetAccessor(ToJsonPath(keyName))
                                                          : GenerateJsonPathAccessorTrie()->GetAccessor(ToJsonPath(keyName));
         AFL_VERIFY(accessorResult.IsSuccess())("keyName", keyName)("jsonPath", ToJsonPath(keyName))("error", accessorResult.GetErrorMessage());
+        return accessorResult.DetachResult();
+    }
 
-        auto accessor = accessorResult.DetachResult();
+    std::optional<ui32> GetKeyIndexOptional(const std::string_view keyName) const {
+        auto accessor = GetPathAccessor(keyName);
         if (!accessor) {
             return std::nullopt;
         }

--- a/ydb/core/formats/arrow/accessor/sub_columns/stats.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/stats.h
@@ -25,7 +25,7 @@ private:
     std::shared_ptr<arrow::UInt32Array> DataSize;
     std::shared_ptr<arrow::UInt8Array> AccessorType;
     std::shared_ptr<arrow::UInt8Array> ValueType;
-    TJsonPathAccessorTriePtr CachedJsonPathAccessorTrie;
+    mutable TJsonPathAccessorTriePtr CachedJsonPathAccessorTrie;
 
     TJsonPathAccessorTriePtr GenerateJsonPathAccessorTrie() const {
         auto jsonPathAccessorTrie = std::make_shared<NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie>();
@@ -65,13 +65,11 @@ public:
     // and the legacy (4-column) layout via try-decode-fallback.
     static TDictStats DeserializeFromBlob(const TString& blob);
 
-    void CreateJsonPathAccessorTrieCache() {
-        CachedJsonPathAccessorTrie = GenerateJsonPathAccessorTrie();
-    }
-
     std::shared_ptr<TJsonPathAccessor> GetPathAccessor(const std::string_view keyName) const {
-        auto accessorResult = CachedJsonPathAccessorTrie ? CachedJsonPathAccessorTrie->GetAccessor(ToJsonPath(keyName))
-                                                         : GenerateJsonPathAccessorTrie()->GetAccessor(ToJsonPath(keyName));
+        if (!CachedJsonPathAccessorTrie) {
+            CachedJsonPathAccessorTrie = GenerateJsonPathAccessorTrie();
+        }
+        auto accessorResult = CachedJsonPathAccessorTrie->GetAccessor(ToJsonPath(keyName));
         AFL_VERIFY(accessorResult.IsSuccess())("keyName", keyName)("jsonPath", ToJsonPath(keyName))("error", accessorResult.GetErrorMessage());
         return accessorResult.DetachResult();
     }

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -290,11 +290,11 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
     Y_UNIT_TEST(JsonPathTrie) {
         TVector<TString> testPaths = {"$.a.b", "$.b", "$.c.d"};
         TVector<std::shared_ptr<IChunkedArray>> testAccessors;
-        TVector<ui64> testCookies;
+        TVector<ui32> testCookies;
         NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie jsonPathAccessorTrie;
 
         {
-            ui64 testCookie = 0;
+            ui32 testCookie = 0;
             for (const auto& path : testPaths) {
                 testAccessors.emplace_back(TTrivialArray::BuildEmpty(std::make_shared<arrow::BinaryType>()));
                 testCookies.emplace_back(testCookie++);
@@ -322,7 +322,7 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
                 auto jsonPathAccessor = jsonPathAccessorResult.DetachResult();
                 UNIT_ASSERT(!jsonPathAccessor->IsValid());
                 UNIT_ASSERT_VALUES_EQUAL(nullptr, jsonPathAccessor->GetChunkedArrayAccessor().get());
-                UNIT_ASSERT_VALUES_EQUAL(std::optional<ui64>{}, jsonPathAccessor->GetCookie());
+                UNIT_ASSERT_VALUES_EQUAL(std::optional<ui32>{}, jsonPathAccessor->GetCookie());
                 UNIT_ASSERT_VALUES_EQUAL(TString{}, jsonPathAccessor->GetRemainingPath());
             }
         }
@@ -595,6 +595,25 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
             values << (value ? *value : TStringBuf("<null>")) << ';';
         });
         UNIT_ASSERT_VALUES_EQUAL(values, "1;2;");
+    }
+
+    Y_UNIT_TEST(PartialArrayNeedsOthersForDeeperPath) {
+        auto columnsBuilder = NSubColumns::TDictStats::MakeBuilder();
+        columnsBuilder.Add(TString(R"("a")"), 2, 2, IChunkedArray::EType::Array, NSubColumns::EValueType::BinaryJson);
+        auto othersBuilder = NSubColumns::TDictStats::MakeBuilder();
+        othersBuilder.Add(TString(R"("a"."b")"), 2, 2, IChunkedArray::EType::Array, NSubColumns::EValueType::BinaryJson);
+
+        NKikimrArrowAccessorProto::TSubColumnsAccessor proto;
+        auto header = NSubColumns::TSubColumnsHeader(columnsBuilder.Finish(), othersBuilder.Finish(), std::move(proto), 0);
+        auto partial = std::make_shared<TSubColumnsPartialArray>(std::move(header), 2, arrow::binary(), NSubColumns::TSettings());
+
+        TTrivialArray::TPlainBuilder<arrow::BinaryType> valuesBuilder;
+        valuesBuilder.AddRecord(0, "");
+        valuesBuilder.AddRecord(1, "");
+        partial->AddColumn(R"("a")", valuesBuilder.Finish(2));
+
+        // Others was not loaded because only a.b was requested.
+        UNIT_ASSERT(!partial->HasSubColumnData(R"("a"."b")"));
     }
 };
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -540,6 +540,7 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         const auto deep = std::make_shared<NSubColumns::TJsonPathAccessor>(nullptr, "strict $.b", NSubColumns::EValueType::BinaryJson, 2);
         const auto equallyDeep = std::make_shared<NSubColumns::TJsonPathAccessor>(nullptr, "strict $.c", NSubColumns::EValueType::BinaryJson, 3);
 
+        UNIT_ASSERT_EQUAL(NSubColumns::TJsonPathAccessor::SelectBestMatch(nullptr, deep), deep);
         UNIT_ASSERT_EQUAL(NSubColumns::TJsonPathAccessor::SelectBestMatch(invalid, deep), deep);
         UNIT_ASSERT_EQUAL(NSubColumns::TJsonPathAccessor::SelectBestMatch(deep, invalid), deep);
         UNIT_ASSERT_EQUAL(NSubColumns::TJsonPathAccessor::SelectBestMatch(shallow, deep), deep);

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/formats/arrow/accessor/sub_columns/constructor.h>
 #include <ydb/core/formats/arrow/accessor/sub_columns/data_extractor.h>
 #include <ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h>
+#include <ydb/core/formats/arrow/accessor/sub_columns/partial.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
 #include <ydb/core/formats/arrow/serializer/abstract.h>
 
@@ -533,6 +534,18 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         CheckValueByPath(jsonPathAccessorTrie, "$.k.m[1]", "4");
     }
 
+    Y_UNIT_TEST(JsonPathAccessorSelectBestMatch) {
+        const auto invalid = std::make_shared<NSubColumns::TJsonPathAccessor>(nullptr, TString{}, NSubColumns::EValueType::BinaryJson);
+        const auto shallow = std::make_shared<NSubColumns::TJsonPathAccessor>(nullptr, "strict $.a.b", NSubColumns::EValueType::BinaryJson, 1);
+        const auto deep = std::make_shared<NSubColumns::TJsonPathAccessor>(nullptr, "strict $.b", NSubColumns::EValueType::BinaryJson, 2);
+        const auto equallyDeep = std::make_shared<NSubColumns::TJsonPathAccessor>(nullptr, "strict $.c", NSubColumns::EValueType::BinaryJson, 3);
+
+        UNIT_ASSERT_EQUAL(NSubColumns::TJsonPathAccessor::SelectBestMatch(invalid, deep), deep);
+        UNIT_ASSERT_EQUAL(NSubColumns::TJsonPathAccessor::SelectBestMatch(deep, invalid), deep);
+        UNIT_ASSERT_EQUAL(NSubColumns::TJsonPathAccessor::SelectBestMatch(shallow, deep), deep);
+        UNIT_ASSERT_EQUAL(NSubColumns::TJsonPathAccessor::SelectBestMatch(deep, equallyDeep), deep);
+    }
+
     Y_UNIT_TEST(SubColumnNameFromDifferentPaths) {
         UNIT_ASSERT_VALUES_EQUAL(R"("a")", NSubColumns::ToSubcolumnName("a"));
         UNIT_ASSERT_VALUES_EQUAL(R"("a")", NSubColumns::ToSubcolumnName("$.a"));
@@ -551,6 +564,36 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
             expected[str] = 1;
             UNIT_ASSERT_VALUES_EQUAL(expected, restorer.GetResult());
         }
+    }
+
+    // Checks that a weaker, unfetched Others match does not prevent using a loaded separated match.
+    Y_UNIT_TEST(PartialArrayUsesLoadedBestMatch) {
+        auto columnsBuilder = NSubColumns::TDictStats::MakeBuilder();
+        columnsBuilder.Add(TString(R"("a"."b")"), 2, 2, IChunkedArray::EType::Array, NSubColumns::EValueType::BinaryJson);
+        auto othersBuilder = NSubColumns::TDictStats::MakeBuilder();
+        othersBuilder.Add(TString(R"("a")"), 2, 2, IChunkedArray::EType::Array, NSubColumns::EValueType::BinaryJson);
+
+        NKikimrArrowAccessorProto::TSubColumnsAccessor proto;
+        auto header = NSubColumns::TSubColumnsHeader(columnsBuilder.Finish(), othersBuilder.Finish(), std::move(proto), 0);
+        auto partial = std::make_shared<TSubColumnsPartialArray>(std::move(header), 2, arrow::binary(), NSubColumns::TSettings());
+
+        TTrivialArray::TPlainBuilder<arrow::BinaryType> valuesBuilder;
+        for (ui32 i = 0; i < 2; ++i) {
+            const auto binaryJson = NBinaryJson::SerializeToBinaryJson(ToString(i + 1));
+            const auto* value = std::get_if<NBinaryJson::TBinaryJson>(&binaryJson);
+            UNIT_ASSERT(value);
+            valuesBuilder.AddRecord(i, std::string_view(value->data(), value->size()));
+        }
+        partial->AddColumn(R"("a"."b")", valuesBuilder.Finish(2));
+
+        UNIT_ASSERT(partial->HasSubColumnData(R"("a"."b")"));
+        auto accessorResult = partial->GetPathAccessor("$.a.b", 2);
+        UNIT_ASSERT_C(accessorResult.IsSuccess(), accessorResult.GetErrorMessage());
+        TStringBuilder values;
+        accessorResult.DetachResult()->VisitValues([&](const std::optional<TStringBuf>& value) {
+            values << (value ? *value : TStringBuf("<null>")) << ';';
+        });
+        UNIT_ASSERT_VALUES_EQUAL(values, "1;2;");
     }
 };
 

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/logic.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/logic.cpp
@@ -30,7 +30,6 @@ void TSubColumnsMerger::DoStart(const std::vector<std::shared_ptr<NArrow::NAcces
     AFL_VERIFY(statRecordsCount);
     auto commonStats = TDictStats::Merge(stats, GetSettings(), statRecordsCount);
     ResultColumnStats = commonStats.SelectSeparatedColumns(GetSettings(), statRecordsCount);
-    ResultColumnStats->CreateJsonPathAccessorTrieCache();
     RemapKeyIndex.RegisterColumnStats(*ResultColumnStats);
     for (auto&& i : OrderedIterators) {
         i.Start();

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.cpp
@@ -34,17 +34,15 @@ void TRemapColumns::StartSourceChunk(const ui32 sourceIdx, const TDictStats& sou
     auto& remapSourceInfo = RemapInfo[sourceIdx];
     remapSourceInfo.resize(2);
     auto& remapSourceInfoColumns = remapSourceInfo[1];
-    AFL_VERIFY(ResultColumnStats);
     for (ui32 i = 0; i < sourceColumnStats.GetColumnsCount(); ++i) {
         if (remapSourceInfoColumns.size() <= i) {
             remapSourceInfoColumns.resize((i + 1) * 2);
         }
         AFL_VERIFY(!remapSourceInfoColumns[i]);
-        if (auto commonKeyIndex = ResultColumnStats->GetKeyIndexOptional(sourceColumnStats.GetColumnName(i))) {
-            remapSourceInfoColumns[i] = TRemapInfo(*commonKeyIndex, true);
+        if (const auto it = ResultColumnKeyIndex.find(sourceColumnStats.GetColumnName(i)); it != ResultColumnKeyIndex.end()) {
+            remapSourceInfoColumns[i] = TRemapInfo(it->second, true);
         } else {
-            commonKeyIndex = RegisterNewOtherIndex(sourceColumnStats.GetColumnName(i));
-            remapSourceInfoColumns[i] = TRemapInfo(*commonKeyIndex, false);
+            remapSourceInfoColumns[i] = TRemapInfo(RegisterNewOtherIndex(sourceColumnStats.GetColumnName(i)), false);
         }
     }
     auto& remapSourceInfoOthers = remapSourceInfo[0];
@@ -53,11 +51,10 @@ void TRemapColumns::StartSourceChunk(const ui32 sourceIdx, const TDictStats& sou
             remapSourceInfoOthers.resize((i + 1) * 2);
         }
         AFL_VERIFY(!remapSourceInfoOthers[i]);
-        if (auto commonKeyIndex = ResultColumnStats->GetKeyIndexOptional(sourceOtherStats.GetColumnName(i))) {
-            remapSourceInfoOthers[i] = TRemapInfo(*commonKeyIndex, true);
+        if (const auto it = ResultColumnKeyIndex.find(sourceOtherStats.GetColumnName(i)); it != ResultColumnKeyIndex.end()) {
+            remapSourceInfoOthers[i] = TRemapInfo(it->second, true);
         } else {
-            commonKeyIndex = RegisterNewOtherIndex(sourceOtherStats.GetColumnName(i));
-            remapSourceInfoOthers[i] = TRemapInfo(*commonKeyIndex, false);
+            remapSourceInfoOthers[i] = TRemapInfo(RegisterNewOtherIndex(sourceOtherStats.GetColumnName(i)), false);
         }
     }
 }

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.cpp
@@ -27,6 +27,7 @@ TRemapColumns::TOthersData::TFinishContext TRemapColumns::BuildRemapInfo(
 }
 
 void TRemapColumns::StartSourceChunk(const ui32 sourceIdx, const TDictStats& sourceColumnStats, const TDictStats& sourceOtherStats) {
+    AFL_VERIFY(ColumnStatsRegistered);
     if (RemapInfo.size() <= sourceIdx) {
         RemapInfo.resize((sourceIdx + 1) * 2);
     }

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.h
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.h
@@ -6,6 +6,8 @@
 #include <ydb/core/tx/columnshard/engines/changes/compaction/abstract/merger.h>
 #include <ydb/core/tx/columnshard/engines/storage/chunks/column.h>
 
+#include <util/generic/hash.h>
+
 namespace NKikimr::NOlap::NCompaction::NSubColumns {
 
 class TRemapColumns {
@@ -50,8 +52,8 @@ private:
         }
     };
 
-    const TDictStats* ResultColumnStats = nullptr;
     std::vector<std::vector<std::vector<std::optional<TRemapInfo>>>> RemapInfo;
+    THashMap<std::string_view, ui32> ResultColumnKeyIndex;
     std::map<TString, ui32> TemporaryKeyIndex;
 
     ui32 RegisterNewOtherIndex(const TString& keyName) {
@@ -69,7 +71,9 @@ public:
         const std::vector<TDictStats::TRTStatsValue>& statsByKeyIndex, const TSettings& settings, const ui32 recordsCount) const;
 
     void RegisterColumnStats(const TDictStats& resultColumnStats) {
-        ResultColumnStats = &resultColumnStats;
+        for (ui32 i = 0; i < resultColumnStats.GetColumnsCount(); ++i) {
+            AFL_VERIFY(ResultColumnKeyIndex.emplace(resultColumnStats.GetColumnName(i), i).second);
+        }
     }
 
     void StartSourceChunk(const ui32 sourceIdx, const TDictStats& sourceColumnStats, const TDictStats& sourceOtherStats);

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.h
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.h
@@ -53,8 +53,9 @@ private:
     };
 
     std::vector<std::vector<std::vector<std::optional<TRemapInfo>>>> RemapInfo;
-    THashMap<std::string_view, ui32> ResultColumnKeyIndex;
+    THashMap<TString, ui32> ResultColumnKeyIndex;
     std::map<TString, ui32> TemporaryKeyIndex;
+    bool ColumnStatsRegistered = false;
 
     ui32 RegisterNewOtherIndex(const TString& keyName) {
         return TemporaryKeyIndex.emplace(keyName, TemporaryKeyIndex.size()).first->second;
@@ -71,6 +72,8 @@ public:
         const std::vector<TDictStats::TRTStatsValue>& statsByKeyIndex, const TSettings& settings, const ui32 recordsCount) const;
 
     void RegisterColumnStats(const TDictStats& resultColumnStats) {
+        AFL_VERIFY(!ColumnStatsRegistered);
+        ColumnStatsRegistered = true;
         for (ui32 i = 0; i < resultColumnStats.GetColumnsCount(); ++i) {
             AFL_VERIFY(ResultColumnKeyIndex.emplace(resultColumnStats.GetColumnName(i), i).second);
         }

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/ut/ut_merger.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/ut/ut_merger.cpp
@@ -175,4 +175,46 @@ Y_UNIT_TEST_SUITE(SubColumnsCompaction) {
         UNIT_ASSERT_VALUES_EQUAL(values, "xxxx;<null>;yyyy;<null>;");
         UNIT_ASSERT_VALUES_EQUAL(RenderDocs(merged), RenderDocs(BuildChunk(docs, settings)));
     }
+
+    // Bug-triggering scenario:
+    // Source portions expose an ancestor and its child as separated columns.
+    // The unselected path must move to Others in merged portion; it must never be remapped to the selected path.
+    Y_UNIT_TEST(ChildAndAncestorPathMix) {
+        auto settings = MakeSettings();
+        settings.SetColumnsLimit(1);
+        const std::vector<TString> ancestorDocs = {
+            R"({"a":["xxxxxxxxxxxxxxxx"]})",
+            R"({"a":["yyyyyyyyyyyyyyyy"]})",
+        };
+        const std::vector<TString> childDocs = {
+            R"({"a":{"b":1}})",
+            R"({"a":{"b":2}})",
+        };
+
+        {
+            auto merged = MergeChunks({ BuildChunk(ancestorDocs, settings), BuildChunk(childDocs, settings) }, settings);
+            const auto& stats = merged->GetColumnsData().GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetColumnsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetColumnNameString(0), R"("a")");
+            UNIT_ASSERT_VALUES_EQUAL(
+                RenderDocs(merged), R"({"a":["xxxxxxxxxxxxxxxx"]};{"a":["yyyyyyyyyyyyyyyy"]};{"a":{"b":1}};{"a":{"b":2}};)");
+        }
+
+        const std::vector<TString> scalarAncestorDocs = {
+            R"({"a":1})",
+            R"({"a":2})",
+        };
+        const std::vector<TString> largeChildDocs = {
+            R"({"a":{"b":"xxxxxxxxxxxxxxxx"}})",
+            R"({"a":{"b":"yyyyyyyyyyyyyyyy"}})",
+        };
+
+        {
+            auto merged = MergeChunks({ BuildChunk(scalarAncestorDocs, settings), BuildChunk(largeChildDocs, settings) }, settings);
+            const auto& stats = merged->GetColumnsData().GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetColumnsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetColumnNameString(0), R"("a"."b")");
+            UNIT_ASSERT_VALUES_EQUAL(RenderDocs(merged), R"({"a":1};{"a":2};{"a":{"b":"xxxxxxxxxxxxxxxx"}};{"a":{"b":"yyyyyyyyyyyyyyyy"}};)");
+        }
+    }
 }

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/ut/ut_merger.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/ut/ut_merger.cpp
@@ -86,6 +86,17 @@ Y_UNIT_TEST_SUITE(SubColumnsCompaction) {
         return out;
     }
 
+    TString RenderPathValues(const std::shared_ptr<TSubColumnsArray>& arr, const std::string_view path) {
+        auto accessorResult = arr->GetPathAccessor(path, arr->GetRecordsCount());
+        UNIT_ASSERT_C(accessorResult.IsSuccess(), accessorResult.GetErrorMessage());
+        auto accessor = accessorResult.DetachResult();
+        TStringBuilder out;
+        accessor->VisitValues([&](const std::optional<TStringBuf>& value) {
+            out << (value ? *value : TStringBuf("<null>")) << ';';
+        });
+        return out;
+    }
+
     std::shared_ptr<TSubColumnsArray> MergeChunks(const std::vector<std::shared_ptr<TSubColumnsArray>>& chunks, const TSettings& settings) {
         NArrow::NAccessor::TCompositeChunkedArray::TBuilder cb(chunks.front()->GetDataType());
         ui32 total = 0;
@@ -198,6 +209,7 @@ Y_UNIT_TEST_SUITE(SubColumnsCompaction) {
             UNIT_ASSERT_VALUES_EQUAL(stats.GetColumnNameString(0), R"("a")");
             UNIT_ASSERT_VALUES_EQUAL(
                 RenderDocs(merged), R"({"a":["xxxxxxxxxxxxxxxx"]};{"a":["yyyyyyyyyyyyyyyy"]};{"a":{"b":1}};{"a":{"b":2}};)");
+            UNIT_ASSERT_VALUES_EQUAL(RenderPathValues(merged, "$.a.b"), "<null>;<null>;1;2;");
         }
 
         const std::vector<TString> scalarAncestorDocs = {
@@ -215,6 +227,7 @@ Y_UNIT_TEST_SUITE(SubColumnsCompaction) {
             UNIT_ASSERT_VALUES_EQUAL(stats.GetColumnsCount(), 1);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetColumnNameString(0), R"("a"."b")");
             UNIT_ASSERT_VALUES_EQUAL(RenderDocs(merged), R"({"a":1};{"a":2};{"a":{"b":"xxxxxxxxxxxxxxxx"}};{"a":{"b":"yyyyyyyyyyyyyyyy"}};)");
+            UNIT_ASSERT_VALUES_EQUAL(RenderPathValues(merged, "$.a"), "1;2;<null>;<null>;");
         }
     }
 }

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/ut/ut_merger.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/ut/ut_merger.cpp
@@ -230,4 +230,57 @@ Y_UNIT_TEST_SUITE(SubColumnsCompaction) {
             UNIT_ASSERT_VALUES_EQUAL(RenderPathValues(merged, "$.a"), "1;2;<null>;<null>;");
         }
     }
+
+    Y_UNIT_TEST(PromotesOthersKeyToSelectedColumn) {
+        auto settings = MakeSettings();
+        settings.SetColumnsLimit(1);
+        // "b" is selected in the source, leaving "a" in Others; larger aggregate "a" is selected after merging.
+        const TString largeA(128, 'a');
+        const TString mediumB(64, 'b');
+        const std::vector<TString> othersDocs = {
+            TStringBuilder() << R"({"a":1,"b":")" << mediumB << R"("})",
+            TStringBuilder() << R"({"a":2,"b":")" << mediumB << R"("})",
+        };
+        const std::vector<TString> columnDocs = {
+            TStringBuilder() << R"({"a":")" << largeA << R"("})",
+            TStringBuilder() << R"({"a":")" << largeA << R"("})",
+        };
+
+        auto othersChunk = BuildChunk(othersDocs, settings);
+        UNIT_ASSERT_VALUES_EQUAL(othersChunk->GetColumnsData().GetStats().GetColumnNameString(0), R"("b")");
+        UNIT_ASSERT_VALUES_EQUAL(othersChunk->GetOthersData().GetStats().GetColumnNameString(0), R"("a")");
+
+        auto merged = MergeChunks({ othersChunk, BuildChunk(columnDocs, settings) }, settings);
+        UNIT_ASSERT_VALUES_EQUAL(merged->GetColumnsData().GetStats().GetColumnNameString(0), R"("a")");
+        UNIT_ASSERT_VALUES_EQUAL(RenderPathValues(merged, "$.a"), TStringBuilder() << "1;2;" << largeA << ';' << largeA << ';');
+        UNIT_ASSERT_VALUES_EQUAL(
+            RenderDocs(merged), RenderDocs(BuildChunk({ othersDocs[0], othersDocs[1], columnDocs[0], columnDocs[1] }, settings)));
+    }
+
+    Y_UNIT_TEST(KeepsQuotedAndNestedNamesDistinct) {
+        auto settings = MakeSettings();
+        settings.SetColumnsLimit(1);
+        // "z" is selected in the source, leaving flat "a.b" in Others; larger nested "a"."b" is selected after merging.
+        const TString largeB(128, 'b');
+        const TString mediumZ(64, 'z');
+        const std::vector<TString> flatDocs = {
+            TStringBuilder() << R"({"a.b":1,"z":")" << mediumZ << R"("})",
+            TStringBuilder() << R"({"a.b":2,"z":")" << mediumZ << R"("})",
+        };
+        const std::vector<TString> nestedDocs = {
+            TStringBuilder() << R"({"a":{"b":")" << largeB << R"("}})",
+            TStringBuilder() << R"({"a":{"b":")" << largeB << R"("}})",
+        };
+
+        auto flatChunk = BuildChunk(flatDocs, settings);
+        UNIT_ASSERT_VALUES_EQUAL(flatChunk->GetColumnsData().GetStats().GetColumnNameString(0), R"("z")");
+        UNIT_ASSERT_VALUES_EQUAL(flatChunk->GetOthersData().GetStats().GetColumnNameString(0), R"("a.b")");
+
+        auto merged = MergeChunks({ flatChunk, BuildChunk(nestedDocs, settings) }, settings);
+        UNIT_ASSERT_VALUES_EQUAL(merged->GetColumnsData().GetStats().GetColumnNameString(0), R"("a"."b")");
+        UNIT_ASSERT_VALUES_EQUAL(RenderPathValues(merged, R"($."a.b")"), "1;2;<null>;<null>;");
+        UNIT_ASSERT_VALUES_EQUAL(RenderPathValues(merged, "$.a.b"), TStringBuilder() << "<null>;<null>;" << largeB << ';' << largeB << ';');
+        UNIT_ASSERT_VALUES_EQUAL(
+            RenderDocs(merged), RenderDocs(BuildChunk({ flatDocs[0], flatDocs[1], nestedDocs[0], nestedDocs[1] }, settings)));
+    }
 }

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
@@ -102,12 +102,13 @@ public:
         AFL_VERIFY(!HeaderRange);
         if (!!PartialArray) {
             for (auto&& subColumnName : subColumns) {
-                if (auto colIndex = PartialArray->GetHeader().GetColumnStats().GetKeyIndexOptional(subColumnName)) {
-                    auto colBlobRange = PartialArray->GetColumnReadRange(*colIndex);
+                const auto source = PartialArray->GetBestPathSource(subColumnName);
+                if (source.ColumnIndex) {
+                    auto colBlobRange = PartialArray->GetColumnReadRange(*source.ColumnIndex);
                     const TBlobRange subRange = FullChunkRange.BuildSubset(colBlobRange.GetOffset(), colBlobRange.GetSize());
                     reading->AddRange(subRange);
-                    AddFetchData(subColumnName, subRange, *colIndex);
-                } else if (!PartialArray->HasOthers() && !OthersReadData && PartialArray->IsOtherColumn(subColumnName)) {
+                    AddFetchData(subColumnName, subRange, *source.ColumnIndex);
+                } else if (!PartialArray->HasOthers() && !OthersReadData && source.IsOther) {
                     auto readRange = PartialArray->GetHeader().GetOthersReadRange();
                     OthersReadData = FullChunkRange.BuildSubset(readRange.GetOffset(), readRange.GetSize());
                     reading->AddRange(*OthersReadData);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
