### PR TITLE
add EnableDataShardLocksTransferOnSplit feature flag

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -382,4 +382,5 @@ message TFeatureFlags {
     // size-class slots. Reads of the stripe format work even when this flag is off.
     optional bool EnableVDiskHeapAllocator = 324 [default = false, (RequireRestart) = true];
     optional bool EnableCheckpointsCompression = 325 [default = false];
+    optional bool EnableDataShardLocksTransferOnSplit = 326 [default = false];
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

Feature flag for transferring locks from datashard split source shards to destination shards.
