### PR TITLE
Split large row-table ANALYZE scans by PK range

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -3423,7 +3423,11 @@ message TStatisticsConfig {
 
     // Column tables smaller than or equal to this size are scanned as a whole table
     // rather than per shard. 0 disables the optimization (always per-shard).
-    optional uint64 AnalyzeWholeTableScanMaxBytes = 9 [default = 10737418240]; // 10 GiB
+    optional uint64 AnalyzeColumnTableWholeTableScanMaxBytes = 9 [default = 10737418240]; // 10 GiB
+
+    // Row tables: whole-table scan if size is known and <= this. Else one PK range
+    // per DataShard, merged down to ceil(tableBytes / this). 0: always split.
+    optional uint64 AnalyzeRowTableWholeTableScanMaxBytes = 14 [default = 10737418240]; // 10 GiB
 
     // Auto-collect PK equi-height histogram on ANALYZE. Declared stats ignore this.
     optional bool AnalyzeCollectPrimaryKeyHistogram = 10 [default = false];

--- a/ydb/core/statistics/aggregator/aggregator_impl.cpp
+++ b/ydb/core/statistics/aggregator/aggregator_impl.cpp
@@ -1207,7 +1207,8 @@ void TStatisticsAggregator::StartAnalyzeActor(const TActorContext& ctx, const TS
     auto analyzeActorConfig = TAnalyzeActor::TConfig{
         .MaxTotalScanActorsInFlight = StatisticsConfig.GetAnalyzeMaxTotalScanActorsInFlight(),
         .MaxPerNodeScanActorsInFlight = StatisticsConfig.GetAnalyzeMaxPerNodeScanActorsInFlight(),
-        .WholeTableScanMaxBytes = StatisticsConfig.GetAnalyzeWholeTableScanMaxBytes(),
+        .ColumnTableWholeTableScanMaxBytes = StatisticsConfig.GetAnalyzeColumnTableWholeTableScanMaxBytes(),
+        .RowTableWholeTableScanMaxBytes = StatisticsConfig.GetAnalyzeRowTableWholeTableScanMaxBytes(),
         .TableBytesSize = GetTableBytesSize(pathId),
         .CollectPrimaryKeyHistogram = StatisticsConfig.GetAnalyzeCollectPrimaryKeyHistogram(),
         .HistogramOversampleFactor = oversampleFactor,

--- a/ydb/core/statistics/aggregator/aggregator_impl.h
+++ b/ydb/core/statistics/aggregator/aggregator_impl.h
@@ -367,7 +367,7 @@ private: // stored in local db
         TPathId PathId;
         TVector<ui32> ColumnTags;
         TString Path;            // full table path, persisted in ForceTraversalTables
-        ui32 ShardsTotal = 0;   // set by TEvAnalyzeActorProgress; 1 for row tables
+        ui32 ShardsTotal = 0;   // set by TEvAnalyzeActorProgress
         ui32 ShardsDone  = 0;   // incremented per scan completion (current batch)
 
         enum class EStatus : ui8 {

--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -1,4 +1,5 @@
 #include "analyze_actor.h"
+#include "key_range_predicate.h"
 
 #include <ydb/library/query_actor/query_actor.h>
 #include <ydb/core/base/request_types.h>
@@ -36,17 +37,23 @@ std::optional<EStatType> ConvertMultiColumnStatType(NKikimrSchemeOp::EMultiColum
 
 class TAnalyzeActor::TScanActor : public TQueryBase {
 public:
-    TScanActor(TActorId parent, TString Database, TString query, size_t columnCount)
+    TScanActor(
+        TActorId parent,
+        TString Database,
+        TString query,
+        size_t columnCount,
+        std::optional<NYdb::TParamsBuilder> params)
         : TQueryBase(NKikimrServices::STATISTICS, {}, std::move(Database))
         , Parent(parent)
         , Query(std::move(query))
         , ColumnCount(columnCount)
+        , Params(std::move(params))
     {
         RequestType = TString(NRequestTypes::Analyze);
     }
 
     void OnRunQuery() override {
-        RunStreamQuery(Query);
+        RunStreamQuery(Query, Params ? &*Params : nullptr);
     }
 
     void OnStreamResult(NYdb::TResultSet&& resultSet) override {
@@ -117,6 +124,7 @@ private:
     TActorId Parent;
     TString Query;
     size_t ColumnCount;
+    std::optional<NYdb::TParamsBuilder> Params;
     bool ResponseSent = false;
 };
 
@@ -279,10 +287,13 @@ void TAnalyzeActor::HandleNavigateResult() {
         tag2Column[col.second.Id] = col.second;
 
         if (col.second.KeyOrder >= 0) {
-            KeyColumnTypes.resize(Max<size_t>(KeyColumnTypes.size(), col.second.KeyOrder + 1));
+            const size_t keySize = static_cast<size_t>(col.second.KeyOrder) + 1;
+            KeyColumnTypes.resize(Max(KeyColumnTypes.size(), keySize));
             KeyColumnTypes[col.second.KeyOrder] = col.second.PType;
+            KeyColumnNames.resize(Max(KeyColumnNames.size(), keySize));
+            KeyColumnNames[col.second.KeyOrder] = col.second.Name;
 
-            keyColumns.resize(Max<size_t>(keyColumns.size(), col.second.KeyOrder + 1));
+            keyColumns.resize(Max(keyColumns.size(), keySize));
             keyColumns[col.second.KeyOrder] = {col.second.Name, col.second.Id};
         }
     }
@@ -436,13 +447,18 @@ void TAnalyzeActor::HandleNavigateResult() {
         return;
     }
 
-    // Per-shard scans for column tables unless size is known and at or below
-    // the whole-table threshold. Unknown size (missing/unparsed base stats)
-    // stays per-shard to avoid a full-table scan of a potentially large table.
-    UsePerShardScans = IsColumnTable
-        && (Config.WholeTableScanMaxBytes == 0
-            || !Config.TableBytesSize
-            || *Config.TableBytesSize > Config.WholeTableScanMaxBytes);
+    // Split large/unknown-size tables: column tables by TabletId, row tables by PK range.
+    const ui64 wholeTableScanMaxBytes = IsColumnTable
+        ? Config.ColumnTableWholeTableScanMaxBytes
+        : Config.RowTableWholeTableScanMaxBytes;
+    const bool shouldSplit = wholeTableScanMaxBytes == 0
+        || !Config.TableBytesSize
+        || *Config.TableBytesSize > wholeTableScanMaxBytes;
+    if (shouldSplit) {
+        ScanMode = IsColumnTable ? EScanMode::PerShard : EScanMode::PerRange;
+    } else {
+        ScanMode = EScanMode::WholeTable;
+    }
     YDB_LOG_DEBUG("Scan strategy",
         {"selfId", SelfId()},
         {"operationId", OperationId.Quote()},
@@ -450,11 +466,29 @@ void TAnalyzeActor::HandleNavigateResult() {
         {"isColumnTable", IsColumnTable},
         {"tableBytesSizeKnown", Config.TableBytesSize.has_value()},
         {"tableBytesSize", Config.TableBytesSize.value_or(0)},
-        {"wholeTableScanMaxBytes", Config.WholeTableScanMaxBytes},
-        {"usePerShardScans", UsePerShardScans});
+        {"wholeTableScanMaxBytes", wholeTableScanMaxBytes},
+        {"scanMode", static_cast<int>(ScanMode)});
 
-    if (UsePerShardScans) {
-        // Resolve table shard ids.
+    if (ScanMode == EScanMode::PerRange) {
+        TStringBuf reason;
+        if (KeyColumnNames.empty() || AnyOf(KeyColumnNames, [](const TString& name) {
+            return name.empty();
+        })) {
+            reason = "key columns are incomplete";
+        } else if (!CanEncodeKeyRangePredicate(KeyColumnTypes)) {
+            reason = "PK type cannot be encoded as a range predicate";
+        }
+        if (reason) {
+            YDB_LOG_WARN("Falling back to whole-table ANALYZE scan",
+                {"reason", reason},
+                {"operationId", OperationId.Quote()},
+                {"pathId", PathId});
+            ScanMode = EScanMode::WholeTable;
+        }
+    }
+
+    if (IsPartitionedScan()) {
+        // Resolve shard ids (and PK range bounds for row tables).
         TVector<TCell> minusInf(KeyColumnTypes.size());
         TVector<TCell> plusInf;
         TTableRange range(minusInf, true, plusInf, true, false);
@@ -466,8 +500,8 @@ void TAnalyzeActor::HandleNavigateResult() {
         resolveRequest->ResultSet.emplace_back(std::move(keyDesc));
         Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvResolveKeySet(resolveRequest.release()));
     } else {
-        StartColumnStatEvalTasks();
         Become(&TThis::StateScan);
+        StartColumnStatEvalTasks();
     }
 }
 
@@ -492,8 +526,60 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& 
         return;
     }
 
-    for (const auto& part : entry.KeyDescription->GetPartitions()) {
-        TabletIdsToLocate.insert(part.ShardId);
+    if (ScanMode == EScanMode::PerRange) {
+        for (const auto& part : entry.KeyDescription->GetPartitions()) {
+            if (!part.Range) {
+                FinishWithFailure(
+                    TEvStatistics::TEvAnalyzeActorResult::EStatus::InternalError,
+                    NYql::TIssue("DataShard partition is missing a key range"));
+                return;
+            }
+        }
+        TString encodeError;
+        for (auto& [shardId, range] : MakeBudgetedSubranges(
+                entry.KeyDescription->GetPartitions(),
+                Config.TableBytesSize,
+                Config.RowTableWholeTableScanMaxBytes))
+        {
+            TString where;
+            TString declares;
+            TString error;
+            NYdb::TParamsBuilder params;
+            if (!TryBuildKeyRangePredicate(
+                    KeyColumnNames, KeyColumnTypes, range, where, declares, params, error))
+            {
+                encodeError = std::move(error);
+                break;
+            }
+            RangeWorkItems.push_back(TScanWorkItem{
+                .TabletId = shardId,
+                .Range = std::move(range),
+            });
+            TabletIdsToLocate.insert(shardId);
+        }
+        if (encodeError) {
+            YDB_LOG_WARN("Falling back to whole-table ANALYZE scan",
+                {"reason", encodeError},
+                {"operationId", OperationId.Quote()},
+                {"pathId", PathId});
+            RangeWorkItems.clear();
+            TabletIdsToLocate.clear();
+            ScanMode = EScanMode::WholeTable;
+            Become(&TThis::StateScan);
+            StartColumnStatEvalTasks();
+            return;
+        }
+    } else {
+        for (const auto& part : entry.KeyDescription->GetPartitions()) {
+            TabletIdsToLocate.insert(part.ShardId);
+        }
+    }
+
+    if (TabletIdsToLocate.empty()) {
+        FinishWithFailure(
+            TEvStatistics::TEvAnalyzeActorResult::EStatus::InternalError,
+            NYql::TIssue("ANALYZE found no table partitions to scan"));
+        return;
     }
 
     Send(SelfId(), new TEvPrivate::TEvRequestTableDistribution);
@@ -531,12 +617,12 @@ void TAnalyzeActor::Handle(TEvHive::TEvResponseTabletDistribution::TPtr& ev) {
     }
 
     // Report initial progress: shards known, none done yet
-    ui32 shardsTotal = UsePerShardScans ? static_cast<ui32>(TabletId2NodeId.size()) : 1;
+    ui32 shardsTotal = IsPartitionedScan() ? PartitionedScanCount() : 1;
     SendProgressEvent(shardsTotal, 0);
 
     Send(MakePipePerNodeCacheID(EPipePerNodeCache::Leader), new TEvPipeCache::TEvUnlink(0));
-    StartColumnStatEvalTasks();
     Become(&TThis::StateScan);
+    StartColumnStatEvalTasks();
 }
 
 void TAnalyzeActor::Handle(TEvPipeCache::TEvDeliveryProblem::TPtr&) {
@@ -563,14 +649,20 @@ void TAnalyzeActor::StartColumnStatEvalTasks() {
     Y_ENSURE(InProgressTasks.empty());
     Y_ENSURE(!PendingTasks.empty());
 
-
-    if (UsePerShardScans) {
+    if (ScanMode == EScanMode::PerShard) {
         for (const auto& [tabletId, nodeId] : TabletId2NodeId) {
-            NodeId2State.try_emplace(nodeId, nodeId).first->second.PendingTablets.push_back(tabletId);
+            NodeId2State.try_emplace(nodeId, nodeId).first->second.PendingScans.push_back(
+                TScanWorkItem{.TabletId = tabletId});
+        }
+    } else if (ScanMode == EScanMode::PerRange) {
+        for (const auto& item : RangeWorkItems) {
+            auto nodeIt = TabletId2NodeId.find(item.TabletId);
+            Y_ENSURE(nodeIt != TabletId2NodeId.end());
+            NodeId2State.try_emplace(nodeIt->second, nodeIt->second).first->second.PendingScans.push_back(item);
         }
     }
 
-    SelectBuilder.emplace(/*isIntermediateAggregation=*/UsePerShardScans);
+    SelectBuilder.emplace(/*isIntermediateAggregation=*/IsPartitionedScan());
     size_t totalSize = 0;
 
     if (!CountSeq && !RowCount) {
@@ -602,25 +694,31 @@ void TAnalyzeActor::StartColumnStatEvalTasks() {
         PendingTasks.pop();
     }
 
-    DispatchSomeScanActors();
+    if (!DispatchSomeScanActors()) {
+        return;
+    }
 }
 
-void TAnalyzeActor::DispatchSomeScanActors() {
-    auto dispatchActor = [&](ui32 nodeId, std::optional<ui64> tabletId) {
+bool TAnalyzeActor::DispatchSomeScanActors() {
+    auto dispatchActor = [&](ui32 nodeId, std::optional<ui64> tabletId, TStringBuf where,
+            TStringBuf declares, std::optional<NYdb::TParamsBuilder> params)
+    {
         auto actor = std::make_unique<TScanActor>(
             SelfId(), DatabaseName,
-            SelectBuilder->Build(TableName, tabletId), SelectBuilder->ColumnCount());
+            SelectBuilder->Build(TableName, tabletId, where, declares),
+            SelectBuilder->ColumnCount(),
+            std::move(params));
         ScanActorsInFlight[Register(actor.release(), TMailboxType::HTSwap, AppData()->BatchPoolId)] = TScanActorInfo{
             .TabletNodeId = nodeId,
         };
     };
 
-    if (!UsePerShardScans) {
+    if (!IsPartitionedScan()) {
         Y_ENSURE(ScanActorsInFlight.empty());
         YDB_LOG_DEBUG("Dispatching scan actor for the whole table",
             {"selfId", SelfId()});
-        dispatchActor(0, std::nullopt);
-        return;
+        dispatchActor(0, std::nullopt, {}, {}, {});
+        return true;
     }
 
     // Run a simple scheduling algorithm, dispatching scans fairly among nodes hosting tablets,
@@ -628,13 +726,13 @@ void TAnalyzeActor::DispatchSomeScanActors() {
     // longer tablet ids queue.
 
     auto isSchedulable = [&](const TNodeState& node) {
-        return !node.PendingTablets.empty()
+        return !node.PendingScans.empty()
             && node.TabletsInFlight < Config.MaxPerNodeScanActorsInFlight;
     };
 
     auto nodeCmp = [](TNodeState* left, TNodeState* right) {
-        return std::tuple(-left->TabletsInFlight, left->PendingTablets.size())
-            < std::tuple(-right->TabletsInFlight, right->PendingTablets.size());
+        return std::tuple(-left->TabletsInFlight, left->PendingScans.size())
+            < std::tuple(-right->TabletsInFlight, right->PendingScans.size());
     };
 
     std::priority_queue<TNodeState*, std::vector<TNodeState*>, decltype(nodeCmp)> schedulableQueue;
@@ -648,21 +746,42 @@ void TAnalyzeActor::DispatchSomeScanActors() {
             && ScanActorsInFlight.size() < Config.MaxTotalScanActorsInFlight) {
         auto* node = schedulableQueue.top();
         schedulableQueue.pop();
-        Y_ENSURE(!node->PendingTablets.empty());
-        ui64 tabletId = node->PendingTablets.back();
+        Y_ENSURE(!node->PendingScans.empty());
+        TScanWorkItem work = std::move(node->PendingScans.back());
+        node->PendingScans.pop_back();
+
+        std::optional<ui64> scanTabletId;
+        TString where;
+        TString declares;
+        std::optional<NYdb::TParamsBuilder> params;
+        if (ScanMode == EScanMode::PerShard) {
+            scanTabletId = work.TabletId;
+        } else {
+            params.emplace();
+            TString error;
+            if (!TryBuildKeyRangePredicate(
+                    KeyColumnNames, KeyColumnTypes, work.Range, where, declares, *params, error))
+            {
+                FinishWithFailure(
+                    TEvStatistics::TEvAnalyzeActorResult::EStatus::InternalError,
+                    NYql::TIssue(error));
+                return false;
+            }
+        }
 
         YDB_LOG_DEBUG("Dispatching scan actor",
             {"selfId", SelfId()},
-            {"tabletId", tabletId},
-            {"nodeId", node->Id});
-        dispatchActor(node->Id, tabletId);
-        node->PendingTablets.pop_back();
+            {"tabletId", work.TabletId},
+            {"nodeId", node->Id},
+            {"scanMode", static_cast<int>(ScanMode)});
+        dispatchActor(node->Id, scanTabletId, where, declares, std::move(params));
         ++node->TabletsInFlight;
 
         if (isSchedulable(*node)) {
             schedulableQueue.push(node);
         }
     }
+    return true;
 }
 
 void TAnalyzeActor::HandleImpl(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
@@ -672,7 +791,7 @@ void TAnalyzeActor::HandleImpl(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
     ScanActorsInFlight.erase(actorIt);
 
     ++ScansCompletedTotal;
-    const ui32 shardsTotal = UsePerShardScans ? static_cast<ui32>(TabletId2NodeId.size()) : 1;
+    const ui32 shardsTotal = IsPartitionedScan() ? PartitionedScanCount() : 1;
     // Cap intermediate progress below 100%: simple-stats and stage-2 rounds share
     // ScansCompletedTotal, so 100% is only emitted from the final-result branch.
     const ui32 shardsDoneCap = shardsTotal > 0 ? shardsTotal - 1 : 0;
@@ -694,11 +813,13 @@ void TAnalyzeActor::HandleImpl(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
         auto nodeIt = NodeId2State.find(tabletNodeId);
         Y_ENSURE(nodeIt != NodeId2State.end());
         --nodeIt->second.TabletsInFlight;
-        if (!nodeIt->second.TabletsInFlight && nodeIt->second.PendingTablets.empty()) {
+        if (!nodeIt->second.TabletsInFlight && nodeIt->second.PendingScans.empty()) {
             NodeId2State.erase(nodeIt);
         }
 
-        DispatchSomeScanActors();
+        if (!DispatchSomeScanActors()) {
+            return;
+        }
     }
 
     if (CountSeq) {

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -23,7 +23,8 @@ public:
     struct TConfig {
         ui64 MaxTotalScanActorsInFlight = 100;
         i64 MaxPerNodeScanActorsInFlight = 1;
-        ui64 WholeTableScanMaxBytes = 10ULL << 30; // 10 GiB
+        ui64 ColumnTableWholeTableScanMaxBytes = 10ULL << 30; // 10 GiB
+        ui64 RowTableWholeTableScanMaxBytes = 10ULL << 30; // 10 GiB
         std::optional<ui64> TableBytesSize;
         bool CollectPrimaryKeyHistogram = false;
         ui32 HistogramOversampleFactor = 8;
@@ -103,10 +104,22 @@ private:
 
     TString TableName;
     bool IsColumnTable = false;
-    bool UsePerShardScans = false;
+
+    enum class EScanMode : ui8 {
+        WholeTable,
+        PerShard,
+        PerRange,
+    };
+    EScanMode ScanMode = EScanMode::WholeTable;
+
+    bool IsPartitionedScan() const {
+        return ScanMode != EScanMode::WholeTable;
+    }
+
     TVector<TColumnDesc> Columns;
     TVector<TMultiColumnStatDesc> MultiColumnStatDescs;
     TVector<NScheme::TTypeInfo> KeyColumnTypes;
+    TVector<TString> KeyColumnNames;
     ui64 HiveId = 0;
 
     ui32 ScansCompletedTotal = 0;
@@ -129,6 +142,18 @@ private:
 
     THashSet<ui64> TabletIdsToLocate;
     THashMap<ui64, ui32> TabletId2NodeId;
+
+    struct TScanWorkItem {
+        ui64 TabletId = 0;
+        TSerializedTableRange Range;
+    };
+    TVector<TScanWorkItem> RangeWorkItems;
+
+    ui32 PartitionedScanCount() const {
+        return ScanMode == EScanMode::PerRange
+            ? static_cast<ui32>(RangeWorkItems.size())
+            : static_cast<ui32>(TabletId2NodeId.size());
+    }
 
     size_t HiveRetryCount = 0;
     static constexpr size_t MaxHiveRetryCount = 3;
@@ -176,7 +201,7 @@ private:
     struct TNodeState {
         ui32 Id = 0;
         i64 TabletsInFlight = 0;
-        TVector<ui64> PendingTablets;
+        TVector<TScanWorkItem> PendingScans;
 
         explicit TNodeState(ui32 id) : Id(id) {}
     };
@@ -192,7 +217,7 @@ private:
     class TScanActor;
 
     void StartColumnStatEvalTasks();
-    void DispatchSomeScanActors();
+    bool DispatchSomeScanActors();
 
     void HandleImpl(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev);
     void Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev);

--- a/ydb/core/statistics/aggregator/column_statistic_eval.cpp
+++ b/ydb/core/statistics/aggregator/column_statistic_eval.cpp
@@ -557,16 +557,16 @@ bool IStage2ColumnStatisticEval::AreMinMaxNeeded(const NScheme::TTypeInfo& typeI
 
 // Eq-height histogram collection has three integration paths:
 //
-// 1. DataShard PK (sorted input): keys arrive in PK order → AddSorted fast path
-//    → RankUncertainty == 0 (exact). Finalize runs in the YQL query; no actor-side merge.
+// 1. Whole-table DataShard PK (sorted input): keys arrive in PK order → AddSorted
+//    fast path → RankUncertainty == 0 (exact). Finalize in YQL; no actor-side merge.
 //
 // 2. DataShard non-PK (unsorted input): keys arrive in PK order but the histogram
 //    is over non-PK columns → staging buffer → InterleaveInto → RankUncertainty > 0
 //    (bounded approximate). Finalize runs in the YQL query; no actor-side merge.
 //
-// 3. ColumnShard (per-shard): each shard runs Serialize in the YQL query,
-//    returning an intermediate state. The actor merges them here via
-//    IntermediateState->Merge(), then calls Finalize() to produce the final blob.
+// 3. Partitioned scans (ColumnShard per-shard or DataShard per-PK-range): each part
+//    runs Serialize in YQL; the actor merges via IntermediateState->Merge() then
+//    Finalize(). Disjoint PK ranges stay exact (RankUncertainty == 0).
 //    IntermediateState is created only for this path (IsIntermediateAggregation).
 class TMultiColumnEqHeightHistogramEval : public IMultiColumnStatisticEval {
     std::vector<TString> ColumnNames;

--- a/ydb/core/statistics/aggregator/key_range_predicate.cpp
+++ b/ydb/core/statistics/aggregator/key_range_predicate.cpp
@@ -1,0 +1,376 @@
+#include "key_range_predicate.h"
+
+#include <ydb/core/scheme/scheme_type_info.h>
+#include <ydb/core/ydb_convert/ydb_convert.h>
+#include <ydb/public/api/protos/ydb_value.pb.h>
+#include <ydb/public/lib/scheme_types/scheme_type_id.h>
+#include <yql/essentials/types/dynumber/dynumber.h>
+
+#include <util/string/builder.h>
+#include <util/string/escape.h>
+#include <util/string/join.h>
+#include <util/string/subst.h>
+#include <util/generic/algorithm.h>
+#include <util/generic/utility.h>
+#include <util/generic/yexception.h>
+
+#include <string>
+
+namespace NKikimr::NStat {
+
+bool CanEncodeKeyBoundType(NScheme::TTypeId typeId) {
+    switch (typeId) {
+    case NScheme::NTypeIds::Bool:
+    case NScheme::NTypeIds::Int8:
+    case NScheme::NTypeIds::Uint8:
+    case NScheme::NTypeIds::Int16:
+    case NScheme::NTypeIds::Uint16:
+    case NScheme::NTypeIds::Int32:
+    case NScheme::NTypeIds::Uint32:
+    case NScheme::NTypeIds::Int64:
+    case NScheme::NTypeIds::Uint64:
+    case NScheme::NTypeIds::Date:
+    case NScheme::NTypeIds::Datetime:
+    case NScheme::NTypeIds::Timestamp:
+    case NScheme::NTypeIds::Interval:
+    case NScheme::NTypeIds::Date32:
+    case NScheme::NTypeIds::Datetime64:
+    case NScheme::NTypeIds::Timestamp64:
+    case NScheme::NTypeIds::Interval64:
+    case NScheme::NTypeIds::String:
+    case NScheme::NTypeIds::Utf8:
+    case NScheme::NTypeIds::Uuid:
+    case NScheme::NTypeIds::DyNumber:
+    case NScheme::NTypeIds::Decimal:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool CanEncodeKeyRangePredicate(TConstArrayRef<NScheme::TTypeInfo> keyColumnTypes) {
+    return !keyColumnTypes.empty() && AllOf(keyColumnTypes, [](const NScheme::TTypeInfo& type) {
+        return CanEncodeKeyBoundType(type.GetTypeId());
+    });
+}
+
+namespace {
+
+TString EscapeYqlId(TStringBuf identifier) {
+    auto escaped = EscapeC(identifier);
+    SubstGlobal(escaped, "`", "\\`");
+    return TStringBuilder() << '`' << escaped << '`';
+}
+
+void AddDecimalParam(
+    NYdb::TParamsBuilder& params,
+    const std::string& paramName,
+    const NScheme::TTypeInfo& typeInfo,
+    const TCell& cell)
+{
+    NYdb::TDecimalType decimalType{
+        static_cast<ui8>(typeInfo.GetDecimalType().GetPrecision()),
+        static_cast<ui8>(typeInfo.GetDecimalType().GetScale())
+    };
+    const auto loHi = cell.AsValue<std::pair<ui64, i64>>();
+    Ydb::Value valueProto;
+    valueProto.set_low_128(loHi.first);
+    valueProto.set_high_128(loHi.second);
+    NYdb::TValueBuilder vb;
+    vb.Decimal({valueProto, decimalType});
+    params.AddParam(paramName, vb.Build());
+}
+
+bool AddCellParam(
+    NYdb::TParamsBuilder& params,
+    TString& declares,
+    const TString& paramName,
+    const NScheme::TTypeInfo& typeInfo,
+    const TCell& cell,
+    TString& error)
+{
+    Y_ENSURE(!cell.IsNull());
+    if (!CanEncodeKeyBoundType(typeInfo.GetTypeId())) {
+        error = TStringBuilder() << "unsupported key column type "
+            << NScheme::TypeName(typeInfo) << " in a PK range predicate";
+        return false;
+    }
+
+    const std::string sdkParamName(paramName.data(), paramName.size());
+    if (typeInfo.GetTypeId() == NScheme::NTypeIds::Decimal) {
+        AddDecimalParam(params, sdkParamName, typeInfo, cell);
+    } else if (typeInfo.GetTypeId() == NScheme::NTypeIds::DyNumber) {
+        // YQL DyNumber parameters are text; cell bytes are the binary form.
+        auto text = NDyNumber::DyNumberToString(cell.AsBuf());
+        if (!text) {
+            error = "invalid DyNumber key bound";
+            return false;
+        }
+        NYdb::TValueBuilder vb;
+        vb.DyNumber(std::string(text->data(), text->size()));
+        params.AddParam(sdkParamName, vb.Build());
+    } else {
+        NYdb::TValueBuilder vb;
+        ProtoValueFromCell(vb, typeInfo, cell);
+        params.AddParam(sdkParamName, vb.Build());
+    }
+
+    declares += TStringBuilder()
+        << "DECLARE " << paramName << " AS " << NScheme::TypeName(typeInfo) << ";\n";
+    return true;
+}
+
+TString JoinAnd(const TVector<TString>& parts) {
+    if (parts.empty()) {
+        return "TRUE";
+    }
+    if (parts.size() == 1) {
+        return parts[0];
+    }
+    return TStringBuilder() << '(' << JoinSeq(" AND ", parts) << ')';
+}
+
+TString JoinOr(const TVector<TString>& parts) {
+    if (parts.empty()) {
+        return "FALSE";
+    }
+    if (parts.size() == 1) {
+        return parts[0];
+    }
+    return TStringBuilder() << '(' << JoinSeq(" OR ", parts) << ')';
+}
+
+// DataShard: NULL == NULL and NULL < non-NULL. Empty rhs[i] is a NULL bound cell.
+TString BuildLexicographicBoundExpr(
+    TConstArrayRef<TString> columns,
+    TConstArrayRef<TString> rhs,
+    TStringBuf op)
+{
+    const bool wantLess = op == "<" || op == "<=";
+    const bool inclusive = op == "<=" || op == ">=";
+
+    TVector<TString> terms;
+    TVector<TString> prefixEq;
+    terms.reserve(columns.size() + 1);
+    prefixEq.reserve(columns.size());
+
+    for (size_t i = 0; i < columns.size(); ++i) {
+        const bool last = (i + 1 == columns.size());
+        TString cmp;
+        if (wantLess) {
+            if (!rhs[i].empty()) {
+                const TStringBuf cmpOp = (inclusive && last) ? "<=" : "<";
+                cmp = TStringBuilder() << '(' << columns[i] << " IS NULL OR "
+                    << columns[i] << " " << cmpOp << " " << rhs[i] << ')';
+            }
+        } else if (rhs[i].empty()) {
+            cmp = TStringBuilder() << columns[i] << " IS NOT NULL";
+        } else {
+            const TStringBuf cmpOp = (inclusive && last) ? ">=" : ">";
+            cmp = TStringBuilder() << columns[i] << " " << cmpOp << " " << rhs[i];
+        }
+
+        if (cmp) {
+            TVector<TString> term = prefixEq;
+            term.push_back(std::move(cmp));
+            terms.push_back(JoinAnd(term));
+        }
+
+        if (rhs[i].empty()) {
+            prefixEq.push_back(TStringBuilder() << columns[i] << " IS NULL");
+        } else {
+            prefixEq.push_back(TStringBuilder() << columns[i] << " = " << rhs[i]);
+        }
+    }
+
+    // Inclusive equality is folded into <= / >= on the last non-NULL component.
+    if (inclusive && !rhs.empty() && rhs.back().empty()) {
+        terms.push_back(JoinAnd(prefixEq));
+    }
+    return JoinOr(terms);
+}
+
+// Trailing NULLs pad DataShard split keys to full PK width.
+// k < (P, NULL, ...) <=> k < P; k >= (P, NULL, ...) <=> k >= P.
+TConstArrayRef<TCell> StripEquivalentTrailingNulls(TConstArrayRef<TCell> cells, TStringBuf op) {
+    if (op != ">=" && op != "<") {
+        return cells;
+    }
+    while (!cells.empty() && cells.back().IsNull()) {
+        cells = cells.first(cells.size() - 1);
+    }
+    return cells;
+}
+
+bool BuildBoundExpr(
+    TStringBuf paramPrefix,
+    TConstArrayRef<TString> keyColumnNames,
+    TConstArrayRef<NScheme::TTypeInfo> keyColumnTypes,
+    TConstArrayRef<TCell> cells,
+    TStringBuf op,
+    NYdb::TParamsBuilder& params,
+    TString& declares,
+    TString& expr,
+    TString& error)
+{
+    if (cells.empty()) {
+        expr.clear();
+        return true;
+    }
+    if (cells.size() > keyColumnNames.size()) {
+        error = TStringBuilder() << "key bound has " << cells.size()
+            << " components, table PK has " << keyColumnNames.size();
+        return false;
+    }
+
+    const TConstArrayRef<TCell> bound = StripEquivalentTrailingNulls(cells, op);
+    if (bound.empty()) {
+        // >= min key is unbounded below; < min key matches nothing.
+        expr = (op == "<") ? TString("FALSE") : TString();
+        return true;
+    }
+
+    TVector<TString> columns;
+    TVector<TString> rhs;
+    columns.reserve(bound.size());
+    rhs.reserve(bound.size());
+    bool anyNull = false;
+    for (size_t i = 0; i < bound.size(); ++i) {
+        if (keyColumnNames[i].empty()) {
+            error = TStringBuilder() << "missing name for key column at position " << i;
+            return false;
+        }
+        columns.push_back(EscapeYqlId(keyColumnNames[i]));
+        if (bound[i].IsNull()) {
+            anyNull = true;
+            rhs.emplace_back();
+            continue;
+        }
+        const TString paramName = TStringBuilder() << "$" << paramPrefix << "_" << i;
+        if (!AddCellParam(params, declares, paramName, keyColumnTypes[i], bound[i], error)) {
+            return false;
+        }
+        rhs.push_back(paramName);
+    }
+
+    if (anyNull || op == "<" || op == "<=") {
+        expr = BuildLexicographicBoundExpr(columns, rhs, op);
+    } else if (bound.size() == 1) {
+        expr = TStringBuilder() << columns[0] << " " << op << " " << rhs[0];
+    } else {
+        expr = TStringBuilder()
+            << "AsTuple(" << JoinSeq(",", columns) << ") "
+            << op
+            << " AsTuple(" << JoinSeq(",", rhs) << ")";
+    }
+    return true;
+}
+
+} // anonymous namespace
+
+TVector<std::pair<ui64, TSerializedTableRange>> MakeShardSubranges(
+    const TVector<TKeyDesc::TPartitionInfo>& partitions)
+{
+    TVector<std::pair<ui64, TSerializedTableRange>> result;
+    result.reserve(partitions.size());
+
+    TSerializedCellVec prevEnd;
+    bool prevInclusive = false;
+    for (const auto& part : partitions) {
+        TSerializedTableRange range;
+        if (!result.empty()) {
+            range.From = prevEnd;
+            range.FromInclusive = !prevInclusive;
+        }
+        if (part.Range && part.Range->EndKeyPrefix) {
+            range.To = part.Range->EndKeyPrefix;
+            range.ToInclusive = part.Range->IsInclusive || part.Range->IsPoint;
+            prevEnd = part.Range->EndKeyPrefix;
+            prevInclusive = range.ToInclusive;
+        }
+        result.emplace_back(part.ShardId, std::move(range));
+    }
+    return result;
+}
+
+TVector<std::pair<ui64, TSerializedTableRange>> MakeBudgetedSubranges(
+    const TVector<TKeyDesc::TPartitionInfo>& partitions,
+    std::optional<ui64> tableBytesSize,
+    ui64 rangeBudgetBytes)
+{
+    auto shardRanges = MakeShardSubranges(partitions);
+    if (shardRanges.empty() || rangeBudgetBytes == 0 || !tableBytesSize || *tableBytesSize == 0) {
+        return shardRanges;
+    }
+
+    ui64 target = (*tableBytesSize - 1) / rangeBudgetBytes + 1;
+    target = Min<ui64>(target, MaxAnalyzeRowTableSubranges);
+    const ui64 shardCount = shardRanges.size();
+    if (target >= shardCount) {
+        return shardRanges;
+    }
+
+    TVector<std::pair<ui64, TSerializedTableRange>> result;
+    result.reserve(target);
+    ui64 offset = 0;
+    for (ui64 g = 0; g < target; ++g) {
+        const ui64 count = shardCount / target + (g < shardCount % target ? 1 : 0);
+        TSerializedTableRange merged;
+        merged.From = shardRanges[offset].second.From;
+        merged.FromInclusive = shardRanges[offset].second.FromInclusive;
+        const ui64 last = offset + count - 1;
+        merged.To = shardRanges[last].second.To;
+        merged.ToInclusive = shardRanges[last].second.ToInclusive;
+        result.emplace_back(shardRanges[offset].first, std::move(merged));
+        offset += count;
+    }
+    return result;
+}
+
+bool TryBuildKeyRangePredicate(
+    TConstArrayRef<TString> keyColumnNames,
+    TConstArrayRef<NScheme::TTypeInfo> keyColumnTypes,
+    const TSerializedTableRange& range,
+    TString& where,
+    TString& declares,
+    NYdb::TParamsBuilder& params,
+    TString& error)
+{
+    where.clear();
+    declares.clear();
+    error.clear();
+
+    if (keyColumnNames.size() != keyColumnTypes.size()) {
+        error = TStringBuilder() << "key column names/types size mismatch: "
+            << keyColumnNames.size() << " vs " << keyColumnTypes.size();
+        return false;
+    }
+    if (keyColumnNames.empty()) {
+        error = "table has no primary key columns";
+        return false;
+    }
+
+    TString fromExpr;
+    TString toExpr;
+    const TStringBuf fromOp = range.FromInclusive ? ">=" : ">";
+    const TStringBuf toOp = range.ToInclusive ? "<=" : "<";
+    if (!BuildBoundExpr("from", keyColumnNames, keyColumnTypes, range.From.GetCells(),
+            fromOp, params, declares, fromExpr, error)) {
+        return false;
+    }
+    if (!BuildBoundExpr("to", keyColumnNames, keyColumnTypes, range.To.GetCells(),
+            toOp, params, declares, toExpr, error)) {
+        return false;
+    }
+
+    if (fromExpr && toExpr) {
+        where = TStringBuilder() << fromExpr << " AND " << toExpr;
+    } else if (fromExpr) {
+        where = std::move(fromExpr);
+    } else if (toExpr) {
+        where = std::move(toExpr);
+    }
+    return true;
+}
+
+} // namespace NKikimr::NStat

--- a/ydb/core/statistics/aggregator/key_range_predicate.h
+++ b/ydb/core/statistics/aggregator/key_range_predicate.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <ydb/core/scheme/scheme_tabledefs.h>
+#include <ydb/core/scheme_types/scheme_type_info.h>
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/params/params.h>
+
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/generic/array_ref.h>
+#include <optional>
+#include <utility>
+
+namespace NKikimr::NStat {
+
+constexpr ui32 MaxAnalyzeRowTableSubranges = 4096;
+
+// DataShard EndKeyPrefix → disjoint PK ranges.
+TVector<std::pair<ui64, TSerializedTableRange>> MakeShardSubranges(
+    const TVector<TKeyDesc::TPartitionInfo>& partitions);
+
+// Merge consecutive shard ranges down to ceil(tableBytes / budget) when known.
+// Never splits a shard. Budget 0 or unknown size: one range per shard.
+TVector<std::pair<ui64, TSerializedTableRange>> MakeBudgetedSubranges(
+    const TVector<TKeyDesc::TPartitionInfo>& partitions,
+    std::optional<ui64> tableBytesSize,
+    ui64 rangeBudgetBytes);
+
+// Types that can be encoded as YQL range-predicate parameters.
+bool CanEncodeKeyBoundType(NScheme::TTypeId typeId);
+bool CanEncodeKeyRangePredicate(TConstArrayRef<NScheme::TTypeInfo> keyColumnTypes);
+
+// YQL WHERE + DECLARE + params. Empty From/To (-inf/+inf) are omitted.
+// Comparisons use DataShard NULL-as-min order, including NULL cells in bounds.
+bool TryBuildKeyRangePredicate(
+    TConstArrayRef<TString> keyColumnNames,
+    TConstArrayRef<NScheme::TTypeInfo> keyColumnTypes,
+    const TSerializedTableRange& range,
+    TString& where,
+    TString& declares,
+    NYdb::TParamsBuilder& params,
+    TString& error);
+
+} // namespace NKikimr::NStat

--- a/ydb/core/statistics/aggregator/select_builder.cpp
+++ b/ydb/core/statistics/aggregator/select_builder.cpp
@@ -41,8 +41,15 @@ ui32 TSelectBuilder::AddFactory(const TStringBuf& udafName, size_t paramCount) {
     return it->second.Id;
 }
 
-TString TSelectBuilder::Build(const TStringBuf& table, std::optional<ui64> tabletId) const {
+TString TSelectBuilder::Build(
+    const TStringBuf& table,
+    std::optional<ui64> tabletId,
+    const TStringBuf& where,
+    const TStringBuf& declares) const {
     TStringBuilder res;
+    if (declares) {
+        res << declares;
+    }
     for (const auto& [udaf, factory] : Udaf2Factory) {
         TStringBuilder paramsStr;
         for (size_t i = 0; i < factory.ParamCount; ++i) {
@@ -112,6 +119,9 @@ TString TSelectBuilder::Build(const TStringBuf& table, std::optional<ui64> table
     res << " FROM " << TEscapedId{table};
     if (tabletId) {
         res << " WITH TabletId = '" << *tabletId << "'";
+    }
+    if (where) {
+        res << " WHERE " << where;
     }
     return res;
 }

--- a/ydb/core/statistics/aggregator/select_builder.h
+++ b/ydb/core/statistics/aggregator/select_builder.h
@@ -53,7 +53,11 @@ public:
     ui32 AddUDAFAggregationTuple(std::vector<TString> columnNames, ETupleEncoding encoding,
                                  const TStringBuf& udafName, TArgs&&... params);
 
-    TString Build(const TStringBuf& table, std::optional<ui64> tabletId) const;
+    TString Build(
+        const TStringBuf& table,
+        std::optional<ui64> tabletId = {},
+        const TStringBuf& where = {},
+        const TStringBuf& declares = {}) const;
 
     size_t ColumnCount() const {
         return Columns.size();

--- a/ydb/core/statistics/aggregator/ut/ut_analyze.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_analyze.cpp
@@ -18,6 +18,25 @@
 namespace NKikimr {
 namespace NStat {
 
+namespace {
+
+void CheckTableSummaryRowCount(TTestActorRuntime& runtime, const TPathId& pathId, ui64 expected) {
+    auto responses = GetStatistics(runtime, pathId, EStatType::TABLE_SUMMARY, {std::nullopt});
+    UNIT_ASSERT_VALUES_EQUAL(responses.size(), 1);
+    UNIT_ASSERT_C(responses[0].Success, "TABLE_SUMMARY was not saved");
+    UNIT_ASSERT(responses[0].TableSummary.Data);
+    UNIT_ASSERT_VALUES_EQUAL(responses[0].TableSummary.Data->GetRowCount(), expected);
+}
+
+TTableInfo ResolveRowTable(TTestActorRuntime& runtime, const TString& path) {
+    TTableInfo tableInfo;
+    tableInfo.Path = path;
+    tableInfo.PathId = ResolvePathId(runtime, path, &tableInfo.DomainKey, &tableInfo.SaTabletId);
+    return tableInfo;
+}
+
+} // namespace
+
 Y_UNIT_TEST_SUITE(AnalyzeStatistics) {
 
     Y_UNIT_TEST_TWIN(Analyze, ColumnShard) {
@@ -44,7 +63,13 @@ Y_UNIT_TEST_SUITE(AnalyzeStatistics) {
 
     Y_UNIT_TEST_TWIN(AnalyzeEqHeightHistogram, ColumnShard) {
         TTestEnv env(1, 1, false, [](Tests::TServerSettings& settings) {
-            settings.AppConfig->MutableStatisticsConfig()->SetAnalyzeCollectPrimaryKeyHistogram(true);
+            auto* cfg = settings.AppConfig->MutableStatisticsConfig();
+            cfg->SetAnalyzeCollectPrimaryKeyHistogram(true);
+            if constexpr (ColumnShard) {
+                cfg->SetAnalyzeColumnTableWholeTableScanMaxBytes(0);
+            } else {
+                cfg->SetAnalyzeRowTableWholeTableScanMaxBytes(0);
+            }
         });
         auto& runtime = *env.GetServer().GetRuntime();
         CreateDatabase(env, "Database");
@@ -870,6 +895,58 @@ Y_UNIT_TEST_SUITE(AnalyzeStatistics) {
         UNIT_ASSERT_VALUES_EQUAL(response->Get()->Record.GetStatus(), NKikimrStat::TEvAnalyzeResponse::STATUS_SUCCESS);
 
         ValidateStatistics(runtime, tableInfo.PathId);
+    }
+
+    Y_UNIT_TEST(AnalyzeRangeScanCountsNullKeys) {
+        TTestEnv env(1, 1, false, [](Tests::TServerSettings& settings) {
+            settings.AppConfig->MutableStatisticsConfig()->SetAnalyzeRowTableWholeTableScanMaxBytes(0);
+        });
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        ExecuteYqlScript(env, R"(
+            CREATE TABLE `Root/Database/Table` (
+                Key Uint64,
+                Value String,
+                PRIMARY KEY (Key)
+            )
+            WITH (PARTITION_AT_KEYS = (10));
+        )");
+        ExecuteYqlScript(env, R"(
+            UPSERT INTO `Root/Database/Table` (Key, Value) VALUES
+                (NULL, "null"),
+                (1, "one"),
+                (11, "eleven");
+        )");
+
+        const auto tableInfo = ResolveRowTable(runtime, "/Root/Database/Table");
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
+        CheckTableSummaryRowCount(runtime, tableInfo.PathId, 3);
+    }
+
+    Y_UNIT_TEST(AnalyzePgKeyFallsBackToWholeTableScan) {
+        TTestEnv env(1, 1, false, [](Tests::TServerSettings& settings) {
+            settings.SetEnableTablePgTypes(true);
+            settings.AppConfig->MutableFeatureFlags()->SetEnableTablePgTypes(true);
+            settings.AppConfig->MutableStatisticsConfig()->SetAnalyzeRowTableWholeTableScanMaxBytes(0);
+        });
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        ExecuteYqlScript(env, R"(
+            CREATE TABLE `Root/Database/Table` (
+                Key pgint8,
+                Value String,
+                PRIMARY KEY (Key)
+            );
+        )");
+        ExecuteYqlScript(env, R"(
+            UPSERT INTO `Root/Database/Table` (Key, Value) VALUES
+                (1pb, "one"),
+                (2pb, "two");
+        )");
+
+        const auto tableInfo = ResolveRowTable(runtime, "/Root/Database/Table");
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
+        CheckTableSummaryRowCount(runtime, tableInfo.PathId, 2);
     }
 }
 

--- a/ydb/core/statistics/aggregator/ut/ut_analyze_op.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_analyze_op.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/core/statistics/events.h>
 #include <ydb/core/statistics/service/service.h>
+#include <ydb/core/protos/config.pb.h>
 
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/core/grpc_services/local_rpc/local_rpc.h>
@@ -20,6 +21,33 @@ void Out<Ydb::Table::AnalyzeState_State>(IOutputStream& o, Ydb::Table::AnalyzeSt
 
 namespace NKikimr {
 namespace NStat {
+
+namespace {
+
+void SetMatchingWholeTableScanMaxBytes(NKikimrConfig::TStatisticsConfig* cfg, bool columnShard, ui64 value) {
+    if (columnShard) {
+        cfg->SetAnalyzeColumnTableWholeTableScanMaxBytes(value);
+    } else {
+        cfg->SetAnalyzeRowTableWholeTableScanMaxBytes(value);
+    }
+}
+
+void SetOtherWholeTableScanMaxBytes(NKikimrConfig::TStatisticsConfig* cfg, bool columnShard, ui64 value) {
+    if (columnShard) {
+        cfg->SetAnalyzeRowTableWholeTableScanMaxBytes(value);
+    } else {
+        cfg->SetAnalyzeColumnTableWholeTableScanMaxBytes(value);
+    }
+}
+
+TTableInfo PrepareFourShardTable(TTestEnv& env, bool columnShard) {
+    if (columnShard) {
+        return PrepareColumnTable(env, "Database", "Table", /*shardCount=*/4);
+    }
+    return PrepareUniformTableWithData(env, "Database", "Table");
+}
+
+} // anonymous namespace
 
 Y_UNIT_TEST_SUITE(AnalyzeOpList) {
 
@@ -229,30 +257,15 @@ Y_UNIT_TEST_SUITE(AnalyzeOpList) {
     }
 
     Y_UNIT_TEST_TWIN(ProgressIntermediate, ColumnShard) {
-        // The AnalyzeActor reports progress to the Statistics Aggregator as each
-        // shard's scan completes. Verify that intermediate progress is reflected
-        // by GetAnalyzeOperation while the analyze is still in flight.
-        // Threshold 0 disables whole-table scans so the column-table branch
-        // still dispatches one scan per shard.
+        // Threshold 0: per-shard (column) or per-range (row) scans so progress is visible.
         TTestEnv env(1, 1, /*useRealThreads=*/false,
             [](Tests::TServerSettings& settings) {
-                settings.AppConfig->MutableStatisticsConfig()
-                    ->SetAnalyzeWholeTableScanMaxBytes(0);
+                SetMatchingWholeTableScanMaxBytes(
+                    settings.AppConfig->MutableStatisticsConfig(), ColumnShard, 0);
             });
         auto& runtime = *env.GetServer().GetRuntime();
         CreateDatabase(env, "Database");
-
-        // ColumnTable dispatches one scan actor per shard, so shardsTotal equals
-        // the shard count and intermediate progress is observable. DataShard
-        // dispatches a single scan actor for the whole table (shardsTotal = 1),
-        // so only 0% is observable before completion.
-        TTableInfo tableInfo;
-        if constexpr (ColumnShard) {
-            constexpr int kShardCount = 4;
-            tableInfo = PrepareColumnTable(env, "Database", "Table", kShardCount);
-        } else {
-            tableInfo = PrepareTable(env, "Database", "Table", ColumnShard);
-        }
+        const auto tableInfo = PrepareFourShardTable(env, ColumnShard);
 
         const ui64 saTabletId = tableInfo.SaTabletId;
         const TPathId pathId = tableInfo.PathId;
@@ -264,9 +277,9 @@ Y_UNIT_TEST_SUITE(AnalyzeOpList) {
 
         // Block progress events at or above the cap (shardsTotal - 1) so the SA
         // stores the last unblocked ShardsDone value while the analyze is mid-flight.
-        const ui32 blockThreshold = ColumnShard ? 3 : 1;
+        constexpr ui32 blockThreshold = 3;
         TBlockEvents<TEvStatistics::TEvAnalyzeActorProgress> blockHigh(runtime,
-            [blockThreshold](auto& ev) {
+            [](auto& ev) {
                 return ev->Get()->ShardsDone >= blockThreshold;
             });
 
@@ -288,27 +301,24 @@ Y_UNIT_TEST_SUITE(AnalyzeOpList) {
         UNIT_ASSERT_VALUES_EQUAL_C(op.GetState(),
             Ydb::Table::AnalyzeState::STATE_IN_PROGRESS,
             "Expected STATE_IN_PROGRESS while analyze is mid-flight");
-        if constexpr (ColumnShard) {
-            // 4 shards, 2 done → 50%.
-            UNIT_ASSERT_DOUBLES_EQUAL(op.GetProgress(), 50.0f, 0.01f);
-        } else {
-            // 1 shard, 0 done → 0%.
-            UNIT_ASSERT_DOUBLES_EQUAL(op.GetProgress(), 0.0f, 0.01f);
-        }
+        // 4 shards/subranges, 2 done → 50%.
+        UNIT_ASSERT_DOUBLES_EQUAL(op.GetProgress(), 50.0f, 0.01f);
         // The active table appears in InProgressPaths while traversal is running.
         UNIT_ASSERT_VALUES_EQUAL(op.InProgressPathsSize(), 1);
         UNIT_ASSERT_VALUES_EQUAL(op.GetInProgressPaths(0), tableInfo.Path);
         UNIT_ASSERT_VALUES_EQUAL(op.DonePathsSize(), 0);
     }
 
-    Y_UNIT_TEST(SmallColumnTableWholeTableScan) {
-        // Small column tables (default 10 GiB threshold) skip Hive locate
-        // and scan the whole table in one query. Wait for base statistics so
-        // table size is known; unknown size would fall back to per-shard scans.
-        TTestEnv env(1, 1);
+    Y_UNIT_TEST_TWIN(SmallTableWholeTableScan, ColumnShard) {
+        // Default 10 GiB threshold: one whole-table scan, no Hive. Other type's knob is 0.
+        TTestEnv env(1, 1, /*useRealThreads=*/false,
+            [](Tests::TServerSettings& settings) {
+                SetOtherWholeTableScanMaxBytes(
+                    settings.AppConfig->MutableStatisticsConfig(), ColumnShard, 0);
+            });
         auto& runtime = *env.GetServer().GetRuntime();
         CreateDatabase(env, "Database");
-        const auto tableInfo = PrepareColumnTable(env, "Database", "Table", /*shardCount=*/4);
+        const auto tableInfo = PrepareFourShardTable(env, ColumnShard);
         WaitForSchemeShardStatsUpdate(runtime, tableInfo.PathId.OwnerId, /*requireFull=*/true);
 
         ui32 hiveDistributionRequests = 0;
@@ -321,10 +331,8 @@ Y_UNIT_TEST_SUITE(AnalyzeOpList) {
         ValidateStatistics(runtime, tableInfo.PathId);
     }
 
-    Y_UNIT_TEST(ColumnTablePerShardScanWhenSizeUnknown) {
-        // When the table is known but BytesSize is absent, TableBytesSize is
-        // unset and a column table must use per-shard scans rather than
-        // treating a missing size as 0 (small).
+    Y_UNIT_TEST_TWIN(PerShardOrRangeScanWhenSizeUnknown, ColumnShard) {
+        // Missing BytesSize must not be treated as 0 (small); use partitioned scans.
         TTestEnv env(1, 1);
         auto& runtime = *env.GetServer().GetRuntime();
         CreateDatabase(env, "Database");
@@ -345,7 +353,7 @@ Y_UNIT_TEST_SUITE(AnalyzeOpList) {
                 statsSeen = true;
             });
 
-        const auto tableInfo = PrepareColumnTable(env, "Database", "Table", /*shardCount=*/4);
+        const auto tableInfo = PrepareFourShardTable(env, ColumnShard);
         runtime.WaitFor("SchemeShard stats without BytesSize", [&]{ return statsSeen; });
 
         ui32 hiveDistributionRequests = 0;
@@ -358,15 +366,15 @@ Y_UNIT_TEST_SUITE(AnalyzeOpList) {
         ValidateStatistics(runtime, tableInfo.PathId);
     }
 
-    Y_UNIT_TEST(ColumnTablePerShardScanWhenThresholdDisabled) {
+    Y_UNIT_TEST_TWIN(PerShardOrRangeScanWhenThresholdDisabled, ColumnShard) {
         TTestEnv env(1, 1, /*useRealThreads=*/false,
             [](Tests::TServerSettings& settings) {
-                settings.AppConfig->MutableStatisticsConfig()
-                    ->SetAnalyzeWholeTableScanMaxBytes(0);
+                SetMatchingWholeTableScanMaxBytes(
+                    settings.AppConfig->MutableStatisticsConfig(), ColumnShard, 0);
             });
         auto& runtime = *env.GetServer().GetRuntime();
         CreateDatabase(env, "Database");
-        const auto tableInfo = PrepareColumnTable(env, "Database", "Table", /*shardCount=*/4);
+        const auto tableInfo = PrepareFourShardTable(env, ColumnShard);
 
         ui32 hiveDistributionRequests = 0;
         auto observer = runtime.AddObserver<TEvHive::TEvRequestTabletDistribution>(

--- a/ydb/core/statistics/aggregator/ut/ut_key_range_predicate.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_key_range_predicate.cpp
@@ -1,0 +1,343 @@
+#include <ydb/core/statistics/aggregator/key_range_predicate.h>
+#include <ydb/core/statistics/aggregator/select_builder.h>
+
+#include <ydb/core/scheme/scheme_tablecell.h>
+#include <ydb/core/scheme_types/scheme_type_info.h>
+#include <ydb/public/lib/scheme_types/scheme_type_id.h>
+#include <yql/essentials/parser/pg_wrapper/interface/type_desc.h>
+#include <yql/essentials/types/dynumber/dynumber.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <optional>
+
+using namespace NKikimr;
+using namespace NKikimr::NStat;
+
+Y_UNIT_TEST_SUITE(KeyRangePredicate) {
+
+    TSerializedTableRange MakeRange(
+        TVector<TCell> from, bool fromInclusive,
+        TVector<TCell> to, bool toInclusive)
+    {
+        TSerializedTableRange range;
+        if (!from.empty()) {
+            range.From = TSerializedCellVec(from);
+        }
+        range.FromInclusive = fromInclusive;
+        if (!to.empty()) {
+            range.To = TSerializedCellVec(to);
+        }
+        range.ToInclusive = toInclusive;
+        return range;
+    }
+
+    TVector<TKeyDesc::TPartitionInfo> MakeUniformPartitions(ui32 shardCount, ui64 endStep) {
+        TVector<TKeyDesc::TPartitionInfo> partitions(shardCount);
+        for (ui32 i = 0; i < shardCount; ++i) {
+            partitions[i].ShardId = i + 1;
+            if (i + 1 < shardCount) {
+                partitions[i].Range = TKeyDesc::TPartitionRangeInfo{
+                    .EndKeyPrefix = TSerializedCellVec(TVector<TCell>{TCell::Make(endStep * (i + 1))}),
+                    .IsInclusive = false,
+                };
+            } else {
+                partitions[i].Range = TKeyDesc::TPartitionRangeInfo{};
+            }
+        }
+        return partitions;
+    }
+
+    struct TPred {
+        TString Where;
+        TString Declares;
+        TString Error;
+        NYdb::TParamsBuilder Params;
+    };
+
+    bool BuildPred(
+        TConstArrayRef<TString> names,
+        TConstArrayRef<NScheme::TTypeInfo> types,
+        const TSerializedTableRange& range,
+        TPred& p)
+    {
+        return TryBuildKeyRangePredicate(names, types, range, p.Where, p.Declares, p.Params, p.Error);
+    }
+
+    const TVector<TString> Key{"Key"};
+    const TVector<NScheme::TTypeInfo> Uint64{NScheme::TTypeInfo(NScheme::NTypeIds::Uint64)};
+    const TVector<TString> KeyValue{"Key", "Value"};
+    const TVector<NScheme::TTypeInfo> Uint64String{
+        NScheme::TTypeInfo(NScheme::NTypeIds::Uint64),
+        NScheme::TTypeInfo(NScheme::NTypeIds::String),
+    };
+
+    Y_UNIT_TEST(FullRangeIsEmptyWhere) {
+        TPred p;
+        UNIT_ASSERT(BuildPred(Key, Uint64, TSerializedTableRange{}, p));
+        UNIT_ASSERT_VALUES_EQUAL(p.Where, "");
+        UNIT_ASSERT_VALUES_EQUAL(p.Declares, "");
+        UNIT_ASSERT(p.Params.Build().Empty());
+    }
+
+    Y_UNIT_TEST(SingleColumnExclusiveInclusive) {
+        auto range = MakeRange(
+            {TCell::Make(ui64(100))}, false,
+            {TCell::Make(ui64(200))}, true);
+        TPred p;
+        UNIT_ASSERT_C(BuildPred(Key, Uint64, range, p), p.Error);
+        UNIT_ASSERT(p.Where.Contains("`Key` > $from_0"));
+        UNIT_ASSERT(p.Where.Contains("(`Key` IS NULL OR `Key` <= $to_0)"));
+        UNIT_ASSERT(p.Declares.Contains("DECLARE $from_0 AS Uint64;"));
+        UNIT_ASSERT(p.Declares.Contains("DECLARE $to_0 AS Uint64;"));
+        UNIT_ASSERT(!p.Params.Build().Empty());
+    }
+
+    Y_UNIT_TEST(OpenUpperBound) {
+        TPred p;
+        UNIT_ASSERT_C(BuildPred(Key, Uint64, MakeRange({TCell::Make(ui64(100))}, true, {}, false), p), p.Error);
+        UNIT_ASSERT_VALUES_EQUAL(p.Where, "`Key` >= $from_0");
+        UNIT_ASSERT(!p.Where.Contains("IS NULL"));
+        UNIT_ASSERT(!p.Declares.Contains("$to_"));
+    }
+
+    Y_UNIT_TEST(OpenLowerBound) {
+        TPred p;
+        UNIT_ASSERT_C(BuildPred(Key, Uint64, MakeRange({}, true, {TCell::Make(ui64(200))}, false), p), p.Error);
+        UNIT_ASSERT_VALUES_EQUAL(p.Where, "(`Key` IS NULL OR `Key` < $to_0)");
+        UNIT_ASSERT(!p.Where.Contains("$from_"));
+    }
+
+    Y_UNIT_TEST(CompositePrefixBound) {
+        auto range = MakeRange({TCell::Make(ui64(100))}, false, {TCell::Make(ui64(200))}, true);
+        TPred p;
+        UNIT_ASSERT_C(BuildPred(KeyValue, Uint64String, range, p), p.Error);
+        UNIT_ASSERT(p.Where.Contains("`Key` > $from_0"));
+        UNIT_ASSERT(p.Where.Contains("(`Key` IS NULL OR `Key` <= $to_0)"));
+        UNIT_ASSERT(!p.Where.Contains("AsTuple"));
+    }
+
+    Y_UNIT_TEST(CompositeFullKeyBound) {
+        TString value("abc");
+        auto range = MakeRange(
+            {TCell::Make(ui64(100)), TCell(value.data(), value.size())}, true,
+            {TCell::Make(ui64(200)), TCell(value.data(), value.size())}, false);
+        TPred p;
+        UNIT_ASSERT_C(BuildPred(KeyValue, Uint64String, range, p), p.Error);
+        UNIT_ASSERT(p.Where.Contains("AsTuple(`Key`,`Value`) >= AsTuple($from_0,$from_1)"));
+        UNIT_ASSERT(p.Where.Contains(
+            "((`Key` IS NULL OR `Key` < $to_0) OR "
+            "(`Key` = $to_0 AND (`Value` IS NULL OR `Value` < $to_1)))"));
+        UNIT_ASSERT(p.Declares.Contains("DECLARE $from_1 AS String;"));
+    }
+
+    Y_UNIT_TEST(SelectHasWhereAndNoTabletId) {
+        auto range = MakeRange({TCell::Make(ui64(100))}, true, {TCell::Make(ui64(200))}, false);
+        TPred p;
+        UNIT_ASSERT_C(BuildPred(Key, Uint64, range, p), p.Error);
+
+        TSelectBuilder builder(/*isIntermediateAggregation=*/true);
+        builder.AddBuiltinAggregation({}, "count");
+        const TString sql = builder.Build("Table", /*tabletId=*/{}, p.Where, p.Declares);
+        UNIT_ASSERT(sql.Contains("DECLARE $from_0 AS Uint64;"));
+        UNIT_ASSERT(sql.Contains("WHERE `Key` >= $from_0 AND (`Key` IS NULL OR `Key` < $to_0)"));
+        UNIT_ASSERT(!sql.Contains("TabletId"));
+    }
+
+    Y_UNIT_TEST(InclusiveNullLowerBoundIsOpen) {
+        TPred p;
+        UNIT_ASSERT_C(BuildPred(Key, Uint64, MakeRange({TCell()}, true, {}, false), p), p.Error);
+        UNIT_ASSERT_VALUES_EQUAL(p.Where, "");
+    }
+
+    Y_UNIT_TEST(TrailingNullPaddingIsPrefixBound) {
+        auto range = MakeRange(
+            {TCell::Make(ui64(100)), TCell()}, true,
+            {TCell::Make(ui64(200)), TCell()}, false);
+        TPred p;
+        UNIT_ASSERT_C(BuildPred(KeyValue, Uint64String, range, p), p.Error);
+        UNIT_ASSERT_VALUES_EQUAL(p.Where, "`Key` >= $from_0 AND (`Key` IS NULL OR `Key` < $to_0)");
+        UNIT_ASSERT(!p.Declares.Contains("$from_1"));
+        UNIT_ASSERT(!p.Where.Contains("AsTuple"));
+    }
+
+    Y_UNIT_TEST(SplitRangesIncludeNullOnlyOnTheLeft) {
+        TVector<TKeyDesc::TPartitionInfo> partitions(2);
+        partitions[0].ShardId = 1;
+        partitions[0].Range = TKeyDesc::TPartitionRangeInfo{
+            .EndKeyPrefix = TSerializedCellVec(TVector<TCell>{TCell::Make(ui64(10))}),
+            .IsInclusive = false,
+        };
+        partitions[1].ShardId = 2;
+        partitions[1].Range = TKeyDesc::TPartitionRangeInfo{};
+
+        auto subranges = MakeShardSubranges(partitions);
+        UNIT_ASSERT_VALUES_EQUAL(subranges.size(), 2);
+
+        TPred left;
+        UNIT_ASSERT_C(BuildPred(Key, Uint64, subranges[0].second, left), left.Error);
+        UNIT_ASSERT_VALUES_EQUAL(left.Where, "(`Key` IS NULL OR `Key` < $to_0)");
+
+        TPred right;
+        UNIT_ASSERT_C(BuildPred(Key, Uint64, subranges[1].second, right), right.Error);
+        UNIT_ASSERT_VALUES_EQUAL(right.Where, "`Key` >= $from_0");
+        UNIT_ASSERT(!right.Where.Contains("IS NULL"));
+    }
+
+    Y_UNIT_TEST(NullPrefixBoundIsEncoded) {
+        TString mid("m");
+        auto range = MakeRange({TCell(), TCell(mid.data(), mid.size())}, true, {}, false);
+        TPred p;
+        UNIT_ASSERT_C(BuildPred(KeyValue, Uint64String, range, p), p.Error);
+        UNIT_ASSERT_VALUES_EQUAL(p.Where,
+            "(`Key` IS NOT NULL OR (`Key` IS NULL AND `Value` >= $from_1))");
+        UNIT_ASSERT(p.Declares.Contains("DECLARE $from_1 AS String;"));
+        UNIT_ASSERT(!p.Declares.Contains("$from_0"));
+        UNIT_ASSERT(!p.Params.Build().Empty());
+    }
+
+    Y_UNIT_TEST(NullPrefixExclusiveUpperBound) {
+        TString mid("m");
+        auto range = MakeRange({}, true, {TCell(), TCell(mid.data(), mid.size())}, false);
+        TPred p;
+        UNIT_ASSERT_C(BuildPred(KeyValue, Uint64String, range, p), p.Error);
+        UNIT_ASSERT_VALUES_EQUAL(p.Where,
+            "(`Key` IS NULL AND (`Value` IS NULL OR `Value` < $to_1))");
+        UNIT_ASSERT(p.Declares.Contains("DECLARE $to_1 AS String;"));
+        UNIT_ASSERT(!p.Declares.Contains("$to_0"));
+    }
+
+    Y_UNIT_TEST(SplitAtNullPrefixCoversBothSides) {
+        TString mid("m");
+        TVector<TKeyDesc::TPartitionInfo> partitions(2);
+        partitions[0].ShardId = 1;
+        partitions[0].Range = TKeyDesc::TPartitionRangeInfo{
+            .EndKeyPrefix = TSerializedCellVec(TVector<TCell>{
+                TCell(), TCell(mid.data(), mid.size())}),
+            .IsInclusive = false,
+        };
+        partitions[1].ShardId = 2;
+        partitions[1].Range = TKeyDesc::TPartitionRangeInfo{};
+
+        auto subranges = MakeShardSubranges(partitions);
+        UNIT_ASSERT_VALUES_EQUAL(subranges.size(), 2);
+
+        TPred left;
+        UNIT_ASSERT_C(BuildPred(KeyValue, Uint64String, subranges[0].second, left), left.Error);
+        UNIT_ASSERT(left.Where.Contains("`Key` IS NULL"));
+        UNIT_ASSERT(left.Where.Contains("`Value` < $to_1"));
+        UNIT_ASSERT(!left.Where.Contains("IS NOT NULL"));
+
+        TPred right;
+        UNIT_ASSERT_C(BuildPred(KeyValue, Uint64String, subranges[1].second, right), right.Error);
+        UNIT_ASSERT(right.Where.Contains("`Key` IS NOT NULL"));
+        UNIT_ASSERT(right.Where.Contains("`Value` >= $from_1"));
+    }
+
+    Y_UNIT_TEST(ExclusiveNullLowerBound) {
+        TPred p;
+        UNIT_ASSERT_C(BuildPred(Key, Uint64, MakeRange({TCell()}, false, {}, false), p), p.Error);
+        UNIT_ASSERT_VALUES_EQUAL(p.Where, "`Key` IS NOT NULL");
+        UNIT_ASSERT_VALUES_EQUAL(p.Declares, "");
+    }
+
+    Y_UNIT_TEST(InclusiveNullUpperBound) {
+        TPred p;
+        UNIT_ASSERT_C(BuildPred(Key, Uint64, MakeRange({}, true, {TCell()}, true), p), p.Error);
+        UNIT_ASSERT_VALUES_EQUAL(p.Where, "`Key` IS NULL");
+        UNIT_ASSERT_VALUES_EQUAL(p.Declares, "");
+    }
+
+    Y_UNIT_TEST(UnsupportedTypeFails) {
+        const TVector<NScheme::TTypeInfo> types{NScheme::TTypeInfo(NScheme::NTypeIds::PairUi64Ui64)};
+        TPred p;
+        UNIT_ASSERT(!BuildPred(Key, types, MakeRange({TCell::Make(ui64(1))}, true, {}, false), p));
+        UNIT_ASSERT(p.Error.Contains("unsupported key column type"));
+        UNIT_ASSERT(!CanEncodeKeyBoundType(NScheme::NTypeIds::PairUi64Ui64));
+        UNIT_ASSERT(!CanEncodeKeyBoundType(NScheme::NTypeIds::Pg));
+        UNIT_ASSERT(!CanEncodeKeyRangePredicate(types));
+        UNIT_ASSERT(CanEncodeKeyBoundType(NScheme::NTypeIds::DyNumber));
+        UNIT_ASSERT(CanEncodeKeyRangePredicate(Uint64));
+    }
+
+    Y_UNIT_TEST(PgTypeFailsEncoding) {
+        auto* desc = NPg::TypeDescFromPgTypeName("pgint8");
+        UNIT_ASSERT(desc);
+        const TVector<NScheme::TTypeInfo> types{NScheme::TTypeInfo(desc)};
+        TPred p;
+        UNIT_ASSERT(!BuildPred(Key, types, MakeRange({TCell::Make(i64(1))}, true, {}, false), p));
+        UNIT_ASSERT(p.Error.Contains("unsupported key column type"));
+        UNIT_ASSERT(p.Error.Contains("pgint8"));
+        UNIT_ASSERT(!CanEncodeKeyRangePredicate(types));
+    }
+
+    Y_UNIT_TEST(DyNumberBoundUsesTextParam) {
+        const TString text = "10.23";
+        auto binary = NDyNumber::ParseDyNumberString(text);
+        UNIT_ASSERT(binary);
+        UNIT_ASSERT_VALUES_UNEQUAL(*binary, text);
+
+        TPred p;
+        const TVector<NScheme::TTypeInfo> types{NScheme::TTypeInfo(NScheme::NTypeIds::DyNumber)};
+        UNIT_ASSERT_C(
+            BuildPred(Key, types, MakeRange({TCell(binary->data(), binary->size())}, true, {}, false), p),
+            p.Error);
+        UNIT_ASSERT_VALUES_EQUAL(p.Where, "`Key` >= $from_0");
+        UNIT_ASSERT(p.Declares.Contains("DECLARE $from_0 AS DyNumber;"));
+
+        auto built = p.Params.Build();
+        auto value = built.GetValue("$from_0");
+        UNIT_ASSERT(value);
+        NYdb::TValueParser parser(*value);
+        const auto& dyNumber = parser.GetDyNumber();
+        auto canonical = NDyNumber::DyNumberToString(*binary);
+        UNIT_ASSERT(canonical);
+        UNIT_ASSERT_VALUES_EQUAL(TString(dyNumber.data(), dyNumber.size()), *canonical);
+        UNIT_ASSERT(NDyNumber::IsValidDyNumberString(dyNumber));
+        UNIT_ASSERT_VALUES_UNEQUAL(TString(dyNumber.data(), dyNumber.size()), *binary);
+    }
+
+    Y_UNIT_TEST(MakeShardSubrangesFromEndPrefixes) {
+        TVector<TKeyDesc::TPartitionInfo> partitions(3);
+        partitions[0].ShardId = 1;
+        partitions[0].Range = TKeyDesc::TPartitionRangeInfo{
+            .EndKeyPrefix = TSerializedCellVec(TVector<TCell>{TCell::Make(ui64(100))}),
+            .IsInclusive = false,
+        };
+        partitions[1].ShardId = 2;
+        partitions[1].Range = TKeyDesc::TPartitionRangeInfo{
+            .EndKeyPrefix = TSerializedCellVec(TVector<TCell>{TCell::Make(ui64(200))}),
+            .IsInclusive = false,
+        };
+        partitions[2].ShardId = 3;
+        partitions[2].Range = TKeyDesc::TPartitionRangeInfo{};
+
+        auto subranges = MakeShardSubranges(partitions);
+        UNIT_ASSERT_VALUES_EQUAL(subranges.size(), 3);
+        UNIT_ASSERT(!subranges[0].second.From);
+        UNIT_ASSERT(subranges[0].second.To);
+        UNIT_ASSERT(!subranges[0].second.ToInclusive);
+        UNIT_ASSERT(subranges[1].second.FromInclusive);
+        UNIT_ASSERT(!subranges[2].second.To);
+    }
+
+    Y_UNIT_TEST(BudgetedSubrangesMergeTenShardsToFive) {
+        auto subranges = MakeBudgetedSubranges(
+            MakeUniformPartitions(10, 100), /*tableBytesSize=*/500, /*rangeBudgetBytes=*/100);
+        UNIT_ASSERT_VALUES_EQUAL(subranges.size(), 5);
+        UNIT_ASSERT_VALUES_EQUAL(subranges[0].first, 1);
+        UNIT_ASSERT_VALUES_EQUAL(subranges[1].first, 3);
+        UNIT_ASSERT_VALUES_EQUAL(subranges[4].first, 9);
+        UNIT_ASSERT(!subranges[4].second.To);
+    }
+
+    Y_UNIT_TEST(BudgetedSubrangesDoNotSplitShards) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeBudgetedSubranges(MakeUniformPartitions(4, 100), 500, 100).size(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeBudgetedSubranges(MakeUniformPartitions(4, 100), 500, 0).size(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeBudgetedSubranges(MakeUniformPartitions(4, 100), std::nullopt, 100).size(), 4);
+    }
+
+}

--- a/ydb/core/statistics/aggregator/ut/ya.make
+++ b/ydb/core/statistics/aggregator/ut/ya.make
@@ -19,10 +19,12 @@ PEERDIR(
     ydb/core/kqp/node_service
     ydb/core/protos
     ydb/core/scheme
-    ydb/core/testlib/default
+    ydb/core/testlib/pg
     ydb/core/statistics/ut_common
     ydb/core/tx/conveyor_composite/usage
+    ydb/public/sdk/cpp/src/client/params
     yql/essentials/core/histogram
+    yql/essentials/types/dynumber
     yql/essentials/udfs/common/digest
     yql/essentials/udfs/common/hyperloglog
 )
@@ -31,6 +33,7 @@ SRCS(
     ut_analyze.cpp
     ut_traverse.cpp
     ut_analyze_op.cpp
+    ut_key_range_predicate.cpp
 )
 
 END()

--- a/ydb/core/statistics/aggregator/ya.make
+++ b/ydb/core/statistics/aggregator/ya.make
@@ -9,6 +9,8 @@ SRCS(
     analyze_actor.cpp
     column_statistic_eval.h
     column_statistic_eval.cpp
+    key_range_predicate.h
+    key_range_predicate.cpp
     schema.h
     schema.cpp
     select_builder.h
@@ -31,12 +33,17 @@ PEERDIR(
     ydb/core/base
     ydb/core/engine/minikql
     ydb/core/protos
+    ydb/core/scheme
+    ydb/core/ydb_convert
     ydb/core/tablet
     ydb/core/tablet_flat
     ydb/core/statistics/database
+    ydb/library/query_actor
     ydb/library/yql/udfs/statistics_internal
+    ydb/public/sdk/cpp/src/client/params
     yql/essentials/core/histogram
     yql/essentials/core/minsketch
+    yql/essentials/types/dynumber
 )
 
 YQL_LAST_ABI_VERSION()


### PR DESCRIPTION
Encode DataShard bounds as YQL predicates (NULL-as-min, including  NULL-containing composite keys) and fall back to a whole-table scan when a PK type or bound cannot be encoded.

- Large or unknown-size row tables are scanned as disjoint PK ranges (merged by byte budget) instead of one whole-table query. Column tables stay per-shard.
- Range predicates follow DataShard NULL-as-min order, including leading/embedded NULLs in composite split keys.
- Unencodable PK types (e.g. Pg) or a bound that still cannot be encoded fall back to a whole-table scan instead of aborting ANALYZE.
- Whole-table thresholds are split: `AnalyzeColumnTableWholeTableScanMaxBytes` (field 9) and `AnalyzeRowTableWholeTableScanMaxBytes` (field 14).
