### PR TITLE
[SQS] Do not charge extra RU for content-based deduplication

### DIFF
--- a/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
@@ -2191,7 +2191,7 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
         // => Cost = base + blocks
         const ui64 blocks = RuPayloadBlocks(
             RuMetering_MessageCount * RuMetering_MessageSize, NBilling::WRITE_BLOCK_SIZE);
-        const ui64 expected = NBilling::CalcRu(blocks, NBilling::WRITE_BASE_COST, NBilling::WRITE_COST_PER_BLOCK, false, false);
+        const ui64 expected = NBilling::CalcRu(blocks, NBilling::WRITE_BASE_COST, NBilling::WRITE_COST_PER_BLOCK, false);
         UNIT_ASSERT_VALUES_EQUAL(blocks, 5);
         UNIT_ASSERT_VALUES_EQUAL(expected, 7);
         UNIT_ASSERT_VALUES_EQUAL(charges[0].Amount, expected);
@@ -2248,7 +2248,7 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
         // => Cost = base + blocks
         const ui64 blocks = RuPayloadBlocks(
             RuMetering_MessageCount * RuMetering_MessageSize, NBilling::READ_BLOCK_SIZE);
-        const ui64 expected = NBilling::CalcRu(blocks, NBilling::READ_BASE_COST, NBilling::READ_COST_PER_BLOCK, false, false);
+        const ui64 expected = NBilling::CalcRu(blocks, NBilling::READ_BASE_COST, NBilling::READ_COST_PER_BLOCK, false);
         UNIT_ASSERT_VALUES_EQUAL(totalReadRu, expected);
     }
 
@@ -2311,7 +2311,7 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
         UNIT_ASSERT_VALUES_EQUAL_C(charges.size(), 1, "expected exactly one delete RU charge");
         // adjunct 0.
         // Cost = base(2).
-        const ui64 expected = NBilling::CalcRu(0, NBilling::DELETE_BASE_COST, 0, false, false);
+        const ui64 expected = NBilling::CalcRu(0, NBilling::DELETE_BASE_COST, 0);
         UNIT_ASSERT_VALUES_EQUAL(expected, 2);
         UNIT_ASSERT_VALUES_EQUAL(charges[0].Amount, expected);
         UNIT_ASSERT_VALUES_EQUAL(charges[0].Quoter, ru.CoordinationNodePath);

--- a/ydb/services/sqs_topic/billing.h
+++ b/ydb/services/sqs_topic/billing.h
@@ -28,20 +28,13 @@ namespace NKikimr::NSqsTopic::V1::NBilling {
     constexpr double WRITE_COST_PER_BLOCK = 1.0;
     constexpr double READ_COST_PER_BLOCK = 1.0;
 
-    // FIFO ordering and content-based deduplication require extra work on the
-    // server side, so the corresponding requests are charged more.
+    // FIFO ordering requires extra work on the server side, so the
+    // corresponding requests are charged more. Content-based deduplication
+    // does not add an extra RU.
     constexpr double FIFO_COST_ADJUNCT = 1.0;
-    constexpr double DEDUP_COST_ADJUNCT = 1.0;
 
-    inline double CostAdjunct(bool fifo, bool dedup) {
-        double adjunct = 0.0;
-        if (fifo) {
-            adjunct += FIFO_COST_ADJUNCT;
-        }
-        if (dedup) {
-            adjunct += DEDUP_COST_ADJUNCT;
-        }
-        return adjunct;
+    inline double CostAdjunct(bool fifo) {
+        return fifo ? FIFO_COST_ADJUNCT : 0.0;
     }
 
     // Rounds a floating-point RU amount to the whole number of Request Units
@@ -54,10 +47,9 @@ namespace NKikimr::NSqsTopic::V1::NBilling {
     }
 
     // payloadBlocks is the block-based consumption produced by
-    // TRlHelpers::CalcRuConsumption(payloadSize). 
-    inline ui64 CalcRu(ui64 payloadBlocks, double baseCost, double costPerBlock, bool fifo, bool dedup) {
-        const double ru = baseCost
-                + payloadBlocks * costPerBlock + CostAdjunct(fifo, dedup);
+    // TRlHelpers::CalcRuConsumption(payloadSize).
+    inline ui64 CalcRu(ui64 payloadBlocks, double baseCost, double costPerBlock, bool fifo = false) {
+        const double ru = baseCost + payloadBlocks * costPerBlock + CostAdjunct(fifo);
         return RoundRu(ru);
     }
 

--- a/ydb/services/sqs_topic/delete_message.cpp
+++ b/ydb/services/sqs_topic/delete_message.cpp
@@ -253,7 +253,7 @@ namespace NKikimr::NSqsTopic::V1 {
                 if (auto rlContext = this->ExtractRlContext(ev)) {
                     SetRlContext(*rlContext);
                     if (IsQuotaRequired()) {
-                        const ui64 ru = NBilling::CalcRu(0, NBilling::DELETE_BASE_COST, 0, false, false);
+                        const ui64 ru = NBilling::CalcRu(0, NBilling::DELETE_BASE_COST, 0);
                         AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()))
                             ("ru", ru)("path", FullTopicPath_);
                         return;

--- a/ydb/services/sqs_topic/receive_message.cpp
+++ b/ydb/services/sqs_topic/receive_message.cpp
@@ -299,7 +299,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
             if (ShouldBeCharged_ && IsQuotaRequired()) {
                 const ui64 ru = NBilling::CalcRu(
-                    CalcRuConsumption(payloadSize), NBilling::READ_BASE_COST, NBilling::READ_COST_PER_BLOCK, Fifo_, false);
+                    CalcRuConsumption(payloadSize), NBilling::READ_BASE_COST, NBilling::READ_COST_PER_BLOCK, Fifo_);
                 AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx))("ru", ru)("path", FullTopicPath_);
                 return;
             }

--- a/ydb/services/sqs_topic/send_message.cpp
+++ b/ydb/services/sqs_topic/send_message.cpp
@@ -281,7 +281,6 @@ namespace NKikimr::NSqsTopic::V1 {
         }
 
         void ApplyContentBasedDeduplication(bool enabled) {
-            ContentBasedDeduplication_ = enabled;
             if (!Fifo_ || !WriterSettings_) {
                 return;
             }
@@ -325,8 +324,7 @@ namespace NKikimr::NSqsTopic::V1 {
                             CalcRuConsumption(PayloadSize_),
                             NBilling::WRITE_BASE_COST,
                             NBilling::WRITE_COST_PER_BLOCK,
-                            Fifo_,
-                            ContentBasedDeduplication_);
+                            Fifo_);
                         AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()))
                             ("ru", ru)("path", FullTopicPath_);
                         return;
@@ -419,7 +417,6 @@ namespace NKikimr::NSqsTopic::V1 {
         TActorId WriterActor_;
         ui64 PayloadSize_{};
         bool Fifo_{};
-        bool ContentBasedDeduplication_ = false;
         TMaybe<NPQ::NMLP::TWriterSettings> WriterSettings_;
     };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

SQS over topics no longer charges an extra Request Unit for content-based deduplication.

### Description for reviewers <!-- (optional) description for those who read this PR -->

SendMessage on a FIFO queue with content-based deduplication was billed `+1 RU` (`DEDUP_COST_ADJUNCT`) in addition to the FIFO adjunct. That extra charge is removed.

FIFO still adds `+1 RU`. Payload-based write/read/delete costs are unchanged.