### PR TITLE
Plan2svg: draw the "W" warning badge on top of the stage

### DIFF
--- a/ydb/library/plan2svg/model.h
+++ b/ydb/library/plan2svg/model.h
@@ -138,6 +138,9 @@ public:
     ui64 UpdateTime = 0;
     bool External = false;
     TStringBuilder Svg;
+    // Tooltip of the "W" badge the CPU strip asks for. The badge itself is drawn
+    // at the very end of the stage, see TPlan::PrepareStageSvg.
+    TString WaitInputWarning;
     TConnection* IngressConnection = nullptr;
     std::vector<std::pair<ui64, ui64>> HotRegions;
     ui64 CriticalCpuTotal = 0;

--- a/ydb/library/plan2svg/render.cpp
+++ b/ydb/library/plan2svg/render.cpp
@@ -768,10 +768,11 @@ void TPlan::PrintCpuStrip(const std::shared_ptr<TStage>& s, ui32& y0, ui64 px, u
                     }
                 }
                 if (waitOutputPeers) {
-                    // The stage draws into its own nested svg, so the badge is placed
-                    // relative to that stage box, not to its offset in the whole plan.
-                    PrintWarningBadge(s->Svg, Config.TaskLeft + Config.TaskWidth / 2, s->Height,
-                        TStringBuilder() << "Wait input with peer stage(s) " << waitOutputPeers << " wait output", "W");
+                    // Only remembered here: the badge sits at the bottom of the stage,
+                    // in the task column that later strips keep painting over, so it is
+                    // emitted last by PrepareStageSvg.
+                    s->WaitInputWarning = TStringBuilder()
+                        << "Wait input with peer stage(s) " << waitOutputPeers << " wait output";
                 }
             }
         }
