### PR TITLE
Add cancellation token support to SDK retries

### DIFF
--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -1,6 +1,8 @@
 * Added `EQ_HEIGHT_HISTOGRAM` to `EMultiColumnStatisticsType`.
 
-* Added `std::stop_token` cancellation to C++ SDK retry operations through `TRetryOperationSettings::CancellationToken`. Cancellation does not stop an in-flight RPC or roll back its effects; `CLIENT_CANCELLED` may replace a successful result.
+* Added `std::stop_token` cancellation to C++ SDK retry operations through `TRetryOperationSettings::CancellationToken`. Cancellation does not stop an in-flight RPC or roll back its effects; `CLIENT_CANCELLED` may replace a successful result. `CLIENT_CANCELLED` is terminal even with `RetryUndefined(true)`. Synchronous exceptions while starting an asynchronous retry attempt are reported through its returned future.
+
+* Fixed built-in `BulkUpsert` retries to apply timeout and backoff settings starting with the first attempt. Unlimited retry timeouts no longer produce a finite operation timeout.
 
 # v3.22.0
 

--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -1,5 +1,7 @@
 * Added `EQ_HEIGHT_HISTOGRAM` to `EMultiColumnStatisticsType`.
 
+* Added `std::stop_token` cancellation to C++ SDK retry operations through `TRetryOperationSettings::CancellationToken`.
+
 # v3.22.0
 
 * Added `IWriteSession::Flush` to asynchronously wait until all previously accepted topic writes are acknowledged.

--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -1,6 +1,6 @@
 * Added `EQ_HEIGHT_HISTOGRAM` to `EMultiColumnStatisticsType`.
 
-* Added `std::stop_token` cancellation to C++ SDK retry operations through `TRetryOperationSettings::CancellationToken`.
+* Added `std::stop_token` cancellation to C++ SDK retry operations through `TRetryOperationSettings::CancellationToken`. Cancellation does not stop an in-flight RPC or roll back its effects; `CLIENT_CANCELLED` may replace a successful result.
 
 # v3.22.0
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/retry/retry.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/retry/retry.h
@@ -3,6 +3,8 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/fluent_settings_helpers.h>
 #include <util/datetime/base.h>
 
