### PR TITLE
NBS-7459: skip PBuffer cleanup while older-generation records are inflight

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
@@ -372,13 +372,17 @@ TDirectBlockGroupMock::BatchEraseFromPBuffer(
 
 void TDirectBlockGroupMock::BarrierEraseFromPBuffer(ui64 lsn)
 {
-    Y_UNUSED(lsn);
+    if (BarrierEraseFromPBufferHandler) {
+        BarrierEraseFromPBufferHandler(lsn);
+    }
 }
 
 NThreading::TFuture<std::optional<TPBufferKey>>
 TDirectBlockGroupMock::GatherSafeBarrierForErase()
 {
-    return NThreading::MakeFuture<std::optional<TPBufferKey>>(std::nullopt);
+    return NThreading::MakeFuture<std::optional<TPBufferKey>>(
+        GatherSafeBarrierForEraseHandler ? GatherSafeBarrierForEraseHandler()
+                                         : std::nullopt);
 }
 
 NThreading::TFuture<TDBGRestoreResponse>

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
@@ -149,6 +149,9 @@ public:
         std::function<void(const NProto::TError& error)>;
     using TTakeCopyRangeBudgetHandler =
         std::function<TDuration(ui64 byteCount)>;
+    using TGatherSafeBarrierForEraseHandler =
+        std::function<std::optional<TPBufferKey>()>;
+    using TBarrierEraseFromPBufferHandler = std::function<void(ui64 lsn)>;
 
     TExecutorPtr Executor;
     TOracleMock Oracle;
@@ -166,6 +169,9 @@ public:
     TOnAddHostSucceededHandler OnAddHostSucceededHandler;
     TOnAddHostFailedHandler OnAddHostFailedHandler;
     TTakeCopyRangeBudgetHandler TakeCopyRangeBudgetHandler;
+    // Optional: unset means "no constraint" / no-op, as before.
+    TGatherSafeBarrierForEraseHandler GatherSafeBarrierForEraseHandler;
+    TBarrierEraseFromPBufferHandler BarrierEraseFromPBufferHandler;
 
     TVector<TVChunkWeakPtr> VChunks;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -741,6 +741,14 @@ void TFastPathService::FinishPBufferCleanup()
         return;
     }
 
+    // The PBuffer-side barrier drops every record of a previous generation
+    // regardless of the lsn bound. Records restored from the previous life
+    // stay live until flushed and erased, so no barrier goes out while any
+    // of them is still inflight.
+    if (globalMin->Generation != DiskDescription.Generation) {
+        return;
+    }
+
     LastSafeBarrier.store(globalMin->Lsn);
 
     const ui64 cleanupBound = globalMin->Lsn - 1;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service_ut.cpp
@@ -70,6 +70,7 @@ struct TFixture: public NUnitTest::TBaseFixture
     TIntrusivePtr<NMonitoring::TDynamicCounters> Counters{
         new NMonitoring::TDynamicCounters()};
     TVector<std::shared_ptr<TChaosInjectorControlMock>> ChaosInjectorControls;
+    TVector<std::shared_ptr<TDirectBlockGroupMock>> DirectBlockGroups;
 
     void SetUp(NUnitTest::TTestContext& context) override
     {
@@ -85,10 +86,14 @@ struct TFixture: public NUnitTest::TBaseFixture
             .Dcb = {}});
     }
 