@@ -1072,6 +1073,14 @@ void TPlan::PrepareStageSvg(const std::shared_ptr<TStage>& s, ui64 maxTime, ui32
 
     PrintIngressStrip(s, y0, px, pw);
     s->Svg << "</g>" << Endl;
+
+    // Last, so that nothing drawn for the stage can hide it: the badge shares the
+    // task column with the throughput overlay, which spans the whole stage box.
+    // The stage draws into its own nested svg, so the badge is placed relative to
+    // that stage box, not to its offset in the whole plan.
+    if (s->WaitInputWarning) {
+        PrintWarningBadge(s->Svg, Config.TaskLeft + Config.TaskWidth / 2, s->Height, s->WaitInputWarning, "W");
+    }
 }
 
 void TPlan::PrepareSvg(ui64 maxTime, ui32 timelineDelta, ui32& offsetY) {

--- a/ydb/library/plan2svg/render.cpp
+++ b/ydb/library/plan2svg/render.cpp
@@ -1072,15 +1072,17 @@ void TPlan::PrepareStageSvg(const std::shared_ptr<TStage>& s, ui64 maxTime, ui32
     PrintStageConnections(s, y0, px, pw);
 
     PrintIngressStrip(s, y0, px, pw);
-    s->Svg << "</g>" << Endl;
 
     // Last, so that nothing drawn for the stage can hide it: the badge shares the
     // task column with the throughput overlay, which spans the whole stage box.
+    // Still inside the selectable group, so clicking the badge selects the stage.
     // The stage draws into its own nested svg, so the badge is placed relative to
     // that stage box, not to its offset in the whole plan.
     if (s->WaitInputWarning) {
         PrintWarningBadge(s->Svg, Config.TaskLeft + Config.TaskWidth / 2, s->Height, s->WaitInputWarning, "W");
     }
+
+    s->Svg << "</g>" << Endl;
 }
 
 void TPlan::PrepareSvg(ui64 maxTime, ui32 timelineDelta, ui32& offsetY) {

--- a/ydb/library/plan2svg/ut/data/wait_input_peer.svg
+++ b/ydb/library/plan2svg/ut/data/wait_input_peer.svg
@@ -666,10 +666,10 @@
   <line x1='964' y1='73' x2='964' y2='80' stroke-width='3' stroke='var(--minmax-line, #FFDB4D)' />
 <path d='M619,79c3,0,6,-4,10,-4c3,0,7,0,11,0c3,0,7,0,11,0c3,0,7,-1,11,-1c3,0,6,3,10,3c3,0,7,2,11,2c3,0,7,-13,11,-13c3,0,7,9,11,9c3,0,7,0,11,0c3,0,6,0,10,0c3,0,7,0,11,0c3,0,7,0,11,0c3,0,7,0,11,0c3,0,7,0,11,0c3,0,6,3,10,3c3,0,7,-6,11,-6c3,0,7,6,11,6c3,0,7,-6,11,-6c3,0,7,3,11,3c3,0,6,0,10,0c3,0,7,0,11,0c3,0,7,0,11,0c3,0,7,2,11,2c3,0,7,2,11,2c3,0,6,-8,10,-8c3,0,7,7,11,7c3,0,7,0,11,0c3,0,7,0,11,0c3,0,7,1,11,1c3,0,6,-1,10,-1c3,0,7,1,11,1c3,0,7,0,11,0c0,0,0,0,0,0z' stroke-width='1' stroke='var(--input-dark, #466364)' fill='none' />
 </g>
-</g>
 <g><title>Wait input with peer stage(s) 0 wait output</title>
   <circle cx='383' cy='74' r='7' stroke='none' fill='var(--stage-texthl, #FC2824)' />
   <text text-anchor='middle' font-family='Verdana' font-size='8px' fill='var(--text-light, #FFFFFF)' x='383' y='78'>W</text>
+</g>
 </g>
 </svg>
 <svg data-stage='outer 0' data-height='122' width='1280' height='122' x='0' y='85'>

--- a/ydb/library/plan2svg/ut/data/wait_input_peer.svg
+++ b/ydb/library/plan2svg/ut/data/wait_input_peer.svg
@@ -611,10 +611,6 @@
   <rect x='368' y='77%' width='30' height='23%' stroke-width='0' fill='var(--input-light, #7CA3A5)'/>
 </g>
 <path d='M619,47c6,0,13,-2,20,-2c7,0,14,-1,21,-1c6,0,13,-1,20,-1c7,0,14,4,21,4c7,0,14,-8,21,-8c6,0,13,5,20,5c7,0,14,-2,21,-2c6,0,13,4,20,4c7,0,14,1,21,1c7,0,14,-13,21,-13c6,0,13,11,20,11c7,0,14,-2,21,-2c6,0,13,3,20,3c7,0,14,1,21,1c7,0,14,0,21,0c6,0,13,-5,20,-5c7,0,14,-1,21,-1c7,0,14,5,21,5c6,0,13,1,20,1c7,0,14,0,21,0c6,0,13,0,20,0c7,0,14,-1,21,-1c7,0,14,1,21,1c6,0,13,0,20,0c7,0,14,-1,21,-1c6,0,13,1,20,1c7,0,14,0,21,0c7,0,14,0,21,0c6,0,13,0,20,0c7,0,14,0,21,0c6,0,13,0,20,0c7,0,14,0,21,0c0,0,0,0,0,0z' stroke-width='1' stroke='var(--input-medium, #5A8183)' fill='var(--input-light, #7CA3A5)' />
-<g><title>Wait input with peer stage(s) 0 wait output</title>
-  <circle cx='383' cy='74' r='7' stroke='none' fill='var(--stage-texthl, #FC2824)' />
-  <text text-anchor='middle' font-family='Verdana' font-size='8px' fill='var(--text-light, #FFFFFF)' x='383' y='78'>W</text>
-</g>
 <g><title>Wait Output Time 0%, ∑1m 30s, 0.31s | 0.35s | 0.55s</title>
   <rect x='368' y='0%' width='30' height='0%' stroke-width='0' fill='var(--output-light, #6F93C3)'/>
 </g>
@@ -670,6 +666,10 @@
   <line x1='964' y1='73' x2='964' y2='80' stroke-width='3' stroke='var(--minmax-line, #FFDB4D)' />
 <path d='M619,79c3,0,6,-4,10,-4c3,0,7,0,11,0c3,0,7,0,11,0c3,0,7,-1,11,-1c3,0,6,3,10,3c3,0,7,2,11,2c3,0,7,-13,11,-13c3,0,7,9,11,9c3,0,7,0,11,0c3,0,6,0,10,0c3,0,7,0,11,0c3,0,7,0,11,0c3,0,7,0,11,0c3,0,7,0,11,0c3,0,6,3,10,3c3,0,7,-6,11,-6c3,0,7,6,11,6c3,0,7,-6,11,-6c3,0,7,3,11,3c3,0,6,0,10,0c3,0,7,0,11,0c3,0,7,0,11,0c3,0,7,2,11,2c3,0,7,2,11,2c3,0,6,-8,10,-8c3,0,7,7,11,7c3,0,7,0,11,0c3,0,7,0,11,0c3,0,7,1,11,1c3,0,6,-1,10,-1c3,0,7,1,11,1c3,0,7,0,11,0c0,0,0,0,0,0z' stroke-width='1' stroke='var(--input-dark, #466364)' fill='none' />
 </g>
+</g>
+<g><title>Wait input with peer stage(s) 0 wait output</title>
+  <circle cx='383' cy='74' r='7' stroke='none' fill='var(--stage-texthl, #FC2824)' />
+  <text text-anchor='middle' font-family='Verdana' font-size='8px' fill='var(--text-light, #FFFFFF)' x='383' y='78'>W</text>
 </g>
 </svg>
 <svg data-stage='outer 0' data-height='122' width='1280' height='122' x='0' y='85'>


### PR DESCRIPTION
The badge sits at the bottom of the stage box, in the task column, but PrintCpuStrip emitted it before the "Input Throughput" overlay - a percentage-sized rect in that same column spanning the whole stage box. SVG paints in document order, so on plans where the overlay reaches the bottom of the stage the badge ended up behind it and was invisible.

The CPU strip now only records the warning text; PrepareStageSvg emits the badge as the last element of the stage's nested svg, so nothing the stage draws can cover it. The badge geometry is unchanged, and the golden diff is just its <g> moving to the end of the stage svg.

Fixes #52363