+#include <stop_token>
+
 namespace NYdb::inline Dev::NRetry {
 
 struct TBackoffSettings {
@@ -31,6 +33,8 @@ struct TRetryOperationSettings {
     }
     FLUENT_SETTING_FLAG(Verbose);
     FLUENT_SETTING_FLAG(RetryUndefined);
+    // Stops retry orchestration without cancelling an already running RPC.
+    FLUENT_SETTING_DEFAULT(std::stop_token, CancellationToken, std::stop_token{});
 
     static TBackoffSettings DefaultFastBackoffSettings() {
         return TBackoffSettings()

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/retry/retry.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/retry/retry.h
@@ -32,6 +32,7 @@ struct TRetryOperationSettings {
         return static_cast<TSelf&>(*this);
     }
     FLUENT_SETTING_FLAG(Verbose);
+    // CLIENT_CANCELLED is always terminal, including when RetryUndefined is enabled.
     FLUENT_SETTING_FLAG(RetryUndefined);
     // Stops retry orchestration without cancelling an already running RPC.
     // CLIENT_CANCELLED may replace a successful result; it does not imply rollback.

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/retry/retry.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/retry/retry.h
@@ -34,6 +34,7 @@ struct TRetryOperationSettings {
     FLUENT_SETTING_FLAG(Verbose);
     FLUENT_SETTING_FLAG(RetryUndefined);
     // Stops retry orchestration without cancelling an already running RPC.
+    // CLIENT_CANCELLED may replace a successful result; it does not imply rollback.
     FLUENT_SETTING_DEFAULT(std::stop_token, CancellationToken, std::stop_token{});
 
     static TBackoffSettings DefaultFastBackoffSettings() {

--- a/ydb/public/sdk/cpp/src/client/common_client/impl/client.h
+++ b/ydb/public/sdk/cpp/src/client/common_client/impl/client.h
@@ -53,10 +53,6 @@ public:
         return DbDriverState_->DiscoveryCompleted();
     }
 
-    void PostToResponseQueue(std::function<void()>&& fn) {
-        Connections_->PostToResponseQueue(std::move(fn));
-    }
-
     void ScheduleTask(const std::function<void()>& fn, TDeadline::Duration delay) override {
         std::weak_ptr<IClientImplCommon> weak = this->shared_from_this();
         auto cbGuard = [weak, fn]() {

--- a/ydb/public/sdk/cpp/src/client/common_client/impl/client.h
+++ b/ydb/public/sdk/cpp/src/client/common_client/impl/client.h
@@ -53,6 +53,10 @@ public:
         return DbDriverState_->DiscoveryCompleted();
     }
 
+    void PostToResponseQueue(std::function<void()>&& fn) {
+        Connections_->PostToResponseQueue(std::move(fn));
+    }
+
     void ScheduleTask(const std::function<void()>& fn, TDeadline::Duration delay) override {
         std::weak_ptr<IClientImplCommon> weak = this->shared_from_this();
         auto cbGuard = [weak, fn]() {

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.cpp
@@ -3,8 +3,10 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/retry/retry.h>
 
 #include <ydb/public/sdk/cpp/src/client/common_client/impl/iface.h>
+#include <ydb/public/sdk/cpp/src/client/impl/observability/span.h>
 
 #include <util/random/random.h>
+#include <util/system/type_name.h>
 
 #include <thread>
 
@@ -13,6 +15,26 @@ namespace NYdb::inline Dev::NRetry {
 using TBackoffDuration = std::chrono::duration<double, std::micro>;
 
 constexpr TBackoffDuration MAX_BACKOFF_DURATION = std::chrono::hours(1);
+
+void TRetryContextBase::EndRetrySpan(EStatus status) {
+    if (ParentSpan_) {
+        ParentSpan_->SetRetryCount(RetryNumber_);
+        ParentSpan_->End(status);
+    }
+}
+
+void TRetryContextBase::EndRetrySpan(std::exception_ptr exception) {
+    if (ParentSpan_) {
+        ParentSpan_->SetRetryCount(RetryNumber_);
+        try {
+            std::rethrow_exception(exception);
+        } catch (const std::exception& e) {
+            ParentSpan_->EndWithException(TypeName(e).c_str(), e.what());
+        } catch (...) {
+            ParentSpan_->EndWithException("unknown", "unknown exception");
+        }
+    }
+}
 
 namespace {
 

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.h
@@ -8,16 +8,21 @@
 
 #include <library/cpp/threading/future/core/fwd.h>
 #include <util/datetime/base.h>
+#include <util/generic/function.h>
 #include <util/generic/ptr.h>
 #include <util/system/types.h>
 #include <util/string/cast.h>
 
+#include <exception>
 #include <functional>
 #include <memory>
 #include <type_traits>
 
 namespace NYdb::inline Dev {
 class IClientImplCommon;
+namespace NObservability {
+class TRequestSpan;
+}
 }
 
 namespace NYdb::inline Dev::NRetry {
@@ -33,32 +38,52 @@ enum class NextStep {
     Finish,
 };
 
-inline bool ShouldRetryStatus(EStatus status, const TRetryOperationSettings& settings) {
+struct TRetryDecision {
+    NextStep Step;
+    bool ResetSession = false;
+};
+
+inline TRetryDecision GetRetryDecision(EStatus status, const TRetryOperationSettings& settings) {
     switch (status) {
+        case EStatus::SUCCESS:
+        case EStatus::CLIENT_CANCELLED:
+            return {NextStep::Finish};
         case EStatus::ABORTED:
+            return {NextStep::RetryImmediately};
         case EStatus::OVERLOADED:
         case EStatus::CLIENT_RESOURCE_EXHAUSTED:
+            return {NextStep::RetrySlowBackoff};
         case EStatus::UNAVAILABLE:
+            return {NextStep::RetryFastBackoff};
         case EStatus::BAD_SESSION:
         case EStatus::SESSION_BUSY:
-            return true;
+            return {NextStep::RetryImmediately, true};
         case EStatus::NOT_FOUND:
-            return settings.RetryNotFound_;
+            return {settings.RetryNotFound_ ? NextStep::RetryImmediately : NextStep::Finish};
         case EStatus::UNDETERMINED:
+            return {settings.Idempotent_ ? NextStep::RetryFastBackoff : NextStep::Finish};
         case EStatus::TRANSPORT_UNAVAILABLE:
-            return settings.Idempotent_;
-        case EStatus::CLIENT_CANCELLED:
-            return false;
+            return {settings.Idempotent_ ? NextStep::RetryFastBackoff : NextStep::Finish, settings.Idempotent_};
+        case EStatus::CLIENT_DEADLINE_EXCEEDED:
+            return {settings.RetryUndefined_ ? NextStep::RetrySlowBackoff : NextStep::Finish, true};
         default:
-            return settings.RetryUndefined_;
+            return {settings.RetryUndefined_ ? NextStep::RetrySlowBackoff : NextStep::Finish};
     }
 }
+
+inline bool ShouldRetryStatus(EStatus status, const TRetryOperationSettings& settings) {
+    return GetRetryDecision(status, settings).Step != NextStep::Finish;
+}
+
+template <typename TClient>
+class TInRetryOperationContextClientGuard;
 
 class TRetryContextBase : TNonCopyable {
 protected:
     TRetryOperationSettings Settings_;
     std::uint32_t RetryNumber_;
     TInstant RetryStartTime_;
+    std::shared_ptr<NObservability::TRequestSpan> ParentSpan_;
 
 protected:
     TRetryContextBase(const TRetryOperationSettings& settings)
@@ -82,63 +107,35 @@ protected:
     }
 
     NextStep GetNextStep(const TStatus& status) {
-        if (status.IsSuccess() || status.GetStatus() == EStatus::CLIENT_CANCELLED) {
+        const auto decision = GetRetryDecision(status.GetStatus(), Settings_);
+        if ((decision.Step == NextStep::Finish && !decision.ResetSession)
+            || RetryNumber_ >= Settings_.MaxRetries_
+            || TInstant::Now() - RetryStartTime_ >= Settings_.MaxTimeout_)
+        {
             return NextStep::Finish;
         }
-        if (RetryNumber_ >= Settings_.MaxRetries_) {
-            return NextStep::Finish;
+        if (decision.ResetSession) {
+            Reset();
         }
-        if (TInstant::Now() - RetryStartTime_ >= Settings_.MaxTimeout_) {
-            return NextStep::Finish;
-        }
-        switch (status.GetStatus()) {
-            case EStatus::ABORTED:
-                return NextStep::RetryImmediately;
-
-            case EStatus::OVERLOADED:
-            case EStatus::CLIENT_RESOURCE_EXHAUSTED:
-                return NextStep::RetrySlowBackoff;
-
-            case EStatus::UNAVAILABLE:
-                return NextStep::RetryFastBackoff;
-
-            case EStatus::BAD_SESSION:
-            case EStatus::SESSION_BUSY:
-                Reset();
-                return NextStep::RetryImmediately;
-
-            case EStatus::NOT_FOUND:
-                if (Settings_.RetryNotFound_) {
-                    return NextStep::RetryImmediately;
-                } else {
-                    return NextStep::Finish;
-                }
-
-            case EStatus::UNDETERMINED:
-                if (Settings_.Idempotent_) {
-                    return NextStep::RetryFastBackoff;
-                } else {
-                    return NextStep::Finish;
-                }
-
-            case EStatus::TRANSPORT_UNAVAILABLE:
-                if (Settings_.Idempotent_) {
-                    Reset();
-                    return NextStep::RetryFastBackoff;
-                } else {
-                    return NextStep::Finish;
-                }
-
-            case EStatus::CLIENT_DEADLINE_EXCEEDED:
-                Reset();
-                [[fallthrough]];
-            default:
-                return Settings_.RetryUndefined_ ? NextStep::RetrySlowBackoff : NextStep::Finish;
-        }
+        return decision.Step;
     }
 
     TDuration GetRemainingTimeout() {
-        return Settings_.MaxTimeout_ - (TInstant::Now() - RetryStartTime_);
+        return Settings_.MaxTimeout_ == TDuration::Max()
+            ? TDuration::Max() : Settings_.MaxTimeout_ - (TInstant::Now() - RetryStartTime_);
+    }
+
+    void EndRetrySpan(EStatus status);
+    void EndRetrySpan(std::exception_ptr exception);
+
+    template <typename TClient, typename TOperation, typename TTarget>
+    auto InvokeOperation(TClient& client, TOperation& operation, TTarget& target) {
+        TInRetryOperationContextClientGuard<TClient> guard(client);
+        if constexpr (TFunctionArgs<TOperation>::Length == 1) {
+            return operation(target);
+        } else {
+            return operation(target, GetRemainingTimeout());
+        }
     }
 };
 

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.h
@@ -47,6 +47,8 @@ inline bool ShouldRetryStatus(EStatus status, const TRetryOperationSettings& set
         case EStatus::UNDETERMINED:
         case EStatus::TRANSPORT_UNAVAILABLE:
             return settings.Idempotent_;
+        case EStatus::CLIENT_CANCELLED:
+            return false;
         default:
             return settings.RetryUndefined_;
     }
@@ -67,6 +69,10 @@ protected:
 
     virtual void Reset() {}
 
+    bool IsCancellationRequested() const noexcept {
+        return Settings_.CancellationToken_.stop_requested();
+    }
+
     void LogRetry(const TStatus& status) {
         if (Settings_.Verbose_) {
             std::cerr << "Previous query attempt was finished with unsuccessful status "
@@ -76,7 +82,7 @@ protected:
     }
 
     NextStep GetNextStep(const TStatus& status) {
-        if (status.IsSuccess()) {
+        if (status.IsSuccess() || status.GetStatus() == EStatus::CLIENT_CANCELLED) {
             return NextStep::Finish;
         }
         if (RetryNumber_ >= Settings_.MaxRetries_) {
@@ -139,6 +145,12 @@ protected:
 template <typename TStatusType>
 TStatusType MakeRetryResultFromStatus(TStatus&& status) {
     return TStatusType(TStatus(std::move(status)));
+}
+
+template <typename TStatusType>
+TStatusType MakeRetryCancelledResult() {
+    return MakeRetryResultFromStatus<TStatusType>(
+        TStatus(EStatus::CLIENT_CANCELLED, NIssue::TIssues{NIssue::TIssue("Retry operation was cancelled")}));
 }
 
 template <typename TStatusType, typename F>

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_async.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_async.h
@@ -20,38 +20,45 @@ namespace NYdb::inline Dev::NRetry::Async {
 
 template <typename TStatusType>
 class TRetryCompletion {
+    enum class EState {
+        Running,
+        Finished,
+        Cancelled,
+    };
+
 public:
-    TRetryCompletion(std::stop_token token, NThreading::TPromise<TStatusType> promise)
-        : Promise_(std::move(promise))
-        , StopCallback_(token, [this]() noexcept {
-            auto promise = Promise_;
-            if (!TryFinish()) {
+    template <typename TClientImpl>
+    TRetryCompletion(const std::shared_ptr<TClientImpl>& client, std::stop_token token,
+        NThreading::TPromise<TStatusType> promise)
+        : StopCallback_(token, [this, client, promise]() noexcept {
+            if (!TryFinish(EState::Cancelled)) {
                 return;
             }
-            try {
-                promise.TrySetValue(MakeRetryCancelledResult<TStatusType>());
-            } catch (...) {
-                promise.TrySetException(std::current_exception());
-            }
+            client->PostToResponseQueue([promise]() mutable {
+                try {
+                    promise.TrySetValue(MakeRetryCancelledResult<TStatusType>());
+                } catch (...) {
+                    promise.TrySetException(std::current_exception());
+                }
+            });
         })
     {}
 
     bool IsFinished() const noexcept {
-        return Finished_.load();
+        return State_.load() != EState::Running;
     }
 
     bool IsCancelled() const noexcept {
-        return Promise_.HasValue() && GetRetryStatusCode(Promise_.GetValue()) == EStatus::CLIENT_CANCELLED;
+        return State_.load() == EState::Cancelled;
     }
 
-    bool TryFinish() noexcept {
-        bool expected = false;
-        return Finished_.compare_exchange_strong(expected, true);
+    bool TryFinish(EState state = EState::Finished) noexcept {
+        auto expected = EState::Running;
+        return State_.compare_exchange_strong(expected, state);
     }
 
 private:
-    NThreading::TPromise<TStatusType> Promise_;
-    std::atomic_bool Finished_ = false;
+    std::atomic<EState> State_ = EState::Running;
     std::stop_callback<std::function<void()>> StopCallback_;
 };
 
@@ -115,7 +122,7 @@ protected:
         : TRetryContextBase(settings)
         , Client_(client)
         , Promise_(NThreading::NewPromise<TStatusType>())
-        , Completion_(settings.CancellationToken_, Promise_)
+        , Completion_(Client_.Impl_, settings.CancellationToken_, Promise_)
     {}
 
     virtual void Retry() = 0;

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_async.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_async.h
@@ -5,21 +5,19 @@
 #include <ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.h>
 #include <ydb/public/sdk/cpp/src/client/impl/observability/span.h>
 
-#include <util/generic/function.h>
-#include <util/system/type_name.h>
-
 #include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <exception>
 #include <functional>
 #include <memory>
-#include <typeinfo>
+#include <optional>
+#include <utility>
 
 namespace NYdb::inline Dev::NRetry::Async {
 
-template <typename TStatusType>
-class TRetryCompletion {
+template <typename TClient, typename TAsyncStatusType>
+class TRetryContext : public TThrRefBase, public TRetryContextBase {
     enum class EState {
         Running,
         Finished,
@@ -27,22 +25,54 @@ class TRetryCompletion {
     };
 
 public:
-    template <typename TClientImpl>
-    TRetryCompletion(const std::shared_ptr<TClientImpl>& client, std::stop_token token,
-        NThreading::TPromise<TStatusType> promise)
-        : StopCallback_(token, [this, client, promise]() noexcept {
-            if (!TryFinish(EState::Cancelled)) {
-                return;
-            }
-            client->PostToResponseQueue([promise]() mutable {
-                try {
-                    promise.TrySetValue(MakeRetryCancelledResult<TStatusType>());
-                } catch (...) {
-                    promise.TrySetException(std::current_exception());
+    using TStatusType = typename TAsyncStatusType::value_type;
+    using TPtr = TIntrusivePtr<Async::TRetryContext<TClient, TAsyncStatusType>>;
+
+protected:
+    TClient Client_;
+    NThreading::TPromise<TStatusType> Promise_;
+
+public:
+    TAsyncStatusType Execute() {
+        ParentSpan_ = Client_.Impl_->CreateRetryRootSpan();
+
+        this->RetryStartTime_ = TInstant::Now();
+        TPtr self(this);
+        auto future = Promise_.GetFuture();
+        // Retain cancellation registration even if an attempt drops its future.
+        future.Subscribe([self](const auto&) {});
+        DoRetry(self);
+        return future;
+    }
+
+    ~TRetryContext() {
+        if (IsCancelled()) {
+            EndAttemptSpan(EStatus::CLIENT_CANCELLED);
+            EndRetrySpan(EStatus::CLIENT_CANCELLED);
+        }
+    }
+
+protected:
+    explicit TRetryContext(const TClient& client, const TRetryOperationSettings& settings)
+        : TRetryContextBase(settings)
+        , Client_(client)
+        , Promise_(NThreading::NewPromise<TStatusType>())
+    {
+        if (settings.CancellationToken_.stop_possible()) {
+            StopCallback_.emplace(settings.CancellationToken_, [this, client = Client_.Impl_, promise = Promise_]() noexcept {
+                if (!TryFinish(EState::Cancelled)) {
+                    return;
                 }
+                client->ScheduleTask([promise]() mutable {
+                    try {
+                        promise.TrySetValue(MakeRetryCancelledResult<TStatusType>());
+                    } catch (...) {
+                        promise.TrySetException(std::current_exception());
+                    }
+                }, TDeadline::Duration::zero());
             });
-        })
-    {}
+        }
+    }
 
     bool IsFinished() const noexcept {
         return State_.load() != EState::Running;
@@ -57,80 +87,12 @@ public:
         return State_.compare_exchange_strong(expected, state);
     }
 
-private:
-    std::atomic<EState> State_ = EState::Running;
-    std::stop_callback<std::function<void()>> StopCallback_;
-};
-
-template <typename TClient, typename TAsyncStatusType>
-class TRetryContext : public TThrRefBase, public TRetryContextBase {
-public:
-    using TStatusType = typename TAsyncStatusType::value_type;
-    using TPtr = TIntrusivePtr<Async::TRetryContext<TClient, TAsyncStatusType>>;
-
-protected:
-    TClient Client_;
-    NThreading::TPromise<TStatusType> Promise_;
-    TRetryCompletion<TStatusType> Completion_;
-
-public:
-    TAsyncStatusType Execute() {
-        ParentSpan_ = Client_.Impl_->CreateRetryRootSpan();
-
-        this->RetryStartTime_ = TInstant::Now();
-        TPtr self(this);
-        DoRetry(self);
-
-        return this->Promise_.GetFuture().Apply(
-            [self](const auto& f) mutable {
-                try {
-                    auto value = f.GetValue();
-                    if (!self->Completion_.IsCancelled() && self->ParentSpan_) {
-                        self->ParentSpan_->SetRetryCount(self->RetryNumber_);
-                        self->ParentSpan_->End(GetRetryStatusCode(value));
-                    }
-                    return value;
-                } catch (...) {
-                    if (!self->Completion_.IsCancelled() && self->ParentSpan_) {
-                        self->ParentSpan_->SetRetryCount(self->RetryNumber_);
-                        try {
-                            std::rethrow_exception(std::current_exception());
-                        } catch (const std::exception& e) {
-                            self->ParentSpan_->EndWithException(TypeName(e).c_str(), e.what());
-                        } catch (...) {
-                            self->ParentSpan_->EndWithException("unknown", "unknown exception");
-                        }
-                    }
-                    throw;
-                }
-            }
-        );
-    }
-
-    ~TRetryContext() {
-        if (Completion_.IsCancelled()) {
-            EndAttemptSpan(EStatus::CLIENT_CANCELLED);
-            if (ParentSpan_) {
-                ParentSpan_->SetRetryCount(this->RetryNumber_);
-                ParentSpan_->End(EStatus::CLIENT_CANCELLED);
-            }
-        }
-    }
-
-protected:
-    explicit TRetryContext(const TClient& client, const TRetryOperationSettings& settings)
-        : TRetryContextBase(settings)
-        , Client_(client)
-        , Promise_(NThreading::NewPromise<TStatusType>())
-        , Completion_(Client_.Impl_, settings.CancellationToken_, Promise_)
-    {}
-
     virtual void Retry() = 0;
 
     virtual TAsyncStatusType RunOperation() = 0;
 
     static void DoRetry(TPtr self) {
-        if (self->Completion_.IsFinished()) {
+        if (self->IsFinished()) {
             return;
         }
         try {
@@ -157,15 +119,11 @@ protected:
     }
 
     static void HandleExceptionAsync(TPtr self, std::exception_ptr e) {
-        if (!self->Completion_.TryFinish()) {
-            return;
-        }
-        self->EndAttemptSpan(EStatus::CLIENT_INTERNAL_ERROR);
-        self->Promise_.TrySetException(e);
+        self->Finish([e]() -> TStatusType { std::rethrow_exception(e); });
     }
 
     static void HandleStatusAsync(TPtr self, const TStatusType& status) {
-        if (self->Completion_.IsFinished()) {
+        if (self->IsFinished()) {
             return;
         }
         const TStatus& retryStatus = GetRetryStatus(status);
@@ -185,19 +143,12 @@ protected:
             case NextStep::RetrySlowBackoff:
                 return DoBackoff(self, false);
             case NextStep::Finish:
-                if (self->Completion_.TryFinish()) {
-                    try {
-                        self->Promise_.TrySetValue(status);
-                    } catch (...) {
-                        self->Promise_.TrySetException(std::current_exception());
-                    }
-                }
-                return;
+                return self->Finish([&] { return status; });
         }
     }
 
     static void DoRunOperation(TPtr self) {
-        if (self->Completion_.IsFinished()) {
+        if (self->IsFinished()) {
             return;
         }
         try {
@@ -226,6 +177,23 @@ protected:
     }
 
 private:
+    template <typename F>
+    void Finish(F&& getResult) {
+        if (!TryFinish()) {
+            return;
+        }
+        try {
+            auto result = std::forward<F>(getResult)();
+            EndAttemptSpan(GetRetryStatusCode(result));
+            EndRetrySpan(GetRetryStatusCode(result));
+            Promise_.TrySetValue(std::move(result));
+        } catch (...) {
+            EndAttemptSpan(EStatus::CLIENT_INTERNAL_ERROR);
+            EndRetrySpan(std::current_exception());
+            Promise_.TrySetException(std::current_exception());
+        }
+    }
+
     void StartAttemptSpan() {
         AttemptSpan_ = Client_.Impl_->CreateRetryAttemptSpan(
             this->RetryNumber_, LastBackoffMs_, ParentSpan_);
@@ -238,9 +206,10 @@ private:
         }
     }
 
-    std::shared_ptr<NObservability::TRequestSpan> ParentSpan_;
     std::shared_ptr<NObservability::TRequestSpan> AttemptSpan_;
     std::int64_t LastBackoffMs_ = 0;
+    std::atomic<EState> State_ = EState::Running;
+    std::optional<std::stop_callback<std::function<void()>>> StopCallback_;
 };
 
 template <typename TClient, typename TOperation, typename TAsyncStatusType = TFunctionResult<TOperation>>
@@ -265,12 +234,7 @@ public:
 
 protected:
     TAsyncStatusType RunOperation() override {
-        TInRetryOperationContextClientGuard guard(this->Client_);
-        if constexpr (TFunctionArgs<TOperation>::Length == 1) {
-            return Operation_(this->Client_);
-        } else {
-            return Operation_(this->Client_, this->GetRemainingTimeout());
-        }
+        return this->InvokeOperation(this->Client_, Operation_, this->Client_);
     }
 };
 
@@ -297,7 +261,7 @@ public:
 
     void Retry() override {
         TIntrusivePtr<TRetryWithSession> self(this);
-        if (self->Completion_.IsFinished()) {
+        if (self->IsFinished()) {
             return;
         }
         if (!Session_) {
@@ -308,7 +272,7 @@ public:
             this->Client_.GetSession(settings).Subscribe(
                 [self](const TAsyncCreateSessionResult& resultFuture) {
                     [[maybe_unused]] auto attemptScope = self->ActivateAttemptSpan();
-                    if (self->Completion_.IsFinished()) {
+                    if (self->IsFinished()) {
                         return;
                     }
                     try {
@@ -337,12 +301,7 @@ private:
     }
 
     TAsyncStatusType RunOperation() override {
-        TInRetryOperationContextClientGuard guard(this->Client_);
-        if constexpr (TFunctionArgs<TOperation>::Length == 1) {
-            return Operation_(this->Session_.value());
-        } else {
-            return Operation_(this->Session_.value(), this->GetRemainingTimeout());
-        }
+        return this->InvokeOperation(this->Client_, Operation_, this->Session_.value());
     }
 };
 

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_async.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_async.h
@@ -20,47 +20,38 @@ namespace NYdb::inline Dev::NRetry::Async {
 
 template <typename TStatusType>
 class TRetryCompletion {
-    enum class EState {
-        Running,
-        Finished,
-        Cancelled,
-    };
-
 public:
     TRetryCompletion(std::stop_token token, NThreading::TPromise<TStatusType> promise)
         : Promise_(std::move(promise))
-        , StopCallback_(token, [this]() noexcept { Cancel(); })
+        , StopCallback_(token, [this]() noexcept {
+            auto promise = Promise_;
+            if (!TryFinish()) {
+                return;
+            }
+            try {
+                promise.TrySetValue(MakeRetryCancelledResult<TStatusType>());
+            } catch (...) {
+                promise.TrySetException(std::current_exception());
+            }
+        })
     {}
 
     bool IsFinished() const noexcept {
-        return State_.load() != EState::Running;
+        return Finished_.load();
     }
 
     bool IsCancelled() const noexcept {
-        return State_.load() == EState::Cancelled;
+        return Promise_.HasValue() && GetRetryStatusCode(Promise_.GetValue()) == EStatus::CLIENT_CANCELLED;
     }
 
     bool TryFinish() noexcept {
-        auto expected = EState::Running;
-        return State_.compare_exchange_strong(expected, EState::Finished);
+        bool expected = false;
+        return Finished_.compare_exchange_strong(expected, true);
     }
 
 private:
-    void Cancel() noexcept {
-        auto promise = Promise_;
-        auto expected = EState::Running;
-        if (!State_.compare_exchange_strong(expected, EState::Cancelled)) {
-            return;
-        }
-        try {
-            promise.TrySetValue(MakeRetryCancelledResult<TStatusType>());
-        } catch (...) {
-            promise.TrySetException(std::current_exception());
-        }
-    }
-
     NThreading::TPromise<TStatusType> Promise_;
-    std::atomic<EState> State_ = EState::Running;
+    std::atomic_bool Finished_ = false;
     std::stop_callback<std::function<void()>> StopCallback_;
 };
 
@@ -257,7 +248,7 @@ public:
     explicit TRetryWithoutSession(
         const TClient& client, TOperation&& operation, const TRetryOperationSettings& settings)
         : TRetryContext(client, settings)
-        , Operation_(operation)
+        , Operation_(std::move(operation))
     {}
 
     void Retry() override {

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_async.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_async.h
@@ -8,13 +8,61 @@
 #include <util/generic/function.h>
 #include <util/system/type_name.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <exception>
+#include <functional>
 #include <memory>
 #include <typeinfo>
 
 namespace NYdb::inline Dev::NRetry::Async {
+
+template <typename TStatusType>
+class TRetryCompletion {
+    enum class EState {
+        Running,
+        Finished,
+        Cancelled,
+    };
+
+public:
+    TRetryCompletion(std::stop_token token, NThreading::TPromise<TStatusType> promise)
+        : Promise_(std::move(promise))
+        , StopCallback_(token, [this]() noexcept { Cancel(); })
+    {}
+
+    bool IsFinished() const noexcept {
+        return State_.load() != EState::Running;
+    }
+
+    bool IsCancelled() const noexcept {
+        return State_.load() == EState::Cancelled;
+    }
+
+    bool TryFinish() noexcept {
+        auto expected = EState::Running;
+        return State_.compare_exchange_strong(expected, EState::Finished);
+    }
+
+private:
+    void Cancel() noexcept {
+        auto promise = Promise_;
+        auto expected = EState::Running;
+        if (!State_.compare_exchange_strong(expected, EState::Cancelled)) {
+            return;
+        }
+        try {
+            promise.TrySetValue(MakeRetryCancelledResult<TStatusType>());
+        } catch (...) {
+            promise.TrySetException(std::current_exception());
+        }
+    }
+
+    NThreading::TPromise<TStatusType> Promise_;
+    std::atomic<EState> State_ = EState::Running;
+    std::stop_callback<std::function<void()>> StopCallback_;
+};
 
 template <typename TClient, typename TAsyncStatusType>
 class TRetryContext : public TThrRefBase, public TRetryContextBase {
@@ -25,6 +73,7 @@ public:
 protected:
     TClient Client_;
     NThreading::TPromise<TStatusType> Promise_;
+    TRetryCompletion<TStatusType> Completion_;
 
 public:
     TAsyncStatusType Execute() {
@@ -38,13 +87,13 @@ public:
             [self](const auto& f) mutable {
                 try {
                     auto value = f.GetValue();
-                    if (self->ParentSpan_) {
+                    if (!self->Completion_.IsCancelled() && self->ParentSpan_) {
                         self->ParentSpan_->SetRetryCount(self->RetryNumber_);
                         self->ParentSpan_->End(GetRetryStatusCode(value));
                     }
                     return value;
                 } catch (...) {
-                    if (self->ParentSpan_) {
+                    if (!self->Completion_.IsCancelled() && self->ParentSpan_) {
                         self->ParentSpan_->SetRetryCount(self->RetryNumber_);
                         try {
                             std::rethrow_exception(std::current_exception());
@@ -60,11 +109,22 @@ public:
         );
     }
 
+    ~TRetryContext() {
+        if (Completion_.IsCancelled()) {
+            EndAttemptSpan(EStatus::CLIENT_CANCELLED);
+            if (ParentSpan_) {
+                ParentSpan_->SetRetryCount(this->RetryNumber_);
+                ParentSpan_->End(EStatus::CLIENT_CANCELLED);
+            }
+        }
+    }
+
 protected:
     explicit TRetryContext(const TClient& client, const TRetryOperationSettings& settings)
         : TRetryContextBase(settings)
         , Client_(client)
         , Promise_(NThreading::NewPromise<TStatusType>())
+        , Completion_(settings.CancellationToken_, Promise_)
     {}
 
     virtual void Retry() = 0;
@@ -72,12 +132,19 @@ protected:
     virtual TAsyncStatusType RunOperation() = 0;
 
     static void DoRetry(TPtr self) {
-        [[maybe_unused]] auto parentScope = self->ParentSpan_ ? self->ParentSpan_->Activate() : nullptr;
+        if (self->Completion_.IsFinished()) {
+            return;
+        }
+        try {
+            [[maybe_unused]] auto parentScope = self->ParentSpan_ ? self->ParentSpan_->Activate() : nullptr;
 
-        self->StartAttemptSpan();
+            self->StartAttemptSpan();
 
-        [[maybe_unused]] auto attemptScope = self->AttemptSpan_ ? self->AttemptSpan_->Activate() : nullptr;
-        self->Retry();
+            [[maybe_unused]] auto attemptScope = self->AttemptSpan_ ? self->AttemptSpan_->Activate() : nullptr;
+            self->Retry();
+        } catch (...) {
+            HandleExceptionAsync(self, std::current_exception());
+        }
     }
 
     static void DoBackoff(TPtr self, bool fast) {
@@ -92,11 +159,17 @@ protected:
     }
 
     static void HandleExceptionAsync(TPtr self, std::exception_ptr e) {
+        if (!self->Completion_.TryFinish()) {
+            return;
+        }
         self->EndAttemptSpan(EStatus::CLIENT_INTERNAL_ERROR);
-        self->Promise_.SetException(e);
+        self->Promise_.TrySetException(e);
     }
 
     static void HandleStatusAsync(TPtr self, const TStatusType& status) {
+        if (self->Completion_.IsFinished()) {
+            return;
+        }
         const TStatus& retryStatus = GetRetryStatus(status);
         self->EndAttemptSpan(retryStatus.GetStatus());
         auto nextStep = self->GetNextStep(retryStatus);
@@ -114,11 +187,21 @@ protected:
             case NextStep::RetrySlowBackoff:
                 return DoBackoff(self, false);
             case NextStep::Finish:
-                return self->Promise_.SetValue(status);
+                if (self->Completion_.TryFinish()) {
+                    try {
+                        self->Promise_.TrySetValue(status);
+                    } catch (...) {
+                        self->Promise_.TrySetException(std::current_exception());
+                    }
+                }
+                return;
         }
     }
 
     static void DoRunOperation(TPtr self) {
+        if (self->Completion_.IsFinished()) {
+            return;
+        }
         try {
             self->RunOperation().Subscribe(
                 [self](const TAsyncStatusType& result) {
@@ -216,6 +299,9 @@ public:
 
     void Retry() override {
         TIntrusivePtr<TRetryWithSession> self(this);
+        if (self->Completion_.IsFinished()) {
+            return;
+        }
         if (!Session_) {
             auto settings = TCreateSessionSettings()
                 .ClientTimeout(this->Settings_.GetSessionClientTimeout_)
@@ -224,6 +310,9 @@ public:
             this->Client_.GetSession(settings).Subscribe(
                 [self](const TAsyncCreateSessionResult& resultFuture) {
                     [[maybe_unused]] auto attemptScope = self->ActivateAttemptSpan();
+                    if (self->Completion_.IsFinished()) {
+                        return;
+                    }
                     try {
                         auto& result = resultFuture.GetValue();
                         if (!result.IsSuccess()) {

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_settings.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_settings.h
@@ -56,17 +56,22 @@ template <typename TClient, typename TRunOnce>
 auto RunUnaryWithRetry(TClient& client, TRetryOperationSettings settings, TRunOnce&& runOnce)
     -> decltype(runOnce(TDuration::Max()))
 {
-    if (client.GetInRetryOperationContext()) {
+    const bool nested = client.GetInRetryOperationContext();
+    if (nested && !settings.CancellationToken_.stop_possible()) {
         return runOnce(TDuration::Max());
     }
-    if (!IsRetryEnabled(settings)) {
+    if (!IsRetryEnabled(settings) && !settings.CancellationToken_.stop_possible()) {
         return runOnce(settings.MaxTimeout_);
+    }
+    if (nested) {
+        settings.MaxRetries(0);
     }
 
     using TResult = decltype(runOnce(TDuration::Max()));
 
-    auto operation = [runOnce = std::forward<TRunOnce>(runOnce)](TClient& /*clientRef*/, TDuration remainingTimeout) -> TResult {
-        return runOnce(remainingTimeout);
+    auto operation = [runOnce = std::forward<TRunOnce>(runOnce), nested]
+        (TClient& /*clientRef*/, TDuration remainingTimeout) mutable -> TResult {
+        return runOnce(nested ? TDuration::Max() : remainingTimeout);
     };
 
     using TRetryAsync = Async::TRetryWithoutSession<TClient, decltype(operation), TResult>;

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_settings.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_settings.h
@@ -52,16 +52,19 @@ inline TRetryOperationSettings ResolveRetrySettings(
         clientDefault, operationOverride, std::nullopt, operationClientTimeout, idempotentDefault);
 }
 
+template <typename TClient>
+bool ShouldUseUnaryRetryContext(TClient& client, const TRetryOperationSettings& settings) {
+    return settings.CancellationToken_.stop_possible()
+        || (IsRetryEnabled(settings) && !client.GetInRetryOperationContext());
+}
+
 template <typename TClient, typename TRunOnce>
 auto RunUnaryWithRetry(TClient& client, TRetryOperationSettings settings, TRunOnce&& runOnce)
     -> decltype(runOnce(TDuration::Max()))
 {
     const bool nested = client.GetInRetryOperationContext();
-    if (nested && !settings.CancellationToken_.stop_possible()) {
-        return runOnce(TDuration::Max());
-    }
-    if (!IsRetryEnabled(settings) && !settings.CancellationToken_.stop_possible()) {
-        return runOnce(settings.MaxTimeout_);
+    if (!ShouldUseUnaryRetryContext(client, settings)) {
+        return runOnce(nested ? TDuration::Max() : settings.MaxTimeout_);
     }
     if (nested) {
         settings.MaxRetries(0);

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_settings.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_settings.h
@@ -58,24 +58,30 @@ bool ShouldUseUnaryRetryContext(TClient& client, const TRetryOperationSettings& 
         || (IsRetryEnabled(settings) && !client.GetInRetryOperationContext());
 }
 
-template <typename TClient, typename TRunOnce>
-auto RunUnaryWithRetry(TClient& client, TRetryOperationSettings settings, TRunOnce&& runOnce)
-    -> decltype(runOnce(TDuration::Max()))
+template <typename TClient, typename TRequestSettings, typename TRunOnce>
+auto RunUnaryWithRetry(TClient& client, TRetryOperationSettings settings,
+    const TRequestSettings& requestSettings, TRunOnce&& runOnce)
+    -> decltype(runOnce(std::declval<TRequestSettings&>()))
 {
     const bool nested = client.GetInRetryOperationContext();
+    const bool retryEnabled = IsRetryEnabled(settings) && !nested;
+    using TResult = decltype(runOnce(std::declval<TRequestSettings&>()));
+
+    auto operation = [requestSettings = requestSettings, runOnce = std::forward<TRunOnce>(runOnce), nested, retryEnabled]
+        (TClient& /*clientRef*/, TDuration remainingTimeout) mutable -> TResult {
+        auto attemptSettings = retryEnabled ? requestSettings : std::move(requestSettings);
+        if (!nested && remainingTimeout != TDuration::Max()) {
+            attemptSettings.ClientTimeout(remainingTimeout);
+        }
+        return runOnce(attemptSettings);
+    };
+
     if (!ShouldUseUnaryRetryContext(client, settings)) {
-        return runOnce(nested ? TDuration::Max() : settings.MaxTimeout_);
+        return operation(client, settings.MaxTimeout_);
     }
     if (nested) {
         settings.MaxRetries(0);
     }
-
-    using TResult = decltype(runOnce(TDuration::Max()));
-
-    auto operation = [runOnce = std::forward<TRunOnce>(runOnce), nested]
-        (TClient& /*clientRef*/, TDuration remainingTimeout) mutable -> TResult {
-        return runOnce(nested ? TDuration::Max() : remainingTimeout);
-    };
 
     using TRetryAsync = Async::TRetryWithoutSession<TClient, decltype(operation), TResult>;
     using TRetryContextAsync = Async::TRetryContext<TClient, TResult>;

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_sync.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_sync.h
@@ -7,11 +7,8 @@
 #include <ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.h>
 #include <ydb/public/sdk/cpp/src/client/impl/observability/span.h>
 
-#include <util/system/type_name.h>
-
 #include <exception>
 #include <memory>
-#include <typeinfo>
 
 namespace NYdb::inline Dev::NRetry::Sync {
 
@@ -25,26 +22,12 @@ public:
         ParentSpan_ = Client_.Impl_->CreateRetryRootSpan();
 
         [[maybe_unused]] auto parentScope = ParentSpan_ ? ParentSpan_->Activate() : nullptr;
-        auto& parentSpan = ParentSpan_;
-
         try {
             auto status = ExecuteImpl();
-            if (parentSpan) {
-                parentSpan->SetRetryCount(this->RetryNumber_);
-                parentSpan->End(status.GetStatus());
-            }
+            EndRetrySpan(status.GetStatus());
             return status;
         } catch (...) {
-            if (parentSpan) {
-                parentSpan->SetRetryCount(this->RetryNumber_);
-                try {
-                    std::rethrow_exception(std::current_exception());
-                } catch (const std::exception& e) {
-                    parentSpan->EndWithException(TypeName(e).c_str(), e.what());
-                } catch (...) {
-                    parentSpan->EndWithException("unknown", "unknown exception");
-                }
-            }
+            EndRetrySpan(std::current_exception());
             throw;
         }
     }
@@ -123,7 +106,6 @@ private:
         return status;
     }
 
-    std::shared_ptr<NObservability::TRequestSpan> ParentSpan_;
 };
 
 template<typename TClient, typename TOperation, typename TStatusType = TFunctionResult<TOperation>>
@@ -144,12 +126,7 @@ protected:
 
     TStatusType RunOperation() override {
         return InvokeWithRangeErrorCatch<TStatusType>([&]() -> TStatusType {
-            TInRetryOperationContextClientGuard guard(this->Client_);
-            if constexpr (TFunctionArgs<TOperation>::Length == 1) {
-                return Operation_(this->Client_);
-            } else {
-                return Operation_(this->Client_, this->GetRemainingTimeout());
-            }
+            return this->InvokeOperation(this->Client_, Operation_, this->Client_);
         });
     }
 };
@@ -173,42 +150,28 @@ public:
 
 protected:
     TStatusType Retry() override {
-        std::optional<TStatusType> status;
-
         if (!Session_) {
             auto settings = TCreateSessionSettings()
                 .ClientTimeout(this->Settings_.GetSessionClientTimeout_)
                 .Deadline(Deadline_);
 
             auto sessionResult = this->Client_.GetSession(settings).GetValueSync();
-            if (this->IsCancellationRequested()) {
-                return MakeRetryCancelledResult<TStatusType>();
+            if (!sessionResult.IsSuccess()) {
+                return MakeRetryResultFromStatus<TStatusType>(TStatus(sessionResult));
             }
-            if (sessionResult.IsSuccess()) {
-                Session_ = sessionResult.GetSession();
-                TRetryDeadlineHelper<TClient>::SetDeadline(*Session_, Deadline_);
-            }
-            status = MakeRetryResultFromStatus<TStatusType>(TStatus(sessionResult));
+            Session_ = sessionResult.GetSession();
+            TRetryDeadlineHelper<TClient>::SetDeadline(*Session_, Deadline_);
         }
 
-        if (Session_) {
-            if (this->IsCancellationRequested()) {
-                return MakeRetryCancelledResult<TStatusType>();
-            }
-            status = RunOperation();
+        if (this->IsCancellationRequested()) {
+            return MakeRetryCancelledResult<TStatusType>();
         }
-
-        return *status;
+        return RunOperation();
     }
 
     TStatusType RunOperation() override {
         return InvokeWithRangeErrorCatch<TStatusType>([&]() -> TStatusType {
-            TInRetryOperationContextClientGuard guard(this->Client_);
-            if constexpr (TFunctionArgs<TOperation>::Length == 1) {
-                return Operation_(this->Session_.value());
-            } else {
-                return Operation_(this->Session_.value(), this->GetRemainingTimeout());
-            }
+            return this->InvokeOperation(this->Client_, Operation_, this->Session_.value());
         });
     }
 

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_sync.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_sync.h
@@ -60,6 +60,9 @@ protected:
     virtual TStatusType RunOperation() = 0;
 
     std::chrono::microseconds DoBackoff(bool fast) {
+        if (this->IsCancellationRequested()) {
+            return {};
+        }
         const auto &settings = fast ? this->Settings_.FastBackoffSettings_
                                     : this->Settings_.SlowBackoffSettings_;
         return Backoff(settings, this->RetryNumber_);

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_sync.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_sync.h
@@ -177,17 +177,10 @@ protected:
                 .ClientTimeout(this->Settings_.GetSessionClientTimeout_)
                 .Deadline(Deadline_);
 
-            auto sessionFuture = this->Client_.GetSession(settings);
-            if (this->Settings_.CancellationToken_.stop_possible()) {
-                auto ready = NThreading::NewPromise<void>();
-                std::stop_callback stopCallback(this->Settings_.CancellationToken_, [&ready] { ready.TrySetValue(); });
-                sessionFuture.Subscribe([ready](const auto&) mutable { ready.TrySetValue(); });
-                ready.GetFuture().Wait();
-                if (this->IsCancellationRequested()) {
-                    return MakeRetryCancelledResult<TStatusType>();
-                }
+            auto sessionResult = this->Client_.GetSession(settings).GetValueSync();
+            if (this->IsCancellationRequested()) {
+                return MakeRetryCancelledResult<TStatusType>();
             }
-            auto sessionResult = sessionFuture.GetValueSync();
             if (sessionResult.IsSuccess()) {
                 Session_ = sessionResult.GetSession();
                 TRetryDeadlineHelper<TClient>::SetDeadline(*Session_, Deadline_);

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_sync.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_sync.h
@@ -86,6 +86,9 @@ private:
                 case NextStep::Finish:
                     return status;
             }
+            if (this->IsCancellationRequested()) {
+                return MakeRetryCancelledResult<TStatusType>();
+            }
             this->RetryNumber_++;
             this->LogRetry(status);
             this->Client_.Impl_->CollectRetryStatSync(status.GetStatus());
@@ -96,6 +99,9 @@ private:
     }
 
     TStatusType RunAttempt(std::int64_t backoffMs) {
+        if (this->IsCancellationRequested()) {
+            return MakeRetryCancelledResult<TStatusType>();
+        }
         auto attemptSpan = Client_.Impl_->CreateRetryAttemptSpan(this->RetryNumber_, backoffMs, ParentSpan_);
         [[maybe_unused]] std::unique_ptr<NTrace::IScope> scope;
         if (attemptSpan) {
@@ -103,6 +109,10 @@ private:
         }
 
         TStatusType status = Retry();
+
+        if (this->IsCancellationRequested()) {
+            status = MakeRetryCancelledResult<TStatusType>();
+        }
 
         if (attemptSpan) {
             attemptSpan->End(status.GetStatus());
@@ -167,7 +177,17 @@ protected:
                 .ClientTimeout(this->Settings_.GetSessionClientTimeout_)
                 .Deadline(Deadline_);
 
-            auto sessionResult = this->Client_.GetSession(settings).GetValueSync();
+            auto sessionFuture = this->Client_.GetSession(settings);
+            if (this->Settings_.CancellationToken_.stop_possible()) {
+                auto ready = NThreading::NewPromise<void>();
+                std::stop_callback stopCallback(this->Settings_.CancellationToken_, [&ready] { ready.TrySetValue(); });
+                sessionFuture.Subscribe([ready](const auto&) mutable { ready.TrySetValue(); });
+                ready.GetFuture().Wait();
+                if (this->IsCancellationRequested()) {
+                    return MakeRetryCancelledResult<TStatusType>();
+                }
+            }
+            auto sessionResult = sessionFuture.GetValueSync();
             if (sessionResult.IsSuccess()) {
                 Session_ = sessionResult.GetSession();
                 TRetryDeadlineHelper<TClient>::SetDeadline(*Session_, Deadline_);
@@ -176,6 +196,9 @@ protected:
         }
 
         if (Session_) {
+            if (this->IsCancellationRequested()) {
+                return MakeRetryCancelledResult<TStatusType>();
+            }
             status = RunOperation();
         }
 

--- a/ydb/public/sdk/cpp/src/client/query/client.cpp
+++ b/ydb/public/sdk/cpp/src/client/query/client.cpp
@@ -754,13 +754,9 @@ TAsyncExecuteQueryResult TQueryClient::ExecuteQuery(const std::string& query, co
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::False);
 
-    return NRetry::RunUnaryWithRetry(*this, retrySettings,
-        [this, query, txControl, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->ExecuteQuery(query, txControl, {}, opSettings);
+    return NRetry::RunUnaryWithRetry(*this, retrySettings, settings,
+        [impl = Impl_, query, txControl](const TExecuteQuerySettings& opSettings) {
+            return impl->ExecuteQuery(query, txControl, {}, opSettings);
         });
 }
 
@@ -773,13 +769,9 @@ TAsyncExecuteQueryResult TQueryClient::ExecuteQuery(const std::string& query, co
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::False);
 
-    return NRetry::RunUnaryWithRetry(*this, retrySettings,
-        [this, query, txControl, params, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->ExecuteQuery(query, txControl, params, opSettings);
+    return NRetry::RunUnaryWithRetry(*this, retrySettings, settings,
+        [impl = Impl_, query, txControl, params](const TExecuteQuerySettings& opSettings) {
+            return impl->ExecuteQuery(query, txControl, params, opSettings);
         });
 }
 
@@ -806,13 +798,9 @@ NThreading::TFuture<TScriptExecutionOperation> TQueryClient::ExecuteScript(const
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::False);
 
-    return NRetry::RunUnaryWithRetry(*this, resolvedRetrySettings,
-        [this, script, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->ExecuteScript(script, {}, opSettings);
+    return NRetry::RunUnaryWithRetry(*this, resolvedRetrySettings, settings,
+        [impl = Impl_, script](const TExecuteScriptSettings& opSettings) {
+            return impl->ExecuteScript(script, {}, opSettings);
         });
 }
 
@@ -827,13 +815,9 @@ NThreading::TFuture<TScriptExecutionOperation> TQueryClient::ExecuteScript(const
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::False);
 
-    return NRetry::RunUnaryWithRetry(*this, resolvedRetrySettings,
-        [this, script, params, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->ExecuteScript(script, params, opSettings);
+    return NRetry::RunUnaryWithRetry(*this, resolvedRetrySettings, settings,
+        [impl = Impl_, script, params](const TExecuteScriptSettings& opSettings) {
+            return impl->ExecuteScript(script, params, opSettings);
         });
 }
 
@@ -848,13 +832,9 @@ TAsyncFetchScriptResultsResult TQueryClient::FetchScriptResults(const NKikimr::N
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::True);
 
-    return NRetry::RunUnaryWithRetry(*this, resolvedRetrySettings,
-        [this, operationId, resultSetIndex, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->FetchScriptResults(operationId, resultSetIndex, opSettings);
+    return NRetry::RunUnaryWithRetry(*this, resolvedRetrySettings, settings,
+        [impl = Impl_, operationId, resultSetIndex](const TFetchScriptResultsSettings& opSettings) {
+            return impl->FetchScriptResults(operationId, resultSetIndex, opSettings);
         });
 }
 
@@ -871,13 +851,9 @@ TAsyncStatus TQueryClient::DeleteSession(const std::string& sessionId, const TDe
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::True);
 
-    return NRetry::RunUnaryWithRetry(*this, resolvedRetrySettings,
-        [this, sessionId, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->DeleteSession(sessionId, opSettings);
+    return NRetry::RunUnaryWithRetry(*this, resolvedRetrySettings, settings,
+        [impl = Impl_, sessionId](const TDeleteSessionSettings& opSettings) {
+            return impl->DeleteSession(sessionId, opSettings);
         });
 }
 

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -1714,45 +1714,13 @@ TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, TValue
         return Impl_->BulkUpsert(table, std::move(rows), settings);
     }
 
-    auto state = std::make_shared<NRetry::TBulkUpsertRetryState>(retrySettings);
-    auto opSettings = settings;
-    opSettings.RetryRowsState_ = retryEnabled ? state : nullptr;
-    const auto startedAt = TInstant::Now();
-
-    auto firstAttemptSettings = retrySettings;
-    firstAttemptSettings.MaxRetries(0);
-    return NRetry::RunUnaryWithRetry(*this, firstAttemptSettings,
-        [this, table, rows = std::move(rows), opSettings = std::move(opSettings)](TDuration) mutable {
-            return Impl_->BulkUpsert(table, std::move(rows), opSettings);
-        }).Apply(
-        [this, table, settings, retrySettings, retryEnabled, state, startedAt](const TAsyncBulkUpsertResult& f) {
-            const auto result = f.GetValue();
-            if (!retryEnabled || result.IsSuccess()
-                || !NRetry::ShouldRetryStatus(result.GetStatus(), retrySettings)) {
-                return NThreading::MakeFuture(result);
-            }
-            Y_ABORT_UNLESS(state->HasBackup());
-
-            const auto elapsed = TInstant::Now() - startedAt;
-            if (retrySettings.MaxTimeout_ != TDuration::Max() && elapsed >= retrySettings.MaxTimeout_) {
-                return NThreading::MakeFuture(result);
-            }
-
-            auto remaining = retrySettings;
-            remaining.MaxRetries(retrySettings.MaxRetries_ - 1);
-            if (retrySettings.MaxTimeout_ != TDuration::Max()) {
-                remaining.MaxTimeout(retrySettings.MaxTimeout_ - elapsed);
-            }
-
-            return NRetry::RunUnaryWithRetry(*this, remaining,
-                [this, table, state, settings](TDuration timeout) {
-                    auto op = settings;
-                    op.RetryRowsState_.reset();
-                    if (timeout != TDuration::Max()) {
-                        op.ClientTimeout(timeout);
-                    }
-                    return Impl_->BulkUpsert(table, state->GetBackupCopy(), op);
-                });
+    auto state = retryEnabled ? std::make_shared<NRetry::TBulkUpsertRetryState>(retrySettings) : nullptr;
+    return NRetry::RunUnaryWithRetry(*this, retrySettings, settings,
+        [impl = Impl_, table, rows = std::move(rows), state, firstAttempt = true](TBulkUpsertSettings& opSettings) mutable {
+            opSettings.RetryRowsState_ = firstAttempt ? state : nullptr;
+            auto requestRows = firstAttempt ? std::move(rows) : state->GetBackupCopy();
+            firstAttempt = false;
+            return impl->BulkUpsert(table, std::move(requestRows), opSettings);
         });
 }
 
@@ -1768,13 +1736,16 @@ TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, EDataF
         return Impl_->BulkUpsert(table, format, data, schema, settings);
     }
 
-    return NRetry::RunUnaryWithRetry(*this, retrySettings,
-        [this, table, format, data, schema, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
+    if (!NRetry::IsRetryEnabled(retrySettings) || GetInRetryOperationContext()) {
+        // A single attempt runs synchronously, so its inputs need no retry copies.
+        return NRetry::RunUnaryWithRetry(*this, retrySettings, settings, [&](const TBulkUpsertSettings& opSettings) {
             return Impl_->BulkUpsert(table, format, data, schema, opSettings);
+        });
+    }
+
+    return NRetry::RunUnaryWithRetry(*this, retrySettings, settings,
+        [impl = Impl_, table, format, data, schema](const TBulkUpsertSettings& opSettings) {
+            return impl->BulkUpsert(table, format, data, schema, opSettings);
         });
 }
 
@@ -1789,15 +1760,12 @@ TAsyncReadRowsResult TTableClient::ReadRows(const std::string& table, TValue&& r
     if (!NRetry::ShouldUseUnaryRetryContext(*this, retrySettings)) {
         return Impl_->ReadRows(table, std::move(rows), columns, settings);
     }
-    TValue keysCopy = std::move(rows);
+    const bool retryEnabled = NRetry::IsRetryEnabled(retrySettings) && !GetInRetryOperationContext();
 
-    return NRetry::RunUnaryWithRetry(*this, retrySettings,
-        [this, table, keysCopy = std::move(keysCopy), columns, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->ReadRows(table, TValue{keysCopy}, columns, opSettings);
+    return NRetry::RunUnaryWithRetry(*this, retrySettings, settings,
+        [impl = Impl_, table, keys = std::move(rows), columns, retryEnabled](const TReadRowsSettings& opSettings) mutable {
+            auto requestKeys = retryEnabled ? keys : std::move(keys);
+            return impl->ReadRows(table, std::move(requestKeys), columns, opSettings);
         });
 }
 

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -1710,19 +1710,19 @@ TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, TValue
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::True);
     const bool retryEnabled = NRetry::IsRetryEnabled(retrySettings) && !GetInRetryOperationContext();
-    if (!retryEnabled && !retrySettings.CancellationToken_.stop_possible()) {
+    if (!NRetry::ShouldUseUnaryRetryContext(*this, retrySettings)) {
         return Impl_->BulkUpsert(table, std::move(rows), settings);
     }
 
     auto state = std::make_shared<NRetry::TBulkUpsertRetryState>(retrySettings);
     auto opSettings = settings;
-    opSettings.RetryRowsState_ = state;
+    opSettings.RetryRowsState_ = retryEnabled ? state : nullptr;
     const auto startedAt = TInstant::Now();
 
     auto firstAttemptSettings = retrySettings;
     firstAttemptSettings.MaxRetries(0);
     return NRetry::RunUnaryWithRetry(*this, firstAttemptSettings,
-        [this, table, rows = std::move(rows), opSettings](TDuration) mutable {
+        [this, table, rows = std::move(rows), opSettings = std::move(opSettings)](TDuration) mutable {
             return Impl_->BulkUpsert(table, std::move(rows), opSettings);
         }).Apply(
         [this, table, settings, retrySettings, retryEnabled, state, startedAt](const TAsyncBulkUpsertResult& f) {
@@ -1764,8 +1764,7 @@ TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, EDataF
         settings.RetrySettings_,
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::True);
-    if ((!NRetry::IsRetryEnabled(retrySettings) || GetInRetryOperationContext())
-        && !retrySettings.CancellationToken_.stop_possible()) {
+    if (!NRetry::ShouldUseUnaryRetryContext(*this, retrySettings)) {
         return Impl_->BulkUpsert(table, format, data, schema, settings);
     }
 
@@ -1787,8 +1786,7 @@ TAsyncReadRowsResult TTableClient::ReadRows(const std::string& table, TValue&& r
         settings.RetrySettings_,
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::True);
-    if ((!NRetry::IsRetryEnabled(retrySettings) || GetInRetryOperationContext())
-        && !retrySettings.CancellationToken_.stop_possible()) {
+    if (!NRetry::ShouldUseUnaryRetryContext(*this, retrySettings)) {
         return Impl_->ReadRows(table, std::move(rows), columns, settings);
     }
     TValue keysCopy = std::move(rows);

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -1709,7 +1709,8 @@ TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, TValue
         settings.RetrySettings_,
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::True);
-    if (!NRetry::IsRetryEnabled(retrySettings) || GetInRetryOperationContext()) {
+    const bool retryEnabled = NRetry::IsRetryEnabled(retrySettings) && !GetInRetryOperationContext();
+    if (!retryEnabled && !retrySettings.CancellationToken_.stop_possible()) {
         return Impl_->BulkUpsert(table, std::move(rows), settings);
     }
 
@@ -1718,10 +1719,15 @@ TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, TValue
     opSettings.RetryRowsState_ = state;
     const auto startedAt = TInstant::Now();
 
-    return Impl_->BulkUpsert(table, std::move(rows), opSettings).Apply(
-        [this, table, settings, retrySettings, state, startedAt](const TAsyncBulkUpsertResult& f) {
+    auto firstAttemptSettings = retrySettings;
+    firstAttemptSettings.MaxRetries(0);
+    return NRetry::RunUnaryWithRetry(*this, firstAttemptSettings,
+        [this, table, rows = std::move(rows), opSettings](TDuration) mutable {
+            return Impl_->BulkUpsert(table, std::move(rows), opSettings);
+        }).Apply(
+        [this, table, settings, retrySettings, retryEnabled, state, startedAt](const TAsyncBulkUpsertResult& f) {
             const auto result = f.GetValue();
-            if (result.IsSuccess()
+            if (!retryEnabled || result.IsSuccess()
                 || !NRetry::ShouldRetryStatus(result.GetStatus(), retrySettings)) {
                 return NThreading::MakeFuture(result);
             }
@@ -1758,7 +1764,8 @@ TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, EDataF
         settings.RetrySettings_,
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::True);
-    if (!NRetry::IsRetryEnabled(retrySettings) || GetInRetryOperationContext()) {
+    if ((!NRetry::IsRetryEnabled(retrySettings) || GetInRetryOperationContext())
+        && !retrySettings.CancellationToken_.stop_possible()) {
         return Impl_->BulkUpsert(table, format, data, schema, settings);
     }
 
@@ -1780,7 +1787,8 @@ TAsyncReadRowsResult TTableClient::ReadRows(const std::string& table, TValue&& r
         settings.RetrySettings_,
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::True);
-    if (!NRetry::IsRetryEnabled(retrySettings) || GetInRetryOperationContext()) {
+    if ((!NRetry::IsRetryEnabled(retrySettings) || GetInRetryOperationContext())
+        && !retrySettings.CancellationToken_.stop_possible()) {
         return Impl_->ReadRows(table, std::move(rows), columns, settings);
     }
     TValue keysCopy = std::move(rows);

--- a/ydb/public/sdk/cpp/tests/unit/client/retry/retry_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/retry/retry_ut.cpp
@@ -4,7 +4,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/result/rows.h>
 #include <ydb/public/sdk/cpp/src/client/row_ranges/rows_stream_drain.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
-#include <ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_sync.h>
+#include <ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.h>
 #include <ydb/public/sdk/cpp/tests/common/fake_trace_provider.h>
 
 #include <ydb/public/api/protos/ydb_value.pb.h>
@@ -24,6 +24,7 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
+#include <atomic>
 #include <deque>
 #include <functional>
 #include <stdexcept>
@@ -94,6 +95,7 @@ void SimulateScanDrainFailure() {
 class TMockTableService : public Ydb::Table::V1::TableService::Service {
 public:
     std::function<void()> OnCreateSession;
+    std::function<Ydb::StatusIds::StatusCode(const Ydb::Table::BulkUpsertRequest&)> OnBulkUpsert;
 
     grpc::Status CreateSession(
         grpc::ServerContext*,
@@ -110,6 +112,15 @@ public:
         op->set_ready(true);
         op->set_status(Ydb::StatusIds::SUCCESS);
         op->mutable_result()->PackFrom(result);
+        return grpc::Status::OK;
+    }
+
+    grpc::Status BulkUpsert(grpc::ServerContext*, const Ydb::Table::BulkUpsertRequest* request,
+        Ydb::Table::BulkUpsertResponse* response) override
+    {
+        auto* op = response->mutable_operation();
+        op->set_ready(true);
+        op->set_status(OnBulkUpsert(*request));
         return grpc::Status::OK;
     }
 };
@@ -305,7 +316,55 @@ Y_UNIT_TEST_SUITE(TTableRangeErrorRetryTest) {
     }
 }
 
+Y_UNIT_TEST_SUITE(TRetryPolicyTest) {
+    Y_UNIT_TEST(TerminalStatusesAndSessionReset) {
+        for (bool idempotent : {false, true}) {
+            for (bool retryUndefined : {false, true}) {
+                const auto settings = FastRetrySettings().Idempotent(idempotent).RetryUndefined(retryUndefined);
+                UNIT_ASSERT(!NRetry::ShouldRetryStatus(EStatus::SUCCESS, settings));
+                UNIT_ASSERT(!NRetry::ShouldRetryStatus(EStatus::CLIENT_CANCELLED, settings));
+                const auto transport = NRetry::GetRetryDecision(EStatus::TRANSPORT_UNAVAILABLE, settings);
+                const auto undetermined = NRetry::GetRetryDecision(EStatus::UNDETERMINED, settings);
+                UNIT_ASSERT(transport.Step == (idempotent ? NRetry::NextStep::RetryFastBackoff : NRetry::NextStep::Finish));
+                UNIT_ASSERT(undetermined.Step == transport.Step);
+                UNIT_ASSERT_VALUES_EQUAL(transport.ResetSession, idempotent);
+                UNIT_ASSERT(!undetermined.ResetSession);
+                const auto deadline = NRetry::GetRetryDecision(EStatus::CLIENT_DEADLINE_EXCEEDED, settings);
+                UNIT_ASSERT(deadline.Step == (retryUndefined ? NRetry::NextStep::RetrySlowBackoff : NRetry::NextStep::Finish));
+                UNIT_ASSERT(deadline.ResetSession);
+            }
+        }
+    }
+}
+
 Y_UNIT_TEST_SUITE(TRetryCancellationTest) {
+    Y_UNIT_TEST(CancellationAfterAttemptFutureIsAbandoned) {
+        TTableClientFixture fixture;
+        std::stop_source stopSource;
+        auto result = fixture.Client->RetryOperation(
+            [](NTable::TTableClient&) { return NThreading::NewPromise<TStatus>().GetFuture(); },
+            FastRetrySettings().CancellationToken(stopSource.get_token()));
+        UNIT_ASSERT(!result.Wait(TDuration::Zero()));
+        stopSource.request_stop();
+        UNIT_ASSERT_VALUES_EQUAL(result.GetValue(TDuration::Seconds(5)).GetStatus(), EStatus::CLIENT_CANCELLED);
+    }
+
+    Y_UNIT_TEST(CancellationDuringBackoff) {
+        TTableClientFixture fixture;
+        std::stop_source stopSource;
+        size_t attempts = 0;
+        auto settings = FastRetrySettings().CancellationToken(stopSource.get_token());
+        settings.FastBackoffSettings_.SlotDuration(TDuration::Hours(1)).UncertainRatio(0);
+        auto result = fixture.Client->RetryOperation([&](NTable::TTableClient&) {
+            ++attempts;
+            return NThreading::MakeFuture(UnavailableStatus());
+        }, settings);
+        // The ready failure has scheduled backoff before RetryOperation returns.
+        stopSource.request_stop();
+        UNIT_ASSERT_VALUES_EQUAL(result.GetValue(TDuration::Seconds(5)).GetStatus(), EStatus::CLIENT_CANCELLED);
+        UNIT_ASSERT_VALUES_EQUAL(attempts, 1u);
+    }
+
     Y_UNIT_TEST(AsyncCancellationCompletesBeforeLateResult) {
         for (bool lateException : {false, true}) {
             auto traces = std::make_shared<NTests::TFakeTraceProvider>();
@@ -345,10 +404,11 @@ Y_UNIT_TEST_SUITE(TRetryCancellationTest) {
             auto attemptResult = NThreading::NewPromise<TStatus>();
             auto result = fixture.Client->RetryOperation(
                 [&](NTable::TTableClient&) { return attemptResult.GetFuture(); },
-                FastRetrySettings().CancellationToken(stopSource.get_token()));
+                FastRetrySettings().RetryUndefined(true).CancellationToken(stopSource.get_token()));
             auto checked = result.Apply([&](const TAsyncStatus& future) {
                 UNIT_ASSERT_VALUES_EQUAL(future.GetValue().GetStatus(), status);
                 stopSource.request_stop();
+                UNIT_ASSERT_VALUES_EQUAL(traces->GetFakeTracer("ydb-cpp-sdk-table")->GetSpans().size(), 2u);
                 for (const auto& span : traces->GetFakeTracer("ydb-cpp-sdk-table")->GetSpans()) {
                     UNIT_ASSERT(span.Span->IsEnded());
                 }
@@ -358,32 +418,17 @@ Y_UNIT_TEST_SUITE(TRetryCancellationTest) {
         }
     }
 
-    Y_UNIT_TEST(PreStoppedTokenSkipsBackoff) {
-        TTableClientFixture fixture;
-        std::stop_source stopSource;
-        stopSource.request_stop();
-        auto operation = [](NTable::TTableClient&) { return OkStatus(); };
-        struct TRetryContext : NRetry::Sync::TRetryWithoutSession<NTable::TTableClient, decltype(operation)> {
-            using TBase = NRetry::Sync::TRetryWithoutSession<NTable::TTableClient, decltype(operation)>;
-            using TBase::TBase;
-            using TBase::DoBackoff;
-        };
-        TRetryContext retry(*fixture.Client, operation,
-            FastRetrySettings().CancellationToken(stopSource.get_token()));
-        UNIT_ASSERT_VALUES_EQUAL(retry.DoBackoff(true).count(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(retry.DoBackoff(false).count(), 0);
-    }
-
     Y_UNIT_TEST(SyncCancellationStopsAfterAttempt) {
-        TTableClientFixture fixture;
-        std::stop_source stopSource;
-
-        auto result = fixture.Client->RetryOperationSync(
-            [&](NTable::TSession) {
-                stopSource.request_stop();
-                return OkStatus();
-            }, FastRetrySettings().CancellationToken(stopSource.get_token()));
-        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::CLIENT_CANCELLED);
+        for (auto status : {EStatus::SUCCESS, EStatus::UNAVAILABLE, EStatus::OVERLOADED}) {
+            TTableClientFixture fixture;
+            std::stop_source stopSource;
+            auto result = fixture.Client->RetryOperationSync(
+                [&](NTable::TSession) {
+                    stopSource.request_stop();
+                    return TStatus(status, NIssue::TIssues{});
+                }, FastRetrySettings().CancellationToken(stopSource.get_token()));
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::CLIENT_CANCELLED);
+        }
     }
 
     Y_UNIT_TEST(PreStoppedTokenSkipsAttempts) {
@@ -445,6 +490,34 @@ Y_UNIT_TEST_SUITE(TRetryCancellationTest) {
             NQuery::TQueryClient queryClient(*fixture.Driver);
             checkCancelled(queryClient.ExecuteQuery("SELECT 1", NQuery::TTxControl::NoTx(),
                 NQuery::TExecuteQuerySettings().RetrySettings(settings)));
+        }
+    }
+}
+
+Y_UNIT_TEST_SUITE(TUnaryBulkUpsertRetryTest) {
+    Y_UNIT_TEST(RetriesPreserveRowsAndApplyTimeout) {
+        for (auto timeout : {TDuration::Max(), TDuration::Seconds(30)}) {
+            TTableClientFixture fixture;
+            std::atomic<size_t> attempts = 0;
+            auto rows = TValueBuilder().BeginList().AddListItem().BeginStruct()
+                .AddMember("key").Uint64(42).EndStruct().EndList().Build();
+            const auto expected = rows.GetProto().SerializeAsString();
+            const auto expectedType = rows.GetType().GetProto().SerializeAsString();
+            fixture.TableService.OnBulkUpsert = [&](const auto& request) {
+                const auto& params = request.operation_params();
+                const bool validTimeout = timeout == TDuration::Max() ? !params.has_operation_timeout()
+                    : params.has_operation_timeout() && params.operation_timeout().seconds() <= 30;
+                if (request.rows().value().SerializeAsString() != expected
+                    || request.rows().type().SerializeAsString() != expectedType || !validTimeout)
+                {
+                    return Ydb::StatusIds::BAD_REQUEST;
+                }
+                return ++attempts == 1 ? Ydb::StatusIds::UNAVAILABLE : Ydb::StatusIds::SUCCESS;
+            };
+            auto result = fixture.Client->BulkUpsert("/unused", std::move(rows),
+                NTable::TBulkUpsertSettings().RetrySettings(FastRetrySettings().MaxRetries(1).MaxTimeout(timeout)));
+            UNIT_ASSERT(result.GetValue(TDuration::Seconds(5)).IsSuccess());
+            UNIT_ASSERT_VALUES_EQUAL(attempts.load(), 2u);
         }
     }
 }

--- a/ydb/public/sdk/cpp/tests/unit/client/retry/retry_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/retry/retry_ut.cpp
@@ -4,6 +4,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/result/rows.h>
 #include <ydb/public/sdk/cpp/src/client/row_ranges/rows_stream_drain.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_sync.h>
 #include <ydb/public/sdk/cpp/tests/common/fake_trace_provider.h>
 
 #include <ydb/public/api/protos/ydb_value.pb.h>
@@ -26,6 +27,7 @@
 #include <deque>
 #include <functional>
 #include <stdexcept>
+#include <thread>
 
 using namespace NYdb;
 using namespace NYdb::NStatusHelpers;
@@ -315,7 +317,11 @@ Y_UNIT_TEST_SUITE(TRetryCancellationTest) {
                     return attemptResult.GetFuture();
                 },
                 FastRetrySettings().CancellationToken(stopSource.get_token()));
+            auto callbackThread = result.Apply([](const TAsyncStatus&) {
+                return std::this_thread::get_id();
+            });
             stopSource.request_stop();
+            UNIT_ASSERT(callbackThread.GetValue(TDuration::Seconds(1)) != std::this_thread::get_id());
             UNIT_ASSERT_VALUES_EQUAL(result.GetValue(TDuration::Seconds(1)).GetStatus(), EStatus::CLIENT_CANCELLED);
             auto tracer = traces->GetFakeTracer("ydb-cpp-sdk-table");
             UNIT_ASSERT(!tracer->GetLastSpan()->IsEnded());
@@ -324,10 +330,48 @@ Y_UNIT_TEST_SUITE(TRetryCancellationTest) {
             } else {
                 attemptResult.SetValue(OkStatus());
             }
+            fixture.Driver->Stop(true);
             for (const auto& span : tracer->GetSpans()) {
                 UNIT_ASSERT(span.Span->IsEnded());
             }
         }
+    }
+
+    Y_UNIT_TEST(OperationResultEndsSpansBeforeContinuations) {
+        for (auto status : {EStatus::SUCCESS, EStatus::CLIENT_CANCELLED}) {
+            auto traces = std::make_shared<NTests::TFakeTraceProvider>();
+            TTableClientFixture fixture(traces);
+            std::stop_source stopSource;
+            auto attemptResult = NThreading::NewPromise<TStatus>();
+            auto result = fixture.Client->RetryOperation(
+                [&](NTable::TTableClient&) { return attemptResult.GetFuture(); },
+                FastRetrySettings().CancellationToken(stopSource.get_token()));
+            auto checked = result.Apply([&](const TAsyncStatus& future) {
+                UNIT_ASSERT_VALUES_EQUAL(future.GetValue().GetStatus(), status);
+                stopSource.request_stop();
+                for (const auto& span : traces->GetFakeTracer("ydb-cpp-sdk-table")->GetSpans()) {
+                    UNIT_ASSERT(span.Span->IsEnded());
+                }
+            });
+            attemptResult.SetValue(TStatus(status, NIssue::TIssues{}));
+            checked.GetValueSync();
+        }
+    }
+
+    Y_UNIT_TEST(PreStoppedTokenSkipsBackoff) {
+        TTableClientFixture fixture;
+        std::stop_source stopSource;
+        stopSource.request_stop();
+        auto operation = [](NTable::TTableClient&) { return OkStatus(); };
+        struct TRetryContext : NRetry::Sync::TRetryWithoutSession<NTable::TTableClient, decltype(operation)> {
+            using TBase = NRetry::Sync::TRetryWithoutSession<NTable::TTableClient, decltype(operation)>;
+            using TBase::TBase;
+            using TBase::DoBackoff;
+        };
+        TRetryContext retry(*fixture.Client, operation,
+            FastRetrySettings().CancellationToken(stopSource.get_token()));
+        UNIT_ASSERT_VALUES_EQUAL(retry.DoBackoff(true).count(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(retry.DoBackoff(false).count(), 0);
     }
 
     Y_UNIT_TEST(SyncCancellationStopsAfterAttempt) {

--- a/ydb/public/sdk/cpp/tests/unit/client/retry/retry_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/retry/retry_ut.cpp
@@ -293,7 +293,9 @@ Y_UNIT_TEST_SUITE(TTableRangeErrorRetryTest) {
         UNIT_ASSERT(status.IsSuccess());
         UNIT_ASSERT_VALUES_EQUAL(attempts, 2u);
     }
+}
 
+Y_UNIT_TEST_SUITE(TRetryCancellationTest) {
     Y_UNIT_TEST(AsyncCancellationCompletesBeforeLateResult) {
         TTableClientFixture fixture;
         std::stop_source stopSource;

--- a/ydb/public/sdk/cpp/tests/unit/client/retry/retry_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/retry/retry_ut.cpp
@@ -4,6 +4,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/result/rows.h>
 #include <ydb/public/sdk/cpp/src/client/row_ranges/rows_stream_drain.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <ydb/public/sdk/cpp/tests/common/fake_trace_provider.h>
 
 #include <ydb/public/api/protos/ydb_value.pb.h>
 
@@ -23,6 +24,7 @@
 #include <grpcpp/server_context.h>
 
 #include <deque>
+#include <functional>
 #include <stdexcept>
 
 using namespace NYdb;
@@ -89,11 +91,16 @@ void SimulateScanDrainFailure() {
 
 class TMockTableService : public Ydb::Table::V1::TableService::Service {
 public:
+    std::function<void()> OnCreateSession;
+
     grpc::Status CreateSession(
         grpc::ServerContext*,
         const Ydb::Table::CreateSessionRequest*,
         Ydb::Table::CreateSessionResponse* response) override
     {
+        if (OnCreateSession) {
+            OnCreateSession();
+        }
         Ydb::Table::CreateSessionResult result;
         result.set_session_id("fake-table-session-id");
 
@@ -144,7 +151,7 @@ struct TTableClientFixture {
     std::unique_ptr<TDriver> Driver;
     std::unique_ptr<NTable::TTableClient> Client;
 
-    TTableClientFixture() {
+    TTableClientFixture(std::shared_ptr<NTrace::ITraceProvider> traceProvider = {}) {
         NTesting::InitPortManagerFromEnv();
         const auto portHolder = NTesting::GetFreePort();
         const ui16 port = portHolder;
@@ -153,6 +160,7 @@ struct TTableClientFixture {
         GrpcServer = StartGrpcServer(endpoint, TableService);
         Driver = std::make_unique<TDriver>(
             TDriverConfig()
+                .SetTraceProvider(std::move(traceProvider))
                 .SetEndpoint(endpoint)
                 .SetDiscoveryMode(EDiscoveryMode::Off)
                 .SetDatabase("/Root/My/DB"));
@@ -297,17 +305,29 @@ Y_UNIT_TEST_SUITE(TTableRangeErrorRetryTest) {
 
 Y_UNIT_TEST_SUITE(TRetryCancellationTest) {
     Y_UNIT_TEST(AsyncCancellationCompletesBeforeLateResult) {
-        TTableClientFixture fixture;
-        std::stop_source stopSource;
-        auto attemptResult = NThreading::NewPromise<TStatus>();
-        auto result = fixture.Client->RetryOperation(
-            [&](NTable::TTableClient&) -> TAsyncStatus {
-                return attemptResult.GetFuture();
-            },
-            FastRetrySettings().CancellationToken(stopSource.get_token()));
-        stopSource.request_stop();
-        UNIT_ASSERT_VALUES_EQUAL(result.GetValue(TDuration::Seconds(1)).GetStatus(), EStatus::CLIENT_CANCELLED);
-        attemptResult.SetValue(OkStatus());
+        for (bool lateException : {false, true}) {
+            auto traces = std::make_shared<NTests::TFakeTraceProvider>();
+            TTableClientFixture fixture(traces);
+            std::stop_source stopSource;
+            auto attemptResult = NThreading::NewPromise<TStatus>();
+            auto result = fixture.Client->RetryOperation(
+                [&](NTable::TTableClient&) -> TAsyncStatus {
+                    return attemptResult.GetFuture();
+                },
+                FastRetrySettings().CancellationToken(stopSource.get_token()));
+            stopSource.request_stop();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetValue(TDuration::Seconds(1)).GetStatus(), EStatus::CLIENT_CANCELLED);
+            auto tracer = traces->GetFakeTracer("ydb-cpp-sdk-table");
+            UNIT_ASSERT(!tracer->GetLastSpan()->IsEnded());
+            if (lateException) {
+                attemptResult.SetException(std::make_exception_ptr(std::runtime_error("late failure")));
+            } else {
+                attemptResult.SetValue(OkStatus());
+            }
+            for (const auto& span : tracer->GetSpans()) {
+                UNIT_ASSERT(span.Span->IsEnded());
+            }
+        }
     }
 
     Y_UNIT_TEST(SyncCancellationStopsAfterAttempt) {
@@ -320,6 +340,68 @@ Y_UNIT_TEST_SUITE(TRetryCancellationTest) {
                 return OkStatus();
             }, FastRetrySettings().CancellationToken(stopSource.get_token()));
         UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::CLIENT_CANCELLED);
+    }
+
+    Y_UNIT_TEST(PreStoppedTokenSkipsAttempts) {
+        TTableClientFixture fixture;
+        std::stop_source stopSource;
+        stopSource.request_stop();
+        auto settings = FastRetrySettings().CancellationToken(stopSource.get_token());
+        auto operation = [](NTable::TSession) -> TStatus {
+            UNIT_FAIL("A pre-stopped operation must not run");
+            return OkStatus();
+        };
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Client->RetryOperationSync(operation, settings).GetStatus(), EStatus::CLIENT_CANCELLED);
+        auto result = fixture.Client->RetryOperation(
+            [operation](NTable::TSession session) { return NThreading::MakeFuture(operation(session)); }, settings);
+        UNIT_ASSERT_VALUES_EQUAL(result.GetValue(TDuration::Seconds(1)).GetStatus(), EStatus::CLIENT_CANCELLED);
+    }
+
+    Y_UNIT_TEST(CancellationDuringSessionCreationSkipsOperation) {
+        for (bool async : {false, true}) {
+            std::stop_source stopSource;
+            TTableClientFixture fixture;
+            fixture.TableService.OnCreateSession = [stopSource]() mutable { stopSource.request_stop(); };
+            auto settings = FastRetrySettings().CancellationToken(stopSource.get_token());
+            auto operation = [](NTable::TSession) -> TStatus {
+                UNIT_FAIL("Cancellation during session creation must skip the operation");
+                return OkStatus();
+            };
+            auto result = async
+                ? fixture.Client->RetryOperation(
+                    [operation](NTable::TSession session) { return NThreading::MakeFuture(operation(session)); }, settings)
+                    .GetValue(TDuration::Seconds(5))
+                : fixture.Client->RetryOperationSync(operation, settings);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::CLIENT_CANCELLED);
+            fixture.Driver->Stop(true);
+        }
+    }
+
+    Y_UNIT_TEST(UnaryCancellationWorksWithoutRetriesAndWhenNested) {
+        TTableClientFixture fixture;
+        std::stop_source stopSource;
+        stopSource.request_stop();
+        for (ui32 maxRetries : {0u, 3u}) {
+            auto settings = FastRetrySettings().MaxRetries(maxRetries).RetryUndefined(true)
+                .CancellationToken(stopSource.get_token());
+            auto checkCancelled = [](const auto& future) {
+                UNIT_ASSERT_VALUES_EQUAL(future.GetValue(TDuration::Seconds(1)).GetStatus(), EStatus::CLIENT_CANCELLED);
+            };
+            auto operation = [&](NTable::TTableClient& client) {
+                checkCancelled(client.BulkUpsert("/unused", TValueBuilder().Int32(1).Build(),
+                    NTable::TBulkUpsertSettings().RetrySettings(settings)));
+                checkCancelled(client.BulkUpsert("/unused", NTable::EDataFormat::CSV, "1", "",
+                    NTable::TBulkUpsertSettings().RetrySettings(settings)));
+                checkCancelled(client.ReadRows("/unused", TValueBuilder().Int32(1).Build(), {},
+                    NTable::TReadRowsSettings().RetrySettings(settings)));
+                return NThreading::MakeFuture(OkStatus());
+            };
+            UNIT_ASSERT(operation(*fixture.Client).GetValueSync().IsSuccess());
+            UNIT_ASSERT(fixture.Client->RetryOperation(operation).GetValueSync().IsSuccess());
+            NQuery::TQueryClient queryClient(*fixture.Driver);
+            checkCancelled(queryClient.ExecuteQuery("SELECT 1", NQuery::TTxControl::NoTx(),
+                NQuery::TExecuteQuerySettings().RetrySettings(settings)));
+        }
     }
 }
 

--- a/ydb/public/sdk/cpp/tests/unit/client/retry/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/retry/ya.make
@@ -10,7 +10,7 @@ ENDIF()
 FORK_SUBTESTS()
 
 SRCS(
-    retry_range_ut.cpp
+    retry_ut.cpp
 )
 
 PEERDIR(

--- a/ydb/public/sdk/cpp/tests/unit/client/retry/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/retry/ya.make
@@ -17,6 +17,7 @@ PEERDIR(
     library/cpp/testing/common
     ydb/public/api/grpc
     ydb/public/api/protos
+    ydb/public/sdk/cpp/src/client/impl/internal/retry
     ydb/public/sdk/cpp/src/client/query
     ydb/public/sdk/cpp/src/client/row_ranges
     ydb/public/sdk/cpp/src/client/table

--- a/ydb/public/sdk/cpp/tests/unit/client/retry_range/retry_range_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/retry_range/retry_range_ut.cpp
@@ -371,3 +371,20 @@ Y_UNIT_TEST_SUITE(TQueryRangeErrorRetryTest) {
             TYdbErrorException);
     }
 }
+
+Y_UNIT_TEST_SUITE(TRetryCancellationTest) {
+    Y_UNIT_TEST(AsyncCancellationCompletesBeforeLateResult) {
+        TTableClientFixture fixture;
+        std::stop_source stopSource;
+        auto attemptResult = NThreading::NewPromise<TStatus>();
+        auto result = fixture.Client->RetryOperation(
+            [&](NTable::TTableClient&) -> TAsyncStatus {
+                return attemptResult.GetFuture();
+            },
+            FastRetrySettings().CancellationToken(stopSource.get_token()));
+        stopSource.request_stop();
+        UNIT_ASSERT(result.Wait(TDuration::Seconds(1)));
+        UNIT_ASSERT_VALUES_EQUAL(result.GetValueSync().GetStatus(), EStatus::CLIENT_CANCELLED);
+        attemptResult.SetValue(OkStatus());
+    }
+}

--- a/ydb/public/sdk/cpp/tests/unit/client/retry_range/retry_range_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/retry_range/retry_range_ut.cpp
@@ -293,6 +293,32 @@ Y_UNIT_TEST_SUITE(TTableRangeErrorRetryTest) {
         UNIT_ASSERT(status.IsSuccess());
         UNIT_ASSERT_VALUES_EQUAL(attempts, 2u);
     }
+
+    Y_UNIT_TEST(AsyncCancellationCompletesBeforeLateResult) {
+        TTableClientFixture fixture;
+        std::stop_source stopSource;
+        auto attemptResult = NThreading::NewPromise<TStatus>();
+        auto result = fixture.Client->RetryOperation(
+            [&](NTable::TTableClient&) -> TAsyncStatus {
+                return attemptResult.GetFuture();
+            },
+            FastRetrySettings().CancellationToken(stopSource.get_token()));
+        stopSource.request_stop();
+        UNIT_ASSERT_VALUES_EQUAL(result.GetValue(TDuration::Seconds(1)).GetStatus(), EStatus::CLIENT_CANCELLED);
+        attemptResult.SetValue(OkStatus());
+    }
+
+    Y_UNIT_TEST(SyncCancellationStopsAfterAttempt) {
+        TTableClientFixture fixture;
+        std::stop_source stopSource;
+
+        auto result = fixture.Client->RetryOperationSync(
+            [&](NTable::TSession) {
+                stopSource.request_stop();
+                return OkStatus();
+            }, FastRetrySettings().CancellationToken(stopSource.get_token()));
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::CLIENT_CANCELLED);
+    }
 }
 
 Y_UNIT_TEST_SUITE(TQueryRangeErrorRetryTest) {
@@ -369,22 +395,5 @@ Y_UNIT_TEST_SUITE(TQueryRangeErrorRetryTest) {
                 },
                 FastRetrySettings()).GetValueSync(),
             TYdbErrorException);
-    }
-}
-
-Y_UNIT_TEST_SUITE(TRetryCancellationTest) {
-    Y_UNIT_TEST(AsyncCancellationCompletesBeforeLateResult) {
-        TTableClientFixture fixture;
-        std::stop_source stopSource;
-        auto attemptResult = NThreading::NewPromise<TStatus>();
-        auto result = fixture.Client->RetryOperation(
-            [&](NTable::TTableClient&) -> TAsyncStatus {
-                return attemptResult.GetFuture();
-            },
-            FastRetrySettings().CancellationToken(stopSource.get_token()));
-        stopSource.request_stop();
-        UNIT_ASSERT(result.Wait(TDuration::Seconds(1)));
-        UNIT_ASSERT_VALUES_EQUAL(result.GetValueSync().GetStatus(), EStatus::CLIENT_CANCELLED);
-        attemptResult.SetValue(OkStatus());
     }
 }

--- a/ydb/public/sdk/cpp/tests/unit/client/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/ya.make
@@ -14,7 +14,7 @@ RECURSE(
     query
     result
     row_ranges
-    retry_range
+    retry
     table
     value
 )

--- a/ydb/services/ydb/ydb_unary_retry_ut.cpp
+++ b/ydb/services/ydb/ydb_unary_retry_ut.cpp
@@ -17,6 +17,10 @@ namespace {
 
 class TMockUnaryRetryClientImpl : public IClientImplCommon {
 public:
+    void PostToResponseQueue(std::function<void()>&& fn) {
+        fn();
+    }
+
     void ScheduleTask(const std::function<void()>& fn, TDeadline::Duration) override {
         fn();
     }

--- a/ydb/services/ydb/ydb_unary_retry_ut.cpp
+++ b/ydb/services/ydb/ydb_unary_retry_ut.cpp
@@ -1,9 +1,12 @@
 #include "ydb_common_ut.h"
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/retry/retry.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status/status.h>
 
 #include <library/cpp/threading/future/future.h>
+
+#include <stop_token>
 
 #define INCLUDE_YDB_INTERNAL_H
 #include <ydb/public/sdk/cpp/src/client/common_client/impl/iface.h>
@@ -17,10 +20,6 @@ namespace {
 
 class TMockUnaryRetryClientImpl : public IClientImplCommon {
 public:
-    void PostToResponseQueue(std::function<void()>&& fn) {
-        fn();
-    }
-
     void ScheduleTask(const std::function<void()>& fn, TDeadline::Duration) override {
         fn();
     }
@@ -154,17 +153,23 @@ Y_UNIT_TEST_SUITE(YdbUnaryRetrySettings) {
         TMockUnaryRetryClient client;
         client.SetInRetryOperationContext(true);
 
+        std::stop_source stopSource;
+        const auto requestSettings = NYdb::NTable::TBulkUpsertSettings().ClientTimeout(TDuration::Seconds(10));
+        for (const auto& settings : {
+            FastUnaryRetrySettings(5).MaxTimeout(TDuration::Seconds(1)),
+            FastUnaryRetrySettings(5).MaxTimeout(TDuration::Seconds(1)).CancellationToken(stopSource.get_token())})
+        {
+            ui32 callCount = 0;
+            const auto result = RunUnaryWithRetry(client, settings, requestSettings,
+                [&callCount, &requestSettings](const NYdb::NTable::TBulkUpsertSettings& attemptSettings) {
+                    ++callCount;
+                    UNIT_ASSERT_VALUES_EQUAL(attemptSettings.ClientTimeout_, requestSettings.ClientTimeout_);
+                    return NThreading::MakeFuture(TStatus(EStatus::UNAVAILABLE, NYdb::NIssue::TIssues()));
+                }).GetValueSync();
 
-        ui32 callCount = 0;
-        const auto settings = FastUnaryRetrySettings(5);
-
-        const auto result = RunUnaryWithRetry(client, settings, [&callCount](TDuration) {
-            ++callCount;
-            return NThreading::MakeFuture(TStatus(EStatus::UNAVAILABLE, NYdb::NIssue::TIssues()));
-        }).GetValueSync();
-
-        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::UNAVAILABLE);
-        UNIT_ASSERT_VALUES_EQUAL(callCount, 1u);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::UNAVAILABLE);
+            UNIT_ASSERT_VALUES_EQUAL(callCount, 1u);
+        }
         client.SetInRetryOperationContext(false);
     }
 
@@ -173,17 +178,21 @@ Y_UNIT_TEST_SUITE(YdbUnaryRetrySettings) {
 
         ui32 callCount = 0;
         const ui32 failCount = 2;
-        const auto settings = FastUnaryRetrySettings(5);
+        const auto settings = FastUnaryRetrySettings(5).MaxTimeout(TDuration::Seconds(10));
+        const auto requestSettings = NYdb::NTable::TBulkUpsertSettings().ClientTimeout(TDuration::Seconds(30));
 
-        const auto result = RunUnaryWithRetry(client, settings, [&callCount](TDuration) {
-            ++callCount;
-            if (callCount <= failCount) {
-                return NThreading::MakeFuture(TStatus(EStatus::UNAVAILABLE, NYdb::NIssue::TIssues()));
-            }
-            return NThreading::MakeFuture(TStatus(EStatus::SUCCESS, NYdb::NIssue::TIssues()));
-        }).GetValueSync();
+        const auto result = RunUnaryWithRetry(client, settings, requestSettings,
+            [&callCount, &settings](const NYdb::NTable::TBulkUpsertSettings& attemptSettings) {
+                ++callCount;
+                UNIT_ASSERT(attemptSettings.ClientTimeout_ <= settings.MaxTimeout_);
+                if (callCount <= failCount) {
+                    return NThreading::MakeFuture(TStatus(EStatus::UNAVAILABLE, NYdb::NIssue::TIssues()));
+                }
+                return NThreading::MakeFuture(TStatus(EStatus::SUCCESS, NYdb::NIssue::TIssues()));
+            }).GetValueSync();
 
         UNIT_ASSERT(result.IsSuccess());
         UNIT_ASSERT_VALUES_EQUAL(callCount, failCount + 1);
+        UNIT_ASSERT_VALUES_EQUAL(requestSettings.ClientTimeout_, TDuration::Seconds(30));
     }
 }


### PR DESCRIPTION
Adds std::stop_token cancellation to SDK retry settings. Refactored retries to centralize unary re
try behaviour.
Cancelled retries complete with CLIENT_CANCELLED while preserving the existing sync and async backoff behavior.