### PR TITLE
Fix uninitialized rate-limiter amount in topic fetch request

### DIFF
--- a/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
@@ -13,6 +13,8 @@
 
 #include <library/cpp/containers/absl/flat_hash_set.h>
 
+#include <optional>
+
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_FETCH_REQUEST
 
 #define LOG_PREFIX TStringBuilder() << "[" << NActors::TlsActivationContext->AsActorContext().SelfID << "] "
@@ -66,7 +68,7 @@ private:
     THashMap<ui64, TTabletInfo> TabletInfo;
 
     TActorId RequesterId;
-    ui64 PendingQuotaAmount;
+    std::optional<ui64> PendingQuotaAmount;
 
     TActorId YdbProxy;
     TActorId LongTimer;
@@ -137,12 +139,15 @@ public:
         switch (tag) {
             case EWakeupTag::RlAllowed:
                 ProceedFetchRequest(ctx);
-                PendingQuotaAmount = 0;
+                PendingQuotaAmount.reset();
                 break;
 
             case EWakeupTag::RlNoResource:
-                // Re-requesting the quota. We do this until we get a quota.
-                RequestDataQuota(PendingQuotaAmount, ctx);
+                // Ignore until a quota amount is known. Otherwise a wakeup in StateDescribe
+                // would acquire with a dummy amount and ProceedFetchRequest too early.
+                if (PendingQuotaAmount) {
+                    RequestDataQuota(*PendingQuotaAmount, ctx);
+                }
                 break;
 
             default:
@@ -449,7 +454,7 @@ public:
         } else if (IsQuotaRequired()) {
             PendingQuotaAmount = CalcRuConsumption(GetPayloadSize(record)) + (Settings.RuPerRequest ? 1 : 0);
             Settings.RuPerRequest = false;
-            RequestDataQuota(PendingQuotaAmount, ctx);
+            RequestDataQuota(*PendingQuotaAmount, ctx);
         } else {
             ProceedFetchRequest(ctx);
         }


### PR DESCRIPTION
Fixes [YDBBUGS-759](https://st.yandex-team.ru/YDBBUGS-759): `PendingQuotaAmount` in `TPQFetchRequestActor` was never initialized. An `RlNoResource` wakeup in `StateDescribe` was an MSan use-of-uninitialized-value and could start a dummy quota acquire, then call `ProceedFetchRequest` before describe finished.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

* Topics: do not retry fetch-request rate-limiter quota until the RU amount is known.

### Description for reviewers <!-- (optional) description for those who read this PR -->

* `PendingQuotaAmount` is `std::optional<ui64>` so “no amount yet” is distinct from a computed zero.
* `RlNoResource` retries `RequestDataQuota` only after `TEvResponse` has set the amount.
* `TFetchRequestTests.QuotaNoResourceThenAllowed` covers injected wakeups before describe completes.