### PR TITLE
Fix hang in KafkaProtocol.TopicsCompactionGapFromRetention

### DIFF
--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -2990,7 +2990,8 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         // blob only if it is a pure superseded key-1: the write session packs the
         // unique key-new records into the current Head, so they land in the last
         // large blob. Two large writes put key-new into the first remaining blob
-        // and startOffset stays at 1 forever.
+        // and startOffset stays at 1 forever. cyclesCount = 3 keeps key-new out of
+        // that remaining blob so compaction can advance startOffset to 2.
         WriteMessagesWithKeys(writeSession, {{"key-1", 7_MB}}, 3);
         WriteMessagesWithKeys(writeSession, {{"key-new", 100}}, 3);
         waitStartOffsetAtLeast(1, TDuration::Seconds(60), "retention");

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -2985,9 +2985,13 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
                                  << (lastStartOffset ? ToString(*lastStartOffset) : "n/a"));
         };
 
-        // 7_MB exceeds LowWatermark (6MB), so each write becomes its own blob and retention/compaction
-        // can move startOffset. Two blobs plus a few small records are enough to form a gap.
-        WriteMessagesWithKeys(writeSession, {{"key-1", 7_MB}}, 2);
+        // 7_MB exceeds LowWatermark (6MB), so a large write becomes its own blob.
+        // Retention drops the first blob (offset 0). Compaction can drop the second
+        // blob only if it is a pure superseded key-1: the write session packs the
+        // unique key-new records into the current Head, so they land in the last
+        // large blob. Two large writes put key-new into the first remaining blob
+        // and startOffset stays at 1 forever.
+        WriteMessagesWithKeys(writeSession, {{"key-1", 7_MB}}, 3);
         WriteMessagesWithKeys(writeSession, {{"key-new", 100}}, 3);
         waitStartOffsetAtLeast(1, TDuration::Seconds(60), "retention");
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

`#52078` cut the large `key-1` writes from 3 to 2. The write session packs unique `key-new` records into the current Head, so they land in the last large blob. After retention drops offset 0, that remaining blob still contains live unique keys. Compaction cannot drop it, `startOffset` stays at 1, and the test times out waiting for `>= 2`.

Restore a third 7MB blob so retention, compaction, and live unique keys each occupy their own blob.