### PR TITLE
YDB-3506 Account KQP RM memory pools only for real pool limits

### DIFF
--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -23,6 +23,8 @@
 
 #include <library/cpp/containers/absl/flat_hash_map.h>
 
+#include <cmath>
+
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::KQP_RESOURCE_MANAGER
 
 namespace NKikimr {
@@ -32,6 +34,13 @@ namespace NRm {
 using namespace NActors;
 using namespace NResourceBroker;
 
+static double NormalizePoolPercent(double percent) {
+    if (!std::isfinite(percent) || percent < 0) {
+        return -1;
+    }
+    return Min(percent, 100.0);
+}
+
 TTxState::TTxState(std::shared_ptr<IKqpResourceManager>& resourceManager, ui64 txId, TInstant now, const TString& poolId, const double memoryPoolPercent,
     const TString& database, bool collectBacktrace)
     : ResourceManager(resourceManager)
@@ -39,8 +48,10 @@ TTxState::TTxState(std::shared_ptr<IKqpResourceManager>& resourceManager, ui64 t
     , TxId(txId)
     , CreatedAt(now)
     , PoolId(poolId)
-    , MemoryPoolPercent(memoryPoolPercent)
+    , MemoryPoolPercent(NormalizePoolPercent(memoryPoolPercent))
     , Database(database)
+    , MemoryPoolLimited(!PoolId.empty() && PoolId != NResourcePool::DEFAULT_POOL_ID
+        && MemoryPoolPercent > 0 && MemoryPoolPercent < 100)
     , CollectBacktrace(collectBacktrace)
 {}
 
@@ -397,7 +408,6 @@ public:
                     auto it = MemoryNamedPools.find(tx.MakePoolId());
                     if (it != MemoryNamedPools.end()) {
                         it->second->Release(resources.Memory);
-
                         if (it->second->GetUsed() == 0) {
                             MemoryNamedPools.erase(it);
                         }

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -339,9 +339,6 @@ public:
                         auto it = MemoryNamedPools.find(tx.MakePoolId());
                         if (it != MemoryNamedPools.end()) {
                             it->second->Release(resources.Memory);
-                            if (it->second->GetUsed() == 0) {
-                                MemoryNamedPools.erase(it);
-                            }
                         }
                     }
                 }
@@ -408,9 +405,6 @@ public:
                     auto it = MemoryNamedPools.find(tx.MakePoolId());
                     if (it != MemoryNamedPools.end()) {
                         it->second->Release(resources.Memory);
-                        if (it->second->GetUsed() == 0) {
-                            MemoryNamedPools.erase(it);
-                        }
                     }
                 }
             }

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -122,9 +122,15 @@ public:
         SetActualLimits();
     }
 
+    void SetOverPercent(double overPercent) {
+        OverPercent = overPercent;
+        SetActualLimits();
+    }
+
     void SetActualLimits() {
         Limit = Percentage(BaseLimit, MemoryPoolPercent);
         OverLimit = OverPercentage(Limit, OverPercent);
+        UpdateCookie();
     }
 
     ui64 GetLimit() const {
@@ -278,7 +284,7 @@ public:
                 tx.TotalMemoryCookie = TotalMemoryResource->GetSpillingCookie();
             }
 
