### PR TITLE
Fix Kafka empty Fetch encoding records as null (-1).

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
@@ -106,6 +106,11 @@ TVector<NKikimr::NPQ::TPartitionFetchRequest> TKafkaFetchActor::PrepareFetchRequ
         partPQRequest.Partition = partKafkaRequest.Partition;
         partPQRequest.Offset = partKafkaRequest.FetchOffset;
         partPQRequest.MaxBytes = partKafkaRequest.PartitionMaxBytes;
+        // librdkafka treats Fetch records length -1 (null) as a protocol error
+        // ("invalid MessageSetSize -1"). Empty partitions must be encoded as
+        // zero-length bytes, like Apache Kafka and the pre-26-3 TKafkaRecords
+        // serializer (which wrote size 0 for unset). See LOGBROKER-10644.
+        topicKafkaResponse.Partitions[partIndex].Records = TString();
     }
     return partPQRequests;
 }
@@ -182,6 +187,8 @@ void TKafkaFetchActor::HandleSuccessResponse(const NKikimr::TEvPQ::TEvFetchRespo
             Context->RememberTopicAclOk(TString(topicResponse.Topic.value()));
         }
         if (partPQResponse.GetReadResult().GetResult().size() == 0) {
+            // Keep zero-length records set in PrepareFetchRequestData; do not
+            // clear back to null (would serialize as MessageSetSize=-1).
             continue;
         }
 

--- a/ydb/core/kafka_proxy/ut/kafka_test_client.cpp
+++ b/ydb/core/kafka_proxy/ut/kafka_test_client.cpp
@@ -645,7 +645,8 @@ void TKafkaTestClient::ValidateNoDataInTopics(const std::vector<std::pair<TStrin
     UNIT_ASSERT_VALUES_EQUAL(fetchResponse->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
     for (ui32 topicIndex = 0; topicIndex < topics.size(); topicIndex++) {
         for (ui32 partitionIndex = 0; partitionIndex < topics[topicIndex].second.size(); partitionIndex++) {
-            UNIT_ASSERT(!fetchResponse->Responses[topicIndex].Partitions[partitionIndex].Records.has_value());
+            UNIT_ASSERT(fetchResponse->Responses[topicIndex].Partitions[partitionIndex].Records.has_value());
+            UNIT_ASSERT_VALUES_EQUAL(fetchResponse->Responses[topicIndex].Partitions[partitionIndex].Records->size(), 0);
         }
     }
 }

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -1157,14 +1157,17 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         }
 
         {
-            // Check empty topic (no records)
+            // Check empty topic (no records).
+            // Empty Fetch must return zero-length records bytes, not null:
+            // librdkafka fails on MessageSetSize=-1 (LOGBROKER-10644).
             std::vector<std::pair<TString, std::vector<i32>>> topics {{topicName, {0}}};
             auto msg = client.Fetch(topics);
 
             UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
             UNIT_ASSERT_VALUES_EQUAL(msg->Responses.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(msg->Responses[0].Partitions.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(msg->Responses[0].Partitions[0].Records.has_value(), false);
+            UNIT_ASSERT(msg->Responses[0].Partitions[0].Records.has_value());
+            UNIT_ASSERT_VALUES_EQUAL(msg->Responses[0].Partitions[0].Records->size(), 0);
         }
 
         {
@@ -1355,7 +1358,9 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             std::vector<std::pair<TString, std::vector<i32>>> topics {{feedPath, {0}}};
             auto msg = client.Fetch(topics);
 
-            if (msg->Responses.empty() || msg->Responses[0].Partitions.empty() || !msg->Responses[0].Partitions[0].Records.has_value()) {
+            if (msg->Responses.empty() || msg->Responses[0].Partitions.empty()
+                    || !msg->Responses[0].Partitions[0].Records.has_value()
+                    || msg->Responses[0].Partitions[0].Records->empty()) {
                 UNIT_ASSERT_C(i, "Timeout");
                 Sleep(TDuration::Seconds(1));
                 continue;
@@ -1478,15 +1483,16 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         client.PlainAuthenticateToKafka();
 
         {
-            // Check FETCH
+            // Check FETCH on an empty topic: records must be zero-length bytes,
+            // not null. librdkafka rejects MessageSetSize=-1 (LOGBROKER-10644);
+            // Java clients also normalize null records to MemoryRecords.EMPTY.
             std::vector<std::pair<TString, std::vector<i32>>> topics {{topicName, {0}}};
             auto msg = client.Fetch(topics);
             UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
             UNIT_ASSERT_VALUES_EQUAL(msg->Responses.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(msg->Responses[0].Partitions.size(), 1);
-            // To protect the clients from failing due to null records,
-            // Java SDK always convert null records to MemoryRecords.EMPTY
-            UNIT_ASSERT_VALUES_EQUAL(msg->Responses[0].Partitions[0].Records.has_value(), false);
+            UNIT_ASSERT(msg->Responses[0].Partitions[0].Records.has_value());
+            UNIT_ASSERT_VALUES_EQUAL(msg->Responses[0].Partitions[0].Records->size(), 0);
         }
     } // Y_UNIT_TEST(FetchEmptyTopicScenario)
 
@@ -5419,7 +5425,8 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         auto fetchResponse1 = kafkaClient.Fetch({{outputTopicName, {0}}});
         UNIT_ASSERT_VALUES_EQUAL(fetchResponse1->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-        UNIT_ASSERT(!fetchResponse1->Responses[0].Partitions[0].Records.has_value());
+        UNIT_ASSERT(fetchResponse1->Responses[0].Partitions[0].Records.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(fetchResponse1->Responses[0].Partitions[0].Records->size(), 0);
     }
 
     Y_UNIT_TEST(AbortTransactionScenario) {
@@ -5566,7 +5573,8 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         auto recordsBatch0 = ReadFetchRecords(fetchResponse->Responses[0].Partitions[0].Records);
         UNIT_ASSERT_VALUES_EQUAL(recordsBatch0.Records.size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(TString(recordsBatch0.Records[0].Value.value().data(), recordsBatch0.Records[0].Value.value().size()), "only-part-0");
-        UNIT_ASSERT(!fetchResponse->Responses[0].Partitions[1].Records.has_value());
+        UNIT_ASSERT(fetchResponse->Responses[0].Partitions[1].Records.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(fetchResponse->Responses[0].Partitions[1].Records->size(), 0);
     }
 
     Y_UNIT_TEST(ProducerFencedInTransactionScenario) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix Kafka Fetch responses for empty partitions: encode `records` as zero-length bytes instead of null, so librdkafka clients no longer fail with `invalid MessageSetSize -1` after 26-3.

### Description for reviewers <!-- (optional) description for those who read this PR -->

**Ticket:** [LOGBROKER-10644](https://st.yandex-team.ru/LOGBROKER-10644) (support: [YDBREQUESTS-8550](https://st.yandex-team.ru/YDBREQUESTS-8550))

**Problem.** After the 26-2 → 26-3 upgrade (LOGBROKER-10406), Fetch `records` switched from `TKafkaRecords` to `TKafkaBytesHolder`. The old serializer wrote unset records as length `0`; the new one writes null as `-1`. Empty partitions left `Records` unset, so clients (librdkafka 2.12) hit `PROTOERR … invalid MessageSetSize -1` on empty Fetch. Fetches with data still worked.

**Fix.** Initialize partition `Records` to empty `TString()` when building the Fetch response, so empty partitions serialize as zero-length bytes (same as Apache Kafka / pre-26-3). Tests updated accordingly.