### PR TITLE
return ActualGen from BlockResult all the way to end user

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -1549,11 +1549,13 @@ struct TEvBlobStorage {
         , TEvResultCommon
     {
         bool IsTabletStorageInfoVersionObsolete = false;
+        ui32 ActualGeneration = 0;
 
         TEvBlockResult(NKikimrProto::EReplyStatus status,
-                bool isTabletStorageInfoVersionObsolete = false)
+                bool isTabletStorageInfoVersionObsolete = false, ui32 actualGeneration = 0)
             : TEvResultCommon(status)
             , IsTabletStorageInfoVersionObsolete(isTabletStorageInfoVersionObsolete)
+            , ActualGeneration(actualGeneration)
         {}
 
         TString Print(bool isFull) const {
@@ -1561,6 +1563,7 @@ struct TEvBlobStorage {
             TStringStream str;
             str << "TEvBlockResult {Status# " << NKikimrProto::EReplyStatus_Name(Status).data();
             str << " IsTabletStorageInfoVersionObsolete# " << IsTabletStorageInfoVersionObsolete;
+            str << " ActualGeneration# " << ActualGeneration;
             if (ErrorReason.size()) {
                 str << " ErrorReason# \"" << ErrorReason << "\"";
             }

--- a/ydb/core/blob_depot/agent/agent_impl.h
+++ b/ydb/core/blob_depot/agent/agent_impl.h
@@ -464,7 +464,7 @@ namespace NKikimr::NBlobDepot {
             void CheckQueryExecutionTime(TMonotonic now);
 
             void EndWithError(NKikimrProto::EReplyStatus status, const TString& errorReason,
-                bool isTabletStorageInfoVersionObsolete = false);
+                bool isTabletStorageInfoVersionObsolete = false, ui32 actualGeneration = 0);
             void EndWithSuccess(std::unique_ptr<IEventBase> response);
             TString GetName() const;
             TString GetQueryId() const;

--- a/ydb/core/blob_depot/agent/query.cpp
+++ b/ydb/core/blob_depot/agent/query.cpp
@@ -220,7 +220,7 @@ namespace NKikimr::NBlobDepot {
     }
 
     void TBlobDepotAgent::TQuery::EndWithError(NKikimrProto::EReplyStatus status, const TString& errorReason,
-            bool isTabletStorageInfoVersionObsolete) {
+            bool isTabletStorageInfoVersionObsolete, ui32 actualGeneration) {
         YDB_LOG_INFO("Query ends with error",
             {"marker", "BDA14"},
             {"agentId", Agent.LogId},
@@ -253,6 +253,10 @@ namespace NKikimr::NBlobDepot {
         if (isTabletStorageInfoVersionObsolete) {
             Y_ABORT_UNLESS(Event->GetTypeRewrite() == TEvBlobStorage::EvBlock);
             static_cast<TEvBlobStorage::TEvBlockResult&>(*response).IsTabletStorageInfoVersionObsolete = true;
+        }
+        if (actualGeneration) {
+            Y_ABORT_UNLESS(Event->GetTypeRewrite() == TEvBlobStorage::EvBlock);
+            static_cast<TEvBlobStorage::TEvBlockResult&>(*response).ActualGeneration = actualGeneration;
         }
         Agent.SelfId().Send(Event->Sender, response.release(), 0, Event->Cookie);
         if (Span) {

--- a/ydb/core/blob_depot/agent/storage_block.cpp
+++ b/ydb/core/blob_depot/agent/storage_block.cpp
@@ -44,7 +44,7 @@ namespace NKikimr::NBlobDepot {
                     EndWithError(NKikimrProto::ERROR, "incorrect TEvBlockResult response");
                 } else if (const auto status = msg.Record.GetStatus(); status != NKikimrProto::OK) {
                     EndWithError(status, msg.Record.GetErrorReason(),
-                        msg.Record.GetIsTabletStorageInfoVersionObsolete());
+                        msg.Record.GetIsTabletStorageInfoVersionObsolete(), msg.Record.GetActualGeneration());
                 } else {
                     // update blocks cache
                     auto& blockContext = context->Obtain<TBlockContext>();

--- a/ydb/core/blob_depot/blocks.cpp
+++ b/ydb/core/blob_depot/blocks.cpp
@@ -65,8 +65,10 @@ namespace NKikimr::NBlobDepot {
                 response.SetStatus(NKikimrProto::ERROR);
                 response.SetErrorReason("obsolete tablet storage info version");
                 response.SetIsTabletStorageInfoVersionObsolete(true);
+                response.SetActualGeneration(block.BlockedGeneration);
             } else if (hasBlock && !block.CanSetNewBlock(BlockedGeneration, IssuerGuid)) {
                 response.SetStatus(Version == block.Version ? NKikimrProto::ALREADY : NKikimrProto::ERROR);
+                response.SetActualGeneration(block.BlockedGeneration);
                 if (Version > block.Version) {
                     response.SetErrorReason("generation check failed while increasing tablet storage info version");
                 }
@@ -114,6 +116,7 @@ namespace NKikimr::NBlobDepot {
         std::unique_ptr<IEventHandle> Response;
         ui32 BlocksPending = 0;
         ui32 RetryCount = 0;
+        ui32 ActualGeneration = 0;
         THashSet<ui32> NodesWaitingForPushResult;
         std::weak_ptr<TToken> Token;
 
@@ -145,6 +148,7 @@ namespace NKikimr::NBlobDepot {
             } else {
                 auto& r = Response->Get<TEvBlobDepot::TEvBlockResult>()->Record;
                 r.SetStatus(NKikimrProto::ALREADY);
+                r.SetActualGeneration(block.BlockedGeneration);
                 Finish();
                 return true;
             }
@@ -270,6 +274,7 @@ namespace NKikimr::NBlobDepot {
                 {"blockedTabletId", TabletId},
                 {"blockedGeneration", BlockedGeneration},
                 {"groupId", ev->Cookie});
+            ActualGeneration = Max(ActualGeneration, ev->Get()->ActualGeneration);
             switch (ev->Get()->Status) {
                 case NKikimrProto::OK:
                     if (!--BlocksPending) {
@@ -307,6 +312,8 @@ namespace NKikimr::NBlobDepot {
         }
 
         void Finish() {
+            auto& record = Response->Get<TEvBlobDepot::TEvBlockResult>()->Record;
+            record.SetActualGeneration(Max(ActualGeneration, record.GetActualGeneration()));
             TActivationContext::Send(Response.release());
             PassAway();
         }

--- a/ydb/core/blob_depot/blocks.cpp
+++ b/ydb/core/blob_depot/blocks.cpp
@@ -52,6 +52,7 @@ namespace NKikimr::NBlobDepot {
             } else if (raw) {
                 if (hasBlock && !block.CanSetNewBlock(BlockedGeneration, IssuerGuid)) {
                     response.SetStatus(NKikimrProto::ALREADY);
+                    response.SetActualGeneration(block.BlockedGeneration);
                 } else {
                     block.BlockedGeneration = BlockedGeneration;
                     block.IssuerGuid = IssuerGuid;

--- a/ydb/core/blobstorage/bridge/proxy/bridge_proxy.cpp
+++ b/ydb/core/blobstorage/bridge/proxy/bridge_proxy.cpp
@@ -187,6 +187,7 @@ namespace NKikimr {
                 result->ErrorReason = std::move(ev->ErrorReason);
                 result->IsTabletStorageInfoVersionObsolete = ev->IsTabletStorageInfoVersionObsolete
                     || (current && current->IsTabletStorageInfoVersionObsolete);
+                result->ActualGeneration = Max(ev->ActualGeneration, current ? current->ActualGeneration : 0);
                 return result;
             }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_block.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_block.cpp
@@ -20,6 +20,7 @@ class TBlobStorageGroupBlockRequest : public TBlobStorageGroupRequestActor {
     const TWriteSource WriteSource;
     bool SeenAlready = false;
     bool SeenObsoleteVersion = false;
+    ui32 ActualGeneration = 0;
 
     TGroupQuorumTracker QuorumTracker;
 
@@ -32,6 +33,7 @@ class TBlobStorageGroupBlockRequest : public TBlobStorageGroupRequestActor {
         const TVDiskID vdisk = VDiskIDFromVDiskID(record.GetVDiskID());
         const TVDiskIdShort shortId(ev->Cookie);
         SeenObsoleteVersion |= record.GetIsTabletStorageInfoVersionObsolete();
+        ActualGeneration = Max(ActualGeneration, record.GetGeneration());
 
         Y_ABORT_UNLESS(shortId.FailRealm == vdisk.FailRealm &&
                 shortId.FailDomain == vdisk.FailDomain &&
@@ -103,6 +105,7 @@ class TBlobStorageGroupBlockRequest : public TBlobStorageGroupRequestActor {
         std::unique_ptr<TEvBlobStorage::TEvBlockResult> result(new TEvBlobStorage::TEvBlockResult(status));
         result->ErrorReason = ErrorReason;
         result->IsTabletStorageInfoVersionObsolete = status != NKikimrProto::OK && SeenObsoleteVersion;
+        result->ActualGeneration = ActualGeneration;
         DSP_LOG_LOG_S(PriorityForStatusResult(status), "DSPB04", "Result# " << result->Print(false));
         Mon->CountBlockResponseTime(TActivationContext::Monotonic() - RequestStartTime);
         return SendResponseAndDie(std::move(result));

--- a/ydb/core/blobstorage/ut_blobstorage/extra_block_checks.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/extra_block_checks.cpp
@@ -37,7 +37,7 @@ Y_UNIT_TEST_SUITE(ExtraBlockChecks) {
         result = block(10, 2);
         UNIT_ASSERT_VALUES_EQUAL(result->Get()->Status, NKikimrProto::ERROR);
         UNIT_ASSERT(!result->Get()->IsTabletStorageInfoVersionObsolete);
-        UNIT_ASSERT_VALUES_EQUAL(result->Get()->ActualGeneration, 10);
+        UNIT_ASSERT_VALUES_EQUAL(result->Get()->ActualGeneration, 11);
 
         // The rejected version bump must not mutate either record.
         result = block(12, 1);

--- a/ydb/core/blobstorage/ut_blobstorage/extra_block_checks.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/extra_block_checks.cpp
@@ -37,6 +37,7 @@ Y_UNIT_TEST_SUITE(ExtraBlockChecks) {
         result = block(10, 2);
         UNIT_ASSERT_VALUES_EQUAL(result->Get()->Status, NKikimrProto::ERROR);
         UNIT_ASSERT(!result->Get()->IsTabletStorageInfoVersionObsolete);
+        UNIT_ASSERT_VALUES_EQUAL(result->Get()->ActualGeneration, 10);
 
         // The rejected version bump must not mutate either record.
         result = block(12, 1);

--- a/ydb/core/protos/blob_depot.proto
+++ b/ydb/core/protos/blob_depot.proto
@@ -124,6 +124,7 @@ message TEvBlockResult {
     optional string ErrorReason = 2;
     optional uint32 TimeToLiveMs = 3;
     optional bool IsTabletStorageInfoVersionObsolete = 4 [default = false];
+    optional uint32 ActualGeneration = 5;
 }
 
 message TEvPushNotify {

--- a/ydb/core/tablet/tablet_impl.h
+++ b/ydb/core/tablet/tablet_impl.h
@@ -42,13 +42,16 @@ struct TEvTabletBase {
         const ui64 TabletId;
         const TString ErrorReason;
         const bool IsTabletStorageInfoVersionObsolete;
+        const ui32 ActualGeneration;
 
         TEvBlockBlobStorageResult(NKikimrProto::EReplyStatus status, ui64 tabletId,
-                const TString &reason = TString(), bool isTabletStorageInfoVersionObsolete = false)
+                const TString &reason = TString(), bool isTabletStorageInfoVersionObsolete = false,
+                ui32 actualGeneration = 0)
             : Status(status)
             , TabletId(tabletId)
             , ErrorReason(reason)
             , IsTabletStorageInfoVersionObsolete(isTabletStorageInfoVersionObsolete)
+            , ActualGeneration(actualGeneration)
         {}
     };
 

--- a/ydb/core/tablet/tablet_req_blockbs.cpp
+++ b/ydb/core/tablet/tablet_req_blockbs.cpp
@@ -15,9 +15,9 @@ public:
     ui32 Version;
 
     void ReplyAndDie(NKikimrProto::EReplyStatus status, const TString &reason = { },
-            bool isTabletStorageInfoVersionObsolete = false) {
+            bool isTabletStorageInfoVersionObsolete = false, ui32 actualGeneration = 0) {
         Send(Owner, new TEvTabletBase::TEvBlockBlobStorageResult(status, TabletId, reason,
-            isTabletStorageInfoVersionObsolete));
+            isTabletStorageInfoVersionObsolete, actualGeneration));
         PassAway();
     }
 
@@ -44,9 +44,11 @@ public:
         case NKikimrProto::RACE:
         case NKikimrProto::NO_GROUP:
             // The request will never succeed
-            return ReplyAndDie(msg->Status, msg->ErrorReason, msg->IsTabletStorageInfoVersionObsolete);
+            return ReplyAndDie(msg->Status, msg->ErrorReason, msg->IsTabletStorageInfoVersionObsolete,
+                msg->ActualGeneration);
         default:
-            return ReplyAndDie(NKikimrProto::ERROR, msg->ErrorReason, msg->IsTabletStorageInfoVersionObsolete);
+            return ReplyAndDie(NKikimrProto::ERROR, msg->ErrorReason, msg->IsTabletStorageInfoVersionObsolete,
+                msg->ActualGeneration);
         }
     }
 
@@ -96,9 +98,9 @@ class TTabletReqBlockBlobStorage : public TActorBootstrapped<TTabletReqBlockBlob
     }
 
     void ReplyAndDie(NKikimrProto::EReplyStatus status, const TString &reason = { },
-            bool isTabletStorageInfoVersionObsolete = false) {
+            bool isTabletStorageInfoVersionObsolete = false, ui32 actualGeneration = 0) {
         Send(Owner, new TEvTabletBase::TEvBlockBlobStorageResult(status, TabletId, reason,
-            isTabletStorageInfoVersionObsolete));
+            isTabletStorageInfoVersionObsolete, actualGeneration));
         PassAway();
     }
 
@@ -114,7 +116,8 @@ class TTabletReqBlockBlobStorage : public TActorBootstrapped<TTabletReqBlockBlob
                 return ReplyAndDie(NKikimrProto::OK);
             break;
         default:
-            return ReplyAndDie(msg->Status, msg->ErrorReason, msg->IsTabletStorageInfoVersionObsolete);
+            return ReplyAndDie(msg->Status, msg->ErrorReason, msg->IsTabletStorageInfoVersionObsolete,
+                msg->ActualGeneration);
         }
     }
 

--- a/ydb/core/tablet/tablet_req_blockbs_ut.cpp
+++ b/ydb/core/tablet/tablet_req_blockbs_ut.cpp
@@ -34,6 +34,7 @@ Y_UNIT_TEST_SUITE(TBlockBlobStorageTest) {
                     auto* msg = ev->Get<TEvBlobStorage::TEvBlockResult>();
                     auto target = ev->GetRecipientRewrite();
                     if (msg->Status != NKikimrProto::OK) {
+                        msg->ActualGeneration = 123;
                         Cerr << "... blocking block result " << msg->Status << " for " << target << Endl;
                         blocked.emplace_back(ev.Release());
                         return TTestActorRuntime::EEventAction::DROP;
@@ -74,6 +75,7 @@ Y_UNIT_TEST_SUITE(TBlockBlobStorageTest) {
 
         auto ev = runtime.GrabEdgeEventRethrow<TEvTabletBase::TEvBlockBlobStorageResult>(owner);
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Status, NKikimrProto::NO_GROUP);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->ActualGeneration, 123);
     }
 
 } // Y_UNIT_TEST_SUITE(TBlockBlobStorageTest)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
