### PR TITLE
ydb-bench: centralize KV and Stock workload contracts

### DIFF
--- a/ydb/tools/ydb_bench/benchmarks/local_ydb.py
+++ b/ydb/tools/ydb_bench/benchmarks/local_ydb.py
@@ -2,7 +2,6 @@
 
 import csv
 import io
-import math
 import statistics
 
 from ydb.tools.ydb_bench.benchmarks.registry import (
@@ -12,6 +11,7 @@ from ydb.tools.ydb_bench.benchmarks.registry import (
     MetricDefinition,
 )
 from ydb.tools.ydb_bench.lib.common import BenchmarkError
+from ydb.tools.ydb_bench.lib.local_ydb_workloads import parse_generic_total_metrics
 
 DIMENSIONS = (
     DimensionDefinition("load"),
@@ -20,8 +20,8 @@ DIMENSIONS = (
 METRICS = tuple(
     MetricDefinition(name, unit)
     for name, unit in (
-        ("transactions", "transactions"),
-        ("throughput", "transactions/s"),
+        ("transactions", "operations"),
+        ("throughput", "operations/s"),
         ("retries", "retries"),
         ("errors", "errors"),
         ("p50_ms", "ms"),
@@ -41,41 +41,7 @@ METRICS = tuple(
 
 
 def parse_cli_metrics(stdout):
-    """Parse the stable Total table printed by generic ``ydb workload``."""
-    lines = [line.strip() for line in stdout.splitlines()]
-    for index, line in enumerate(lines):
-        columns = line.split()
-        if not columns or columns[0] != "Total":
-            continue
-        for values_line in lines[index + 1 :]:
-            values = values_line.split()
-            if not values:
-                continue
-            # Current CLI prints the total duration in the first column below
-            # the "Total" heading.  Older builds omitted that value.
-            if len(values) == 9:
-                values = values[1:]
-            if len(values) != 8:
-                break
-            try:
-                result = {
-                    "transactions": int(values[0]),
-                    "throughput": float(values[1]),
-                    "retries": int(values[2]),
-                    "errors": int(values[3]),
-                    "p50_ms": float(values[4]),
-                    "p95_ms": float(values[5]),
-                    "p99_ms": float(values[6]),
-                    "pmax_ms": float(values[7]),
-                }
-                if not all(
-                    math.isfinite(result[name]) for name in ("throughput", "p50_ms", "p95_ms", "p99_ms", "pmax_ms")
-                ):
-                    raise ValueError("non-finite workload metric")
-                return result
-            except ValueError:
-                break
-    raise BenchmarkError("YDB CLI workload output does not contain a valid Total row")
+    return parse_generic_total_metrics(stdout)
 
 
 def parse_metrics(stdout, _benchmark):
@@ -94,11 +60,16 @@ def validate_metrics(rows, configuration, _case):
     if len(rows) != 1:
         raise BenchmarkError("local YDB workload must produce exactly one aggregate row")
     allow_errors = configuration.parameters["local_ydb"]["load"].get("allow_errors", False)
-    if rows[0]["errors"] and not allow_errors:
-        raise BenchmarkError("YDB CLI workload reported {} errors".format(rows[0]["errors"]))
+    errors = rows[0].get("errors", 0)
+    if errors and not allow_errors:
+        raise BenchmarkError("YDB CLI workload reported {} errors".format(errors))
 
 
-def summarize_metrics(repetition_rows, benchmark):
+def summarize_metrics(repetition_rows, benchmark, metric_names=None, metric_aggregations=None):
+    metric_names = (
+        tuple(metric_names) if metric_names is not None else tuple(metric.name for metric in benchmark.metrics)
+    )
+    metric_aggregations = metric_aggregations or {}
     grouped = {}
     for row in repetition_rows:
         key = tuple(row[item.name] for item in benchmark.dimensions)
@@ -106,22 +77,37 @@ def summarize_metrics(repetition_rows, benchmark):
     result = []
     for key in sorted(grouped):
         rows = grouped[key]
+        expected_keys = set(rows[0])
+        if any(set(row) != expected_keys for row in rows[1:]):
+            raise BenchmarkError("workload repetitions returned inconsistent metric keys")
+        if "transactions" in expected_keys and any(row["transactions"] == 0 for row in rows):
+            continue
         record = {"affinity_mode": "roles"}
         record.update({item.name: value for item, value in zip(benchmark.dimensions, key)})
         record["samples"] = len(rows)
-        for metric in benchmark.metrics:
-            values = [row[metric.name] for row in rows]
-            record["median_" + metric.name] = statistics.median(values)
-            record["min_" + metric.name] = min(values)
-            record["max_" + metric.name] = max(values)
+        for name in metric_names:
+            if name not in expected_keys:
+                continue
+            values = [row[name] for row in rows]
+            record["median_" + name] = statistics.median(values)
+            record["min_" + name] = min(values)
+            record["max_" + name] = max(values)
+            if metric_aggregations.get(name) == "sum":
+                record["sum_" + name] = sum(values)
         result.append(record)
     return result
 
 
-def render_summary(rows, benchmark):
+def render_summary(rows, benchmark, metric_names=None, metric_aggregations=None):
+    metric_names = (
+        tuple(metric_names) if metric_names is not None else tuple(metric.name for metric in benchmark.metrics)
+    )
+    metric_aggregations = metric_aggregations or {}
     columns = ["affinity_mode"] + [item.name for item in benchmark.dimensions] + ["samples"]
-    for metric in benchmark.metrics:
-        columns += ["median_" + metric.name, "min_" + metric.name, "max_" + metric.name]
+    for name in metric_names:
+        columns += ["median_" + name, "min_" + name, "max_" + name]
+        if metric_aggregations.get(name) == "sum":
+            columns.append("sum_" + name)
     output = io.StringIO()
     writer = csv.DictWriter(output, fieldnames=columns, lineterminator="\n")
     writer.writeheader()

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -1,0 +1,1068 @@
+"""Declarative local-YDB workload catalog and YDB CLI command builders."""
+
+import math
+import re
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from ydb.tools.ydb_bench.lib.common import BenchmarkError
+
+
+@dataclass(frozen=True)
+class WorkloadCli:
+    executable: object
+    endpoint: str
+    database: str
+
+
+@dataclass(frozen=True)
+class WorkloadCommandPlan:
+    name: str
+    argv: tuple
+    timeout_seconds: float | None = None
+    measurement_window_builder: object = None
+    progress_duration_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class WorkloadMetric:
+    name: str
+    unit: str
+    repetition_aggregation: str = "median"
+    required: bool = False
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class WorkloadRunRequest:
+    load_parameter: str
+    load: int
+    duration_seconds: int
+    warmup_seconds: int
+    client_threads: int
+    objective: object
+
+
+@dataclass(frozen=True)
+class WorkloadResult:
+    metrics: dict
+    details: object = None
+    measurement_window: tuple | None = None
+
+
+@dataclass(frozen=True)
+class WorkloadResultAdapter:
+    schema_id: str
+    parse: object
+    metrics: tuple
+    slo_metrics: tuple = ()
+
+
+def parse_generic_total_metrics(stdout):
+    """Parse the stable Total table printed by generic ``ydb workload``."""
+
+    lines = [line.strip() for line in stdout.splitlines()]
+    for index, line in enumerate(lines):
+        columns = line.split()
+        if not columns or columns[0] != "Total":
+            continue
+        for values_line in lines[index + 1 :]:
+            values = values_line.split()
+            if not values:
+                continue
+            # Current CLI prints the total duration in the first column below
+            # the "Total" heading. Older builds omitted that value.
+            if len(values) == 9:
+                values = values[1:]
+            if len(values) != 8:
+                break
+            try:
+                result = {
+                    "transactions": int(values[0]),
+                    "throughput": float(values[1]),
+                    "retries": int(values[2]),
+                    "errors": int(values[3]),
+                    "p50_ms": float(values[4]),
+                    "p95_ms": float(values[5]),
+                    "p99_ms": float(values[6]),
+                    "pmax_ms": float(values[7]),
+                }
+                if not all(
+                    math.isfinite(result[name]) for name in ("throughput", "p50_ms", "p95_ms", "p99_ms", "pmax_ms")
+                ):
+                    raise ValueError("non-finite workload metric")
+                if any(value < 0 for value in result.values()):
+                    raise ValueError("negative workload metric")
+                return result
+            except ValueError:
+                break
+    raise BenchmarkError("YDB CLI workload output does not contain a valid Total row")
+
+
+def _parse_generic_total_result(command_result, normalized_workload, request):
+    del normalized_workload, request
+    return WorkloadResult(parse_generic_total_metrics(command_result.stdout))
+
+
+GENERIC_TOTAL_RESULT = WorkloadResultAdapter(
+    schema_id="generic-total-v1",
+    parse=_parse_generic_total_result,
+    metrics=tuple(
+        WorkloadMetric(name, unit, repetition_aggregation=aggregation, required=True)
+        for name, unit, aggregation in (
+            ("transactions", "operations", "median"),
+            ("throughput", "operations/s", "median"),
+            ("retries", "retries", "median"),
+            ("errors", "errors", "sum"),
+            ("p50_ms", "ms", "median"),
+            ("p95_ms", "ms", "median"),
+            ("p99_ms", "ms", "median"),
+            ("pmax_ms", "ms", "median"),
+        )
+    ),
+    slo_metrics=(
+        ("p50", "p50_ms"),
+        ("p95", "p95_ms"),
+        ("p99", "p99_ms"),
+        ("pmax", "pmax_ms"),
+    ),
+)
+
+_DEFAULT_CLEANUP_TIMEOUT_SECONDS = 120
+_RESERVED_RESULT_METRIC_NAMES = frozenset(
+    (
+        "load",
+        "dynamic_nodes",
+        "repetition",
+        "empty_repetitions",
+        "attempt",
+        "search_stage",
+        "started_at",
+        "finished_at",
+        "duration_seconds",
+        "commands",
+        "passed",
+        "decision",
+        "search_low",
+        "search_high",
+        "throughput_gain_percent",
+        "target_cpu_saturated",
+        "static_cpu_mean",
+        "static_cpu_max",
+        "dynamic_cpu_mean",
+        "dynamic_cpu_max",
+        "cli_cpu_mean",
+        "cli_cpu_max",
+        "host_cpu_mean",
+        "host_cpu_max",
+    )
+)
+_RESULT_SCHEMA_MAX_METRICS = 128
+_RESULT_SCHEMA_MAX_ID_LENGTH = 256
+_RESULT_SCHEMA_MAX_NAME_LENGTH = 128
+_RESULT_SCHEMA_MAX_UNIT_LENGTH = 128
+_RESULT_SCHEMA_MAX_DESCRIPTION_LENGTH = 4096
+
+
+@dataclass(frozen=True)
+class WorkloadOption:
+    name: str
+    default: object
+    kind: str = "integer"
+    operation_defaults: tuple = ()
+    allow_zero: bool = False
+    maximum: object = None
+    choices: tuple = ()
+    schema_minimum: object = None
+    pattern: str | None = None
+    allow_empty: bool = False
+
+    def default_for(self, operation):
+        return dict(self.operation_defaults).get(operation, self.default)
+
+    @property
+    def minimum(self):
+        if self.kind != "integer":
+            return None
+        if self.schema_minimum is not None:
+            return self.schema_minimum
+        return 0 if self.allow_zero else 1
+
+    def config_schema(self):
+        if self.kind == "integer":
+            if self.choices:
+                return {"enum": list(self.choices)}
+            schema = {"type": "integer", "minimum": self.minimum}
+            if self.maximum is not None:
+                schema["maximum"] = self.maximum
+            return schema
+        if self.kind in ("string", "duration"):
+            schema = {"type": "string"}
+            if not self.allow_empty:
+                schema["minLength"] = 1
+            if self.choices:
+                schema["enum"] = list(self.choices)
+            if self.pattern is not None:
+                schema["pattern"] = self.pattern
+            return schema
+        if self.kind == "boolean":
+            schema = {"type": "boolean"}
+            if self.choices:
+                schema["enum"] = list(self.choices)
+            return schema
+        raise ValueError("unknown workload option kind: {}".format(self.kind))
+
+
+@dataclass(frozen=True)
+class WorkloadDefinition:
+    name: str
+    default_operation: str
+    operations: tuple
+    load_parameters: tuple
+    options: tuple
+    uses_path: bool
+    table_name: str | None
+    init_builder: object
+    run_builder: object
+    options_validator: object
+    dataset_scope: str = "sample"
+    warmup_mode: str = "separate"
+    prepare_plan_builder: object = None
+    run_plan_builder: object = None
+    cleanup_plan_builder: object = None
+    result_adapter: WorkloadResultAdapter = GENERIC_TOTAL_RESULT
+    throughput_unit: str = "operations/s"
+    profile_validator: object = None
+    effective_warmup_builder: object = None
+    minimum_duration_seconds: int = 1
+    maximum_total_seconds: int | None = None
+    load_limits: tuple = ()
+    default_client_threads: int = 64
+    default_warmup_seconds: int | None = 10
+
+
+def _config_error(location, message):
+    raise BenchmarkError("invalid benchmark config at {}: {}".format(location, message))
+
+
+def _is_finite_number(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        return math.isfinite(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
+
+
+def _mapping(value, location, allowed=()):
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        _config_error(location, "must be a mapping")
+    unknown = sorted((item for item in value if item not in allowed), key=str)
+    if unknown:
+        _config_error(location, "contains unknown fields: {}".format(", ".join(map(str, unknown))))
+    return value
+
+
+def _cli_base(cli):
+    return [
+        cli.executable,
+        "--endpoint",
+        cli.endpoint,
+        "--database",
+        cli.database,
+    ]
+
+
+def _workload_base(cli, definition, path):
+    command = _cli_base(cli) + [
+        "workload",
+        definition.name,
+    ]
+    if definition.uses_path:
+        command += ["--path", path]
+    return command
+
+
+def _kv_init_builder(cli, definition, path, workload):
+    options = workload["options"]
+    return _workload_base(cli, definition, path) + [
+        "init",
+        "--init-upserts",
+        options["init-upserts"],
+        "--min-partitions",
+        options["min-partitions"],
+        "--max-partitions",
+        options["max-partitions"],
+        "--partition-size",
+        options["partition-size-mb"],
+        "--max-first-key",
+        options["max-first-key"],
+        "--len",
+        options["value-size"],
+        "--cols",
+        options["columns"],
+        "--int-cols",
+        1,
+        "--key-cols",
+        1,
+        "--rows",
+        options["rows-per-query"],
+    ]
+
+
+def _kv_run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads):
+    options = workload["options"]
+    threads = load if load_parameter == "threads" else client_threads
+    command = _workload_base(cli, definition, path) + [
+        "run",
+        workload["operation"],
+        "--seconds",
+        seconds,
+        "--threads",
+        threads,
+        "--quiet",
+        "--max-first-key",
+        options["max-first-key"],
+        "--int-cols",
+        1,
+        "--key-cols",
+        1,
+        "--cols",
+        options["columns"],
+    ]
+    if workload["operation"] != "mixed":
+        command += ["--rows", options["rows-per-query"]]
+    if workload["operation"] in ("upsert", "mixed"):
+        command += ["--len", options["value-size"]]
+    if load_parameter == "rate":
+        command += ["--rate", load]
+    return command
+
+
+def _stock_init_builder(cli, definition, path, workload):
+    del path
+    options = workload["options"]
+    return _workload_base(cli, definition, None) + [
+        "init",
+        "--products",
+        options["products"],
+        "--quantity",
+        options["quantity"],
+        "--orders",
+        options["orders"],
+        "--min-partitions",
+        options["min-partitions"],
+        "--auto-partition",
+        options["auto-partition"],
+    ]
+
+
+def _stock_run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads):
+    del path
+    options = workload["options"]
+    threads = load if load_parameter == "threads" else client_threads
+    command = _workload_base(cli, definition, None) + [
+        "run",
+        workload["operation"],
+        "--seconds",
+        seconds,
+        "--threads",
+        threads,
+        "--quiet",
+    ]
+    if workload["operation"] in ("user-hist", "rand-user-hist"):
+        command += ["--limit", options["limit"]]
+    else:
+        command += ["--products", options["products"]]
+    if load_parameter == "rate":
+        command += ["--rate", load]
+    return command
+
+
+def _validate_kv_options(options, location):
+    if options["max-partitions"] < options["min-partitions"]:
+        _config_error(location + ".max-partitions", "must not be below min-partitions")
+    if options["columns"] < 2:
+        _config_error(location + ".columns", "must be at least 2")
+
+
+def _validate_stock_options(options, location):
+    del options, location
+
+
+def _validate_option_value(option, value, location):
+    if option.kind == "integer":
+        minimum = 0 if option.allow_zero else 1
+        if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+            requirement = "non-negative" if option.allow_zero else "positive"
+            _config_error(location, "must be a {} integer".format(requirement))
+        if option.maximum is not None and value > option.maximum:
+            _config_error(location, "must not exceed {}".format(option.maximum))
+    elif option.kind in ("string", "duration"):
+        if not isinstance(value, str):
+            _config_error(location, "must be a string")
+        if not option.allow_empty and not value:
+            _config_error(location, "must not be empty")
+        if option.pattern is not None and re.search(option.pattern, value) is None:
+            _config_error(location, "must match pattern {}".format(option.pattern))
+    elif option.kind == "boolean":
+        if not isinstance(value, bool):
+            _config_error(location, "must be a boolean")
+    else:
+        raise ValueError("unknown workload option kind: {}".format(option.kind))
+    if option.choices and value not in option.choices:
+        if option.kind == "integer":
+            _config_error(location, "must be {}".format(" or ".join(map(str, option.choices))))
+        _config_error(location, "must be one of {}".format(", ".join(map(str, option.choices))))
+
+
+def _validate_catalog(definitions):
+    names = [definition.name for definition in definitions]
+    if len(names) != len(set(names)):
+        raise ValueError("local YDB workload names must be unique")
+    option_schemas = {}
+    result_schemas = {}
+    for definition in definitions:
+        adapter = definition.result_adapter
+        if not isinstance(adapter, WorkloadResultAdapter):
+            raise ValueError("invalid result adapter for {}".format(definition.name))
+        if (
+            not isinstance(adapter.schema_id, str)
+            or re.fullmatch("[a-z0-9][a-z0-9._-]*", adapter.schema_id) is None
+            or len(adapter.schema_id) > _RESULT_SCHEMA_MAX_ID_LENGTH
+        ):
+            raise ValueError("invalid result schema id for {}".format(definition.name))
+        if not callable(adapter.parse):
+            raise ValueError("result adapter parse must be callable for {}".format(definition.name))
+        if (
+            not isinstance(adapter.metrics, tuple)
+            or not adapter.metrics
+            or len(adapter.metrics) > _RESULT_SCHEMA_MAX_METRICS
+        ):
+            raise ValueError("result adapter metrics must be a non-empty tuple for {}".format(definition.name))
+        result_schema = (adapter.metrics, adapter.slo_metrics)
+        if adapter.schema_id in result_schemas and result_schemas[adapter.schema_id] != result_schema:
+            raise ValueError("result schema id {} has incompatible definitions".format(adapter.schema_id))
+        result_schemas[adapter.schema_id] = result_schema
+        metric_names = []
+        for metric in adapter.metrics:
+            if not isinstance(metric, WorkloadMetric):
+                raise ValueError("invalid result metric for {}".format(definition.name))
+            if (
+                not isinstance(metric.name, str)
+                or re.fullmatch("[a-z][a-z0-9_]*", metric.name) is None
+                or len(metric.name) > _RESULT_SCHEMA_MAX_NAME_LENGTH
+            ):
+                raise ValueError("invalid result metric name for {}".format(definition.name))
+            if metric.name in _RESERVED_RESULT_METRIC_NAMES:
+                raise ValueError("result metric name is reserved for {}.{}".format(definition.name, metric.name))
+            if not isinstance(metric.unit, str) or not metric.unit or len(metric.unit) > _RESULT_SCHEMA_MAX_UNIT_LENGTH:
+                raise ValueError("result metric {} requires a unit".format(metric.name))
+            if metric.repetition_aggregation not in ("median", "sum"):
+                raise ValueError("invalid repetition aggregation for {}.{}".format(definition.name, metric.name))
+            if not isinstance(metric.required, bool):
+                raise ValueError(
+                    "result metric required flag must be boolean for {}.{}".format(definition.name, metric.name)
+                )
+            if (
+                not isinstance(metric.description, str)
+                or len(metric.description) > _RESULT_SCHEMA_MAX_DESCRIPTION_LENGTH
+            ):
+                raise ValueError(
+                    "result metric description must be a string for {}.{}".format(definition.name, metric.name)
+                )
+            metric_names.append(metric.name)
+        if len(metric_names) != len(set(metric_names)):
+            raise ValueError("result metric names must be unique for {}".format(definition.name))
+        throughput = next((metric for metric in adapter.metrics if metric.name == "throughput"), None)
+        if throughput is None or not throughput.required or throughput.repetition_aggregation != "median":
+            raise ValueError(
+                "result adapter throughput must be required and median-aggregated for {}".format(definition.name)
+            )
+        transactions = next((metric for metric in adapter.metrics if metric.name == "transactions"), None)
+        if transactions is not None and (not transactions.required or transactions.repetition_aggregation != "median"):
+            raise ValueError(
+                "result adapter transactions must be required and median-aggregated for {}".format(definition.name)
+            )
+        errors = next((metric for metric in adapter.metrics if metric.name == "errors"), None)
+        if errors is not None and (not errors.required or errors.repetition_aggregation != "sum"):
+            raise ValueError("result adapter errors must be required and sum-aggregated for {}".format(definition.name))
+        if (
+            not isinstance(definition.throughput_unit, str)
+            or not definition.throughput_unit
+            or len(definition.throughput_unit) > _RESULT_SCHEMA_MAX_UNIT_LENGTH
+        ):
+            raise ValueError("throughput unit must be a non-empty string for {}".format(definition.name))
+        if not isinstance(adapter.slo_metrics, tuple) or len(adapter.slo_metrics) > _RESULT_SCHEMA_MAX_METRICS:
+            raise ValueError("SLO metrics must be a tuple for {}".format(definition.name))
+        slo_percentiles = []
+        for item in adapter.slo_metrics:
+            if not isinstance(item, tuple) or len(item) != 2 or not all(isinstance(value, str) for value in item):
+                raise ValueError("invalid SLO metric mapping for {}".format(definition.name))
+            percentile, metric_name = item
+            if (
+                re.fullmatch(r"p(?:\d+(?:\.\d+)?|max)", percentile) is None
+                or len(percentile) > _RESULT_SCHEMA_MAX_NAME_LENGTH
+                or metric_name not in metric_names
+            ):
+                raise ValueError("invalid SLO metric mapping for {}".format(definition.name))
+            metric = next(metric for metric in adapter.metrics if metric.name == metric_name)
+            if not metric.required or metric.unit != "ms" or metric.repetition_aggregation != "median":
+                raise ValueError(
+                    "SLO metric {}.{} must be required, measured in ms, and median-aggregated".format(
+                        definition.name, metric_name
+                    )
+                )
+            slo_percentiles.append(percentile)
+        if len(slo_percentiles) != len(set(slo_percentiles)):
+            raise ValueError("SLO percentiles must be unique for {}".format(definition.name))
+        if definition.dataset_scope not in ("sample", "geometry", "profile"):
+            raise ValueError("unknown dataset scope for {}: {}".format(definition.name, definition.dataset_scope))
+        if definition.warmup_mode not in ("separate", "inline"):
+            raise ValueError("unknown warmup mode for {}: {}".format(definition.name, definition.warmup_mode))
+        for name in (
+            "prepare_plan_builder",
+            "run_plan_builder",
+            "cleanup_plan_builder",
+            "profile_validator",
+            "effective_warmup_builder",
+        ):
+            builder = getattr(definition, name)
+            if builder is not None and not callable(builder):
+                raise ValueError("{} must be callable for {}".format(name, definition.name))
+        if definition.warmup_mode == "inline" and definition.run_plan_builder is None:
+            raise ValueError("inline warmup requires a run plan builder for {}".format(definition.name))
+        if definition.default_warmup_seconds is not None and (
+            isinstance(definition.default_warmup_seconds, bool)
+            or not isinstance(definition.default_warmup_seconds, int)
+            or definition.default_warmup_seconds < 0
+        ):
+            raise ValueError("default warmup must be a non-negative integer or None for {}".format(definition.name))
+        if definition.default_warmup_seconds is None and definition.effective_warmup_builder is None:
+            raise ValueError("automatic warmup requires an effective warmup builder for {}".format(definition.name))
+        if (
+            isinstance(definition.minimum_duration_seconds, bool)
+            or not isinstance(definition.minimum_duration_seconds, int)
+            or definition.minimum_duration_seconds <= 0
+        ):
+            raise ValueError("minimum duration must be a positive integer for {}".format(definition.name))
+        if definition.maximum_total_seconds is not None and (
+            isinstance(definition.maximum_total_seconds, bool)
+            or not isinstance(definition.maximum_total_seconds, int)
+            or definition.maximum_total_seconds <= 0
+        ):
+            raise ValueError("maximum total duration must be a positive integer or None for {}".format(definition.name))
+        minimum_total_seconds = definition.minimum_duration_seconds + (definition.default_warmup_seconds or 0)
+        if definition.maximum_total_seconds is not None and definition.maximum_total_seconds < minimum_total_seconds:
+            raise ValueError(
+                "maximum total duration cannot fit the default warmup and minimum duration for {}".format(
+                    definition.name
+                )
+            )
+        if (
+            isinstance(definition.default_client_threads, bool)
+            or not isinstance(definition.default_client_threads, int)
+            or definition.default_client_threads <= 0
+        ):
+            raise ValueError("default client threads must be a positive integer for {}".format(definition.name))
+        if len(definition.operations) != len(set(definition.operations)):
+            raise ValueError("operations must be unique for {}".format(definition.name))
+        if len(definition.load_parameters) != len(set(definition.load_parameters)):
+            raise ValueError("load parameters must be unique for {}".format(definition.name))
+        if definition.default_operation not in definition.operations:
+            raise ValueError("default operation must belong to {}".format(definition.name))
+        option_names = [option.name for option in definition.options]
+        if len(option_names) != len(set(option_names)):
+            raise ValueError("option names must be unique for {}".format(definition.name))
+        if not isinstance(definition.load_limits, tuple):
+            raise ValueError("load limits must be a tuple for {}".format(definition.name))
+        limited_parameters = []
+        for limit in definition.load_limits:
+            limit_option = (
+                next((option for option in definition.options if option.name == limit[1]), None)
+                if isinstance(limit, tuple) and len(limit) == 3
+                else None
+            )
+            if (
+                not isinstance(limit, tuple)
+                or len(limit) != 3
+                or limit[0] not in definition.load_parameters
+                or limit_option is None
+                or limit_option.kind != "integer"
+                or isinstance(limit[2], bool)
+                or not isinstance(limit[2], int)
+                or limit[2] <= 0
+            ):
+                raise ValueError("invalid load limit for {}".format(definition.name))
+            limited_parameters.append(limit[0])
+        if len(limited_parameters) != len(set(limited_parameters)):
+            raise ValueError("load limits must be unique for {}".format(definition.name))
+        for option in definition.options:
+            if option.kind not in ("integer", "string", "boolean", "duration"):
+                raise ValueError("unknown workload option kind: {}".format(option.kind))
+            if option.kind != "integer" and (
+                option.allow_zero or option.maximum is not None or option.schema_minimum is not None
+            ):
+                raise ValueError("integer-only metadata is set for {}.{}".format(definition.name, option.name))
+            if option.kind not in ("string", "duration") and (option.pattern is not None or option.allow_empty):
+                raise ValueError("string-only metadata is set for {}.{}".format(definition.name, option.name))
+            if option.kind == "duration" and option.pattern is None:
+                raise ValueError("duration option {} requires a pattern".format(option.name))
+            if option.pattern is not None:
+                if "(?" in option.pattern or "\\" in option.pattern:
+                    raise ValueError("pattern for {}.{} is not portable".format(definition.name, option.name))
+                try:
+                    re.compile(option.pattern)
+                except re.error as error:
+                    raise ValueError("invalid pattern for {}.{}".format(definition.name, option.name)) from error
+            try:
+                choices_are_unique = len(option.choices) == len(set(option.choices))
+            except TypeError as error:
+                raise ValueError("choices must be scalar for {}.{}".format(definition.name, option.name)) from error
+            if not choices_are_unique:
+                raise ValueError("choices must be unique for {}.{}".format(definition.name, option.name))
+            operation_defaults = [operation for operation, _ in option.operation_defaults]
+            if len(operation_defaults) != len(set(operation_defaults)):
+                raise ValueError("operation defaults must be unique for {}.{}".format(definition.name, option.name))
+            for operation, value in ((None, option.default),) + option.operation_defaults:
+                if operation is not None and operation not in definition.operations:
+                    raise ValueError("option default refers to unknown operation {}".format(operation))
+                try:
+                    _validate_option_value(option, value, "{}.{}".format(definition.name, option.name))
+                except BenchmarkError as error:
+                    raise ValueError(
+                        "invalid default for {}.{}: {}".format(definition.name, option.name, error)
+                    ) from error
+            for choice in option.choices:
+                try:
+                    _validate_option_value(option, choice, "{}.{}".format(definition.name, option.name))
+                except BenchmarkError as error:
+                    raise ValueError(
+                        "invalid choice for {}.{}: {}".format(definition.name, option.name, error)
+                    ) from error
+            schema = option.config_schema()
+            if option.name in option_schemas and option_schemas[option.name] != schema:
+                raise ValueError("option {} has incompatible schemas across workloads".format(option.name))
+            option_schemas[option.name] = schema
+
+
+_DEFINITIONS = (
+    WorkloadDefinition(
+        name="kv",
+        default_operation="upsert",
+        operations=("upsert", "select", "read-rows", "mixed"),
+        load_parameters=("rate", "threads"),
+        options=(
+            WorkloadOption("min-partitions", 40),
+            WorkloadOption("max-partitions", 1000),
+            WorkloadOption("partition-size-mb", 2000),
+            WorkloadOption("init-upserts", 1000, operation_defaults=(("upsert", 0),), allow_zero=True),
+            WorkloadOption("max-first-key", 65536),
+            WorkloadOption("value-size", 64),
+            WorkloadOption("columns", 2, schema_minimum=2),
+            WorkloadOption("rows-per-query", 1),
+        ),
+        uses_path=True,
+        table_name=None,
+        init_builder=_kv_init_builder,
+        run_builder=_kv_run_builder,
+        options_validator=_validate_kv_options,
+        throughput_unit="requests/s",
+    ),
+    WorkloadDefinition(
+        name="stock",
+        default_operation="put-rand-order",
+        operations=("user-hist", "rand-user-hist", "add-rand-order", "put-rand-order", "put-same-order"),
+        load_parameters=("rate", "threads"),
+        options=(
+            WorkloadOption("min-partitions", 40),
+            WorkloadOption("products", 100, maximum=500000),
+            WorkloadOption("quantity", 1000),
+            WorkloadOption("orders", 100, allow_zero=True),
+            WorkloadOption("auto-partition", 1, allow_zero=True, choices=(0, 1)),
+            WorkloadOption("limit", 10),
+        ),
+        uses_path=False,
+        table_name="stock",
+        init_builder=_stock_init_builder,
+        run_builder=_stock_run_builder,
+        options_validator=_validate_stock_options,
+        throughput_unit="query operations/s",
+    ),
+)
+_validate_catalog(_DEFINITIONS)
+_WORKLOADS = MappingProxyType({definition.name: definition for definition in _DEFINITIONS})
+
+
+def _definition(workload_type):
+    try:
+        return _WORKLOADS[workload_type]
+    except (KeyError, TypeError) as error:
+        raise BenchmarkError("unknown local YDB workload: {}".format(workload_type)) from error
+
+
+def normalize_workload(raw, location):
+    """Validate and fill defaults for one workload configuration mapping."""
+
+    workload = _mapping(raw, location, ("type", "operation", "options"))
+    for required in ("type", "operation"):
+        if required not in workload:
+            _config_error(location, "missing required field: {}".format(required))
+
+    workload_type = workload["type"]
+    if not isinstance(workload_type, str) or workload_type not in _WORKLOADS:
+        _config_error(location + ".type", "must be one of {}".format(", ".join(_WORKLOADS)))
+    definition = _WORKLOADS[workload_type]
+    operation = workload["operation"]
+    if operation not in definition.operations:
+        _config_error(location + ".operation", "must be one of {}".format(", ".join(definition.operations)))
+
+    options_location = location + ".options"
+    raw_options = _mapping(
+        workload.get("options"), options_location, tuple(option.name for option in definition.options)
+    )
+    options = {}
+    for option in definition.options:
+        value = raw_options.get(option.name, option.default_for(operation))
+        _validate_option_value(option, value, options_location + "." + option.name)
+        options[option.name] = value
+    definition.options_validator(options, options_location)
+    return {"type": definition.name, "operation": operation, "options": options}
+
+
+def workload_config_schema():
+    """Return the structurally compatible config-schema fragment for workloads."""
+
+    option_schemas = {}
+    for definition in _DEFINITIONS:
+        for option in definition.options:
+            option_schemas[option.name] = option.config_schema()
+    operations = tuple(dict.fromkeys(operation for definition in _DEFINITIONS for operation in definition.operations))
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["type", "operation"],
+        "properties": {
+            "type": {"enum": [definition.name for definition in _DEFINITIONS]},
+            "operation": {"enum": list(operations)},
+            "options": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": option_schemas,
+            },
+        },
+    }
+
+
+def _workload_result_schema(definition):
+    adapter = definition.result_adapter
+    metrics = []
+    for metric in adapter.metrics:
+        descriptor = {
+            "name": metric.name,
+            "unit": definition.throughput_unit if metric.name == "throughput" else metric.unit,
+            "repetition_aggregation": metric.repetition_aggregation,
+            "required": metric.required,
+        }
+        if metric.description:
+            descriptor["description"] = metric.description
+        metrics.append(descriptor)
+    return {
+        "schema_id": adapter.schema_id,
+        "metrics": metrics,
+        "slo_metrics": dict(adapter.slo_metrics),
+        "throughput_unit": definition.throughput_unit,
+        "reports_errors": any(metric.name == "errors" for metric in adapter.metrics),
+    }
+
+
+def web_workload_catalog():
+    """Return a stable JSON-compatible workload description for the web builder."""
+
+    return [
+        {
+            "type": definition.name,
+            "default_operation": definition.default_operation,
+            "operations": list(definition.operations),
+            "load_parameters": list(definition.load_parameters),
+            "throughput_unit": definition.throughput_unit,
+            "slo_metrics": dict(definition.result_adapter.slo_metrics),
+            "reports_errors": any(metric.name == "errors" for metric in definition.result_adapter.metrics),
+            "result_schema_id": definition.result_adapter.schema_id,
+            "minimum_duration_seconds": definition.minimum_duration_seconds,
+            "maximum_total_seconds": definition.maximum_total_seconds,
+            "default_client_threads": definition.default_client_threads,
+            "default_warmup_seconds": definition.default_warmup_seconds,
+            "load_limits": {
+                parameter: {"option": option, "multiplier": multiplier}
+                for parameter, option, multiplier in definition.load_limits
+            },
+            "options": [
+                {
+                    "name": option.name,
+                    "kind": option.kind,
+                    "default": option.default,
+                    "operation_defaults": dict(option.operation_defaults),
+                    "allow_zero": option.allow_zero,
+                    "minimum": option.minimum,
+                    "maximum": option.maximum,
+                    "choices": list(option.choices),
+                    "pattern": option.pattern,
+                    "allow_empty": option.allow_empty,
+                    "schema": option.config_schema(),
+                }
+                for option in definition.options
+            ],
+        }
+        for definition in _DEFINITIONS
+    ]
+
+
+def allowed_load_parameters(workload_type):
+    return _definition(workload_type).load_parameters
+
+
+def all_load_parameters():
+    return tuple(dict.fromkeys(parameter for definition in _DEFINITIONS for parameter in definition.load_parameters))
+
+
+def all_slo_percentiles():
+    return tuple(
+        dict.fromkeys(
+            percentile
+            for definition in _DEFINITIONS
+            for percentile, _metric_name in definition.result_adapter.slo_metrics
+        )
+    )
+
+
+def allowed_slo_metrics(workload_type):
+    return dict(_definition(workload_type).result_adapter.slo_metrics)
+
+
+def validate_workload_profile(workload, load, measurement, location):
+    """Validate cross-field constraints owned by one workload definition."""
+
+    definition = _definition(workload["type"])
+    if measurement["duration"] < definition.minimum_duration_seconds:
+        _config_error(
+            location + ".measurement.duration",
+            "must be at least {} for {}".format(definition.minimum_duration_seconds, definition.name),
+        )
+    if definition.profile_validator is not None:
+        definition.profile_validator(workload, load, measurement, location)
+
+
+def workload_effective_warmup_seconds(workload, requested_seconds):
+    """Return the numeric warmup expected from one workload run."""
+
+    definition = _definition(workload["type"])
+    if requested_seconds is None:
+        if definition.default_warmup_seconds is not None:
+            raise BenchmarkError("{} does not support automatic warmup".format(definition.name))
+        if definition.effective_warmup_builder is None:
+            raise BenchmarkError("{} does not support automatic warmup".format(definition.name))
+    if requested_seconds is not None and (
+        isinstance(requested_seconds, bool) or not isinstance(requested_seconds, int) or requested_seconds < 0
+    ):
+        raise BenchmarkError("workload warmup must be a non-negative integer")
+    if definition.effective_warmup_builder is None:
+        return requested_seconds
+    effective = definition.effective_warmup_builder(workload, requested_seconds)
+    if (
+        isinstance(effective, bool)
+        or not isinstance(effective, int)
+        or effective < 0
+        or (requested_seconds is not None and effective < requested_seconds)
+    ):
+        raise BenchmarkError("{} returned an invalid effective warmup".format(definition.name))
+    return effective
+
+
+def build_init_argv(cli, path, workload):
+    definition = _definition(workload["type"])
+    return definition.init_builder(cli, definition, path, workload)
+
+
+def build_run_argv(cli, path, workload, load_parameter, load, seconds, client_threads):
+    definition = _definition(workload["type"])
+    if load_parameter not in definition.load_parameters:
+        raise BenchmarkError(
+            "local YDB workload {} does not support load parameter {}".format(definition.name, load_parameter)
+        )
+    return definition.run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads)
+
+
+def build_clean_argv(cli, path, workload_type):
+    definition = _definition(workload_type)
+    return _workload_base(cli, definition, path) + ["clean"]
+
+
+def _validate_command_plans(plans, description):
+    if not isinstance(plans, tuple) or not plans:
+        raise BenchmarkError("{} must produce a non-empty tuple of command plans".format(description))
+    for plan in plans:
+        if not isinstance(plan, WorkloadCommandPlan):
+            raise BenchmarkError("{} produced an invalid command plan".format(description))
+        if not plan.name or not isinstance(plan.name, str) or re.fullmatch("[a-z0-9-]+", plan.name) is None:
+            raise BenchmarkError("{} produced an invalid command plan name".format(description))
+        if not isinstance(plan.argv, tuple) or not plan.argv:
+            raise BenchmarkError("{} command {} must have a non-empty argv tuple".format(description, plan.name))
+        if not _is_finite_number(plan.timeout_seconds) or plan.timeout_seconds <= 0:
+            raise BenchmarkError("{} command {} must have a positive timeout".format(description, plan.name))
+        if plan.measurement_window_builder is not None and not callable(plan.measurement_window_builder):
+            raise BenchmarkError(
+                "{} command {} has an invalid measurement window builder".format(description, plan.name)
+            )
+        if plan.progress_duration_seconds is not None and (
+            not _is_finite_number(plan.progress_duration_seconds) or plan.progress_duration_seconds <= 0
+        ):
+            raise BenchmarkError("{} command {} must have a positive progress duration".format(description, plan.name))
+    return plans
+
+
+def build_prepare_plan(cli, path, workload):
+    """Build the pure command plan which creates one workload dataset."""
+
+    definition = _definition(workload["type"])
+    if definition.prepare_plan_builder is None:
+        plans = (
+            WorkloadCommandPlan(
+                "init",
+                tuple(definition.init_builder(cli, definition, path, workload)),
+                120,
+            ),
+        )
+    else:
+        plans = definition.prepare_plan_builder(cli, definition, path, workload)
+    return _validate_command_plans(plans, "{} prepare plan".format(definition.name))
+
+
+def build_run_plan(
+    cli,
+    path,
+    workload,
+    load_parameter,
+    load,
+    seconds,
+    client_threads,
+    warmup_seconds=0,
+):
+    """Build one pure workload command plan without executing a process."""
+
+    definition = _definition(workload["type"])
+    workload_effective_warmup_seconds(workload, warmup_seconds)
+    if load_parameter not in definition.load_parameters:
+        raise BenchmarkError(
+            "local YDB workload {} does not support load parameter {}".format(definition.name, load_parameter)
+        )
+    if definition.run_plan_builder is None:
+        if warmup_seconds:
+            raise BenchmarkError("{} does not support inline warmup".format(definition.name))
+        plan = WorkloadCommandPlan(
+            "run",
+            tuple(
+                definition.run_builder(
+                    cli,
+                    definition,
+                    path,
+                    workload,
+                    load_parameter,
+                    load,
+                    seconds,
+                    client_threads,
+                )
+            ),
+            seconds + 30,
+        )
+    else:
+        plan = definition.run_plan_builder(
+            cli,
+            definition,
+            path,
+            workload,
+            load_parameter,
+            load,
+            seconds,
+            client_threads,
+            warmup_seconds,
+        )
+    plan = _validate_command_plans((plan,), "{} run plan".format(definition.name))[0]
+    if (
+        definition.warmup_mode == "inline"
+        and plan.measurement_window_builder is None
+        and definition.result_adapter is GENERIC_TOTAL_RESULT
+    ):
+        raise BenchmarkError("{} inline warmup requires a CPU measurement window".format(definition.name))
+    return plan
+
+
+def build_cleanup_plan(cli, path, workload):
+    """Build the pure command plan which removes one workload dataset."""
+
+    definition = _definition(workload["type"])
+    if definition.cleanup_plan_builder is None:
+        plans = (
+            WorkloadCommandPlan(
+                "clean",
+                tuple(_workload_base(cli, definition, path) + ["clean"]),
+                _DEFAULT_CLEANUP_TIMEOUT_SECONDS,
+            ),
+        )
+    else:
+        plans = definition.cleanup_plan_builder(cli, definition, path, workload)
+    return _validate_command_plans(plans, "{} cleanup plan".format(definition.name))
+
+
+def workload_definition(workload_type):
+    """Return immutable lifecycle metadata for one registered workload."""
+
+    return _definition(workload_type)
+
+
+def workload_result_schema(workload_type):
+    """Return the JSON-compatible metric schema produced by one workload."""
+
+    return _workload_result_schema(_definition(workload_type))
+
+
+def parse_workload_result(workload_type, command_result, normalized_workload, request):
+    """Parse and validate one workload command result through its adapter."""
+
+    definition = _definition(workload_type)
+    adapter = definition.result_adapter
+    if not isinstance(request, WorkloadRunRequest):
+        raise BenchmarkError("workload result adapter requires a valid run request")
+    parsed = adapter.parse(command_result, normalized_workload, request)
+    if not isinstance(parsed, WorkloadResult):
+        raise BenchmarkError("workload result adapter {} returned an invalid result".format(adapter.schema_id))
+    if not isinstance(parsed.metrics, dict):
+        raise BenchmarkError("workload result adapter {} metrics must be a mapping".format(adapter.schema_id))
+    declared = {metric.name: metric for metric in adapter.metrics}
+    unknown = sorted((name for name in parsed.metrics if name not in declared), key=str)
+    if unknown:
+        raise BenchmarkError(
+            "workload result adapter {} returned unknown metrics: {}".format(
+                adapter.schema_id, ", ".join(map(str, unknown))
+            )
+        )
+    missing = [metric.name for metric in adapter.metrics if metric.required and metric.name not in parsed.metrics]
+    if missing:
+        raise BenchmarkError(
+            "workload result adapter {} omitted required metrics: {}".format(adapter.schema_id, ", ".join(missing))
+        )
+    for name, value in parsed.metrics.items():
+        if not _is_finite_number(value) or value < 0:
+            raise BenchmarkError(
+                "workload result adapter {} metric {} must be a finite non-negative number".format(
+                    adapter.schema_id, name
+                )
+            )
+    return WorkloadResult(dict(parsed.metrics), parsed.details, parsed.measurement_window)
+
+
+def workload_table_path(workload_type, path):
+    definition = _definition(workload_type)
+    return definition.table_name if definition.table_name is not None else path

--- a/ydb/tools/ydb_bench/lib/ya.make
+++ b/ydb/tools/ydb_bench/lib/ya.make
@@ -9,6 +9,7 @@ PY_SRCS(
     import_results.py
     load_control.py
     local_ydb.py
+    local_ydb_workloads.py
     linux_telemetry.py
     runner.py
     results.py

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -1,3 +1,4 @@
+import csv
 import hashlib
 import inspect
 import io
@@ -32,6 +33,7 @@ from ydb.tools.ydb_bench.lib import (
     linux_telemetry,
     load_control,
     local_ydb,
+    local_ydb_workloads,
     runner,
     topology,
     web,
@@ -112,6 +114,19 @@ class YdbBenchTest(unittest.TestCase):
             timeout_seconds=timeout,
         )
 
+    @staticmethod
+    def _local_ydb_command_result(command, stdout="", exit_code=0, interrupted=False):
+        return runner.CommandResult(
+            command=tuple(str(part) for part in command),
+            stdout=stdout,
+            stderr="",
+            exit_code=exit_code,
+            started_at="2026-08-25T10:00:00+00:00",
+            finished_at="2026-08-25T10:00:01+00:00",
+            duration_seconds=1.0,
+            interrupted=interrupted,
+        )
+
     def _worker_metrics_benchmark(self):
         return replace(
             PING_BENCHMARK,
@@ -172,6 +187,394 @@ class YdbBenchTest(unittest.TestCase):
         local_load_schema = CONFIG_SCHEMA["properties"]["local-ydb"]["additionalProperties"]["properties"]["load"]
         self.assertEqual(local_load_schema["properties"]["allow-errors"], {"type": "boolean"})
 
+    def test_local_ydb_workload_registry_preserves_defaults_and_validation(self):
+        upsert = local_ydb_workloads.normalize_workload(
+            {"type": "kv", "operation": "upsert"},
+            "local-ydb.profile.workload",
+        )
+        select = local_ydb_workloads.normalize_workload(
+            {"type": "kv", "operation": "select"},
+            "local-ydb.profile.workload",
+        )
+        stock = local_ydb_workloads.normalize_workload(
+            {"type": "stock", "operation": "put-rand-order"},
+            "local-ydb.profile.workload",
+        )
+        self.assertEqual(upsert["options"]["init-upserts"], 0)
+        self.assertEqual(select["options"]["init-upserts"], 1000)
+        self.assertEqual(stock["options"]["orders"], 100)
+
+        invalid = (
+            ({"type": [], "operation": "upsert"}, r"workload\.type.*must be one of kv, stock"),
+            ({"type": "log", "operation": "bulk-upsert"}, r"workload\.type.*must be one of kv, stock"),
+            ({"type": "tpcc", "operation": "run"}, r"workload\.type.*must be one of kv, stock"),
+            ({"type": "topic", "operation": "full"}, r"workload\.type.*must be one of kv, stock"),
+            ({"type": "kv", "operation": "put-rand-order"}, r"workload\.operation.*must be one of upsert"),
+            (
+                {"type": "stock", "operation": "put-rand-order", "options": {"products": 500001}},
+                r"products.*must not exceed 500000",
+            ),
+            (
+                {"type": "stock", "operation": "put-rand-order", "options": {"auto-partition": 2}},
+                r"auto-partition.*must be 0 or 1",
+            ),
+            (
+                {"type": "stock", "operation": "put-rand-order", "options": {"max-partitions": 10}},
+                r"options.*unknown fields: max-partitions",
+            ),
+        )
+        for workload, message in invalid:
+            with self.subTest(workload=workload), self.assertRaisesRegex(BenchmarkError, message):
+                local_ydb_workloads.normalize_workload(workload, "local-ydb.profile.workload")
+
+    def test_local_ydb_workload_registry_supports_typed_options(self):
+        definition = local_ydb_workloads.WorkloadDefinition(
+            name="synthetic",
+            default_operation="run",
+            operations=("run",),
+            load_parameters=("threads",),
+            options=(
+                local_ydb_workloads.WorkloadOption(
+                    "tx-mode",
+                    "serializable-rw",
+                    kind="string",
+                    choices=("serializable-rw", "snapshot-rw"),
+                ),
+                local_ydb_workloads.WorkloadOption("enabled", True, kind="boolean"),
+                local_ydb_workloads.WorkloadOption(
+                    "warmup",
+                    "10s",
+                    kind="duration",
+                    pattern=r"^[1-9][0-9]*s$",
+                ),
+                local_ydb_workloads.WorkloadOption("label", "mode: fast # tagged", kind="string"),
+            ),
+            uses_path=True,
+            table_name=None,
+            init_builder=None,
+            run_builder=None,
+            options_validator=lambda options, location: None,
+        )
+        local_ydb_workloads._validate_catalog((definition,))
+        divergent = replace(
+            definition,
+            name="other",
+            options=(local_ydb_workloads.WorkloadOption("tx-mode", 1),),
+        )
+        with self.assertRaisesRegex(ValueError, "tx-mode has incompatible schemas"):
+            local_ydb_workloads._validate_catalog((definition, divergent))
+        for pattern in (r"(?P<seconds>[0-9]+)s", r"^[0-9]+\s+s$"):
+            nonportable = replace(
+                definition,
+                options=(local_ydb_workloads.WorkloadOption("warmup", "10s", kind="duration", pattern=pattern),),
+            )
+            with self.subTest(pattern=pattern), self.assertRaisesRegex(ValueError, "pattern.*is not portable"):
+                local_ydb_workloads._validate_catalog((nonportable,))
+        with mock.patch.object(local_ydb_workloads, "_DEFINITIONS", (definition,)), mock.patch.object(
+            local_ydb_workloads,
+            "_WORKLOADS",
+            {definition.name: definition},
+        ):
+            workload = local_ydb_workloads.normalize_workload(
+                {"type": "synthetic", "operation": "run"},
+                "workload",
+            )
+            self.assertEqual(
+                workload["options"],
+                {
+                    "tx-mode": "serializable-rw",
+                    "enabled": True,
+                    "warmup": "10s",
+                    "label": "mode: fast # tagged",
+                },
+            )
+            schema = local_ydb_workloads.workload_config_schema()["properties"]["options"]["properties"]
+            self.assertEqual(
+                schema["tx-mode"],
+                {
+                    "type": "string",
+                    "minLength": 1,
+                    "enum": ["serializable-rw", "snapshot-rw"],
+                },
+            )
+            self.assertEqual(schema["enabled"], {"type": "boolean"})
+            self.assertEqual(schema["warmup"]["pattern"], r"^[1-9][0-9]*s$")
+            catalog = local_ydb_workloads.web_workload_catalog()
+            self.assertEqual(
+                [option["kind"] for option in catalog[0]["options"]],
+                ["string", "boolean", "duration", "string"],
+            )
+            self.assertEqual(catalog[0]["options"][2]["schema"], schema["warmup"])
+            special = "mode: fast # tagged\nsecond line"
+            self.assertEqual(yaml.safe_load("option: " + json.dumps(special))["option"], special)
+
+            invalid = (
+                ({"tx-mode": "", "enabled": True, "warmup": "10s"}, "tx-mode.*must not be empty"),
+                ({"tx-mode": "snapshot-rw", "enabled": 1, "warmup": "10s"}, "enabled.*must be a boolean"),
+                ({"tx-mode": "snapshot-rw", "enabled": False, "warmup": "0s"}, "warmup.*must match pattern"),
+            )
+            for options, message in invalid:
+                with self.subTest(options=options), self.assertRaisesRegex(BenchmarkError, message):
+                    local_ydb_workloads.normalize_workload(
+                        {"type": "synthetic", "operation": "run", "options": options},
+                        "workload",
+                    )
+
+    def test_local_ydb_workload_registry_builds_golden_cli_commands(self):
+        cli_context = local_ydb_workloads.WorkloadCli(
+            Path("/tmp/ydb cli"),
+            "grpc://benchmark-host.example:2135",
+            "/Root/bench",
+        )
+        workload = local_ydb_workloads.normalize_workload(
+            {"type": "kv", "operation": "select"},
+            "workload",
+        )
+        base = [
+            Path("/tmp/ydb cli"),
+            "--endpoint",
+            "grpc://benchmark-host.example:2135",
+            "--database",
+            "/Root/bench",
+            "workload",
+            "kv",
+            "--path",
+            "table-prefix",
+        ]
+        self.assertEqual(
+            local_ydb_workloads.build_init_argv(cli_context, "table-prefix", workload),
+            base
+            + [
+                "init",
+                "--init-upserts",
+                1000,
+                "--min-partitions",
+                40,
+                "--max-partitions",
+                1000,
+                "--partition-size",
+                2000,
+                "--max-first-key",
+                65536,
+                "--len",
+                64,
+                "--cols",
+                2,
+                "--int-cols",
+                1,
+                "--key-cols",
+                1,
+                "--rows",
+                1,
+            ],
+        )
+        self.assertEqual(
+            local_ydb_workloads.build_run_argv(cli_context, "table-prefix", workload, "rate", 250, 30, 64),
+            base
+            + [
+                "run",
+                "select",
+                "--seconds",
+                30,
+                "--threads",
+                64,
+                "--quiet",
+                "--max-first-key",
+                65536,
+                "--int-cols",
+                1,
+                "--key-cols",
+                1,
+                "--cols",
+                2,
+                "--rows",
+                1,
+                "--rate",
+                250,
+            ],
+        )
+        self.assertEqual(
+            local_ydb_workloads.build_clean_argv(cli_context, "table-prefix", "kv"),
+            base + ["clean"],
+        )
+        prepare = local_ydb_workloads.build_prepare_plan(cli_context, "table-prefix", workload)
+        run = local_ydb_workloads.build_run_plan(
+            cli_context,
+            "table-prefix",
+            workload,
+            "rate",
+            250,
+            30,
+            64,
+        )
+        cleanup = local_ydb_workloads.build_cleanup_plan(cli_context, "table-prefix", workload)
+        self.assertEqual(
+            prepare,
+            (
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "init",
+                    tuple(
+                        base
+                        + [
+                            "init",
+                            "--init-upserts",
+                            1000,
+                            "--min-partitions",
+                            40,
+                            "--max-partitions",
+                            1000,
+                            "--partition-size",
+                            2000,
+                            "--max-first-key",
+                            65536,
+                            "--len",
+                            64,
+                            "--cols",
+                            2,
+                            "--int-cols",
+                            1,
+                            "--key-cols",
+                            1,
+                            "--rows",
+                            1,
+                        ]
+                    ),
+                    120,
+                ),
+            ),
+        )
+        self.assertEqual(
+            run.argv,
+            tuple(
+                local_ydb_workloads.build_run_argv(
+                    cli_context,
+                    "table-prefix",
+                    workload,
+                    "rate",
+                    250,
+                    30,
+                    64,
+                )
+            ),
+        )
+        self.assertEqual(run.timeout_seconds, 60)
+        self.assertEqual(cleanup[0].argv, tuple(base + ["clean"]))
+        self.assertEqual(cleanup[0].timeout_seconds, 120)
+
+    def test_local_ydb_cleanup_plan_rejects_custom_plan_without_timeout(self):
+        cli_context = local_ydb_workloads.WorkloadCli(Path("ydb"), "grpc://host:2135", "/Root/bench")
+
+        def unbounded_cleanup(*_args):
+            return (local_ydb_workloads.WorkloadCommandPlan("clean", ("ydb", "clean")),)
+
+        definition = replace(
+            local_ydb_workloads.workload_definition("kv"),
+            cleanup_plan_builder=unbounded_cleanup,
+        )
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+            with self.assertRaisesRegex(BenchmarkError, "must have a positive timeout"):
+                local_ydb_workloads.build_cleanup_plan(cli_context, "table-prefix", {"type": "kv"})
+
+    def test_local_ydb_workload_registry_validates_lifecycle_metadata_and_plans(self):
+        definition = local_ydb_workloads.WorkloadDefinition(
+            name="inline",
+            default_operation="run",
+            operations=("run",),
+            load_parameters=("sessions",),
+            options=(),
+            uses_path=True,
+            table_name=None,
+            init_builder=lambda *_args: (),
+            run_builder=lambda *_args: (),
+            options_validator=lambda *_args: None,
+            dataset_scope="profile",
+            warmup_mode="inline",
+            run_plan_builder=lambda *_args: local_ydb_workloads.WorkloadCommandPlan("run", ("ydb",), 1),
+        )
+        local_ydb_workloads._validate_catalog((definition,))
+        local_ydb_workloads._validate_catalog((replace(definition, dataset_scope="geometry"),))
+        with self.assertRaisesRegex(ValueError, "dataset scope"):
+            local_ydb_workloads._validate_catalog((replace(definition, dataset_scope="attempt"),))
+        with self.assertRaisesRegex(ValueError, "inline warmup requires"):
+            local_ydb_workloads._validate_catalog((replace(definition, run_plan_builder=None),))
+        with self.assertRaisesRegex(ValueError, "default client threads"):
+            local_ydb_workloads._validate_catalog((replace(definition, default_client_threads=0),))
+        for invalid_maximum in (0, True, "10"):
+            with self.subTest(maximum_total_seconds=invalid_maximum), self.assertRaisesRegex(
+                ValueError, "maximum total duration"
+            ):
+                local_ydb_workloads._validate_catalog((replace(definition, maximum_total_seconds=invalid_maximum),))
+        with self.assertRaisesRegex(ValueError, "cannot fit"):
+            local_ydb_workloads._validate_catalog((replace(definition, maximum_total_seconds=10),))
+        for invalid_warmup in (-1, True, "10"):
+            with self.subTest(default_warmup_seconds=invalid_warmup), self.assertRaisesRegex(
+                ValueError, "default warmup"
+            ):
+                local_ydb_workloads._validate_catalog((replace(definition, default_warmup_seconds=invalid_warmup),))
+        with self.assertRaisesRegex(ValueError, "automatic warmup requires"):
+            local_ydb_workloads._validate_catalog(
+                (replace(definition, default_warmup_seconds=None, effective_warmup_builder=None),)
+            )
+        string_limit = replace(
+            definition,
+            options=(local_ydb_workloads.WorkloadOption("scale", "auto", kind="string"),),
+            load_limits=(("sessions", "scale", 10),),
+        )
+        with self.assertRaisesRegex(ValueError, "invalid load limit"):
+            local_ydb_workloads._validate_catalog((string_limit,))
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"inline": definition}):
+            with self.assertRaisesRegex(BenchmarkError, "CPU measurement window"):
+                local_ydb_workloads.build_run_plan(
+                    local_ydb_workloads.WorkloadCli("ydb", "endpoint", "database"),
+                    "path",
+                    {"type": "inline", "operation": "run", "options": {}},
+                    "sessions",
+                    1,
+                    1,
+                    1,
+                    warmup_seconds=0,
+                )
+            with self.assertRaisesRegex(BenchmarkError, "non-empty argv"):
+                invalid = replace(
+                    definition,
+                    run_plan_builder=lambda *_args: local_ydb_workloads.WorkloadCommandPlan("run", (), 1),
+                )
+                with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"inline": invalid}):
+                    local_ydb_workloads.build_run_plan(
+                        local_ydb_workloads.WorkloadCli("ydb", "endpoint", "database"),
+                        "path",
+                        {"type": "inline", "operation": "run", "options": {}},
+                        "sessions",
+                        1,
+                        1,
+                        1,
+                        warmup_seconds=1,
+                    )
+            for timeout in (float("nan"), float("inf"), True, 10**1000):
+                nonfinite = replace(
+                    definition,
+                    run_plan_builder=lambda *_args, timeout=timeout: local_ydb_workloads.WorkloadCommandPlan(
+                        "run",
+                        ("ydb",),
+                        timeout,
+                    ),
+                )
+                with self.subTest(timeout=timeout), mock.patch.object(
+                    local_ydb_workloads,
+                    "_WORKLOADS",
+                    {"inline": nonfinite},
+                ), self.assertRaisesRegex(BenchmarkError, "positive timeout"):
+                    local_ydb_workloads.build_run_plan(
+                        local_ydb_workloads.WorkloadCli("ydb", "endpoint", "database"),
+                        "path",
+                        {"type": "inline", "operation": "run", "options": {}},
+                        "sessions",
+                        1,
+                        1,
+                        1,
+                        warmup_seconds=1,
+                    )
+
     def test_local_ydb_cli_total_row_is_parsed_in_milliseconds(self):
         metrics = parse_cli_metrics("""
             Window Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
@@ -198,6 +601,76 @@ class YdbBenchTest(unittest.TestCase):
                 Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
                 20 nan 0 0 1 2 3 4
             """)
