### PR TITLE
Prefetch BlockHash probe directory and slot 8/3 rows ahead.

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/dq_hash_join_table.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_join_table.h
@@ -118,6 +118,14 @@ class TNeumannJoinTable : public NNonCopyable::TMoveOnly {
         return Table_.RequiredMemoryForBuild(nTuples);
     }
 
+    void PrefetchDirectory(TSingleTuple row) const {
+        Table_.PrefetchDirectory(row.PackedData);
+    }
+
+    void PrefetchSlot(TSingleTuple row) const {
+        Table_.PrefetchSlot(row.PackedData);
+    }
+
     void Lookup(TSingleTuple row, std::invocable<TSingleTuple> auto consume) {
         if (Empty()){
             return;

--- a/ydb/library/yql/dq/comp_nodes/dq_join_common.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_join_common.h
@@ -3,6 +3,7 @@
 #include "dq_block_hash_join_settings.h"
 #include "dq_join_filters.h"
 #include <algorithm>
+#include <array>
 #include <numeric>
 #include <vector>
 #include <ydb/library/yql/dq/comp_nodes/hash_join_utils/alloc.h>
@@ -781,33 +782,73 @@ template <typename Source, TSpillerSettings Settings, TPhysicalJoin Join> class 
                 default:
                     MKQL_ENSURE(false, "unhandled ESpillResult case");
                 }
-                ui32 idx = 0;
-                for (TSingleTuple tuple : *state.FetchedPack) {
-                    if (idx++ < state.ResumeIndex) {
-                        continue;
-                    }
-                    if constexpr (IsGrid) {
+                if constexpr (IsGrid) {
+                    ui32 idx = 0;
+                    for (TSingleTuple tuple : *state.FetchedPack) {
+                        if (idx++ < state.ResumeIndex) {
+                            continue;
+                        }
                         if (!MatchGridRowInMemory(state, tuple, lookupToTable, isFull)) {
                             state.ResumeIndex = idx - 1;
                             return EFetchResult::One;
                         }
-                    } else {
-                        int bucketIndex = Settings.BucketIndex(tuple);
-                        bool thisBucketSpilled = state.Spiller.IsBucketSpilled(bucketIndex);
-                        if (thisBucketSpilled) {
-                            state.Spiller.AddRow({.Val = tuple, .Side = ESide::Probe, .BucketIndex = bucketIndex});
+                        if (isFull()) {
+                            state.ResumeIndex = idx;
+                            return EFetchResult::One;
+                        }
+                    }
+                } else {
+                    constexpr i64 dirDistance = 8;
+                    constexpr i64 slotDistance = 3;
+                    const TPackResult& probePack = *state.FetchedPack;
+                    const auto* probeLayout = Layouts_.Probe;
+                    auto& buckets = state.Spiller.GetState().Buckets;
+
+                    constexpr i64 ringMask = 15;
+                    static_assert(dirDistance <= ringMask, "ring must outlive the pipeline window");
+                    std::array<i32, ringMask + 1> bucketRing;
+                    auto enterPipeline = [&](i64 idx) {
+                        if (idx >= probePack.NTuples) {
+                            return;
+                        }
+                        const TSingleTuple aheadTuple = probePack.TupleAt(idx, probeLayout);
+                        const int aheadBucket = Settings.BucketIndex(aheadTuple);
+                        bucketRing[idx & ringMask] = aheadBucket;
+                        if (auto* aheadTable = std::get_if<TTable>(&buckets[aheadBucket])) {
+                            aheadTable->PrefetchDirectory(aheadTuple);
+                        }
+                    };
+
+                    for (i64 idx = state.ResumeIndex; idx < state.ResumeIndex + dirDistance; ++idx) {
+                        enterPipeline(idx);
+                    }
+                    for (i64 idx = state.ResumeIndex; idx < probePack.NTuples; ++idx) {
+                        enterPipeline(idx + dirDistance);
+                        if (const i64 slotAhead = idx + slotDistance; slotAhead < probePack.NTuples) {
+                            const TSingleTuple slotTuple = probePack.TupleAt(slotAhead, probeLayout);
+                            if (auto* slotTable =
+                                    std::get_if<TTable>(&buckets[bucketRing[slotAhead & ringMask]])) {
+                                slotTable->PrefetchSlot(slotTuple);
+                            }
+                        }
+
+                        const TSingleTuple tuple = probePack.TupleAt(idx, probeLayout);
+                        const int bucketIndex = bucketRing[idx & ringMask];
+                        if (state.Spiller.IsBucketSpilled(bucketIndex)) {
+                            state.Spiller.AddRow(
+                                {.Val = tuple, .Side = ESide::Probe, .BucketIndex = bucketIndex});
                         } else {
-                            TTable* thisTable = std::get_if<TTable>(&state.Spiller.GetState().Buckets[bucketIndex]);
+                            TTable* thisTable = std::get_if<TTable>(&buckets[bucketIndex]);
                             MKQL_ENSURE(thisTable, "sanity check");
                             if (!lookupToTable(*thisTable, tuple, state.BuildCursor)) {
-                                state.ResumeIndex = idx - 1;
+                                state.ResumeIndex = static_cast<ui32>(idx);
                                 return EFetchResult::One;
                             }
                         }
-                    }
-                    if (isFull()) {
-                        state.ResumeIndex = idx;
-                        return EFetchResult::One;
+                        if (isFull()) {
+                            state.ResumeIndex = static_cast<ui32>(idx + 1);
+                            return EFetchResult::One;
+                        }
                     }
                 }
                 state.FetchedPack = std::nullopt;

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/layout_converter_common.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/layout_converter_common.h
@@ -69,6 +69,10 @@ struct TPackResult {
     auto begin() const {return Iterator(*this, 0);}
     auto end() const {return Iterator(*this, this->NTuples);}
 
+    TSingleTuple TupleAt(i64 index, const NPackedTuple::TTupleLayout* layout) const {
+        return {.PackedData = PackedTuples.data() + layout->TotalRowSize * index,
+                .OverflowBegin = Overflow.data()};
+    }
 
     void Clear() {
         *this = TPackResult{};

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
@@ -446,6 +446,23 @@ class TNeumannHashTable {
         return Buffer_.empty();
     }
 
+    void PrefetchDirectory(const ui8 *const row) const {
+        if (Directories_.empty()) {
+            return;
+        }
+        const THash thash = ReadUnaligned<THash>(row);
+        NYql::PrefetchForRead(&Directories_[getDirectorySlot(thash)]);
+    }
+
+    void PrefetchSlot(const ui8 *const row) const {
+        if (Directories_.empty()) {
+            return;
+        }
+        const THash thash = ReadUnaligned<THash>(row);
+        const TDirectory dir = Directories_[getDirectorySlot(thash)];
+        NYql::PrefetchForRead(Buffer_.data() + BufferSlotSize_ * dir.BufferSlot);
+    }
+
     void Apply(const ui8 *const row, const ui8 *const overflow,
                std::invocable<const ui8*> auto onMatch) const {
         MKQL_ENSURE(Layout_ != nullptr, "sanity check");

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/spilled_storage.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/spilled_storage.h
@@ -28,10 +28,7 @@ struct TSpillerSettings {
     int SpillingPagesAtTime;
 
     int BucketIndex(TSingleTuple tuple) const {
-        ui32 hash = NPackedTuple::Hash(tuple.PackedData);
-        MKQL_ENSURE(std::popcount(static_cast<ui32>(Buckets) - 1) == std::bit_width(static_cast<ui32>(Buckets)) - 1,
-                    "size of buckets should be power of two");
-        return hash & (static_cast<ui32>(Buckets) - 1);
+        return NPackedTuple::Hash(tuple.PackedData) & (static_cast<ui32>(Buckets) - 1);
     }
 };
 
@@ -58,6 +55,9 @@ inline ESpillResult Wait() {
 NThreading::TFuture<ISpiller::TKey> SpillPage(ISpiller& spiller, TPackResult&& page);
 
 template <TSpillerSettings Settings> class TBucketsSpiller {
+    static_assert(Settings.Buckets > 0 && (Settings.Buckets & (Settings.Buckets - 1)) == 0,
+                  "Buckets must be a power of two");
+
     std::optional<int> FindInMemoryBucketWithMostPages() const {
         std::optional<int> resIndex;
         for (int index = 0; index < std::ssize(Buckets_); ++index) {
@@ -174,6 +174,9 @@ template <TSpillerSettings Settings> class TBucketsSpiller {
 };
 
 template <TSpillerSettings Settings> class TProbeSpiller {
+    static_assert(Settings.Buckets > 0 && (Settings.Buckets & (Settings.Buckets - 1)) == 0,
+                  "Buckets must be a power of two");
+
   public:
     struct EmptyBucket {};
     using Bucket = 


### PR DESCRIPTION
Hides the two random loads at lookup start. Move the power-of-two bucket check to a compile-time static_assert.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
