### PR TITLE
MKQL: use default (tcmalloc) memory allocator WIP DO NOT MERGE

### DIFF
--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -1469,9 +1469,7 @@ void TKikimrRunner::InitializeAllocator(const TKikimrRunConfig& runConfig) {
     }
 
     if (allocConfig.GetEnableDefaultAllocator()) {
-#if defined(ALLOW_DEFAULT_ALLOCATOR)
         NKikimr::UseDefaultAllocator();
-#endif
         NKikimr::UseDefaultArrowAllocator();
     }
 

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -24,6 +24,7 @@
 #include <yql/essentials/core/yql_opt_proposed_by_data.h>
 #include <yql/essentials/core/services/yql_plan.h>
 #include <yql/essentials/core/services/yql_transform_pipeline.h>
+#include <yql/essentials/minikql/aligned_page_pool.h>
 #include <yql/essentials/minikql/invoke_builtins/mkql_builtins.h>
 #include <yql/essentials/providers/common/arrow_resolve/yql_simple_arrow_resolver.h>
 #include <yql/essentials/providers/common/codec/yql_codec.h>
@@ -50,6 +51,15 @@ using namespace NYql::NNodes;
 using namespace NThreading;
 
 namespace {
+
+// MKQL uses the default (tcmalloc) memory allocator, switch it on once at the process startup.
+void EnableDefaultAllocator() {
+    static const bool enabled = [] {
+        NKikimr::UseDefaultAllocator();
+        return true;
+    }();
+    Y_UNUSED(enabled);
+}
 
 void FillColumnMeta(const NKqpProto::TKqpPhyQuery& phyQuery, IKqpHost::TQueryResult& queryResult) {
     const auto& bindings = phyQuery.GetResultBindings();
@@ -1223,6 +1233,8 @@ public:
         , QueryServiceConfig(queryServiceConfig)
         , UsePessimisticLocks(usePessimisticLocks)
     {
+        EnableDefaultAllocator();
+
         if (funcRegistry) {
             FuncRegistry = funcRegistry;
         } else {

--- a/ydb/core/kqp/host/ya.make
+++ b/ydb/core/kqp/host/ya.make
@@ -30,6 +30,7 @@ PEERDIR(
     ydb/library/yql/providers/s3/expr_nodes
     yql/essentials/core
     yql/essentials/core/services
+    yql/essentials/minikql
     yql/essentials/minikql/invoke_builtins
     yql/essentials/parser/pg_wrapper/interface
     yql/essentials/providers/common/codec

--- a/yql/essentials/minikql/aligned_page_pool.cpp
+++ b/yql/essentials/minikql/aligned_page_pool.cpp
@@ -23,17 +23,16 @@
 
 namespace NKikimr {
 
-#if defined(ALLOW_DEFAULT_ALLOCATOR)
-    #if defined(PROFILE_MEMORY_ALLOCATIONS)
+#if defined(PROFILE_MEMORY_ALLOCATIONS)
 static bool IsDefaultAllocator = true;
-    #else
+#else
 static bool IsDefaultAllocator = false;
-    #endif
+#endif
+
 void UseDefaultAllocator() {
     // TODO: check that we didn't already used the MKQL allocator
     IsDefaultAllocator = true;
 }
-#endif
 
 namespace {
 
@@ -733,13 +732,12 @@ void TAlignedPagePoolImpl<T>::ResetGlobalsUT()
     TGlobalPools<T, false>::Instance().Reset();
 }
 
-#if defined(ALLOW_DEFAULT_ALLOCATOR)
 // static
 template <typename T>
 bool TAlignedPagePoolImpl<T>::IsDefaultAllocatorUsed() {
     return IsDefaultAllocator;
 }
-#endif
+
 // static
 template <typename T>
 bool TAlignedPagePoolImpl<T>::IsDefaultArrowAllocatorUsed() {

--- a/yql/essentials/minikql/aligned_page_pool.h
+++ b/yql/essentials/minikql/aligned_page_pool.h
@@ -18,11 +18,9 @@
 
 namespace NKikimr {
 
-#if defined(ALLOW_DEFAULT_ALLOCATOR)
 // By default the default allocator is not used unless PROFILE_MEMORY_ALLOCATIONS is defined.
 // Call this method once at the start of the process - to enable usage of default allocator.
 void UseDefaultAllocator();
-#endif
 void UseDefaultArrowAllocator();
 
 struct TAlignedPagePoolCounters {
@@ -238,13 +236,7 @@ public:
         IsMemoryYellowZoneForcefullyChanged_ = true;
     }
 
-#if defined(ALLOW_DEFAULT_ALLOCATOR)
     static bool IsDefaultAllocatorUsed();
-#else
-    static consteval bool IsDefaultAllocatorUsed() {
-        return false;
-    }
-#endif
     static bool IsDefaultArrowAllocatorUsed();
 
 protected:


### PR DESCRIPTION
Expose UseDefaultAllocator() unconditionally, without the ALLOW_DEFAULT_ALLOCATOR define, and make IsDefaultAllocatorUsed() a runtime check in every build instead of a consteval false. Call UseDefaultAllocator() once from KqpHost on startup.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
