### PR TITLE
[PQ] Assert MLP queue processing only runs outside KV write

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
@@ -746,6 +746,10 @@ void TConsumerActor::ScheduleProcessing() {
 }
 
 void TConsumerActor::ProcessEventQueue() {
+    // Must not apply queued ops while a KV persist is in flight (StateWrite):
+    // callers are gated by InStateWork(); Persist() switches to StateWrite only after this turn starts.
+    AFL_ENSURE(InStateWork());
+
     YDB_LOG_DEBUG("ProcessEventQueue",
         {"logPrefix", NPQ_LOG_PREFIX});
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Assert that MLP consumer ProcessEventQueue runs only in StateWork, not while a KV persist is in flight.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Call sites already gate ProcessEventQueue / ScheduleProcessing with InStateWork(); Persist() switches to StateWrite only after a processing turn starts. This PR adds AFL_ENSURE(InStateWork()) at the start of ProcessEventQueue so a regression fails loudly instead of applying queued ops during StateWrite.

Existing TMLPConsumerWakeupTests already cover wakeups and queued requests during KV write.