### PR TITLE
[YDBBUGS-783] Fix checkpoint counters lookup in compatibility streaming tests

### DIFF
--- a/ydb/tests/fq/streaming_common/common.py
+++ b/ydb/tests/fq/streaming_common/common.py
@@ -170,8 +170,14 @@ def get_ydb_config(request, enable_fq_connector=None):
     return config
 
 
+def counter_nodes(cluster: KiKiMR) -> dict:
+    # Tests that create a tenant database run streaming queries on dynamic nodes (slots).
+    # Compatibility tests use only static nodes, so fall back to them when no slots exist.
+    return cluster.slots if cluster.slots else cluster.nodes
+
+
 def monitoring_endpoint(cluster: KiKiMR, node_id: int) -> str:
-    node = cluster.slots[node_id]
+    node = counter_nodes(cluster)[node_id]
     return f"http://localhost:{node.mon_port}"
 
 
@@ -185,7 +191,7 @@ def get_checkpoint_coordinator_metric(
 ) -> int:
     sensor_sum = 0
     found = False
-    for node_id in cluster.slots:
+    for node_id in counter_nodes(cluster):
         sensor = get_sensors(cluster, node_id, "kqp").find_sensor(
             {"path": path, "subsystem": "checkpoint_coordinator", "sensor": metric_name}
         )
@@ -531,7 +537,7 @@ class StreamingTestBase(TestYdsBase):
         path = f"{kikimr.endpoint.database.rstrip('/')}/{query_name}"
         sum = 0
         found = False
-        for node_id in kikimr.cluster.slots:
+        for node_id in counter_nodes(kikimr.cluster):
             sensor = get_sensors(kikimr.cluster, node_id, "kqp").find_sensor(
                 {"path": path, "subsystem": "streaming_queries", "sensor": metric_name}
             )
@@ -543,7 +549,7 @@ class StreamingTestBase(TestYdsBase):
 
     def get_schemeshard_counter(self, kikimr: Kikimr, counter_name: str) -> int:
         total = 0
-        for node_id in kikimr.cluster.slots:
+        for node_id in counter_nodes(kikimr.cluster):
             sensor = get_sensors(kikimr.cluster, node_id, "tablets").find_sensor(
                 {"type": "SchemeShard", "category": "app", "sensor": counter_name}
             )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Not for changelog (test infrastructure only).

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes YDBBUGS-783: `test_streaming.py.TestStreamingRestartToAnotherVersion` fails in compatibility runs with `AssertionError: Wait checkpoint failed, actual completed: 0, expected 1` for every version pair, including same-version restart.

**Root cause.** #51285 (YQ-5473) changed `ydb/tests/fq/streaming_common/common.py` to read counters from `cluster.slots` instead of `cluster.nodes`. That is right for the FQ streaming suite, which now starts a tenant with dynamic slots. The compatibility fixture (`RestartToAnotherVersionFixture`) starts static nodes only and never registers slots, so `cluster.slots` is empty, `get_checkpoint_coordinator_metric()` returns 0 without querying any node, and `wait_completed_checkpoints()` times out. The server side is not involved: in the failing logs the streaming query produces correct output before the wait starts, and the checkpointing code is identical between main and the tested branch.

Scheduled `Regression-run_compatibility` runs bracket the regression: run 33828469316 (2026-09-04, before #51285) passed all 60 restart variants, run 33938238489 (2026-09-05, after) failed all 36 of them with this assertion. The 36 `muted_ya.txt` entries for this class were added right after that run.

**Fix.** Add `counter_nodes(cluster)` that returns slots when present and static nodes otherwise, and use it in `monitoring_endpoint()`, `get_checkpoint_coordinator_metric()`, `get_streaming_query_metric()` and `get_schemeshard_counter()`. Tenant-based FQ tests keep using slots; static-only compatibility clusters get the pre-#51285 behaviour back.

The `TestStreamingRestartToAnotherVersion` entries in `muted_ya.txt` can be removed once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
