### PR TITLE
Respect ForcedPDiskSpaceColor in CapacityAlert

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -667,11 +667,8 @@ NPDisk::TStatusFlags TPDisk::GetStatusFlags(TOwner ownerId, const EOwnerGroupTyp
         res = Keeper.GetSpaceStatusFlags(keeperOwner, &occupancy_);
     }
 
-    if (i64 forcedColor = ForcedPDiskSpaceColor; forcedColor != 0) {
-        using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
-        if (NKikimrBlobStorage::TPDiskSpaceColor_E_IsValid(static_cast<int>(forcedColor))) {
-            res = SpaceColorToStatusFlag(static_cast<TColor::E>(forcedColor));
-        }
+    if (auto forcedColor = GetForcedPDiskSpaceColorIcb()) {
+        res = SpaceColorToStatusFlag(*forcedColor);
     }
 
     if (occupancy) {
@@ -1752,11 +1749,9 @@ void TPDisk::WhiteboardReport(TWhiteboardReport &whiteboardReport) {
             double occupancy;
             NPDisk::TStatusFlags statusFlags = Keeper.GetSpaceStatusFlags(owner, &occupancy);
             NKikimrBlobStorage::TPDiskSpaceColor::E spaceColor = StatusFlagToSpaceColor(statusFlags);
-            if (i64 forcedColor = ForcedPDiskSpaceColor; forcedColor != 0) {
-                if (NKikimrBlobStorage::TPDiskSpaceColor_E_IsValid(static_cast<int>(forcedColor))) {
-                    spaceColor = static_cast<NKikimrBlobStorage::TPDiskSpaceColor::E>(forcedColor);
-                    statusFlags = SpaceColorToStatusFlag(spaceColor);
-                }
+            if (auto forcedColor = GetForcedPDiskSpaceColorIcb()) {
+                spaceColor = *forcedColor;
+                statusFlags = SpaceColorToStatusFlag(spaceColor);
             }
             double vdiskSlotUsage = Keeper.GetVDiskSlotUsage(owner);
             double vdiskRawUsage = Keeper.GetVDiskRawUsage(owner);
@@ -1809,10 +1804,8 @@ void TPDisk::WhiteboardReport(TWhiteboardReport &whiteboardReport) {
         pdiskState.SetPDiskUsage(pdiskUsage);
 
         auto pdiskCapacityAlert = Keeper.GetPDiskCapacityAlert();
-        if (i64 forcedColor = ForcedPDiskSpaceColor; forcedColor != 0) {
-            if (NKikimrBlobStorage::TPDiskSpaceColor_E_IsValid(static_cast<int>(forcedColor))) {
-                pdiskCapacityAlert = static_cast<NKikimrBlobStorage::TPDiskSpaceColor::E>(forcedColor);
-            }
+        if (auto forcedColor = GetForcedPDiskSpaceColorIcb()) {
+            pdiskCapacityAlert = *forcedColor;
         }
         pDiskMetrics.SetPDiskCapacityAlert(pdiskCapacityAlert);
         pdiskState.SetPDiskCapacityAlert(pdiskCapacityAlert);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -671,10 +671,6 @@ NPDisk::TStatusFlags TPDisk::GetStatusFlags(TOwner ownerId, const EOwnerGroupTyp
         using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
         if (NKikimrBlobStorage::TPDiskSpaceColor_E_IsValid(static_cast<int>(forcedColor))) {
             res = SpaceColorToStatusFlag(static_cast<TColor::E>(forcedColor));
-        } else {
-            YDB_LOG_P_LOG(PRI_ERROR, "ForcedPDiskSpaceColor has invalid value, ignoring",
-                {"marker", "BPD01"},
-                {"forcedPDiskSpaceColor", forcedColor});
         }
     }
 
@@ -1756,6 +1752,12 @@ void TPDisk::WhiteboardReport(TWhiteboardReport &whiteboardReport) {
             double occupancy;
             NPDisk::TStatusFlags statusFlags = Keeper.GetSpaceStatusFlags(owner, &occupancy);
             NKikimrBlobStorage::TPDiskSpaceColor::E spaceColor = StatusFlagToSpaceColor(statusFlags);
+            if (i64 forcedColor = ForcedPDiskSpaceColor; forcedColor != 0) {
+                if (NKikimrBlobStorage::TPDiskSpaceColor_E_IsValid(static_cast<int>(forcedColor))) {
+                    spaceColor = static_cast<NKikimrBlobStorage::TPDiskSpaceColor::E>(forcedColor);
+                    statusFlags = SpaceColorToStatusFlag(spaceColor);
+                }
+            }
             double vdiskSlotUsage = Keeper.GetVDiskSlotUsage(owner);
             double vdiskRawUsage = Keeper.GetVDiskRawUsage(owner);
             vdiskMetrics->SetStatusFlags(statusFlags);
@@ -1807,6 +1809,11 @@ void TPDisk::WhiteboardReport(TWhiteboardReport &whiteboardReport) {
         pdiskState.SetPDiskUsage(pdiskUsage);
 
         auto pdiskCapacityAlert = Keeper.GetPDiskCapacityAlert();
+        if (i64 forcedColor = ForcedPDiskSpaceColor; forcedColor != 0) {
+            if (NKikimrBlobStorage::TPDiskSpaceColor_E_IsValid(static_cast<int>(forcedColor))) {
+                pdiskCapacityAlert = static_cast<NKikimrBlobStorage::TPDiskSpaceColor::E>(forcedColor);
+            }
+        }
         pDiskMetrics.SetPDiskCapacityAlert(pdiskCapacityAlert);
         pdiskState.SetPDiskCapacityAlert(pdiskCapacityAlert);
     }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
@@ -121,6 +121,14 @@ public:
     TControlWrapper StaticGroupChunkReservePerMille;
     i64 StaticGroupChunkReservePerMilleCached = 0;
     TControlWrapper ForcedPDiskSpaceColor;
+    std::optional<NKikimrBlobStorage::TPDiskSpaceColor::E> GetForcedPDiskSpaceColorIcb() const {
+        if (i64 forcedColor = ForcedPDiskSpaceColor; forcedColor != 0) {
+            if (NKikimrBlobStorage::TPDiskSpaceColor_E_IsValid(static_cast<int>(forcedColor))) {
+                return static_cast<NKikimrBlobStorage::TPDiskSpaceColor::E>(forcedColor);
+            }
+        }
+        return std::nullopt;
+    }
     NKikimrBlobStorage::TPDiskSpaceColor::E GetColorBorderIcb() {
         using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
         switch (SemiStrictSpaceIsolation) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
@@ -1395,7 +1395,7 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
         using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
 
         TActorTestContext testCtx{{ .EnablePDiskSpaceColorOverride = true }};
-        TVDiskMock vdisk(&testCtx);
+        TVDiskMock vdisk(&testCtx, false, testCtx.Sender);
         vdisk.InitFull();
 
         // Register the node whiteboard service on the test sender so that
@@ -1421,63 +1421,44 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
             UNIT_ASSERT_VALUES_EQUAL(StatusFlagToSpaceColor(space->StatusFlags), expected);
         };
 
-        // The PDisk sends periodic whiteboard updates carrying both the PDisk
-        // state (TEvPDiskStateUpdate with PDiskCapacityAlert) and per-VDisk
-        // states (TEvVDiskStateUpdate with VDisk CapacityAlert). Both are
-        // delivered to the test sender. This helper inspects a bounded number
-        // of incoming events and verifies that the PDiskCapacityAlert matches
-        // the expected color.
         auto checkPDiskCapacityAlert = [&](TColor::E expected) {
+            Cerr << (TStringBuilder() << "... Awaiting TEvPDiskStateUpdate"
+                << " PDiskCapacityAlert# " << TColor::E_Name(expected)
+                << Endl);
             bool found = false;
-            for (int numInspect = 20; numInspect > 0; --numInspect) {
+            for (int numInspect = 10; numInspect > 0; --numInspect) {
                 const auto ev = testCtx.Recv<NNodeWhiteboard::TEvWhiteboard::TEvPDiskStateUpdate>();
-                if (!ev) {
+                Cerr << (TStringBuilder() << "Got TEvPDiskStateUpdate# " << ev->ToString() << Endl);
+                const auto& pdiskInfo = ev->Record;
+                if (pdiskInfo.HasPDiskCapacityAlert() && pdiskInfo.GetPDiskCapacityAlert() == expected) {
+                    found = true;
                     break;
                 }
-                const NKikimrWhiteboard::TPDiskStateInfo& pdiskInfo = ev->Record;
-                if (!pdiskInfo.HasPDiskCapacityAlert()) {
-                    continue;
-                }
-                // Skip stale updates that reflect a previous color; keep
-                // iterating until we see the expected one.
-                if (pdiskInfo.GetPDiskCapacityAlert() != expected) {
-                    continue;
-                }
-                found = true;
-                break;
             }
             UNIT_ASSERT_C(found, "No TEvPDiskStateUpdate with expected PDiskCapacityAlert received");
         };
 
-        // Similarly verifies the VDisk CapacityAlert reported via
-        // TEvVDiskStateUpdate respects the ForcedPDiskSpaceColor ICB override.
         auto checkVDiskCapacityAlert = [&](TColor::E expected) {
+            Cerr << (TStringBuilder() << "... Awaiting TEvVDiskStateUpdate"
+                << " CapacityAlert# " << TColor::E_Name(expected)
+                << Endl);
             bool found = false;
-            for (int numInspect = 20; numInspect > 0; --numInspect) {
+            for (int numInspect = 10; numInspect > 0; --numInspect) {
                 const auto ev = testCtx.Recv<NNodeWhiteboard::TEvWhiteboard::TEvVDiskStateUpdate>();
-                if (!ev) {
+                Cerr << (TStringBuilder() << "Got TEvVDiskStateUpdate# " << ev->ToString() << Endl);
+                const auto& vdiskInfo = ev->Record;
+                if (vdiskInfo.HasCapacityAlert() && vdiskInfo.GetCapacityAlert() == expected) {
+                    found = true;
                     break;
                 }
-                const NKikimrWhiteboard::TVDiskStateInfo& vdiskInfo = ev->Record;
-                if (!vdiskInfo.HasCapacityAlert()) {
-                    continue;
-                }
-                // Skip stale updates that reflect a previous color; keep
-                // iterating until we see the expected one.
-                if (vdiskInfo.GetCapacityAlert() != expected) {
-                    continue;
-                }
-                found = true;
-                break;
             }
             UNIT_ASSERT_C(found, "No TEvVDiskStateUpdate with expected CapacityAlert received");
         };
 
-        // Triggers a whiteboard report by waking the PDisk actor. The report
-        // emits both TEvPDiskStateUpdate and TEvVDiskStateUpdate to the test
-        // sender, so the capacity-alert checks below can observe them.
-        auto triggerWhiteboardReport = [&] {
+        auto checkCapacityAlerts = [&](TColor::E expected) {
             testCtx.Send(new TEvents::TEvWakeup());
+            checkPDiskCapacityAlert(expected);
+            checkVDiskCapacityAlert(expected);
         };
 
         checkColor(TColor::GREEN);
@@ -1489,21 +1470,15 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
         // override. A single wakeup triggers a whiteboard report that emits
         // both TEvPDiskStateUpdate and TEvVDiskStateUpdate; each check grabs
         // its own event type from the edge, so they don't interfere.
-        triggerWhiteboardReport();
-        checkPDiskCapacityAlert(TColor::YELLOW);
-        checkVDiskCapacityAlert(TColor::YELLOW);
+        checkCapacityAlerts(TColor::YELLOW);
 
         setColor(TColor::RED);
         checkColor(TColor::RED);
-        triggerWhiteboardReport();
-        checkPDiskCapacityAlert(TColor::RED);
-        checkVDiskCapacityAlert(TColor::RED);
+        checkCapacityAlerts(TColor::RED);
 
         setColor(TColor::GREEN);
         checkColor(TColor::GREEN);
-        triggerWhiteboardReport();
-        checkPDiskCapacityAlert(TColor::GREEN);
-        checkVDiskCapacityAlert(TColor::GREEN);
+        checkCapacityAlerts(TColor::GREEN);
 
         setColor(0);
         checkColor(TColor::GREEN);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
@@ -1398,6 +1398,13 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
         TVDiskMock vdisk(&testCtx);
         vdisk.InitFull();
 
+        // Register the node whiteboard service on the test sender so that
+        // TEvPDiskStateUpdate messages (carrying PDiskCapacityAlert) are
+        // delivered to the test and can be inspected.
+        const ui32 firstNodeId = testCtx.GetRuntime()->GetFirstNodeId();
+        testCtx.GetRuntime()->SetDispatchTimeout(10 * TDuration::MilliSeconds(testCtx.GetPDiskConfig()->StatisticsUpdateIntervalMs));
+        testCtx.GetRuntime()->RegisterService(NNodeWhiteboard::MakeNodeWhiteboardServiceId(firstNodeId), testCtx.Sender);
+
         auto& appData = testCtx.GetRuntime()->GetAppData();
         const ui32 pdiskId = testCtx.GetPDisk()->PCtx->PDiskId;
         const TString controlName = Sprintf("PDisk_%u_ForcedPDiskSpaceColor", pdiskId);
@@ -1414,16 +1421,89 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
             UNIT_ASSERT_VALUES_EQUAL(StatusFlagToSpaceColor(space->StatusFlags), expected);
         };
 
+        // The PDisk sends periodic whiteboard updates carrying both the PDisk
+        // state (TEvPDiskStateUpdate with PDiskCapacityAlert) and per-VDisk
+        // states (TEvVDiskStateUpdate with VDisk CapacityAlert). Both are
+        // delivered to the test sender. This helper inspects a bounded number
+        // of incoming events and verifies that the PDiskCapacityAlert matches
+        // the expected color.
+        auto checkPDiskCapacityAlert = [&](TColor::E expected) {
+            bool found = false;
+            for (int numInspect = 20; numInspect > 0; --numInspect) {
+                const auto ev = testCtx.Recv<NNodeWhiteboard::TEvWhiteboard::TEvPDiskStateUpdate>();
+                if (!ev) {
+                    break;
+                }
+                const NKikimrWhiteboard::TPDiskStateInfo& pdiskInfo = ev->Record;
+                if (!pdiskInfo.HasPDiskCapacityAlert()) {
+                    continue;
+                }
+                // Skip stale updates that reflect a previous color; keep
+                // iterating until we see the expected one.
+                if (pdiskInfo.GetPDiskCapacityAlert() != expected) {
+                    continue;
+                }
+                found = true;
+                break;
+            }
+            UNIT_ASSERT_C(found, "No TEvPDiskStateUpdate with expected PDiskCapacityAlert received");
+        };
+
+        // Similarly verifies the VDisk CapacityAlert reported via
+        // TEvVDiskStateUpdate respects the ForcedPDiskSpaceColor ICB override.
+        auto checkVDiskCapacityAlert = [&](TColor::E expected) {
+            bool found = false;
+            for (int numInspect = 20; numInspect > 0; --numInspect) {
+                const auto ev = testCtx.Recv<NNodeWhiteboard::TEvWhiteboard::TEvVDiskStateUpdate>();
+                if (!ev) {
+                    break;
+                }
+                const NKikimrWhiteboard::TVDiskStateInfo& vdiskInfo = ev->Record;
+                if (!vdiskInfo.HasCapacityAlert()) {
+                    continue;
+                }
+                // Skip stale updates that reflect a previous color; keep
+                // iterating until we see the expected one.
+                if (vdiskInfo.GetCapacityAlert() != expected) {
+                    continue;
+                }
+                found = true;
+                break;
+            }
+            UNIT_ASSERT_C(found, "No TEvVDiskStateUpdate with expected CapacityAlert received");
+        };
+
+        // Triggers a whiteboard report by waking the PDisk actor. The report
+        // emits both TEvPDiskStateUpdate and TEvVDiskStateUpdate to the test
+        // sender, so the capacity-alert checks below can observe them.
+        auto triggerWhiteboardReport = [&] {
+            testCtx.Send(new TEvents::TEvWakeup());
+        };
+
         checkColor(TColor::GREEN);
 
         setColor(TColor::YELLOW);
         checkColor(TColor::YELLOW);
+        // The PDiskCapacityAlert and VDisk CapacityAlert reported to the
+        // whiteboard/UI must also respect the ForcedPDiskSpaceColor ICB
+        // override. A single wakeup triggers a whiteboard report that emits
+        // both TEvPDiskStateUpdate and TEvVDiskStateUpdate; each check grabs
+        // its own event type from the edge, so they don't interfere.
+        triggerWhiteboardReport();
+        checkPDiskCapacityAlert(TColor::YELLOW);
+        checkVDiskCapacityAlert(TColor::YELLOW);
 
         setColor(TColor::RED);
         checkColor(TColor::RED);
+        triggerWhiteboardReport();
+        checkPDiskCapacityAlert(TColor::RED);
+        checkVDiskCapacityAlert(TColor::RED);
 
         setColor(TColor::GREEN);
         checkColor(TColor::GREEN);
+        triggerWhiteboardReport();
+        checkPDiskCapacityAlert(TColor::GREEN);
+        checkVDiskCapacityAlert(TColor::GREEN);
 
         setColor(0);
         checkColor(TColor::GREEN);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_env.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_env.h
@@ -291,15 +291,17 @@ struct TVDiskMock {
 
     TActorTestContext *TestCtx;
     const TVDiskID VDiskID;
+    const TActorId WhiteboardProxyId;
     TIntrusivePtr<TPDiskParams> PDiskParams;
     ui64 LastUsedLsn = 0;
     ui64 FirstLsnToKeep = 1;
 
     TMap<EChunkState, TSet<TChunkIdx>> Chunks;
 
-    TVDiskMock(TActorTestContext *testCtx, bool dynamicGroup = false)
+    TVDiskMock(TActorTestContext *testCtx, bool dynamicGroup = false, TActorId whiteboardProxyId = {})
         : TestCtx(testCtx)
         , VDiskID(MakeGroupId(dynamicGroup), 1, 0, 0, 0)
+        , WhiteboardProxyId(whiteboardProxyId)
     {}
 
     static ui32 MakeGroupId(bool dynamicGroup) {
@@ -322,7 +324,7 @@ struct TVDiskMock {
         const auto evInitRes = TestCtx->TestResponse<NPDisk::TEvYardInitResult>(
                 new NPDisk::TEvYardInit(OwnerRound.fetch_add(1), VDiskID,
                     TestCtx->TestCtx.PDiskGuid, TestCtx->Sender,
-                    {}, Max<ui32>(), groupSizeInUnits),
+                    WhiteboardProxyId, Max<ui32>(), groupSizeInUnits),
                 NKikimrProto::OK);
 
         PDiskParams = evInitRes->PDiskParams;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Fix-up for https://github.com/ydb-platform/ydb/pull/35978
- Respect ForcedPDiskSpaceColor in CapacityAlert
- Also avoid logs flood