### PR TITLE
[YDBBUGS-600] pq_async_io ut: fix TSan race at fixture teardown

### DIFF
--- a/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.cpp
+++ b/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.cpp
@@ -106,7 +106,16 @@ TFakeCASetup::TFakeCASetup()
 }
 
 TFakeCASetup::~TFakeCASetup() {
-    auto shouldStop = std::make_shared<std::atomic<bool>>(); 
+    Terminate();
+}
+
+void TFakeCASetup::Terminate() {
+    if (Terminated) {
+        return;
+    }
+    Terminated = true;
+
+    auto shouldStop = std::make_shared<std::atomic<bool>>();
     Execute([shouldStop](TFakeActor& actor) {
         actor.Terminate(shouldStop);
     });

--- a/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.cpp
+++ b/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.cpp
@@ -55,7 +55,7 @@ void TFakeActor::InitAsyncInput(IDqComputeActorAsyncInput* dqAsyncInput, IActor*
     DqAsyncInputAsActor = dqAsyncInputAsActor;
 }
 
-void TFakeActor::Terminate(std::shared_ptr<std::atomic<bool>> done) {
+void TFakeActor::Terminate() {
     if (DqAsyncInputActorId) {
         DqAsyncInput->PassAway();
 
@@ -71,7 +71,6 @@ void TFakeActor::Terminate(std::shared_ptr<std::atomic<bool>> done) {
         DqAsyncOutput = nullptr;
         DqAsyncOutputAsActor = nullptr;
     }
-    done->store(true);
 }
 
 TFakeActor::TAsyncOutputCallbacks& TFakeActor::GetAsyncOutputCallbacks() {
@@ -115,14 +114,11 @@ void TFakeCASetup::Terminate() {
     }
     Terminated = true;
 
-    auto shouldStop = std::make_shared<std::atomic<bool>>();
-    Execute([shouldStop](TFakeActor& actor) {
-        actor.Terminate(shouldStop);
+    // Execute() is a blocking round trip: the fake actor runs the callback and only then
+    // sets the promise Execute() waits on. So the actors are passed away by the time it returns.
+    Execute([](TFakeActor& actor) {
+        actor.Terminate();
     });
-
-    while (!*shouldStop) {
-        Sleep(TDuration::MilliSeconds(200));
-    }
 }
 
 void TFakeCASetup::AsyncOutputWrite(const TWriteValueProducer valueProducer, TMaybe<NDqProto::TCheckpoint> checkpoint, bool finish) {

--- a/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.h
+++ b/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.h
@@ -188,6 +188,12 @@ struct TFakeCASetup {
     TFakeCASetup();
     ~TFakeCASetup();
 
+    // Passes away async input / output actors owned by the fake compute actor while the actor
+    // system is still running. Idempotent; the destructor calls it if it was not called explicitly.
+    // Call it before stopping external clients (e.g. NYdb::TDriver) whose callbacks may still
+    // send events to the actor system, and only then destroy the setup (and the runtime).
+    void Terminate();
+
     template<typename T>
     std::vector<std::variant<T, TInstant>> AsyncInputRead(
         const TReadValueParser<T> parser,
@@ -270,6 +276,9 @@ public:
     NActors::TActorId FakeActorId;
     std::shared_ptr<TAsyncInputPromises> AsyncInputPromises = std::make_shared<TAsyncInputPromises>();
     std::shared_ptr<TAsyncOutputPromises> AsyncOutputPromises = std::make_shared<TAsyncOutputPromises>();
+
+private:
+    bool Terminated = false;
 };
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.h
+++ b/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.h
@@ -126,7 +126,7 @@ public:
 
     void InitAsyncOutput(IDqComputeActorAsyncOutput* dqAsyncOutput, IActor* dqAsyncOutputAsActor);
     void InitAsyncInput(IDqComputeActorAsyncInput* dqAsyncInput, IActor* dqAsyncInputAsActor);
-    void Terminate(std::shared_ptr<std::atomic<bool>> done);
+    void Terminate();
 
     TAsyncOutputCallbacks& GetAsyncOutputCallbacks();
     NKikimr::NMiniKQL::THolderFactory& GetHolderFactory();

--- a/ydb/tests/fq/pq_async_io/ut_helpers.cpp
+++ b/ydb/tests/fq/pq_async_io/ut_helpers.cpp
@@ -67,8 +67,18 @@ TPqIoTestFixture::TPqIoTestFixture() {
 }
 
 TPqIoTestFixture::~TPqIoTestFixture() {
-    CaSetup = nullptr;
+    // Teardown order matters (YDBBUGS-600, https://github.com/ydb-platform/ydb/issues/46513).
+    // Async IO actors subscribe to SDK futures (DescribeTopic, WaitEvent, ...) with callbacks that
+    // call TActorSystem::Send from SDK threads. Resetting the topic client in PassAway does not cancel
+    // requests that are already in flight, so:
+    // 1. pass away the actors while the actor system is still alive;
+    // 2. stop the driver and wait until all in-flight requests and their callbacks are drained
+    //    (a late Send to an already dead actor id is harmless);
+    // 3. only then destroy the test runtime and its actor system.
+    // Destroying the runtime first races TMailboxTable::Cleanup with callbacks pushing events into mailboxes.
+    CaSetup->Terminate();
     Driver.Stop(true);
+    CaSetup = nullptr;
 }
 
 void TPqIoTestFixture::InitAsyncOutput(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes #46513 (YDBBUGS-600): ThreadSanitizer data race in `TDqPqReadActorTest.ReadWithFreeSpace` (`ydb/tests/fq/pq_async_io/ut`), first seen on `stable-26-3-1`; the affected code is identical in `main`.

**Root cause.** The race is in the test fixture teardown order, not in the actor system. `TPqIoTestFixture::~TPqIoTestFixture` destroyed `CaSetup` (and with it the test runtime and its actor system) *before* calling `Driver.Stop(true)`. The read actor subscribes to SDK futures (`DescribeTopic` from the periodic partition-count check, `GetAllTopicClusters`, `WaitEvent`) with callbacks that call `TActorSystem::Send` from SDK threads. `PassAway` resets the topic client, but that does not cancel requests already in flight, so a late callback pushed an event into a mailbox (`TMailbox::Push` → `AppendPreProcessed`) while the main thread was running `TMailboxTable::Cleanup` after the executor threads had been joined. The test enables the partition-count check with a 1 s period, so a `DescribeTopic` is frequently in flight at teardown.

This is *not* a duplicate of #42192 (YDBBUGS-480): that one is in real `ydbd` shutdown; this one only affects the test harness.

**Fix.**
- `TFakeCASetup::Terminate()` — new idempotent method that passes away the async input/output actors while the actor system is still running. The destructor still calls it, so other users (`solomon/actors/ut`) are unaffected.
- `TPqIoTestFixture::~TPqIoTestFixture` now does: `CaSetup->Terminate()` → `Driver.Stop(true)` (drains in-flight requests and their callbacks; a late `Send` to a dead actor id on a live actor system is harmless) → `CaSetup = nullptr` (destroys the runtime).

**Verification (release + `--sanitize=thread`, on `stable-26-3-1`).** The race does not reproduce locally as-is: the local recipe answers `DescribeTopic` within a few ms, and the gap between executor shutdown and mailbox cleanup is narrow, so an in-flight callback rarely lands inside it. With two temporary diagnostic delays (1 s in the `DescribeTopic` callback, 1 s in `TCpuManager::Shutdown` between executor shutdown and mailbox cleanup — not part of this PR) the window becomes deterministic:

| build | attempts with TSan report |
|---|---|
| without fix | 5 / 10 (every attempt with a check in flight at teardown) |
| with fix | 0 / 10 (all 10 had a check in flight at teardown) |

The reproduced stack matches the issue exactly (`CleanupEvents` at `mailbox_lockfree.cpp:341` vs `AppendPreProcessed` at `:375` from the `TEvCheckPartitionCount` callback). With the clean fix, the full `ydb/tests/fq/pq_async_io/ut` suite passes under TSan (38/38) and `solomon/actors/ut` builds.

**Second commit (cleanup, no behaviour change).** `TFakeCASetup::Terminate` used a shared `std::atomic<bool>` plus a `while (!flag) Sleep(200ms)` loop to wait for the fake actor. That wait was already redundant: `Execute` is a blocking round trip that sets its promise only after the callback returns, and the flag was stored as the last statement of that same callback. Instrumenting the loop and running the suite: the flag was already set on 102 of 102 calls, and the loop ran zero iterations. The second commit removes the flag, the loop and the now-pointless parameter of `TFakeActor::Terminate`.

Locally, with both commits, under `--sanitize=thread`: `ydb/tests/fq/pq_async_io/ut` 38/38 and `ydb/library/yql/providers/solomon/actors/ut` 6/6, no sanitizer reports.

Should be cherry-picked to `stable-26-3-1` after merge.