+
+    def test_local_ydb_result_adapter_rejects_invalid_metric_mappings(self):
+        metric_schema = (
+            local_ydb_workloads.WorkloadMetric("throughput", "widgets/s", required=True),
+            local_ydb_workloads.WorkloadMetric("latency_ms", "ms"),
+        )
+        request = local_ydb_workloads.WorkloadRunRequest("threads", 4, 10, 0, 8, None)
+        command_result = self._local_ydb_command_result(("ydb", "workload", "fake"))
+        invalid_results = (
+            ({"throughput": 1, "unknown": 2}, "unknown metrics"),
+            ({"latency_ms": 2}, "omitted required metrics: throughput"),
+            ({"throughput": float("nan")}, "finite non-negative number"),
+            ({"throughput": True}, "finite non-negative number"),
+            ({"throughput": -1}, "finite non-negative number"),
+        )
+        for index, (metrics, message) in enumerate(invalid_results):
+            with self.subTest(metrics=metrics):
+                adapter = local_ydb_workloads.WorkloadResultAdapter(
+                    "fake-invalid-{}".format(index),
+                    lambda _result, _workload, _request, metrics=metrics: local_ydb_workloads.WorkloadResult(metrics),
+                    metric_schema,
+                )
+                definition = replace(
+                    local_ydb_workloads.workload_definition("kv"),
+                    result_adapter=adapter,
+                    throughput_unit="widgets/s",
+                )
+                with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+                    with self.assertRaisesRegex(BenchmarkError, message):
+                        local_ydb_workloads.parse_workload_result(
+                            "kv",
+                            command_result,
+                            {"type": "kv", "operation": "upsert", "options": {}},
+                            request,
+                        )
+
+    def test_local_ydb_catalog_rejects_unsafe_result_metric_contracts(self):
+        definition = local_ydb_workloads.workload_definition("kv")
+        generic = local_ydb_workloads.GENERIC_TOTAL_RESULT
+
+        def changed_metric(name, **changes):
+            return tuple(replace(metric, **changes) if metric.name == name else metric for metric in generic.metrics)
+
+        invalid_adapters = (
+            (replace(generic, schema_id="x" * 257), "schema id"),
+            (replace(generic, metrics=changed_metric("throughput", repetition_aggregation="sum")), "throughput"),
+            (replace(generic, metrics=changed_metric("transactions", required=False)), "transactions"),
+            (replace(generic, metrics=changed_metric("errors", required=False)), "errors"),
+            (replace(generic, metrics=changed_metric("p99_ms", repetition_aggregation="sum")), "SLO metric"),
+            (replace(generic, slo_metrics=(("latency", "p99_ms"),)), "SLO metric mapping"),
+            (
+                local_ydb_workloads.WorkloadResultAdapter(
+                    "reserved-v1",
+                    generic.parse,
+                    (
+                        local_ydb_workloads.WorkloadMetric("throughput", "operations/s", required=True),
+                        local_ydb_workloads.WorkloadMetric("load", "items"),
+                    ),
+                ),
+                "reserved",
+            ),
+        )
+        for adapter, message in invalid_adapters:
+            with self.subTest(message=message), self.assertRaisesRegex(ValueError, message):
+                local_ydb_workloads._validate_catalog((replace(definition, result_adapter=adapter),))
+
+    def test_local_ydb_cli_total_row_rejects_negative_counters(self):
+        for values in ("-1 10 0 0 1 2 3 4", "1 10 -1 0 1 2 3 4", "1 10 0 -1 1 2 3 4"):
+            with self.subTest(values=values), self.assertRaisesRegex(BenchmarkError, "valid Total row"):
+                parse_cli_metrics("Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)\n" + values)
 
     def test_local_ydb_profile_parses_geometry_load_and_role_affinity(self):
         loaded = load_config(self._config("""
@@ -806,6 +1279,43 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(metrics["throughput"], 20)
         self.assertEqual(metrics["errors"], 100)
 
+    def test_local_ydb_summary_omits_points_with_an_empty_repetition(self):
+        rows = [
+            {"load": 1, "dynamic_nodes": 1, "transactions": 10},
+            {"load": 1, "dynamic_nodes": 1, "transactions": 0},
+            {"load": 2, "dynamic_nodes": 1, "transactions": 20},
+        ]
+        for row in rows:
+            row.update({metric.name: row.get(metric.name, 1) for metric in LOCAL_YDB_BENCHMARK.metrics})
+        summary = LOCAL_YDB_BENCHMARK.summarize_metrics(rows, LOCAL_YDB_BENCHMARK)
+        self.assertEqual([(row["load"], row["dynamic_nodes"]) for row in summary], [(2, 1)])
+
+    def test_local_ydb_summary_exports_schema_aggregation(self):
+        rows = [
+            {"load": 10, "dynamic_nodes": 1, "throughput": 100, "errors": 1},
+            {"load": 10, "dynamic_nodes": 1, "throughput": 120, "errors": 1},
+            {"load": 10, "dynamic_nodes": 1, "throughput": 110, "errors": 1},
+        ]
+        metric_names = ("throughput", "errors")
+        aggregations = {"throughput": "median", "errors": "sum"}
+        summary = LOCAL_YDB_BENCHMARK.summarize_metrics(
+            rows,
+            LOCAL_YDB_BENCHMARK,
+            metric_names,
+            aggregations,
+        )
+        self.assertEqual(summary[0]["median_throughput"], 110)
+        self.assertEqual(summary[0]["max_errors"], 1)
+        self.assertEqual(summary[0]["sum_errors"], 3)
+        rendered = LOCAL_YDB_BENCHMARK.render_summary(
+            summary,
+            LOCAL_YDB_BENCHMARK,
+            metric_names,
+            aggregations,
+        )
+        parsed = next(csv.DictReader(io.StringIO(rendered)))
+        self.assertEqual(parsed["sum_errors"], "3")
+
     def test_local_ydb_scaling_uses_failing_boundary_and_minimum_attempt(self):
         attempts = (
             {"load": 50, "dynamic_cpu_mean": 90, "static_cpu_mean": 20},
@@ -1065,45 +1575,6 @@ class YdbBenchTest(unittest.TestCase):
         config = yaml.safe_load((cluster_directory / "cluster.yaml").read_text(encoding="utf-8"))
         self.assertEqual(config["config"]["host_configs"][0]["ssd"], ["SectorMap:map_0:64:NONE"])
         self.assertEqual(start_process.call_args.kwargs["parent_death_wrapper"], self.root / "process_guard")
-
-    def test_local_ydb_scaling_waits_for_every_new_registered_node(self):
-        cluster_directory = self.root / "scaling-cluster"
-        cluster_directory.mkdir()
-        cluster = local_ydb.LocalYdbCluster(
-            self.root / "ydbd",
-            self.root / "ydb",
-            self.root / "process_guard",
-            cluster_directory,
-            {
-                "static_nodes": 1,
-                "dynamic_nodes": 1,
-                "max_dynamic_nodes": 2,
-                "storage_groups": 1,
-                "disk_size_gb": 64,
-            },
-            {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
-            30,
-        )
-        cluster.hostname = "benchmark-host"
-        cluster.static_nodes = [{"grpc_port": 2135}]
-        nodes = (
-            {"grpc_port": 2136, "ic_port": 19002, "mon_port": 8766},
-            {"grpc_port": 2137, "ic_port": 19003, "mon_port": 8767},
-        )
-        with mock.patch.object(cluster, "_node_ports", side_effect=nodes), mock.patch.object(
-            cluster, "_wait_for_port"
-        ) as wait_for_port, mock.patch.object(cluster, "_wait_database_ready") as wait_database, mock.patch.object(
-            cluster, "_wait_tenant_ready"
-        ), mock.patch.object(
-            local_ydb, "start_managed_process", side_effect=(mock.Mock(pid=101), mock.Mock(pid=102))
-        ):
-            cluster.add_dynamic_nodes(2)
-
-        self.assertEqual(
-            wait_for_port.call_args_list,
-            [mock.call(2136, "dynamic node 1"), mock.call(2137, "dynamic node 2")],
-        )
-        wait_database.assert_called_once_with({"benchmark-host:19002", "benchmark-host:19003"})
 
     def test_local_ydb_tenant_readiness_checks_every_dynamic_node(self):
         cluster_directory = self.root / "tenant-ready-cluster"
@@ -3829,7 +4300,3 @@ class WebTest(unittest.TestCase):
         self.assertTrue(service._runs[passed["id"]]["finished"].wait(2))
         self.assertEqual(service.detail(failed["id"])["state"], "failed")
         self.assertEqual(service.detail(passed["id"])["state"], "passed")
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Unify workload options and result metrics for local YDB benchmarks.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Move the existing KV and Stock definitions, CLI plans, validation and metric schemas into a shared catalog. Keep their defaults and supported operations unchanged; no new workload types are added. Reject malformed counters and avoid summarizing empty repetitions as valid results.