-    std::shared_ptr<TFastPathService> MakeService(ui64 copyRangeBandwidthMbs)
+    std::shared_ptr<TFastPathService> MakeService(
+        ui64 copyRangeBandwidthMbs,
+        ui64 pbufferCleanupLsnStep = 0,
+        ui32 tabletGeneration = 1)
     {
         NProto::TStorageServiceConfig storageServiceConfig;
         storageServiceConfig.SetCopyRangeBandwidthMbs(copyRangeBandwidthMbs);
+        storageServiceConfig.SetPBufferCleanupLsnStep(pbufferCleanupLsnStep);
 
         TVector<IDirectBlockGroupPtr> directBlockGroups;
         directBlockGroups.reserve(DirectBlockGroupsCount);
@@ -96,10 +101,13 @@ struct TFixture: public NUnitTest::TBaseFixture
         chaosInjectorControls.reserve(DirectBlockGroupsCount);
         ChaosInjectorControls.clear();
         ChaosInjectorControls.reserve(DirectBlockGroupsCount);
+        DirectBlockGroups.clear();
+        DirectBlockGroups.reserve(DirectBlockGroupsCount);
 
         for (ui32 i = 0; i < DirectBlockGroupsCount; ++i) {
-            directBlockGroups.push_back(
-                std::make_shared<TDirectBlockGroupMock>());
+            auto dbg = std::make_shared<TDirectBlockGroupMock>();
+            DirectBlockGroups.push_back(dbg);
+            directBlockGroups.push_back(std::move(dbg));
             auto control = std::make_shared<TChaosInjectorControlMock>();
             chaosInjectorControls.push_back(control);
             ChaosInjectorControls.push_back(std::move(control));
@@ -111,7 +119,7 @@ struct TFixture: public NUnitTest::TBaseFixture
             TDiskDescription{
                 .DiskId = "disk-id",
                 .TabletId = 100,
-                .Generation = 1},
+                .Generation = tabletGeneration},
             0,
             DefaultBlockSize,
             std::move(directBlockGroups),
@@ -239,6 +247,58 @@ Y_UNIT_TEST_SUITE(TFastPathServiceTest)
         UNIT_ASSERT(service->GetChaosConfig().NodeConfigs.empty());
         for (const auto& control: ChaosInjectorControls) {
             UNIT_ASSERT(!control->IsNodeDisabled(42));
+        }
+    }
+
+    // The PBuffer-side barrier erase drops every record of a previous
+    // generation regardless of the lsn bound. After a restart the restored
+    // records are live again, so while any of them is still inflight the
+    // tablet-wide cleanup must not send a barrier at all.
+    Y_UNIT_TEST_F(
+        ShouldSkipPBufferCleanupWhileOlderGenerationInflight,
+        TFixture)
+    {
+        auto service = MakeService(0, 1 /* every lsn ticks */, 2);
+
+        ui32 barrierErases = 0;
+        for (auto& dbg: DirectBlockGroups) {
+            dbg->GatherSafeBarrierForEraseHandler = []
+            {
+                // Restored from the previous life, not flushed yet.
+                return TPBufferKey{.Generation = 1, .Lsn = 5};
+            };
+            dbg->BarrierEraseFromPBufferHandler = [&](ui64)
+            {
+                ++barrierErases;
+            };
+        }
+
+        service->GenerateLsn();
+
+        UNIT_ASSERT_VALUES_EQUAL(0u, barrierErases);
+    }
+
+    Y_UNIT_TEST_F(ShouldIssuePBufferCleanupForCurrentGeneration, TFixture)
+    {
+        auto service = MakeService(0, 1 /* every lsn ticks */, 2);
+
+        TVector<ui64> barrierLsns;
+        for (auto& dbg: DirectBlockGroups) {
+            dbg->GatherSafeBarrierForEraseHandler = []
+            {
+                return TPBufferKey{.Generation = 2, .Lsn = 5};
+            };
+            dbg->BarrierEraseFromPBufferHandler = [&](ui64 lsn)
+            {
+                barrierLsns.push_back(lsn);
+            };
+        }
+
+        service->GenerateLsn();
+
+        UNIT_ASSERT_VALUES_EQUAL(DirectBlockGroupsCount, barrierLsns.size());
+        for (ui64 lsn: barrierLsns) {
+            UNIT_ASSERT_VALUES_EQUAL(4u, lsn);
         }
     }
 


### PR DESCRIPTION
The PBuffer-side barrier erase drops every record of a previous generation
regardless of the lsn bound (`it->first.Generation < creds.Generation` in
`Handle(TEvErasePersistentBuffer)`). Since #45792 records restored from the
previous generation are live until flushed and erased, so the tablet-wide
cleanup must not send a barrier while any of them is still inflight. Skip the
cleanup tick in `FinishPBufferCleanup` while `globalMin` belongs to a
generation other than the tablet's own.

- tablet restarts into generation N+1 with unflushed records of generation N
  in the PBuffers; restore puts them back into the dirty map;
- the first cleanup tick computes `globalMin = {N, lsn}` and sends a barrier
  stamped with generation N+1;
- the DDisk erases every generation-N record below or above the bound — the
  only copy of the unflushed ones.

`TFastPathServiceTest::ShouldSkipPBufferCleanupWhileOlderGenerationInflight`
is red without the gate (barrier sent to all 32 DBGs) and green with it;
`ShouldIssuePBufferCleanupForCurrentGeneration` pins that same-generation
cleanup still goes out with bound `lsn - 1`.
