### PR TITLE
[DataShard] Update shard stats after DirectImport

### DIFF
--- a/ydb/core/tx/datashard/datashard_direct_import.cpp
+++ b/ydb/core/tx/datashard/datashard_direct_import.cpp
@@ -110,6 +110,13 @@ bool TDataShard::TTxS3DirectWriteFinish::Execute(TTransactionContext& txc, const
     // atomically, so a restart after this commit resumes to completion (via the
     // stored ProcessedBytes == ContentLength) instead of writing a second part.
     txc.Env.AttachPart(localTableId, std::move(msg->Result));
+    Self->SetTableUpdateTime(fullTableId, TAppData::TimeProvider->Now());
+
+    if (auto it = Self->TableInfos.find(msg->TableId); it != Self->TableInfos.end()) {
+        // Direct part import bypasses the memtable and compaction, so the shard
+        // must invalidate cached stats explicitly.
+        it->second->StatsNeedUpdate = true;
+    }
 
     NIceDb::TNiceDb db(txc.DB);
     Self->S3Downloads.Store(db, msg->TxId, msg->Info);
@@ -121,6 +128,10 @@ bool TDataShard::TTxS3DirectWriteFinish::Execute(TTransactionContext& txc, const
 void TDataShard::TTxS3DirectWriteFinish::Complete(const TActorContext& ctx) {
     auto* msg = Ev->Get();
     ctx.Send(Ev->Sender, new TEvDataShard::TEvS3DirectWriteFinishResult(msg->TxId, Success, Error), 0, Ev->Cookie);
+
+    if (Success) {
+        Self->UpdateTableStats(ctx);
+    }
 }
 
 } // namespace NDataShard

--- a/ydb/core/tx/datashard/datashard_direct_import.cpp
+++ b/ydb/core/tx/datashard/datashard_direct_import.cpp
@@ -93,8 +93,8 @@ bool TDataShard::TTxS3DirectWriteFinish::Execute(TTransactionContext& txc, const
     auto* msg = Ev->Get();
 
     const TTableId fullTableId(Self->GetPathOwnerId(), msg->TableId);
-    const ui64 localTableId = Self->GetLocalTableId(fullTableId);
-    if (localTableId == 0) {
+    auto userTablePtr = Self->FindUserTable(fullTableId.PathId);
+    if (!userTablePtr) {
         Success = false;
         Error = TStringBuilder() << "Unknown table id " << msg->TableId;
         // Release the reserved barrier so its blobs get collected.
@@ -109,14 +109,11 @@ bool TDataShard::TTxS3DirectWriteFinish::Execute(TTransactionContext& txc, const
     // Attach the part as a bottom layer and persist the final restore progress
     // atomically, so a restart after this commit resumes to completion (via the
     // stored ProcessedBytes == ContentLength) instead of writing a second part.
-    txc.Env.AttachPart(localTableId, std::move(msg->Result));
+    txc.Env.AttachPart(userTablePtr->LocalTid, std::move(msg->Result));
     Self->SetTableUpdateTime(fullTableId, TAppData::TimeProvider->Now());
-
-    if (auto it = Self->TableInfos.find(msg->TableId); it != Self->TableInfos.end()) {
-        // Direct part import bypasses the memtable and compaction, so the shard
-        // must invalidate cached stats explicitly.
-        it->second->StatsNeedUpdate = true;
-    }
+    // Direct part import bypasses the memtable and compaction, so the shard
+    // must invalidate cached stats explicitly.
+    userTablePtr->StatsNeedUpdate = true;
 
     NIceDb::TNiceDb db(txc.DB);
     Self->S3Downloads.Store(db, msg->TxId, msg->Info);

--- a/ydb/core/tx/datashard/ut_direct_restore/datashard_ut_direct_restore.cpp
+++ b/ydb/core/tx/datashard/ut_direct_restore/datashard_ut_direct_restore.cpp
@@ -1,6 +1,7 @@
 #include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
 
 #include <ydb/core/protos/s3_settings.pb.h>
+#include <ydb/core/protos/table_stats.pb.h>
 #include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/wrappers/ut_helpers/s3_mock.h>
@@ -537,6 +538,37 @@ Y_UNIT_TEST(WriteBlockedDuringRestore) {
     UNIT_ASSERT(opResult);
     UNIT_ASSERT(opResult->GetSuccess());
     UNIT_ASSERT_VALUES_EQUAL(ReadTable(env.Server, shards, tableId), ExpectedUint32TableState(1));
+}
+
+Y_UNIT_TEST(ReportsTableStatsAfterRestore) {
+    TTestEnv env;
+    auto [shards, tableId] = env.CreateUint32Table();
+    const ui64 shardId = shards[0];
+    const auto desc = env.TableDescription(shardId, tableId);
+
+    // Wait for the first report, which means the shard has already built stats for
+    // the still empty table. Otherwise the restore below would ride on that initial
+    // build instead of having to invalidate the stats itself.
+    WaitTableStats(env.Runtime, shardId, [](const NKikimrTableStats::TTableStats& stats) {
+        return stats.GetRowCount() == 0;
+    });
+
+    env.StartS3(MakeCsv(100, ""));
+
+    const auto result = env.ProposeAndPlanRestore(shardId, tableId, desc);
+    UNIT_ASSERT(result.GetSuccess());
+    UNIT_ASSERT_VALUES_EQUAL(result.GetRowsProcessed(), 100u);
+
+    // Nothing went through the memtable and no compaction ran, so the shard must
+    // invalidate cached stats in TTxS3DirectWriteFinish itself.
+    const auto stats = WaitTableStats(env.Runtime, shardId, [](const NKikimrTableStats::TTableStats& stats) {
+        return stats.GetRowCount() > 0;
+    }).GetTableStats();
+
+    UNIT_ASSERT_VALUES_EQUAL(stats.GetRowCount(), 100u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.GetPartCount(), 1u);
+    UNIT_ASSERT_GT(stats.GetDataSize(), 0u);
+    UNIT_ASSERT_GT(stats.GetLastUpdateTime(), 0u);
 }
 
 Y_UNIT_TEST(CompactionAfterRestore) {

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -9,6 +9,7 @@
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 #include <ydb/core/metering/metering.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
+#include <ydb/core/protos/table_stats.pb.h>
 #include <ydb/core/tablet/resource_broker.h>
 #include <ydb/core/tablet_flat/flat_boot_cookie.h>
 #include <ydb/core/testlib/actors/block_events.h>
@@ -715,6 +716,43 @@ value {
 
         auto content = ReadTable(runtime, TTestTxConfig::FakeHiveTablets, "Table", {"key"}, {"key", "value"});
         NKqp::CompareYson(data.YsonStr, content);
+    }
+
+    Y_UNIT_TEST_FLAG(ShouldReportDataSizeWithoutCompaction, EnableDataShardDirectPartImport) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDirectPartImport(EnableDataShardDirectPartImport);
+
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint32" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Let the shard build stats for the still empty table, so that the restore
+        // below has to invalidate them instead of riding on the initial build.
+        env.SimulateSleep(runtime, TDuration::Seconds(30));
+
+        TPortManager portManager;
+        THolder<TS3Mock> s3Mock;
+        RestoreNoWait(runtime, txId, portManager.GetPort(), s3Mock,
+            {GenerateTestData(ECompressionCodec::None, "", 100)});
+        env.TestWaitNotification(runtime, txId);
+
+        // A direct part import goes neither through the memtable nor through a
+        // compaction, so the shard has to notice the attached part on its own.
+        ui64 dataSize = 0;
+        for (ui32 i = 0; i < 10 && !dataSize; ++i) {
+            env.SimulateSleep(runtime, TDuration::Seconds(10));
+            const auto desc = DescribePrivatePath(runtime, "/MyRoot/Table", true, true);
+            dataSize = desc.GetPathDescription().GetTableStats().GetDataSize();
+        }
+
+        UNIT_ASSERT_GT(dataSize, 0);
     }
 
     void ShouldSucceedOnMultipleFrames(bool enableDataShardDirectPartImport, ui32 batchSize) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix stale DataShard table stats after S3 direct part import during restore.

When EnableDataShardDirectPartImport is enabled, restore attaches SST parts directly to the table via AttachPart, bypassing the memtable and compaction. That path never invalidated cached stats, so row count, data size, part count, and LastUpdateTime could stay at pre-restore values until a later compaction or stats rebuild.

This change mirrors the compaction path: after a successful direct import finish transaction, the shard now marks stats as stale, updates the table's last-update time, and triggers a stats rebuild.
