### PR TITLE
WIP [PQ] Support shared PipePerNodeCache sessions in PQ tablet and PQRB.

### DIFF
--- a/ydb/core/persqueue/events/global.h
+++ b/ydb/core/persqueue/events/global.h
@@ -63,6 +63,7 @@ namespace NKikimr::TEvPersQueue {
         EvPartitionUpdateReadMetrics,
         EvCheckMessageDeduplicationRequest,
         EvCheckMessageDeduplicationResponse,
+        EvUnregisterClient,
         EvResponse = EvRequest + 256,
         EvInternalEvents = EvResponse + 256,
         EvEnd
@@ -97,6 +98,11 @@ namespace NKikimr::TEvPersQueue {
     struct TEvRegisterReadSession: public TEventPB<TEvRegisterReadSession,
             NKikimrPQ::TRegisterReadSession, EvRegisterReadSession> {
             TEvRegisterReadSession() {}
+    };
+
+    struct TEvUnregisterClient: public TEventPB<TEvUnregisterClient,
+            NKikimrPQ::TUnregisterClient, EvUnregisterClient> {
+            TEvUnregisterClient() {}
     };
 
     struct TEvGetReadSessionsInfo: public TEventPB<TEvGetReadSessionsInfo,

--- a/ydb/core/persqueue/pqrb/read_balancer.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer.cpp
@@ -882,6 +882,11 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvRegisterReadSession::TPtr& 
     Balancer->Handle(ev, ctx);
 }
 
+void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvUnregisterClient::TPtr& ev, const TActorContext& ctx)
+{
+    Balancer->Handle(ev, ctx);
+}
+
 void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvGetReadSessionsInfo::TPtr& ev, const TActorContext& ctx)
 {
     Balancer->Handle(ev, ctx);
@@ -1179,6 +1184,7 @@ STFUNC(TPersQueueReadBalancer::StateWork) {
         HFunc(TEvPersQueue::TEvGetPartitionIdForWrite, Handle);
         HFunc(TEvPersQueue::TEvUpdateBalancerConfig, Handle);
         HFunc(TEvPersQueue::TEvRegisterReadSession, Handle);
+        HFunc(TEvPersQueue::TEvUnregisterClient, Handle);
         HFunc(TEvPersQueue::TEvGetReadSessionsInfo, Handle);
         HFunc(TEvPersQueue::TEvPartitionReleased, Handle);
         HFunc(TEvTabletPipe::TEvServerConnected, Handle);

--- a/ydb/core/persqueue/pqrb/read_balancer.h
+++ b/ydb/core/persqueue/pqrb/read_balancer.h
@@ -149,6 +149,7 @@ class TPersQueueReadBalancer : public TActor<TPersQueueReadBalancer>,
     void Handle(TEvPersQueue::TEvReadingPartitionFinishedRequest::TPtr& ev, const TActorContext& ctx); // from ReadSession
     void HandleOnInit(TEvPersQueue::TEvRegisterReadSession::TPtr &ev, const TActorContext& ctx); // from ReadSession
     void Handle(TEvPersQueue::TEvRegisterReadSession::TPtr &ev, const TActorContext& ctx); // from ReadSession
+    void Handle(TEvPersQueue::TEvUnregisterClient::TPtr &ev, const TActorContext& ctx); // from ReadSession
     void Handle(TEvPersQueue::TEvPartitionReleased::TPtr& ev, const TActorContext& ctx);  // from ReadSession
 
     void Handle(TEvTabletPipe::TEvServerConnected::TPtr& ev, const TActorContext&);

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -1550,6 +1550,7 @@ void TConsumer::Release(ui32 partitionId, const TActorContext& ctx) {
 
 TSession::TSession(const TActorId& pipe)
             : Pipe(pipe)
+            , PhysicalPipe(pipe)
             , ServerActors(0)
             , ActivePartitionCount(0)
             , InactivePartitionCount(0)
@@ -1817,52 +1818,15 @@ void TBalancer::Handle(TEvPQ::TEvWakeupReleasePartition::TPtr &ev, const TActorC
     consumer->Release(msg->PartitionId, ctx);
 }
 
-void TBalancer::Handle(TEvTabletPipe::TEvServerConnected::TPtr& ev, const TActorContext&) {
-    const TActorId& sender = ev->Get()->ClientId;
-
-    auto it = Sessions.find(sender);
-    if (it == Sessions.end()) {
-        auto [i, _] = Sessions.emplace(sender, std::make_unique<TSession>(sender));
-        it = i;
-    }
+void TBalancer::DropSession(absl::flat_hash_map<TActorId, std::unique_ptr<TSession>, THash<TActorId>>::iterator it,
+                            const TActorContext& ctx)
+{
     auto& session = it->second;
-    ++session->ServerActors;
-
-    YDB_LOG_INFO("Pipe connected; active server",
-        {"logPrefix", LogPrefix()},
-        {"sender", sender},
-        {"actors", session->ServerActors});
-}
-
-void TBalancer::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TActorContext& ctx) {
-    YDB_LOG_DEBUG("Pipe disconnected",
-        {"logPrefix", LogPrefix()},
-        {"clientId", ev->Get()->ClientId});
-    Subscriptions.erase(ev->Get()->ClientId);
-
-    auto it = Sessions.find(ev->Get()->ClientId);
-
-    if (it == Sessions.end()) {
-        YDB_LOG_DEBUG("Pipe disconnected but there aren't sessions exists",
-            {"logPrefix", LogPrefix()},
-            {"clientId", ev->Get()->ClientId});
-        return;
-    }
-
-    YDB_LOG_INFO("Pipe disconnected; active server",
-        {"logPrefix", LogPrefix()},
-        {"clientId", ev->Get()->ClientId},
-        {"actors", (it != Sessions.end() ? it->second->ServerActors : -1)});
-
-    auto& session = it->second;
-    if (--(session->ServerActors) > 0) {
-        return;
-    }
-
     if (!session->SessionName.empty()) {
-        YDB_LOG_NOTICE("Pipe client disconnected session",
+        YDB_LOG_NOTICE("Dropping reading session",
             {"logPrefix", LogPrefix()},
-            {"eventClientId", ev->Get()->ClientId},
+            {"pipe", session->Pipe},
+            {"physicalPipe", session->PhysicalPipe},
             {"sessionClientId", session->ClientId},
             {"sessionName", session->SessionName});
 
@@ -1877,15 +1841,91 @@ void TBalancer::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TAc
                 consumer->ScheduleBalance(ctx);
             }
         }
-
-        Sessions.erase(it);
     } else {
-        YDB_LOG_INFO("Pipe disconnected no session",
+        YDB_LOG_INFO("Dropping pipe without reading session",
             {"logPrefix", LogPrefix()},
-            {"clientId", ev->Get()->ClientId});
-
-        Sessions.erase(it);
+            {"pipe", session->Pipe});
     }
+
+    if (session->IsPipeCacheSession()) {
+        if (auto pit = PipeCacheSessions.find(session->PhysicalPipe); pit != PipeCacheSessions.end()) {
+            pit->second.erase(session->Pipe);
+            if (pit->second.empty()) {
+                PipeCacheSessions.erase(pit);
+            }
+        }
+    }
+
+    Sessions.erase(it);
+}
+
+void TBalancer::DropSessionsOnPhysicalPipe(const TActorId& physicalPipe, const TActorContext& ctx) {
+    if (auto pit = PipeCacheSessions.find(physicalPipe); pit != PipeCacheSessions.end()) {
+        auto logicalPipes = pit->second; // copy — DropSession mutates the map
+        for (const auto& logicalPipe : logicalPipes) {
+            if (auto it = Sessions.find(logicalPipe); it != Sessions.end()) {
+                DropSession(it, ctx);
+            }
+        }
+    }
+
+    if (auto it = Sessions.find(physicalPipe); it != Sessions.end()) {
+        DropSession(it, ctx);
+    }
+}
+
+void TBalancer::Handle(TEvTabletPipe::TEvServerConnected::TPtr& ev, const TActorContext&) {
+    const TActorId& sender = ev->Get()->ClientId;
+    PipeServerToClient[ev->Get()->ServerId] = sender;
+
+    auto it = Sessions.find(sender);
+    if (it == Sessions.end()) {
+        auto [i, _] = Sessions.emplace(sender, std::make_unique<TSession>(sender));
+        it = i;
+    }
+    auto& session = it->second;
+    ++session->ServerActors;
+
+    YDB_LOG_INFO("Pipe connected; active server",
+        {"logPrefix", LogPrefix()},
+        {"sender", sender},
+        {"serverId", ev->Get()->ServerId},
+        {"actors", session->ServerActors});
+}
+
+void TBalancer::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TActorContext& ctx) {
+    YDB_LOG_DEBUG("Pipe disconnected",
+        {"logPrefix", LogPrefix()},
+        {"clientId", ev->Get()->ClientId},
+        {"serverId", ev->Get()->ServerId});
+    Subscriptions.erase(ev->Get()->ClientId);
+    PipeServerToClient.erase(ev->Get()->ServerId);
+
+    auto it = Sessions.find(ev->Get()->ClientId);
+
+    if (it == Sessions.end()) {
+        // Physical pipe entry may be gone, but pipe-cache logical sessions can remain.
+        if (PipeCacheSessions.contains(ev->Get()->ClientId)) {
+            DropSessionsOnPhysicalPipe(ev->Get()->ClientId, ctx);
+        } else {
+            YDB_LOG_DEBUG("Pipe disconnected but there aren't sessions exists",
+                {"logPrefix", LogPrefix()},
+                {"clientId", ev->Get()->ClientId});
+        }
+        return;
+    }
+
+    YDB_LOG_INFO("Pipe disconnected; active server",
+        {"logPrefix", LogPrefix()},
+        {"clientId", ev->Get()->ClientId},
+        {"actors", it->second->ServerActors});
+
+    auto& session = it->second;
+    if (--(session->ServerActors) > 0) {
+        return;
+    }
+
+    DropSessionsOnPhysicalPipe(ev->Get()->ClientId, ctx);
 }
 
 void TBalancer::Handle(TEvPersQueue::TEvRegisterReadSession::TPtr& ev, const TActorContext& ctx) {
@@ -1919,12 +1959,41 @@ void TBalancer::Handle(TEvPersQueue::TEvRegisterReadSession::TPtr& ev, const TAc
 
     auto jt = Sessions.find(pipe);
     if (jt == Sessions.end()) {
-        YDB_LOG_CRIT("Client pipe is not connected and got register session request for session",
+        // Pipe-cache path: PipeClient is a logical holder id, not the physical ClientId.
+        // Resolve the live physical pipe via ServerId carried in ev->Recipient.
+        auto serverIt = PipeServerToClient.find(ev->Recipient);
+        if (serverIt == PipeServerToClient.end()) {
+            YDB_LOG_CRIT("Client pipe is not connected and got register session request for session",
+                {"logPrefix", LogPrefix()},
+                {"consumerName", consumerName},
+                {"pipe", pipe},
+                {"session", r.GetSession()},
+                {"recipient", ev->Recipient});
+            return;
+        }
+
+        const TActorId physicalPipe = serverIt->second;
+        auto physicalIt = Sessions.find(physicalPipe);
+        if (physicalIt == Sessions.end()) {
+            YDB_LOG_CRIT("Client pipe is not connected and got register session request for session",
+                {"logPrefix", LogPrefix()},
+                {"consumerName", consumerName},
+                {"pipe", pipe},
+                {"physicalPipe", physicalPipe},
+                {"session", r.GetSession()});
+            return;
+        }
+
+        auto [inserted, _] = Sessions.emplace(pipe, std::make_unique<TSession>(pipe));
+        jt = inserted;
+        jt->second->PhysicalPipe = physicalPipe;
+        PipeCacheSessions[physicalPipe].insert(pipe);
+
+        YDB_LOG_INFO("Registered pipe-cache reading session on shared pipe",
             {"logPrefix", LogPrefix()},
-            {"consumerName", consumerName},
             {"pipe", pipe},
+            {"physicalPipe", physicalPipe},
             {"session", r.GetSession()});
-        return;
     }
 
     auto* consumerConfig = ::NKikimr::NPQ::GetConsumer(TopicActor.TabletConfig, consumerName);

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -1560,6 +1560,10 @@ TSession::TSession(const TActorId& pipe)
             , Order(RandomNumber<size_t>()) {
 }
 
+bool TSession::IsPipeCacheSession() const {
+    return PhysicalPipe && PhysicalPipe != Pipe;
+}
+
 bool TSession::WithGroups() const { return !Partitions.empty(); }
 
 template<typename TCollection>
@@ -1822,29 +1826,12 @@ void TBalancer::DropSession(absl::flat_hash_map<TActorId, std::unique_ptr<TSessi
                             const TActorContext& ctx)
 {
     auto& session = it->second;
-    if (!session->SessionName.empty()) {
-        YDB_LOG_NOTICE("Dropping reading session",
-            {"logPrefix", LogPrefix()},
-            {"pipe", session->Pipe},
-            {"physicalPipe", session->PhysicalPipe},
-            {"sessionClientId", session->ClientId},
-            {"sessionName", session->SessionName});
-
-        auto* consumer = GetConsumer(session->ClientId);
-        if (consumer) {
-            consumer->UnregisterReadingSession(session.get(), ctx);
-
-            if (consumer->Sessions.empty()) {
-                Notify(consumer->ConsumerName, NKikimrPQ::TEvBalancingSubscribeNotify::FREE, ctx);
-                Consumers.erase(consumer->ConsumerName);
-            } else {
-                consumer->ScheduleBalance(ctx);
-            }
-        }
-    } else {
+    if (session->SessionName.empty()) {
         YDB_LOG_INFO("Dropping pipe without reading session",
             {"logPrefix", LogPrefix()},
             {"pipe", session->Pipe});
+    } else {
+        ClearReadingSession(session.get(), ctx);
     }
 
     if (session->IsPipeCacheSession()) {
@@ -1857,6 +1844,39 @@ void TBalancer::DropSession(absl::flat_hash_map<TActorId, std::unique_ptr<TSessi
     }
 
     Sessions.erase(it);
+}
+
+void TBalancer::ClearReadingSession(TSession* session, const TActorContext& ctx) {
+    if (!session || session->SessionName.empty()) {
+        return;
+    }
+
+    YDB_LOG_NOTICE("Clearing reading session",
+        {"logPrefix", LogPrefix()},
+        {"pipe", session->Pipe},
+        {"physicalPipe", session->PhysicalPipe},
+        {"sessionClientId", session->ClientId},
+        {"sessionName", session->SessionName});
+
+    auto* consumer = GetConsumer(session->ClientId);
+    if (consumer) {
+        consumer->UnregisterReadingSession(session, ctx);
+
+        if (consumer->Sessions.empty()) {
+            Notify(consumer->ConsumerName, NKikimrPQ::TEvBalancingSubscribeNotify::FREE, ctx);
+            Consumers.erase(consumer->ConsumerName);
+        } else {
+            consumer->ScheduleBalance(ctx);
+        }
+    }
+
+    session->ClientId.clear();
+    session->SessionName.clear();
+    session->Sender = {};
+    session->Partitions.clear();
+    session->ClientNode.clear();
+    session->ProxyNodeId = 0;
+    session->CreateTimestamp = {};
 }
 
 void TBalancer::DropSessionsOnPhysicalPipe(const TActorId& physicalPipe, const TActorContext& ctx) {
@@ -2040,6 +2060,61 @@ void TBalancer::Handle(TEvPersQueue::TEvRegisterReadSession::TPtr& ev, const TAc
     auto* consumer = it->second.get();
     consumer->RegisterReadingSession(session, ctx);
     consumer->ScheduleBalance(ctx);
+}
+
+void TBalancer::Handle(TEvPersQueue::TEvUnregisterClient::TPtr& ev, const TActorContext& ctx) {
+    const auto& r = ev->Get()->Record;
+    TActorId pipe = ActorIdFromProto(r.GetPipeClient());
+
+    YDB_LOG_NOTICE("Consumer unregister session for pipe session",
+        {"logPrefix", LogPrefix()},
+        {"consumerName", r.GetClientId()},
+        {"pipe", pipe},
+        {"session", r.GetSession()});
+
+    if (!pipe) {
+        YDB_LOG_CRIT("Ignored the session unregistration with empty Pipe",
+            {"logPrefix", LogPrefix()});
+        return;
+    }
+
+    auto jt = Sessions.find(pipe);
+    if (jt == Sessions.end()) {
+        YDB_LOG_DEBUG("Unregister for unknown pipe session",
+            {"logPrefix", LogPrefix()},
+            {"pipe", pipe},
+            {"session", r.GetSession()});
+        return;
+    }
+
+    auto* session = jt->second.get();
+    if (!session->SessionName.empty()) {
+        if (r.HasSession() && !r.GetSession().empty() && session->SessionName != r.GetSession()) {
+            YDB_LOG_CRIT("Ignored unregister with mismatched session name",
+                {"logPrefix", LogPrefix()},
+                {"pipe", pipe},
+                {"expected", session->SessionName},
+                {"got", r.GetSession()});
+            return;
+        }
+        if (r.HasClientId() && !r.GetClientId().empty() && session->ClientId != r.GetClientId()) {
+            YDB_LOG_CRIT("Ignored unregister with mismatched consumer",
+                {"logPrefix", LogPrefix()},
+                {"pipe", pipe},
+                {"expected", session->ClientId},
+                {"got", r.GetClientId()});
+            return;
+        }
+    }
+
+    if (session->IsPipeCacheSession()) {
+        // Logical holder on a shared pipe: remove completely. Physical pipe stays open.
+        DropSession(jt, ctx);
+        return;
+    }
+
+    // Dedicated pipe: drop reading session but keep the pipe slot (ServerActors).
+    ClearReadingSession(session, ctx);
 }
 
 void TBalancer::Handle(TEvPersQueue::TEvGetReadSessionsInfo::TPtr& ev, const TActorContext& ctx) {

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.h
@@ -256,6 +256,10 @@ struct TSession {
 
     const TActorId Pipe;
 
+    // Physical tablet-pipe ClientId this session is bound to.
+    // For dedicated pipes equals Pipe; for pipe-cache sessions may differ.
+    TActorId PhysicalPipe;
+
     // The consumer name
     TString ClientId;
     TString SessionName;
@@ -269,6 +273,10 @@ struct TSession {
     absl::flat_hash_set<ui32> Partitions;
     // the number of pipes connected from SessionActor to ReadBalancer
     ui32 ServerActors = 0;
+
+    bool IsPipeCacheSession() const {
+        return PhysicalPipe && PhysicalPipe != Pipe;
+    }
 
     // The number of active partitions
     size_t ActivePartitionCount = 0;
@@ -350,10 +358,18 @@ private:
     TString LogPrefix() const;
     ui32 NextStep();
 
+    void DropSession(absl::flat_hash_map<TActorId, std::unique_ptr<TSession>, THash<TActorId>>::iterator it,
+                     const TActorContext& ctx);
+    void DropSessionsOnPhysicalPipe(const TActorId& physicalPipe, const TActorContext& ctx);
+
 private:
     TPersQueueReadBalancer& TopicActor;
 
     absl::flat_hash_map<TActorId, std::unique_ptr<TSession>, THash<TActorId>> Sessions;
+    // pipe ServerId -> physical ClientId (from TEvServerConnected)
+    absl::flat_hash_map<TActorId, TActorId, THash<TActorId>> PipeServerToClient;
+    // physical ClientId -> logical session keys that share this pipe (PipeClient != ClientId)
+    absl::flat_hash_map<TActorId, absl::flat_hash_set<TActorId>, THash<TActorId>> PipeCacheSessions;
     absl::flat_hash_map<TString, std::unique_ptr<TConsumer>> Consumers;
 
     ui32 Step;

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.h
@@ -274,9 +274,7 @@ struct TSession {
     // the number of pipes connected from SessionActor to ReadBalancer
     ui32 ServerActors = 0;
 
-    bool IsPipeCacheSession() const {
-        return PhysicalPipe && PhysicalPipe != Pipe;
-    }
+    bool IsPipeCacheSession() const;
 
     // The number of active partitions
     size_t ActivePartitionCount = 0;
@@ -339,6 +337,7 @@ public:
     void Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TActorContext&);
 
     void Handle(TEvPersQueue::TEvRegisterReadSession::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPersQueue::TEvUnregisterClient::TPtr& ev, const TActorContext& ctx);
 
     void Handle(TEvPersQueue::TEvGetReadSessionsInfo::TPtr& ev, const TActorContext& ctx);
 
@@ -361,6 +360,7 @@ private:
     void DropSession(absl::flat_hash_map<TActorId, std::unique_ptr<TSession>, THash<TActorId>>::iterator it,
                      const TActorContext& ctx);
     void DropSessionsOnPhysicalPipe(const TActorId& physicalPipe, const TActorContext& ctx);
+    void ClearReadingSession(TSession* session, const TActorContext& ctx);
 
 private:
     TPersQueueReadBalancer& TopicActor;

--- a/ydb/core/persqueue/pqrb/ut/pipe_cache_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/pipe_cache_ut.cpp
@@ -74,6 +74,55 @@ Y_UNIT_TEST(TwoLogicalSessionsShareOnePhysicalPipe) {
     UNIT_ASSERT_VALUES_EQUAL(CountNamedSessions(tc), 0u);
 }
 
+Y_UNIT_TEST(UnregisterOneLogicalSessionKeepsTheOther) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    PQTabletPrepare({}, {}, tc);
+    SendBalancerUpdate(tc, TBalancerUpdate{
+        .Partitions = {
+            {0, {tc.TabletId, 1}},
+            {1, {tc.TabletId, 2}},
+        },
+        .NextPartitionId = 2,
+    });
+
+    const TActorId physicalPipe = tc.Runtime->ConnectToPipe(
+        tc.BalancerTabletId, tc.Edge, 0, GetPipeConfigWithRetries());
+    UNIT_ASSERT(physicalPipe);
+
+    const TActorId peer1 = tc.Runtime->AllocateEdgeActor();
+    const TActorId peer2 = tc.Runtime->AllocateEdgeActor();
+
+    RegisterReadSessionOnSharedPipe("session-pipe-cache-0", tc, physicalPipe, peer1);
+    RegisterReadSessionOnSharedPipe("session-pipe-cache-1", tc, physicalPipe, peer2);
+    UNIT_ASSERT_VALUES_EQUAL(CountNamedSessions(tc), 2u);
+
+    auto unregister = MakeHolder<TEvPersQueue::TEvUnregisterClient>();
+    unregister->Record.SetSession("session-pipe-cache-0");
+    ActorIdToProto(peer1, unregister->Record.MutablePipeClient());
+    unregister->Record.SetClientId("user");
+    tc.Runtime->SendToPipe(
+        tc.BalancerTabletId,
+        tc.Edge,
+        unregister.Release(),
+        0,
+        GetPipeConfigWithRetries(),
+        physicalPipe);
+    DispatchFor(tc);
+
+    UNIT_ASSERT_VALUES_EQUAL(CountNamedSessions(tc), 1u);
+
+    auto sessions = MakeHolder<TEvPersQueue::TEvGetReadSessionsInfo>();
+    sessions->Record.SetClientId("user");
+    tc.Runtime->SendToPipe(tc.BalancerTabletId, tc.Edge, sessions.Release(), 0, GetPipeConfigWithRetries());
+    auto info = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvReadSessionsInfoResponse>(TDuration::Seconds(10));
+    UNIT_ASSERT(info);
+    UNIT_ASSERT_VALUES_EQUAL(info->Record.ReadSessionsSize(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(info->Record.GetReadSessions(0).GetSession(), TString("session-pipe-cache-1"));
+}
+
 Y_UNIT_TEST(DedicatedPipeSessionStillWorks) {
     TTestContext tc;
     tc.Prepare();

--- a/ydb/core/persqueue/pqrb/ut/pipe_cache_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/pipe_cache_ut.cpp
@@ -1,0 +1,101 @@
+#include "pqrb_ut_common.h"
+
+namespace NKikimr::NPQ {
+
+namespace {
+
+TActorId RegisterReadSessionOnSharedPipe(
+    const TString& session,
+    TTestContext& tc,
+    const TActorId& physicalPipe,
+    const TActorId& logicalPipeClient)
+{
+    auto request = MakeHolder<TEvPersQueue::TEvRegisterReadSession>();
+    auto& req = request->Record;
+    req.SetSession(session);
+    // Logical holder id (as pipe-cache clients put SelfId), not the physical ClientId.
+    ActorIdToProto(logicalPipeClient, req.MutablePipeClient());
+    req.SetClientId("user");
+
+    tc.Runtime->SendToPipe(
+        tc.BalancerTabletId,
+        tc.Edge,
+        request.Release(),
+        0,
+        GetPipeConfigWithRetries(),
+        physicalPipe);
+    DispatchFor(tc);
+    return logicalPipeClient;
+}
+
+ui32 CountNamedSessions(TTestContext& tc) {
+    auto sessions = MakeHolder<TEvPersQueue::TEvGetReadSessionsInfo>();
+    sessions->Record.SetClientId("user");
+    tc.Runtime->SendToPipe(tc.BalancerTabletId, tc.Edge, sessions.Release(), 0, GetPipeConfigWithRetries());
+    auto info = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvReadSessionsInfoResponse>(TDuration::Seconds(10));
+    UNIT_ASSERT(info);
+    return info->Record.ReadSessionsSize();
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TPqrbPipeCache) {
+
+Y_UNIT_TEST(TwoLogicalSessionsShareOnePhysicalPipe) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    PQTabletPrepare({}, {}, tc);
+    SendBalancerUpdate(tc, TBalancerUpdate{
+        .Partitions = {
+            {0, {tc.TabletId, 1}},
+            {1, {tc.TabletId, 2}},
+        },
+        .NextPartitionId = 2,
+    });
+
+    const TActorId physicalPipe = tc.Runtime->ConnectToPipe(
+        tc.BalancerTabletId, tc.Edge, 0, GetPipeConfigWithRetries());
+    UNIT_ASSERT(physicalPipe);
+
+    const TActorId peer1 = tc.Runtime->AllocateEdgeActor();
+    const TActorId peer2 = tc.Runtime->AllocateEdgeActor();
+
+    RegisterReadSessionOnSharedPipe("session-pipe-cache-0", tc, physicalPipe, peer1);
+    RegisterReadSessionOnSharedPipe("session-pipe-cache-1", tc, physicalPipe, peer2);
+
+    UNIT_ASSERT_VALUES_EQUAL(CountNamedSessions(tc), 2u);
+
+    // Physical disconnect must drop both logical sessions.
+    tc.Runtime->ClosePipe(physicalPipe, tc.Edge, 0);
+    DispatchFor(tc, TDuration::MilliSeconds(200));
+
+    UNIT_ASSERT_VALUES_EQUAL(CountNamedSessions(tc), 0u);
+}
+
+Y_UNIT_TEST(DedicatedPipeSessionStillWorks) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    PQTabletPrepare({}, {}, tc);
+    SendBalancerUpdate(tc, TBalancerUpdate{
+        .Partitions = {
+            {0, {tc.TabletId, 1}},
+        },
+        .NextPartitionId = 1,
+    });
+
+    auto pipe = RegisterReadSession("session-dedicated", tc);
+    UNIT_ASSERT(pipe);
+    UNIT_ASSERT_VALUES_EQUAL(CountNamedSessions(tc), 1u);
+
+    auto lock = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvLockPartition>(TDuration::Seconds(10));
+    UNIT_ASSERT(lock);
+    UNIT_ASSERT_VALUES_EQUAL(lock->Record.GetSession(), TString("session-dedicated"));
+}
+
+} // Y_UNIT_TEST_SUITE(TPqrbPipeCache)
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqrb/ut/ya.make
+++ b/ydb/core/persqueue/pqrb/ut/ya.make
@@ -18,6 +18,7 @@ SRCS(
     partition_scale_manager_graph_cmp_ut.cpp
     partition_scale_manager_ut.cpp
     partitions_location_queue_ut.cpp
+    pipe_cache_ut.cpp
     scale_and_mirror_ut.cpp
     sdk_balancing_ut.cpp
     write_partition_ut.cpp

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -2018,7 +2018,10 @@ void TPersQueue::HandleGetOwnershipRequest(const ui64 responseCookie, NWilson::T
         return;
     }
 
-    it->second = TPipeInfo::ForOwner(partActor, owner, it->second.ServerActors);
+    const ui32 serverActors = it->second.ServerActors;
+    const TActorId physicalPipe = it->second.PhysicalPipe;
+    it->second = TPipeInfo::ForOwner(partActor, owner, serverActors);
+    it->second.PhysicalPipe = physicalPipe;
 
     InitResponseBuilder(responseCookie, 1, COUNTER_LATENCY_PQ_GET_OWNERSHIP);
     THolder<TEvPQ::TEvChangeOwner> event = MakeHolder<TEvPQ::TEvChangeOwner>(responseCookie, owner, pipeClient, sender,
@@ -2213,6 +2216,74 @@ void TPersQueue::DestroySession(TPipeInfo& pipeInfo) {
             )
     );
     pipeInfo.SessionId = TString{};
+}
+
+void TPersQueue::EnsurePipeHolder(const TActorId& pipeClient, const TActorId& pipeServerId) {
+    if (!pipeClient || PipesInfo.contains(pipeClient)) {
+        return;
+    }
+
+    auto serverIt = PipeServerToClient.find(pipeServerId);
+    if (serverIt == PipeServerToClient.end()) {
+        return;
+    }
+
+    const TActorId& physicalPipe = serverIt->second;
+    if (!PipesInfo.contains(physicalPipe)) {
+        return;
+    }
+
+    TPipeInfo info;
+    info.PhysicalPipe = physicalPipe;
+    PipesInfo.emplace(pipeClient, std::move(info));
+    PipeCacheHolders[physicalPipe].insert(pipeClient);
+
+    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Created pipe-cache holder on shared pipe",
+        {"logPrefix", LogPrefix()},
+        {"pipeClient", pipeClient},
+        {"physicalPipe", physicalPipe},
+        {"serverId", pipeServerId});
+}
+
+void TPersQueue::CleanupPipeInfo(const TActorId& pipeClient, const TActorContext& ctx) {
+    auto it = PipesInfo.find(pipeClient);
+    if (it == PipesInfo.end()) {
+        return;
+    }
+
+    if (it->second.PartActor != TActorId()) {
+        ctx.Send(it->second.PartActor, new TEvPQ::TEvPipeDisconnected(
+                it->second.Owner, pipeClient
+        ));
+    }
+    if (!it->second.SessionId.empty()) {
+        DestroySession(it->second);
+    }
+
+    if (it->second.PhysicalPipe) {
+        if (auto hit = PipeCacheHolders.find(it->second.PhysicalPipe); hit != PipeCacheHolders.end()) {
+            hit->second.erase(pipeClient);
+            if (hit->second.empty()) {
+                PipeCacheHolders.erase(hit);
+            }
+        }
+    }
+
+    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Pipe info destroyed",
+        {"logPrefix", LogPrefix()},
+        {"clientId", pipeClient});
+    PipesInfo.erase(it);
+    Counters->Simple()[COUNTER_PQ_TABLET_OPENED_PIPES] = PipesInfo.size();
+}
+
+void TPersQueue::CleanupPhysicalPipe(const TActorId& physicalClientId, const TActorContext& ctx) {
+    if (auto hit = PipeCacheHolders.find(physicalClientId); hit != PipeCacheHolders.end()) {
+        auto holders = hit->second; // copy — CleanupPipeInfo mutates the map
+        for (const auto& logical : holders) {
+            CleanupPipeInfo(logical, ctx);
+        }
+    }
+    CleanupPipeInfo(physicalClientId, ctx);
 }
 
 TMaybe<TEvPQ::TEvRegisterMessageGroup::TBody> TPersQueue::MakeRegisterMessageGroup(
@@ -2605,6 +2676,9 @@ void TPersQueue::Handle(TEvPersQueue::TEvRequest::TPtr& ev, const TActorContext&
 
     auto& req = request.GetPartitionRequest();
     TActorId pipeClient = ActorIdFromProto(req.GetPipeClient());
+    if (pipeClient) {
+        EnsurePipeHolder(pipeClient, ev->Recipient);
+    }
 
     if (request.GetPartitionRequest().HasCmdRead() && s != TMP_REQUEST_MARKER) {
         auto pipeIter = PipesInfo.find(pipeClient);
@@ -2737,11 +2811,14 @@ void TPersQueue::Handle(TEvTabletPipe::TEvServerConnected::TPtr& ev, const TActo
     YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Handle TEvTabletPipe::TEvServerConnected",
         {"logPrefix", LogPrefix()});
 
+    PipeServerToClient[ev->Get()->ServerId] = ev->Get()->ClientId;
+
     auto it = PipesInfo.insert({ev->Get()->ClientId, {}}).first;
     it->second.ServerActors++;
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Server connected, pipe now have active actors on pipe",
         {"logPrefix", LogPrefix()},
         {"clientId", ev->Get()->ClientId},
+        {"serverId", ev->Get()->ServerId},
         {"serverActors", it->second.ServerActors});
 
     Counters->Simple()[COUNTER_PQ_TABLET_OPENED_PIPES] = PipesInfo.size();
@@ -2753,25 +2830,17 @@ void TPersQueue::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TA
     YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Handle TEvTabletPipe::TEvServerDisconnected",
         {"logPrefix", LogPrefix()});
 
+    PipeServerToClient.erase(ev->Get()->ServerId);
+
     //inform partition if needed;
     auto it = PipesInfo.find(ev->Get()->ClientId);
     if (it != PipesInfo.end()) {
         if(--(it->second.ServerActors) > 0) {
             return;
         }
-        if (it->second.PartActor != TActorId()) {
-            ctx.Send(it->second.PartActor, new TEvPQ::TEvPipeDisconnected(
-                    it->second.Owner, it->first
-            ));
-        }
-        if (!it->second.SessionId.empty()) {
-            DestroySession(it->second);
-        }
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Server disconnected, pipe destroyed",
-            {"logPrefix", LogPrefix()},
-            {"clientId", ev->Get()->ClientId});
-        PipesInfo.erase(it);
-        Counters->Simple()[COUNTER_PQ_TABLET_OPENED_PIPES] = PipesInfo.size();
+        CleanupPhysicalPipe(ev->Get()->ClientId, ctx);
+    } else if (PipeCacheHolders.contains(ev->Get()->ClientId)) {
+        CleanupPhysicalPipe(ev->Get()->ClientId, ctx);
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -18,6 +18,9 @@
 
 #include <ydb/library/actors/interconnect/interconnect.h>
 
+#include <library/cpp/containers/absl/flat_hash_map.h>
+#include <library/cpp/containers/absl/flat_hash_set.h>
+
 namespace NKikimr {
 namespace NPQ {
 
@@ -282,6 +285,9 @@ public:
         ui32 ServerActors = 0;
         TString SessionId;
         ui64 PartitionSessionId = 0;
+        // For pipe-cache holders: physical ClientId this logical PipeClient is bound to.
+        // Empty for dedicated pipes (key of PipesInfo is the physical ClientId).
+        TActorId PhysicalPipe;
         TPipeInfo() = default;
         static TPipeInfo ForOwner(const TActorId& partActor, const TString& owner, ui32 serverActors) {
             TPipeInfo res;
@@ -294,6 +300,10 @@ public:
 
 private:
     THashMap<TActorId, TPipeInfo> PipesInfo;
+    // pipe ServerId -> physical ClientId
+    absl::flat_hash_map<TActorId, TActorId, THash<TActorId>> PipeServerToClient;
+    // physical ClientId -> logical PipeClient holders (pipe-cache sessions/owners)
+    absl::flat_hash_map<TActorId, absl::flat_hash_set<TActorId>, THash<TActorId>> PipeCacheHolders;
 
     ui64 NextResponseCookie;
     THashMap<ui64, TAutoPtr<TResponseBuilder>> ResponseProxy;
@@ -493,6 +503,9 @@ private:
 
     ui64 GetGeneration();
     void DestroySession(TPipeInfo& pipeInfo);
+    void EnsurePipeHolder(const TActorId& pipeClient, const TActorId& pipeServerId);
+    void CleanupPipeInfo(const TActorId& pipeClient, const TActorContext& ctx);
+    void CleanupPhysicalPipe(const TActorId& physicalClientId, const TActorContext& ctx);
     bool UseMediatorTimeCast = true;
 
     TVector<TEvPersQueue::TEvStatus::TPtr> StatusRequests;

--- a/ydb/core/persqueue/pqtablet/ya.make
+++ b/ydb/core/persqueue/pqtablet/ya.make
@@ -12,6 +12,7 @@ SRCS(
 
 
 PEERDIR(
+    library/cpp/containers/absl
     ydb/core/base
     ydb/core/persqueue/pqtablet/common
     ydb/core/persqueue/common/proxy

--- a/ydb/core/persqueue/ut/pipe_cache_ut.cpp
+++ b/ydb/core/persqueue/ut/pipe_cache_ut.cpp
@@ -1,0 +1,72 @@
+#include <ydb/core/persqueue/ut/common/pq_ut_common.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NPQ {
+
+Y_UNIT_TEST_SUITE(TPqTabletPipeCache) {
+
+Y_UNIT_TEST(TwoOwnersShareOnePhysicalPipe) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    PQTabletPrepare({}, {}, tc);
+
+    const TActorId physicalPipe = tc.Runtime->ConnectToPipe(tc.TabletId, tc.Edge, 0, GetPipeConfigWithRetries());
+    UNIT_ASSERT(physicalPipe);
+
+    const TActorId peer1 = tc.Runtime->AllocateEdgeActor();
+    const TActorId peer2 = tc.Runtime->AllocateEdgeActor();
+
+    auto sendOwnership = [&](const TActorId& peer, const TString& owner) {
+        auto request = MakeHolder<TEvPersQueue::TEvRequest>();
+        auto* req = request->Record.MutablePartitionRequest();
+        req->SetPartition(0);
+        req->MutableCmdGetOwnership()->SetOwner(owner);
+        req->MutableCmdGetOwnership()->SetForce(true);
+        // Logical holder id, as pipe-cache clients would set.
+        ActorIdToProto(peer, req->MutablePipeClient());
+
+        tc.Runtime->SendToPipe(
+            tc.TabletId,
+            tc.Edge,
+            request.Release(),
+            0,
+            GetPipeConfigWithRetries(),
+            physicalPipe);
+    };
+
+    sendOwnership(peer1, "owner-a");
+    auto resp1 = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(TDuration::Seconds(10));
+    UNIT_ASSERT(resp1);
+    UNIT_ASSERT_EQUAL(resp1->Record.GetErrorCode(), NPersQueue::NErrorCode::OK);
+    UNIT_ASSERT(resp1->Record.GetPartitionResponse().HasCmdGetOwnershipResult());
+
+    sendOwnership(peer2, "owner-b");
+    auto resp2 = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(TDuration::Seconds(10));
+    UNIT_ASSERT(resp2);
+    UNIT_ASSERT_EQUAL(resp2->Record.GetErrorCode(), NPersQueue::NErrorCode::OK);
+    UNIT_ASSERT(resp2->Record.GetPartitionResponse().HasCmdGetOwnershipResult());
+
+    tc.Runtime->ClosePipe(physicalPipe, tc.Edge, 0);
+    tc.Runtime->DispatchEvents();
+}
+
+Y_UNIT_TEST(DedicatedOwnershipStillWorks) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    PQTabletPrepare({}, {}, tc);
+
+    auto [cookie, pipe] = CmdSetOwner(0, tc, "default-owner", true);
+    UNIT_ASSERT(!cookie.empty());
+    UNIT_ASSERT(pipe);
+}
+
+} // Y_UNIT_TEST_SUITE(TPqTabletPipeCache)
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/ut/ya.make
+++ b/ydb/core/persqueue/ut/ya.make
@@ -46,6 +46,7 @@ SRCS(
     partition_ut.cpp
     partitiongraph_ut.cpp
     pqtablet_ut.cpp
+    pipe_cache_ut.cpp
     sourceid_ut.cpp
     user_info_ut.cpp
     utils_ut.cpp

--- a/ydb/core/protos/pqevents_global.proto
+++ b/ydb/core/protos/pqevents_global.proto
@@ -55,6 +55,14 @@ message TRegisterReadSession {
     repeated uint32 Groups = 5;
 }
 
+// Explicitly end a reading session without closing the physical tablet pipe.
+// Required for PipePerNodeCache clients: Unlink does not notify the tablet.
+message TUnregisterClient {
+    optional string Session = 1;
+    optional NActorsProto.TActorId PipeClient = 2;
+    optional string ClientId = 3;
+}
+
 message TGetReadSessionsInfo {
     optional string ClientId = 1;
     repeated uint32 Partitions = 2;


### PR DESCRIPTION
Keep dedicated-pipe semantics unchanged and add an additive path for multiple logical holders on one physical pipe, with tests.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
