### PR TITLE
http_gateway: initialize curl global state once per process, never clean it up

### DIFF
--- a/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
@@ -137,6 +137,14 @@ struct TScriptExecutionsYdbSetup {
         Cerr << "\n\n\n--------------------------- INIT FINISHED ---------------------------\n\n\n";
     }
 
+    ~TScriptExecutionsYdbSetup() {
+        // Stop SDK requests and wait for their completion before the server is destroyed,
+        // otherwise SDK gRPC threads may outlive the server and race with its shutdown
+        if (YdbDriver) {
+            YdbDriver->Stop(true);
+        }
+    }
+
     TTestActorRuntime* GetRuntime() {
         return Server->GetRuntime();
     }

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_gateway.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_gateway.cpp
@@ -704,18 +704,38 @@ private:
     size_t BuffersSizePerStream = CURL_MAX_WRITE_SIZE << 3U;
     TCurlInitConfig InitConfig;
 
+    // libcurl requires curl_global_init() to be called once per process before any other thread is started,
+    // and curl_global_cleanup() to be called once after all other threads are finished (see man libcurl(3)).
+    // The gateway may be created and destroyed several times during the process lifetime (e.g. in tests),
+    // when other threads are already running, so the global state is initialized exactly once and is never
+    // cleaned up: the OS reclaims it at process exit, which libcurl explicitly allows.
+    //
+    // Never calling curl_global_cleanup() is essential rather than a shortcut. It drops the c-ares library
+    // reference count to zero and resets c-ares global state, while other c-ares users in the same process
+    // (grpc, ydb/library/actors/dnscachelib) do not take their own c-ares reference and may still be resolving
+    // names on their threads. This is the data race reported by ThreadSanitizer in ares_library_cleanup_unsafe
+    // (YDBBUGS-482, YDBBUGS-716, YQ-4880).
+    static void InitCurlGlobal() {
+        struct TCurlGlobalInit {
+            TCurlGlobalInit() {
+                const CURLcode globalInitResult = curl_global_init(CURL_GLOBAL_ALL);
+                if (globalInitResult != CURLE_OK) {
+                    throw yexception() << "curl_global_init error " << int(globalInitResult) << ": " << curl_easy_strerror(globalInitResult);
+                }
+            }
+        };
+        // If the constructor throws, the initialization is retried on the next call.
+        static const TCurlGlobalInit init;
+        Y_UNUSED(init);
+    }
+
     void InitCurl() {
-        // FIXME: NOT SAFE (see man libcurl(3))
-        const CURLcode globalInitResult = curl_global_init(CURL_GLOBAL_ALL);
-        if (globalInitResult != CURLE_OK) {
-           throw yexception() << "curl_global_init error " << int(globalInitResult) << ": " << curl_easy_strerror(globalInitResult) << Endl;
-        }
+        InitCurlGlobal();
         Handle = std::shared_ptr<CURLM>(curl_multi_init(), [](auto handle) {
             const CURLMcode multiCleanupResult = curl_multi_cleanup(handle);
             if (multiCleanupResult != CURLM_OK) {
                 Cerr << "curl_multi_cleanup error " << int(multiCleanupResult) << ": " << curl_multi_strerror(multiCleanupResult) << Endl;
             }
-            curl_global_cleanup(); // FIXME: NOT SAFE (see man libcurl(3))
         });
         if (!Handle) {
             throw yexception() << "curl_multi_init error";


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed a data race on c-ares global state during HTTP gateway shutdown (ThreadSanitizer report in `ares_library_cleanup_unsafe`).

### Changelog category

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

Tickets: YDBBUGS-716, YDBBUGS-482 (GitHub #50410, #42190), YQ-4880.

**Root cause.** `THTTPMultiGateway` called `curl_global_init()` in its constructor and `curl_global_cleanup()` in its destructor, from arbitrary threads while other threads were running (the code carried `FIXME: NOT SAFE` comments). `curl_global_cleanup()` calls `ares_library_cleanup()`, which drops the c-ares reference count to zero and resets the global `__ares_malloc`/`__ares_realloc`/`__ares_free` pointers. grpc (`grpc_ares_wrapper.cc`) and `ydb/library/actors/dnscachelib` use c-ares without calling `ares_library_init()` on non-Windows platforms, so they do not hold a reference and may still be resolving names on their threads when the gateway is destroyed. That is the write/read pair ThreadSanitizer reports.

**Fix.** Initialize the curl global state exactly once per process (function-local static, retried if it throws) and never call `curl_global_cleanup()`. libcurl documents cleanup as optional; the OS reclaims the state at exit. With no cleanup call the c-ares reference count never returns to zero, so the racing write no longer exists. `curl_multi_init()`/`curl_multi_cleanup()` remain per gateway instance. This also removes repeated OpenSSL init/cleanup cycles when gateways are created and destroyed repeatedly in tests.

Additionally `TScriptExecutionsYdbSetup` now stops the SDK driver in its destructor before the test server is destroyed, matching `TTestExtEnv` and `TWorkloadServiceYdbSetup`.

**Not changed.** `ydb/library/aws_init/aws.cpp` still pairs `curl_global_init()`/`curl_global_cleanup()`. Once a gateway has been created the curl reference count stays above zero, so that cleanup becomes a no-op; processes that use AWS without the gateway keep the old behavior.

**Verification.** `ydb/library/yql/providers/common/http_gateway/ut` (28 tests) and `ydb/core/kqp/proxy_service/ut -F ScriptExecutionsTest::TestSecureScriptExecutions -F ScriptExecutionsTest::RunCheckLeaseStatus` pass in relwithdebinfo. Not re-run under TSan locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