-            if (hasScanQueryMemory && !tx.PoolId.empty() && tx.MemoryPoolPercent > 0) {
+            if (hasScanQueryMemory && tx.HasMemoryPoolLimit()) {
                 auto [it, success] = MemoryNamedPools.emplace(tx.MakePoolId(), nullptr);
 
                 if (success) {
@@ -318,7 +324,7 @@ public:
                 tx.AckFailedMemoryAlloc(resources.Memory);
                 with_lock (Lock) {
                     TotalMemoryResource->Release(resources.Memory);
-                    if (!tx.PoolId.empty()) {
+                    if (tx.HasMemoryPoolLimit()) {
                         auto it = MemoryNamedPools.find(tx.MakePoolId());
                         if (it != MemoryNamedPools.end()) {
                             it->second->Release(resources.Memory);
@@ -387,7 +393,7 @@ public:
         if (resources.Memory > 0) {
             with_lock (Lock) {
                 TotalMemoryResource->Release(resources.Memory);
-                if (!tx.PoolId.empty()) {
+                if (tx.HasMemoryPoolLimit()) {
                     auto it = MemoryNamedPools.find(tx.MakePoolId());
                     if (it != MemoryNamedPools.end()) {
                         it->second->Release(resources.Memory);
@@ -508,6 +514,7 @@ public:
         MaxTotalChannelBuffersSize.store(config.GetMaxTotalChannelBuffersSize());
         QueryMemoryLimit.store(config.GetQueryMemoryLimit());
         SpillingPercent.store(config.GetSpillingPercent());
+        TotalMemoryResource->SetOverPercent(config.GetSpillingPercent());
         MaxNonParallelTopStageExecutionLimit.store(config.GetMaxNonParallelTopStageExecutionLimit());
         MaxNonParallelTasksExecutionLimit.store(config.GetMaxNonParallelTasksExecutionLimit());
         PreferLocalDatacenterExecution.store(config.GetPreferLocalDatacenterExecution());

--- a/ydb/core/kqp/rm_service/kqp_rm_service.h
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/core/protos/table_service_config.pb.h>
+#include <ydb/core/resource_pools/resource_pool_settings.h>
 #include <ydb/core/kqp/common/simple/kqp_event_ids.h>
 #include <ydb/core/kqp/counters/kqp_counters.h>
 #include <yql/essentials/minikql/computation/mkql_computation_pattern_cache.h>
@@ -84,6 +85,11 @@ public:
         return std::make_pair(Database, PoolId);
     }
 
+    bool HasMemoryPoolLimit() const {
+        return !PoolId.empty() && PoolId != NResourcePool::DEFAULT_POOL_ID
+            && MemoryPoolPercent > 0 && MemoryPoolPercent < 100;
+    }
+
     bool IsReasonableToStartSpilling() {
         return (PoolMemoryCookie && PoolMemoryCookie->SpillingPercentReached.load())
             || (TotalMemoryCookie && TotalMemoryCookie->SpillingPercentReached.load());
@@ -106,7 +112,7 @@ public:
 
         if (!PoolId.empty()) {
             res << ", PoolId: " << PoolId
-                << ", MemoryPoolPercent: " << Sprintf("%.2f", MemoryPoolPercent > 0 ? MemoryPoolPercent : 100);
+                << ", MemoryPoolPercent: " << Sprintf("%.2f", MemoryPoolPercent);
         }
 
         if (CollectBacktrace) {

--- a/ydb/core/kqp/rm_service/kqp_rm_service.h
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.h
@@ -56,6 +56,7 @@ public:
     const TString PoolId;
     const double MemoryPoolPercent;
     const TString Database;
+    const bool MemoryPoolLimited;
     const bool CollectBacktrace;
     TIntrusivePtr<TMemoryResourceCookie> TotalMemoryCookie;
     TIntrusivePtr<TMemoryResourceCookie> PoolMemoryCookie;
@@ -86,8 +87,7 @@ public:
     }
 
     bool HasMemoryPoolLimit() const {
-        return !PoolId.empty() && PoolId != NResourcePool::DEFAULT_POOL_ID
-            && MemoryPoolPercent > 0 && MemoryPoolPercent < 100;
+        return MemoryPoolLimited;
     }
 
     bool IsReasonableToStartSpilling() {

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -302,6 +302,7 @@ public:
         UNIT_TEST(PoolLimitNotReleasedByUnchargedQueryOnRollback);
         UNIT_TEST(PoolLimitNotChargedByHundredPercentQuery);
         UNIT_TEST(PoolLimitNotChargedForDefaultPool);
+        UNIT_TEST(PoolLimitIgnoredForSenselessPercents);
         UNIT_TEST(PoolLimitAppliedJustBelowHundredPercent);
         UNIT_TEST(SpillingPercentAppliedWithoutPoolLimit);
     UNIT_TEST_SUITE_END();
@@ -325,6 +326,7 @@ public:
     void PoolLimitNotReleasedByUnchargedQueryOnRollback();
     void PoolLimitNotChargedByHundredPercentQuery();
     void PoolLimitNotChargedForDefaultPool();
+    void PoolLimitIgnoredForSenselessPercents();
     void PoolLimitAppliedJustBelowHundredPercent();
     void SpillingPercentAppliedWithoutPoolLimit();
 
@@ -840,6 +842,30 @@ void KqpRm::PoolLimitNotChargedForDefaultPool() {
             NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 400}));
         UNIT_ASSERT(!rm->AllocateResources(*overflowingTx, 3,
             NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 1}));
+
+        AssertResourceManagerStats(rm, 0, 98);
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
+}
+
+void KqpRm::PoolLimitIgnoredForSenselessPercents() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    {
+        auto nanTx = MakeTx(1, rm, "p", std::numeric_limits<double>::quiet_NaN());
+        auto overTx = MakeTx(2, rm, "p", 150);
+
+        UNIT_ASSERT(!nanTx->HasMemoryPoolLimit());
+        UNIT_ASSERT(!overTx->HasMemoryPoolLimit());
+
+        UNIT_ASSERT(rm->AllocateResources(*nanTx, 1,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 600}));
+        UNIT_ASSERT(rm->AllocateResources(*overTx, 2,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 400}));
 
         AssertResourceManagerStats(rm, 0, 98);
     }

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/kqp/rm_service/kqp_rm_service.h>
+#include <ydb/core/cms/console/console.h>
 #include <ydb/core/tablet/resource_broker_impl.h>
 
 #include <ydb/core/testlib/actor_helpers.h>
@@ -26,6 +27,8 @@ using namespace NKikimrResourceBroker;
 using namespace NResourceBroker;
 
 namespace {
+
+constexpr ui64 KQP_QUEUE_MEMORY_LIMIT = 50'000;
 
 TTenantTestConfig MakeTenantTestConfig() {
     TTenantTestConfig cfg = {
@@ -78,7 +81,7 @@ TResourceBrokerConfig MakeResourceBrokerTestConfig() {
     queue->SetName("queue_kqp_resource_manager");
     queue->SetWeight(20);
     queue->MutableLimit()->AddResource(4);
-    queue->MutableLimit()->AddResource(50'000);
+    queue->MutableLimit()->AddResource(KQP_QUEUE_MEMORY_LIMIT);
 
     auto task = config.AddTasks();
     task->SetName("unknown");
@@ -173,6 +176,18 @@ public:
         WaitForBootstrap();
     }
 
+    void SetSpillingPercent(double spillingPercent) {
+        auto config = MakeKqpResourceManagerConfig();
+        config.SetSpillingPercent(spillingPercent);
+
+        auto request = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+        request->Record.MutableConfig()->MutableTableServiceConfig()->MutableResourceManager()->CopyFrom(config);
+
+        auto edge = Runtime->AllocateEdgeActor();
+        Runtime->Send(new IEventHandle(ResourceManagers.front(), edge, request.Release()), 0, true);
+        Runtime->GrabEdgeEvent<NConsole::TEvConsole::TEvConfigNotificationResponse>(edge);
+    }
+
     void AssertResourceBrokerSensors(i64 cpu, i64 mem, i64 enqueued, std::optional<i64> finished, i64 infly) {
         auto q = Counters->GetSubgroup("queue", "queue_kqp_resource_manager");
         UNIT_ASSERT_VALUES_EQUAL(q->GetCounter("CPUConsumption")->Val(), cpu);
@@ -193,8 +208,9 @@ public:
         UNIT_ASSERT_VALUES_EQUAL(t->GetCounter("InFlyTasks")->Val(), infly);
     }
 
-    TIntrusivePtr<NRm::TTxState> MakeTx(ui64 txId, std::shared_ptr<NRm::IKqpResourceManager> rm) {
-        return MakeIntrusive<NRm::TTxState>(rm, txId, TInstant::Now(), "", (double)100, "", false);
+    TIntrusivePtr<NRm::TTxState> MakeTx(ui64 txId, std::shared_ptr<NRm::IKqpResourceManager> rm,
+            const TString& poolId = "", double memoryPoolPercent = 100) {
+        return MakeIntrusive<NRm::TTxState>(rm, txId, TInstant::Now(), poolId, memoryPoolPercent, "", false);
     }
 
     void AssertResourceManagerStats(
@@ -282,6 +298,12 @@ public:
         UNIT_TEST(SnapshotSharingByExchanger);
         UNIT_TEST(NodesMembershipByExchanger);
         UNIT_TEST(DisonnectNodes);
+        UNIT_TEST(PoolLimitNotReleasedByUnchargedQuery);
+        UNIT_TEST(PoolLimitNotReleasedByUnchargedQueryOnRollback);
+        UNIT_TEST(PoolLimitNotChargedByHundredPercentQuery);
+        UNIT_TEST(PoolLimitNotChargedForDefaultPool);
+        UNIT_TEST(PoolLimitAppliedJustBelowHundredPercent);
+        UNIT_TEST(SpillingPercentAppliedWithoutPoolLimit);
     UNIT_TEST_SUITE_END();
 
     void SingleTask();
@@ -299,6 +321,12 @@ public:
     void NodesMembership();
     void NodesMembershipByExchanger();
     void DisonnectNodes();
+    void PoolLimitNotReleasedByUnchargedQuery();
+    void PoolLimitNotReleasedByUnchargedQueryOnRollback();
+    void PoolLimitNotChargedByHundredPercentQuery();
+    void PoolLimitNotChargedForDefaultPool();
+    void PoolLimitAppliedJustBelowHundredPercent();
+    void SpillingPercentAppliedWithoutPoolLimit();
 
 private:
     THolder<TTestBasicRuntime> Runtime;
@@ -714,6 +742,156 @@ void KqpRm::DisonnectNodes() {
     Runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
 
     CheckSnapshot(0, {{1000, 100}}, rm_first);
+}
+
+void KqpRm::PoolLimitNotReleasedByUnchargedQuery() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    NRm::TKqpResourcesRequest request{.ExecutionUnits = 1, .Memory = 300};
+
+    {
+        auto limitedTx = MakeTx(1, rm, "p", 50);
+        auto unlimitedTx = MakeTx(2, rm, "p", -1);
+        auto anotherLimitedTx = MakeTx(3, rm, "p", 50);
+
+        UNIT_ASSERT(rm->AllocateResources(*limitedTx, 1, request));
+        UNIT_ASSERT(rm->AllocateResources(*unlimitedTx, 2, request));
+
+        rm->FreeResources(*unlimitedTx, 2, request);
+
+        UNIT_ASSERT(!rm->AllocateResources(*anotherLimitedTx, 3, request));
+        AssertResourceManagerStats(rm, 700, 99);
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
+}
+
+void KqpRm::PoolLimitNotReleasedByUnchargedQueryOnRollback() {
+    auto config = MakeKqpResourceManagerConfig();
+    config.SetQueryMemoryLimit(90'000);
+
+    StartRms({config, MakeKqpResourceManagerConfig()});
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    {
+        auto limitedTx = MakeTx(1, rm, "p", 50);
+        auto unlimitedTx = MakeTx(2, rm, "p", -1);
+        auto anotherLimitedTx = MakeTx(3, rm, "p", 50);
+
+        UNIT_ASSERT(rm->AllocateResources(*limitedTx, 1,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 30'000}));
+        UNIT_ASSERT(!rm->AllocateResources(*unlimitedTx, 2,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = KQP_QUEUE_MEMORY_LIMIT}));
+        UNIT_ASSERT(!rm->AllocateResources(*anotherLimitedTx, 3,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 18'000}));
+
+        AssertResourceManagerStats(rm, 60'000, 99);
+    }
+
+    AssertResourceManagerStats(rm, 90'000, 100);
+}
+
+void KqpRm::PoolLimitNotChargedByHundredPercentQuery() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    {
+        auto limitedTx = MakeTx(1, rm, "p", 50);
+        auto unlimitedTx = MakeTx(2, rm, "p", 100);
+        auto anotherLimitedTx = MakeTx(3, rm, "p", 50);
+        auto overflowingTx = MakeTx(4, rm, "p", 50);
+
+        UNIT_ASSERT(rm->AllocateResources(*limitedTx, 1,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 400}));
+        UNIT_ASSERT(rm->AllocateResources(*unlimitedTx, 2,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 100}));
+        UNIT_ASSERT(rm->AllocateResources(*anotherLimitedTx, 3,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 100}));
+        UNIT_ASSERT(!rm->AllocateResources(*overflowingTx, 4,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 1}));
+
+        AssertResourceManagerStats(rm, 400, 97);
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
+}
+
+void KqpRm::PoolLimitNotChargedForDefaultPool() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    {
+        auto firstTx = MakeTx(1, rm, NResourcePool::DEFAULT_POOL_ID, 50);
+        auto secondTx = MakeTx(2, rm, NResourcePool::DEFAULT_POOL_ID, 50);
+        auto overflowingTx = MakeTx(3, rm, NResourcePool::DEFAULT_POOL_ID, 50);
+
+        UNIT_ASSERT(rm->AllocateResources(*firstTx, 1,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 600}));
+        UNIT_ASSERT(rm->AllocateResources(*secondTx, 2,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 400}));
+        UNIT_ASSERT(!rm->AllocateResources(*overflowingTx, 3,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 1}));
+
+        AssertResourceManagerStats(rm, 0, 98);
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
+}
+
+void KqpRm::PoolLimitAppliedJustBelowHundredPercent() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    {
+        auto firstTx = MakeTx(1, rm, "p", 99);
+        auto secondTx = MakeTx(2, rm, "p", 99);
+        auto overflowingTx = MakeTx(3, rm, "p", 99);
+
+        UNIT_ASSERT(rm->AllocateResources(*firstTx, 1,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 900}));
+        UNIT_ASSERT(rm->AllocateResources(*secondTx, 2,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 50}));
+        UNIT_ASSERT(!rm->AllocateResources(*overflowingTx, 3,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 50}));
+
+        AssertResourceManagerStats(rm, 50, 98);
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
+}
+
+void KqpRm::SpillingPercentAppliedWithoutPoolLimit() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    {
+        auto tx = MakeTx(1, rm, NResourcePool::DEFAULT_POOL_ID, 100);
+
+        UNIT_ASSERT(rm->AllocateResources(*tx, 1,
+            NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 600}));
+        UNIT_ASSERT(!tx->IsReasonableToStartSpilling());
+
+        SetSpillingPercent(20);
+        UNIT_ASSERT(tx->IsReasonableToStartSpilling());
+
+        SetSpillingPercent(80);
+        UNIT_ASSERT(!tx->IsReasonableToStartSpilling());
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
 }
 
 } // namespace NKqp

--- a/ydb/core/kqp/rm_service/ya.make
+++ b/ydb/core/kqp/rm_service/ya.make
@@ -18,6 +18,7 @@ PEERDIR(
     ydb/core/mind
     ydb/core/mon
     ydb/core/protos
+    ydb/core/resource_pools
     ydb/core/tablet
     ydb/core/node_whiteboard
     ydb/core/util


### PR DESCRIPTION
Fixes the asymmetric memory pool accounting in the KQP Resource Manager reported in YDB-3506.

### The defect

The session actor sets `PoolId = DEFAULT_POOL_ID` for every query, and the planner substitutes `MemoryPoolPercent = 100` whenever a query has no `PoolConfig`. RM then charged a pool only when `MemoryPoolPercent > 0`, but released for any non-empty `PoolId`. A query carrying a pool id with percent `-1` therefore released pool memory it never charged. With a mix of percent 100 and percent -1 queries on one key, `Used` was driven to zero and the record erased early, so the pool re-admitted its full limit while memory was still held. The record itself was tautological: 100% of the node query budget.

### The change

`TTxState::HasMemoryPoolLimit()` is now the single predicate for pool record creation, the `Y_DEFER` rollback release and `FreeResourcesImpl`. It holds only for a percent strictly inside `(0, 100)`, so the fabricated `100` and `-1` produce no pool record instead of one that can never deny anything the node budget already allows. `PoolId` and `MemoryPoolPercent` are `const`, so charge and release cannot disagree for a tx.

Because those queries no longer get a `PoolMemoryCookie`, the node level threshold is the only spilling signal left, and it was never refreshed: `SetConfigValues` stored `SpillingPercent` without applying it to `TotalMemoryResource`, whose `OverLimit` is computed in the constructor and recomputed only by `SetNewLimit`, which early returns when the limit and percent are unchanged. A runtime `spilling_percent` change was ignored until the resource broker queue limit changed or the node restarted. `SetConfigValues` now applies it.

### Tests

`ydb/core/kqp/rm_service/kqp_rm_ut.cpp`, 12 -> 17. Four are regressions, red on the pre-fix tree at their intended assertion:

- `PoolLimitNotReleasedByUnchargedQuery` - a percent -1 query releases and the next pool query is wrongly admitted.
- `PoolLimitNotReleasedByUnchargedQueryOnRollback` - same through the `Y_DEFER` path, with the broker rejecting the uncharged query.
- `PoolLimitNotChargedByHundredPercentQuery` - a percent 100 query charges and rewrites the limit of a configured pool's record.
- `SpillingPercentAppliedWithoutPoolLimit` - drives a real console config notification and asserts the lowered threshold takes effect.

`PoolLimitAppliedJustBelowHundredPercent` (percent 99) is a characterization test: it passes either way and pins the lower end of the interval so `< 100` cannot be widened silently.

### Notes for reviewers

- Nothing in the tree configures a pool at exactly 100 (the only occurrence is a parser unit test), so this removes no enforcement anyone relies on. At 100% the pool limit equals the node query limit up to a 1 byte rounding difference, and the total resource is charged first, so such a record could never deny a request the node accepted.
- `NResourcePool::TPoolSettings::IsWorkloadServiceRequired()` still tests `TotalMemoryLimitPercentPerNode > 0`, so a pool explicitly configured at 100 keeps engaging the workload service while RM does no pool accounting for it. Aligning that predicate is a workload manager decision and is left for a separate change.
- The default pool creation loop that spams the log, noted on the same ticket, is out of scope.
