### PR TITLE
YDB-3508 Report the real decode ratio for S3 reads

### DIFF
--- a/ydb/library/yql/providers/s3/common/source_context.h
+++ b/ydb/library/yql/providers/s3/common/source_context.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -54,7 +55,7 @@ struct TSourceContext {
 
     double Ratio() const {
         auto downloadedBytes = DownloadedBytes.load();
-        return downloadedBytes ? static_cast<double>(downloadedBytes) / DownloadedBytes.load() : 1.0;
+        return downloadedBytes ? std::max(1.0, static_cast<double>(DecodedBytes.load()) / downloadedBytes) : 1.0;
     }
 
     ui64 FairShare() {

--- a/ydb/library/yql/providers/s3/common/source_context_ut.cpp
+++ b/ydb/library/yql/providers/s3/common/source_context_ut.cpp
@@ -1,0 +1,47 @@
+#include "source_context.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NYql::NDq {
+
+namespace {
+
+TSourceContext::TPtr MakeSourceContext() {
+    return std::make_shared<TSourceContext>(NActors::TActorId{}, 1000000, nullptr,
+        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+}
+
+}
+
+Y_UNIT_TEST_SUITE(TestSourceContextRatio) {
+    Y_UNIT_TEST(NothingDownloaded) {
+        UNIT_ASSERT_DOUBLES_EQUAL(MakeSourceContext()->Ratio(), 1.0, 1e-9);
+    }
+
+    Y_UNIT_TEST(NothingDecodedYet) {
+        auto context = MakeSourceContext();
+        context->UpdateProgress(1000, 0, 0);
+        UNIT_ASSERT_DOUBLES_EQUAL(context->Ratio(), 1.0, 1e-9);
+    }
+
+    Y_UNIT_TEST(DecodingExpandsData) {
+        auto context = MakeSourceContext();
+        context->UpdateProgress(1000, 3500, 10);
+        UNIT_ASSERT_DOUBLES_EQUAL(context->Ratio(), 3.5, 1e-9);
+    }
+
+    Y_UNIT_TEST(RatioAccumulatesOverUpdates) {
+        auto context = MakeSourceContext();
+        context->UpdateProgress(1000, 4000, 10);
+        context->UpdateProgress(3000, 4000, 10);
+        UNIT_ASSERT_DOUBLES_EQUAL(context->Ratio(), 2.0, 1e-9);
+    }
+
+    Y_UNIT_TEST(DecodingShrinksData) {
+        auto context = MakeSourceContext();
+        context->UpdateProgress(1000, 250, 10);
+        UNIT_ASSERT_DOUBLES_EQUAL(context->Ratio(), 1.0, 1e-9);
+    }
+}
+
+} // namespace NYql::NDq

--- a/ydb/library/yql/providers/s3/common/ut/ya.make
+++ b/ydb/library/yql/providers/s3/common/ut/ya.make
@@ -4,6 +4,14 @@ SRCS(
     util_ut.cpp
 )
 
+IF (CLANG AND NOT WITH_VALGRIND)
+
+    SRCS(
+        source_context_ut.cpp
+    )
+
+ENDIF()
+
 PEERDIR(
     yql/essentials/public/udf/service/stub
     yql/essentials/sql/pg_dummy


### PR DESCRIPTION
### Changelog category

* Bugfix

### Description for reviewers

`TSourceContext::Ratio()` computed `DownloadedBytes / DownloadedBytes`, so it always returned 1.0 and `DecodedBytes` was never read anywhere. The S3 read actor uses `DownloadSize * Ratio()` to decide whether another download coroutine fits into `DataInflight`, so the guard behaved as if decoding expanded nothing and let coroutines over-consume memory. `Ratio()` now returns `DecodedBytes / DownloadedBytes`, floored at 1.0 so that no sample yet, or data that decodes smaller than it downloads, cannot make the estimate shrink below the downloaded size and weaken the guard. Covered by the `TestSourceContextRatio` suite in `ydb/library/yql/providers/s3/common/ut`.