### PR TITLE
DQ Memory Quota 2.0: optional quota, numeric availability, operator memory quota interface

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
@@ -6,6 +6,8 @@
 #include <ydb/core/kqp/node_service/kqp_node_state.h>
 #include <ydb/core/kqp/rm_service/kqp_resource_estimation.h>
 
+#include <atomic>
+
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::KQP_COMPUTE
 
 namespace NKikimr::NKqp::NComputeActor {
@@ -31,6 +33,7 @@ class TKqpCaFactory : public IKqpNodeComputeActorFactory {
     std::atomic<ui64> MinMemAllocSize = 1_MB;
     std::atomic<ui64> MinMemFreeSize = 32_MB;
     std::atomic<ui64> ChannelChunkSizeLimit = 48_MB;
+    std::atomic<bool> EnableOperatorMemoryQuota = false;
 
 public:
     TKqpCaFactory(const NKikimrConfig::TTableServiceConfig::TResourceManager& config,
@@ -65,6 +68,7 @@ public:
         ChannelChunkSizeLimit.store(config.GetChannelChunkSizeLimit());
         MinMemAllocSize.store(config.GetMinMemAllocSize());
         MinMemFreeSize.store(config.GetMinMemFreeSize());
+        EnableOperatorMemoryQuota.store(config.GetEnableOperatorMemoryQuota());
     }
 
     bool GetVerboseMemoryLimitException() override {
@@ -83,6 +87,7 @@ public:
         memoryLimits.MkqlHeavyProgramMemoryLimit = MkqlHeavyProgramMemoryLimit.load();
         memoryLimits.MinMemAllocSize = MinMemAllocSize.load();
         memoryLimits.MinMemFreeSize = MinMemFreeSize.load();
+        memoryLimits.EnableOperatorMemoryQuota = EnableOperatorMemoryQuota.load();
         memoryLimits.ArrayBufferMinFillPercentage = args.Task->GetArrayBufferMinFillPercentage();
         if (args.Task->HasBufferPageAllocSize()) {
             memoryLimits.BufferPageAllocSize = args.Task->GetBufferPageAllocSize();

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph_ut.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph_ut.cpp
@@ -191,6 +191,10 @@ public:
         return Counters_;
     }
 
+    NRm::TMemoryResourceCookies GetMemoryResourceCookies(const TString&, const TString&, double) override {
+        return {};
+    }
+
     NRm::TKqpRMAllocateResult AllocateResources(NRm::TTxState&, ui64, const NRm::TKqpResourcesRequest&) override {
         Y_ABORT("TStubResourceManager::AllocateResources is not used in tests");
     }

--- a/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
+++ b/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
@@ -122,8 +122,11 @@ struct TChannelQuotaManager : public NYql::NDq::IMemoryQuotaManager {
                     {"problem", "cannot_allocate_memory"},
                     {"txId", Tx->TxId},
                     {"taskId", 0},
-                    {"memory", memoryRequired});
-                if (memoryRequired >= AllocationStep * 10) {
+                    {"memory", memoryRequired},
+                    {"optional", isOptional});
+                // a little over-quoting is tolerated for mandatory requests only: the caller of an optional
+                // request can do without the memory, it must not get what the resource manager refused
+                if (isOptional || memoryRequired >= AllocationStep * 10) {
                     AvailableQuota.fetch_add(memorySize);
                     return false;
                 }

--- a/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
+++ b/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
@@ -136,10 +136,9 @@ struct TChannelQuotaManager : public NYql::NDq::IMemoryQuotaManager {
 
     // Node level memory availability of the tx (see NRm::TTxState::GetMemoryAvailability) plus the locally
     // prepaid quota. Channels do not spill on a negative value, but propagate it as back pressure,
-    // see TInputDescriptor::MemoryPressure. A negative node value is never masked by the prepaid quota.
+    // see TInputDescriptor::MemoryPressure.
     i64 GetMemoryAvailability() const override {
-        const i64 tx = Tx->GetMemoryAvailability();
-        return tx < 0 ? tx : NYql::NDq::AddMemoryAvailability(AvailableQuota.load(), tx);
+        return NYql::NDq::CombineMemoryAvailability(AvailableQuota.load(), Tx->GetMemoryAvailability());
     }
 
     void FreeQuota(ui64 memorySize) override {

--- a/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
+++ b/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
@@ -10,6 +10,8 @@
 
 #include <contrib/libs/tcmalloc/tcmalloc/malloc_extension.h>
 
+#include <atomic>
+
 namespace NKikimr::NKqp {
 
 // for CA/task, is NOT thread safe
@@ -55,8 +57,8 @@ struct TMemoryQuotaManager : public NYql::NDq::TGuaranteeQuotaManager {
         ResourceManager->FreeResources(*Tx, TaskId, NRm::TKqpResourcesRequest{.Memory = extraSize});
     }
 
-    bool IsReasonableToUseSpilling() const override {
-        return Tx->IsReasonableToStartSpilling();
+    i64 GetExtraMemoryAvailability() const override {
+        return Tx->GetMemoryAvailability();
     }
 
     TString MemoryConsumptionDetails() const override {
@@ -95,13 +97,19 @@ struct TChannelQuotaManager : public NYql::NDq::IMemoryQuotaManager {
         });
     }
 
-    bool AllocateQuota(ui64 memorySize) override {
+    bool AllocateQuota(ui64 memorySize, bool isOptional) override {
         i64 quota = AvailableQuota.fetch_sub(memorySize);
 
         if (static_cast<i64>(memorySize) > quota) {
             ui64 memoryRequired = memorySize - quota;
             memoryRequired += AllocationStep - 1;
             memoryRequired &= ~(AllocationStep - 1);
+
+            if (isOptional && Tx->GetMemoryAvailability() < static_cast<i64>(memoryRequired)) {
+                // refuse optional requests in advance, no resource manager round trip
+                AvailableQuota.fetch_add(memorySize);
+                return false;
+            }
 
             auto result = ResourceManager->AllocateResources(*Tx, 0, NRm::TKqpResourcesRequest{.Memory = memoryRequired});
             if (result) {
@@ -124,10 +132,12 @@ struct TChannelQuotaManager : public NYql::NDq::IMemoryQuotaManager {
         return true;
     }
 
-    // Node level memory pressure signal, see NRm::TTxState::IsReasonableToStartSpilling.
-    // Channels do not spill on it, but propagate it as back pressure, see TInputDescriptor::MemoryPressure
-    bool IsReasonableToUseSpilling() const override {
-        return Tx->IsReasonableToStartSpilling();
+    // Node level memory availability of the tx (see NRm::TTxState::GetMemoryAvailability) plus the locally
+    // prepaid quota. Channels do not spill on a negative value, but propagate it as back pressure,
+    // see TInputDescriptor::MemoryPressure. A negative node value is never masked by the prepaid quota.
+    i64 GetMemoryAvailability() const override {
+        const i64 tx = Tx->GetMemoryAvailability();
+        return tx < 0 ? tx : NYql::NDq::AddMemoryAvailability(AvailableQuota.load(), tx);
     }
 
     void FreeQuota(ui64 memorySize) override {

--- a/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
+++ b/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
@@ -11,6 +11,7 @@
 #include <contrib/libs/tcmalloc/tcmalloc/malloc_extension.h>
 
 #include <atomic>
+#include <util/generic/bitops.h>
 
 namespace NKikimr::NKqp {
 
@@ -89,7 +90,7 @@ struct TChannelQuotaManager : public NYql::NDq::IMemoryQuotaManager {
     , DataMemoryLimit(limit)
     , AllocationStep(step)
     {
-        Y_ABORT_UNLESS(AllocationStep != 0 && (AllocationStep & (AllocationStep - 1)) == 0, "the allocation step must be a power of two"); // it is used as an alignment mask
+        Y_ABORT_UNLESS(IsPowerOf2(AllocationStep), "the allocation step must be a power of two"); // it is used as an alignment mask
     }
 
     ~TChannelQuotaManager() {

--- a/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
+++ b/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
@@ -88,7 +88,9 @@ struct TChannelQuotaManager : public NYql::NDq::IMemoryQuotaManager {
     , Limit(limit)
     , DataMemoryLimit(limit)
     , AllocationStep(step)
-    {}
+    {
+        Y_ABORT_UNLESS(AllocationStep != 0 && (AllocationStep & (AllocationStep - 1)) == 0, "the allocation step must be a power of two"); // it is used as an alignment mask
+    }
 
     ~TChannelQuotaManager() {
         ResourceManager->FreeResources(*Tx, 0, NRm::TKqpResourcesRequest{

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -169,6 +169,11 @@ public:
         SetNewLimit(BaseLimit, MemoryPoolPercent, overPercent);
     }
 
+    // A new base (the node total of a pool): the limit follows, the share and the threshold percent stay
+    void SetBaseLimit(ui64 baseLimit) {
+        SetNewLimit(baseLimit, MemoryPoolPercent, OverPercent);
+    }
+
     // The configured spilling percent, the node total is its one holder (see TKqpResourceManager::SetConfigValues)
     double GetOverPercent() const {
         return OverPercent;
@@ -555,6 +560,16 @@ public:
         }, tasksCount);
     }
 
+    // A new node total (the resource broker queue limit): every pool is a share of it, so the pools follow
+    void SetTotalMemoryLimit(ui64 limit) {
+        with_lock (Lock) {
+            TotalMemoryResource->SetNewLimit(limit, (double)100, TotalMemoryResource->GetOverPercent());
+            for (auto& [poolKey, poolMemory] : MemoryNamedPools) {
+                poolMemory->SetBaseLimit(TotalMemoryResource->GetLimit());
+            }
+        }
+    }
+
     // Called under Lock from the config notification handler; the constructor calls it before anything else
     // can see the resource manager
     void SetConfigValues(const NKikimrConfig::TTableServiceConfig::TResourceManager& config) {
@@ -834,10 +849,7 @@ private:
         auto& queueConfig = *ev->Get()->QueueConfig;
 
         if (queueConfig.GetLimit().GetMemory() > 0) {
-            with_lock (ResourceManager->Lock) {
-                auto& total = *ResourceManager->TotalMemoryResource;
-                total.SetNewLimit(queueConfig.GetLimit().GetMemory(), (double)100, total.GetOverPercent());
-            }
+            ResourceManager->SetTotalMemoryLimit(queueConfig.GetLimit().GetMemory());
             YDB_LOG_INFO("Total node memory for scan bytes",
                 {"queries", queueConfig.GetLimit().GetMemory()});
         }

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -284,7 +284,7 @@ public:
         with_lock (Lock) {
             cookies.Total = TotalMemoryResource->GetSpillingCookie();
             if (IsMemoryPoolLimited(poolId, memoryPoolPercent)) {
-                cookies.Pool = GetOrCreatePoolMemoryResource(std::make_pair(database, poolId), memoryPoolPercent)->GetSpillingCookie();
+                cookies.Pool = GetOrCreatePoolMemoryResource(TTxState::MakePoolId(database, poolId), memoryPoolPercent)->GetSpillingCookie();
             }
         }
         return cookies;

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -154,7 +154,9 @@ public:
     }
 
     void SetNewLimit(ui64 baseLimit, double memoryPoolPercent, double overPercent) {
-        if (baseLimit == BaseLimit && abs(memoryPoolPercent - MemoryPoolPercent) < MYEPS && abs(overPercent - OverPercent) < MYEPS) {
+        // std::fabs, not abs: unqualified abs may resolve to int abs(int) and truncate, and both percents are
+        // legitimately fractional (SpillingPercent in particular), so a sub-1.0 change must not compare equal
+        if (baseLimit == BaseLimit && std::fabs(memoryPoolPercent - MemoryPoolPercent) < MYEPS && std::fabs(overPercent - OverPercent) < MYEPS) {
             return;
         }
 

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -613,6 +613,9 @@ public:
     std::shared_ptr<TResourceSnapshotState> ResourceSnapshotState;
     TActorId ResourceInfoExchanger = TActorId();
 
+    // Pool resources are never erased, not even when their usage drops to zero: the transactions of a pool keep
+    // the spilling cookie they got on their first allocation (TTxState::PoolMemoryCookie, read lock-free), so the
+    // resource that updates it has to stay the same one for as long as the pool is in use.
     absl::flat_hash_map<std::pair<TString, TString>, TIntrusivePtr<TMemoryResource>, THash<std::pair<TString, TString>>> MemoryNamedPools;
 };
 

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -143,8 +143,9 @@ public:
     }
 
     void SetNewLimit(ui64 baseLimit, double memoryPoolPercent, double overPercent) {
-        if (abs(memoryPoolPercent - MemoryPoolPercent) < MYEPS && baseLimit == BaseLimit)
+        if (baseLimit == BaseLimit && abs(memoryPoolPercent - MemoryPoolPercent) < MYEPS && abs(overPercent - OverPercent) < MYEPS) {
             return;
+        }
 
         BaseLimit = baseLimit;
         MemoryPoolPercent = memoryPoolPercent;
@@ -152,7 +153,12 @@ public:
         SetActualLimits();
     }
 
+    // A runtime SpillingPercent change: the spilling threshold moves, the limit stays
     void SetOverPercent(double overPercent) {
+        if (abs(overPercent - OverPercent) < MYEPS) {
+            return;
+        }
+
         OverPercent = overPercent;
         SetActualLimits();
     }
@@ -537,6 +543,8 @@ public:
         }, tasksCount);
     }
 
+    // Called under Lock from the config notification handler; the constructor calls it before anything else
+    // can see the resource manager
     void SetConfigValues(const NKikimrConfig::TTableServiceConfig::TResourceManager& config) {
         MkqlHeavyProgramMemoryLimit.store(config.GetMkqlHeavyProgramMemoryLimit());
         MkqlLightProgramMemoryLimit.store(config.GetMkqlLightProgramMemoryLimit());
@@ -545,7 +553,12 @@ public:
         MaxTotalChannelBuffersSize.store(config.GetMaxTotalChannelBuffersSize());
         QueryMemoryLimit.store(config.GetQueryMemoryLimit());
         SpillingPercent.store(config.GetSpillingPercent());
+        // the spilling thresholds of the node total and of every pool follow the new percent right away,
+        // the cookies of the running transactions with them
         TotalMemoryResource->SetOverPercent(config.GetSpillingPercent());
+        for (auto& [poolKey, poolMemory] : MemoryNamedPools) {
+            poolMemory->SetOverPercent(config.GetSpillingPercent());
+        }
         MaxNonParallelTopStageExecutionLimit.store(config.GetMaxNonParallelTopStageExecutionLimit());
         MaxNonParallelTasksExecutionLimit.store(config.GetMaxNonParallelTasksExecutionLimit());
         PreferLocalDatacenterExecution.store(config.GetPreferLocalDatacenterExecution());

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -23,6 +23,7 @@
 
 #include <library/cpp/containers/absl/flat_hash_map.h>
 
+#include <algorithm>
 #include <cmath>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::KQP_RESOURCE_MANAGER
@@ -78,12 +79,19 @@ namespace {
 
 static constexpr double MYEPS = 1e-9;
 
+// Percents come from the config and the resource pool settings unchecked: anything outside [0, 100] would turn
+// into a negative double and wrap on the conversion to ui64, so they are clamped here, the one place they are
+// applied. Above 100 behaves as 100 (the spilling threshold at the limit itself), below 0 as 0.
+double ClampPercent(double percent) {
+    return std::clamp(percent, 0.0, 100.0);
+}
+
 ui64 OverPercentage(ui64 limit, double percent) {
-    return static_cast<double>(limit) / 100 * (100 - percent) + MYEPS;
+    return static_cast<double>(limit) / 100 * (100 - ClampPercent(percent)) + MYEPS;
 }
 
 ui64 Percentage(ui64 limit, double percent) {
-    return static_cast<double>(limit) / 100 * percent + MYEPS;
+    return static_cast<double>(limit) / 100 * ClampPercent(percent) + MYEPS;
 }
 
 class TMemoryResource : public TAtomicRefCount<TMemoryResource> {

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -88,6 +88,11 @@ public:
         return Limit > Used ? Limit - Used : 0;
     }
 
+    // bytes left before the spilling threshold, negative when the threshold is exceeded
+    i64 GetMemoryAvailability() const {
+        return static_cast<i64>(Limit) - static_cast<i64>(Used) - static_cast<i64>(OverLimit);
+    }
+
     bool Has(ui64 amount) const {
         return Available() >= amount;
     }
@@ -106,7 +111,7 @@ public:
     }
 
     void UpdateCookie() {
-        SpillingCookie->SpillingPercentReached.store(Available() < OverLimit);
+        SpillingCookie->MemoryAvailability.store(GetMemoryAvailability());
     }
 
     ui64 GetUsed() const {

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -41,8 +41,21 @@ static double NormalizePoolPercent(double percent) {
     return Min(percent, 100.0);
 }
 
+// The rule of TTxState::MemoryPoolLimited, also needed before a TTxState exists (the cookie hand-out).
+// The percent must already be normalized.
+static bool IsMemoryPoolLimited(const TString& poolId, double memoryPoolPercent) {
+    return !poolId.empty() && poolId != NResourcePool::DEFAULT_POOL_ID
+        && memoryPoolPercent > 0 && memoryPoolPercent < 100;
+}
+
 TTxState::TTxState(std::shared_ptr<IKqpResourceManager>& resourceManager, ui64 txId, TInstant now, const TString& poolId, const double memoryPoolPercent,
     const TString& database, bool collectBacktrace)
+    : TTxState(resourceManager, txId, now, poolId, memoryPoolPercent, database, collectBacktrace,
+        resourceManager->GetMemoryResourceCookies(database, poolId, NormalizePoolPercent(memoryPoolPercent)))
+{}
+
+TTxState::TTxState(std::shared_ptr<IKqpResourceManager>& resourceManager, ui64 txId, TInstant now, const TString& poolId, const double memoryPoolPercent,
+    const TString& database, bool collectBacktrace, TMemoryResourceCookies cookies)
     : ResourceManager(resourceManager)
     , Counters(resourceManager->GetCounters())
     , TxId(txId)
@@ -50,9 +63,10 @@ TTxState::TTxState(std::shared_ptr<IKqpResourceManager>& resourceManager, ui64 t
     , PoolId(poolId)
     , MemoryPoolPercent(NormalizePoolPercent(memoryPoolPercent))
     , Database(database)
-    , MemoryPoolLimited(!PoolId.empty() && PoolId != NResourcePool::DEFAULT_POOL_ID
-        && MemoryPoolPercent > 0 && MemoryPoolPercent < 100)
+    , MemoryPoolLimited(IsMemoryPoolLimited(PoolId, MemoryPoolPercent))
     , CollectBacktrace(collectBacktrace)
+    , TotalMemoryCookie(std::move(cookies.Total))
+    , PoolMemoryCookie(std::move(cookies.Pool))
 {}
 
 TTxState::~TTxState() {
@@ -249,6 +263,29 @@ public:
         }
     }
 
+    TMemoryResourceCookies GetMemoryResourceCookies(const TString& database, const TString& poolId, double memoryPoolPercent) override {
+        TMemoryResourceCookies cookies;
+        with_lock (Lock) {
+            cookies.Total = TotalMemoryResource->GetSpillingCookie();
+            if (IsMemoryPoolLimited(poolId, memoryPoolPercent)) {
+                cookies.Pool = GetOrCreatePoolMemoryResource(std::make_pair(database, poolId), memoryPoolPercent)->GetSpillingCookie();
+            }
+        }
+        return cookies;
+    }
+
+    // Must be called under Lock. The pool resource is created on its first use and its limit follows the
+    // latest tx of the pool afterwards.
+    TIntrusivePtr<TMemoryResource> GetOrCreatePoolMemoryResource(const std::pair<TString, TString>& poolKey, double memoryPoolPercent) {
+        auto [it, success] = MemoryNamedPools.emplace(poolKey, nullptr);
+        if (success) {
+            it->second = MakeIntrusive<TMemoryResource>(TotalMemoryResource->GetLimit(), memoryPoolPercent, SpillingPercent.load());
+        } else {
+            it->second->SetNewLimit(TotalMemoryResource->GetLimit(), memoryPoolPercent, SpillingPercent.load());
+        }
+        return it->second;
+    }
+
     TKqpRMAllocateResult AllocateResources(TTxState& tx, ui64 taskId, const TKqpResourcesRequest& resources) override
     {
         const ui64 txId = tx.TxId;
@@ -296,27 +333,12 @@ public:
             }
 
             hasScanQueryMemory = TotalMemoryResource->AcquireIfAvailable(resources.Memory);
-            if (!tx.TotalMemoryCookie) {
-                tx.TotalMemoryCookie = TotalMemoryResource->GetSpillingCookie();
-            }
 
             if (hasScanQueryMemory && tx.HasMemoryPoolLimit()) {
-                auto [it, success] = MemoryNamedPools.emplace(tx.MakePoolId(), nullptr);
-
-                if (success) {
-                    it->second = MakeIntrusive<TMemoryResource>(TotalMemoryResource->GetLimit(), tx.MemoryPoolPercent, SpillingPercent.load());
-                } else {
-                    it->second->SetNewLimit(TotalMemoryResource->GetLimit(), tx.MemoryPoolPercent, SpillingPercent.load());
-                }
-
-                auto& poolMemory = it->second;
+                auto poolMemory = GetOrCreatePoolMemoryResource(tx.MakePoolId(), tx.MemoryPoolPercent);
                 if (!poolMemory->AcquireIfAvailable(resources.Memory)) {
                     hasScanQueryMemory = false;
                     TotalMemoryResource->Release(resources.Memory);
-                }
-
-                if (!tx.PoolMemoryCookie) {
-                    tx.PoolMemoryCookie = poolMemory->GetSpillingCookie();
                 }
             }
         }
@@ -614,7 +636,7 @@ public:
     TActorId ResourceInfoExchanger = TActorId();
 
     // Pool resources are never erased, not even when their usage drops to zero: the transactions of a pool keep
-    // the spilling cookie they got on their first allocation (TTxState::PoolMemoryCookie, read lock-free), so the
+    // the spilling cookie attached at their construction (TTxState::PoolMemoryCookie, read lock-free), so the
     // resource that updates it has to stay the same one for as long as the pool is in use.
     absl::flat_hash_map<std::pair<TString, TString>, TIntrusivePtr<TMemoryResource>, THash<std::pair<TString, TString>>> MemoryNamedPools;
 };

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -283,14 +283,14 @@ public:
         return cookies;
     }
 
-    // Must be called under Lock. The pool resource is created on its first use and its limit follows the
-    // latest tx of the pool afterwards.
+    // Must be called under Lock. The pool resource is created on its first use with the percent of that tx.
+    // The limit of an existing pool is not touched here: it follows the txs that allocate from the pool
+    // (see AllocateResources), a tx that merely gets constructed must not move the threshold under the
+    // running ones.
     TIntrusivePtr<TMemoryResource> GetOrCreatePoolMemoryResource(const std::pair<TString, TString>& poolKey, double memoryPoolPercent) {
         auto [it, success] = MemoryNamedPools.emplace(poolKey, nullptr);
         if (success) {
             it->second = MakeIntrusive<TMemoryResource>(TotalMemoryResource->GetLimit(), memoryPoolPercent, SpillingPercent.load());
-        } else {
-            it->second->SetNewLimit(TotalMemoryResource->GetLimit(), memoryPoolPercent, SpillingPercent.load());
         }
         return it->second;
     }
@@ -345,6 +345,8 @@ public:
 
             if (hasScanQueryMemory && tx.HasMemoryPoolLimit()) {
                 auto poolMemory = GetOrCreatePoolMemoryResource(tx.MakePoolId(), tx.MemoryPoolPercent);
+                // the pool limit follows the latest tx that allocates from the pool
+                poolMemory->SetNewLimit(TotalMemoryResource->GetLimit(), tx.MemoryPoolPercent, SpillingPercent.load());
                 if (!poolMemory->AcquireIfAvailable(resources.Memory)) {
                     hasScanQueryMemory = false;
                     TotalMemoryResource->Release(resources.Memory);

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -166,12 +166,12 @@ public:
 
     // A runtime SpillingPercent change: the spilling threshold moves, the limit stays
     void SetOverPercent(double overPercent) {
-        if (abs(overPercent - OverPercent) < MYEPS) {
-            return;
-        }
+        SetNewLimit(BaseLimit, MemoryPoolPercent, overPercent);
+    }
 
-        OverPercent = overPercent;
-        SetActualLimits();
+    // The configured spilling percent, the node total is its one holder (see TKqpResourceManager::SetConfigValues)
+    double GetOverPercent() const {
+        return OverPercent;
     }
 
     void SetActualLimits() {
@@ -224,7 +224,6 @@ public:
         : Counters(counters)
         , ExecutionUnitsResource(config.GetComputeActorsCount())
         , ExecutionUnitsLimit(config.GetComputeActorsCount())
-        , SpillingPercent(config.GetSpillingPercent())
         , TotalMemoryResource(MakeIntrusive<TMemoryResource>(config.GetQueryMemoryLimit(), (double)100, config.GetSpillingPercent()))
         , ResourceSnapshotState(std::make_shared<TResourceSnapshotState>())
     {
@@ -298,7 +297,7 @@ public:
     TIntrusivePtr<TMemoryResource> GetOrCreatePoolMemoryResource(const std::pair<TString, TString>& poolKey, double memoryPoolPercent) {
         auto [it, success] = MemoryNamedPools.emplace(poolKey, nullptr);
         if (success) {
-            it->second = MakeIntrusive<TMemoryResource>(TotalMemoryResource->GetLimit(), memoryPoolPercent, SpillingPercent.load());
+            it->second = MakeIntrusive<TMemoryResource>(TotalMemoryResource->GetLimit(), memoryPoolPercent, TotalMemoryResource->GetOverPercent());
         }
         return it->second;
     }
@@ -354,7 +353,7 @@ public:
             if (hasScanQueryMemory && tx.HasMemoryPoolLimit()) {
                 auto poolMemory = GetOrCreatePoolMemoryResource(tx.MakePoolId(), tx.MemoryPoolPercent);
                 // the pool limit follows the latest tx that allocates from the pool
-                poolMemory->SetNewLimit(TotalMemoryResource->GetLimit(), tx.MemoryPoolPercent, SpillingPercent.load());
+                poolMemory->SetNewLimit(TotalMemoryResource->GetLimit(), tx.MemoryPoolPercent, TotalMemoryResource->GetOverPercent());
                 if (!poolMemory->AcquireIfAvailable(resources.Memory)) {
                     hasScanQueryMemory = false;
                     TotalMemoryResource->Release(resources.Memory);
@@ -565,12 +564,11 @@ public:
         MinChannelBufferSize.store(config.GetMinChannelBufferSize());
         MaxTotalChannelBuffersSize.store(config.GetMaxTotalChannelBuffersSize());
         QueryMemoryLimit.store(config.GetQueryMemoryLimit());
-        SpillingPercent.store(config.GetSpillingPercent());
         // the spilling thresholds of the node total and of every pool follow the new percent right away,
-        // the cookies of the running transactions with them
+        // the cookies of the running transactions with them; the node total is the holder of the percent
         TotalMemoryResource->SetOverPercent(config.GetSpillingPercent());
         for (auto& [poolKey, poolMemory] : MemoryNamedPools) {
-            poolMemory->SetOverPercent(config.GetSpillingPercent());
+            poolMemory->SetOverPercent(TotalMemoryResource->GetOverPercent());
         }
         MaxNonParallelTopStageExecutionLimit.store(config.GetMaxNonParallelTopStageExecutionLimit());
         MaxNonParallelTasksExecutionLimit.store(config.GetMaxNonParallelTasksExecutionLimit());
@@ -641,7 +639,6 @@ public:
     // limits (guarded by Lock)
     std::atomic<i32> ExecutionUnitsResource;
     std::atomic<i32> ExecutionUnitsLimit;
-    std::atomic<double> SpillingPercent;
     TIntrusivePtr<TMemoryResource> TotalMemoryResource;
     std::atomic<ui64> ExternalDataQueryMemory = 0;
     std::atomic<ui64> MaxNonParallelTopStageExecutionLimit = 1;
@@ -838,7 +835,8 @@ private:
 
         if (queueConfig.GetLimit().GetMemory() > 0) {
             with_lock (ResourceManager->Lock) {
-                ResourceManager->TotalMemoryResource->SetNewLimit(queueConfig.GetLimit().GetMemory(), (double)100, ResourceManager->SpillingPercent.load());
+                auto& total = *ResourceManager->TotalMemoryResource;
+                total.SetNewLimit(queueConfig.GetLimit().GetMemory(), (double)100, total.GetOverPercent());
             }
             YDB_LOG_INFO("Total node memory for scan bytes",
                 {"queries", queueConfig.GetLimit().GetMemory()});

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -102,7 +102,10 @@ public:
         return Limit > Used ? Limit - Used : 0;
     }
 
-    // bytes left before the spilling threshold, negative when the threshold is exceeded
+    // Bytes left before the spilling threshold, negative when the threshold is exceeded. Negative whenever Used
+    // is past Limit - OverLimit, including a threshold equal to the limit (SpillingPercent = 100, OverLimit = 0)
+    // with Used above Limit after the limit was lowered under live usage; the former SpillingPercentReached flag
+    // compared the clamped Available() with OverLimit and stayed silent there.
     i64 GetMemoryAvailability() const {
         return static_cast<i64>(Limit) - static_cast<i64>(Used) - static_cast<i64>(OverLimit);
     }

--- a/ydb/core/kqp/rm_service/kqp_rm_service.h
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.h
@@ -14,9 +14,12 @@
 
 #include "kqp_resource_estimation.h"
 
+#include <algorithm>
 #include <array>
+#include <atomic>
 #include <bitset>
 #include <functional>
+#include <limits>
 #include <utility>
 
 
@@ -41,7 +44,10 @@ struct TKqpResourcesRequest {
 
 class TMemoryResourceCookie : public TAtomicRefCount<TMemoryResourceCookie> {
 public:
-    std::atomic<bool> SpillingPercentReached{false};
+    // Limit - Used - OverLimit of the owning TMemoryResource, i.e. the bytes left before the spilling
+    // threshold (negative = over the threshold, |value| is the overuse). Written under the resource
+    // manager lock, read lock-free by compute actors, see TTxState::GetMemoryAvailability.
+    std::atomic<i64> MemoryAvailability{std::numeric_limits<i64>::max()};
 };
 
 class IKqpResourceManager;
@@ -90,9 +96,17 @@ public:
         return MemoryPoolLimited;
     }
 
-    bool IsReasonableToStartSpilling() {
-        return (PoolMemoryCookie && PoolMemoryCookie->SpillingPercentReached.load())
-            || (TotalMemoryCookie && TotalMemoryCookie->SpillingPercentReached.load());
+    // Node level memory availability of this tx: the minimum over the node total and the pool resource,
+    // see TMemoryResourceCookie. Unlimited until the first successful allocation assigns the cookies.
+    i64 GetMemoryAvailability() const {
+        i64 result = std::numeric_limits<i64>::max();
+        if (TotalMemoryCookie) {
+            result = std::min(result, TotalMemoryCookie->MemoryAvailability.load());
+        }
+        if (PoolMemoryCookie) {
+            result = std::min(result, PoolMemoryCookie->MemoryAvailability.load());
+        }
+        return result;
     }
 
     TKqpResourcesRequest FreeResourcesRequest() const {

--- a/ydb/core/kqp/rm_service/kqp_rm_service.h
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.h
@@ -50,6 +50,13 @@ public:
     std::atomic<i64> MemoryAvailability{std::numeric_limits<i64>::max()};
 };
 
+// The cookies a tx reads its memory availability from: the node total and, for a tx with a resource pool,
+// the pool resource. Handed out by the resource manager when the tx is constructed, see TTxState.
+struct TMemoryResourceCookies {
+    TIntrusivePtr<TMemoryResourceCookie> Total;
+    TIntrusivePtr<TMemoryResourceCookie> Pool;
+};
+
 class IKqpResourceManager;
 
 class TTxState : public TAtomicRefCount<TTxState> {
@@ -64,8 +71,10 @@ public:
     const TString Database;
     const bool MemoryPoolLimited;
     const bool CollectBacktrace;
-    TIntrusivePtr<TMemoryResourceCookie> TotalMemoryCookie;
-    TIntrusivePtr<TMemoryResourceCookie> PoolMemoryCookie;
+    // Attached at construction and never written again, so that GetMemoryAvailability() can be read from any
+    // thread without a lock, see IKqpResourceManager::GetMemoryResourceCookies
+    const TIntrusivePtr<TMemoryResourceCookie> TotalMemoryCookie;
+    const TIntrusivePtr<TMemoryResourceCookie> PoolMemoryCookie;
 
     std::atomic<ui64> TxScanQueryMemory = 0;
     std::atomic<ui64> TxExternalDataQueryMemory = 0;
@@ -88,6 +97,11 @@ public:
         const TString& database, bool collectBacktrace);
     ~TTxState();
 
+private:
+    TTxState(std::shared_ptr<IKqpResourceManager>& resourceManager, ui64 txId, TInstant now, const TString& poolId, const double memoryPoolPercent,
+        const TString& database, bool collectBacktrace, TMemoryResourceCookies cookies);
+
+public:
     std::pair<TString, TString> MakePoolId() const {
         return std::make_pair(Database, PoolId);
     }
@@ -97,12 +111,10 @@ public:
     }
 
     // Node level memory availability of this tx: the minimum over the node total and the pool resource,
-    // see TMemoryResourceCookie. Unlimited until the first successful allocation assigns the cookies.
+    // see TMemoryResourceCookie. The cookies are attached at construction, nothing to synchronize here.
+    // Unlimited only with a resource manager that hands out no cookies (test stubs).
     i64 GetMemoryAvailability() const {
-        i64 result = std::numeric_limits<i64>::max();
-        if (TotalMemoryCookie) {
-            result = std::min(result, TotalMemoryCookie->MemoryAvailability.load());
-        }
+        i64 result = TotalMemoryCookie ? TotalMemoryCookie->MemoryAvailability.load() : std::numeric_limits<i64>::max();
         if (PoolMemoryCookie) {
             result = std::min(result, PoolMemoryCookie->MemoryAvailability.load());
         }
@@ -290,6 +302,10 @@ public:
     virtual ~IKqpResourceManager() = default;
 
     virtual const TIntrusivePtr<TKqpCounters>& GetCounters() const = 0;
+
+    // The spilling cookies for a new tx: the node total and, with a resource pool, the pool resource (created on
+    // its first use). Called by the TTxState constructor, the cookies then stay with the tx for its whole life.
+    virtual TMemoryResourceCookies GetMemoryResourceCookies(const TString& database, const TString& poolId, double memoryPoolPercent) = 0;
 
     virtual TKqpRMAllocateResult AllocateResources(TTxState& tx, ui64 taskId, const TKqpResourcesRequest& resources) = 0;
 

--- a/ydb/core/kqp/rm_service/kqp_rm_service.h
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.h
@@ -102,8 +102,14 @@ private:
         const TString& database, bool collectBacktrace, TMemoryResourceCookies cookies);
 
 public:
+    // The key of a resource pool in the resource manager, the one rule for the tx and for the cookie hand-out
+    // that runs before the tx exists (IKqpResourceManager::GetMemoryResourceCookies)
+    static std::pair<TString, TString> MakePoolId(const TString& database, const TString& poolId) {
+        return std::make_pair(database, poolId);
+    }
+
     std::pair<TString, TString> MakePoolId() const {
-        return std::make_pair(Database, PoolId);
+        return MakePoolId(Database, PoolId);
     }
 
     bool HasMemoryPoolLimit() const {

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -835,6 +835,14 @@ void KqpRm::SpillingPercentReconfigure() {
         UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 400);
         UNIT_ASSERT_VALUES_EQUAL(poolTx->GetMemoryAvailability(), 250);
 
+        // out of range values are clamped: above 100 behaves as 100, below 0 as 0 (pressure at any usage)
+        reconfigure(120);
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 900);
+        UNIT_ASSERT_VALUES_EQUAL(poolTx->GetMemoryAvailability(), 500);
+        reconfigure(-20);
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), -100); // 1000 - 100 - 1000
+        UNIT_ASSERT_VALUES_EQUAL(poolTx->GetMemoryAvailability(), -100); // the pool reads 500 - 0 - 500 = 0, the node total wins
+
         rm->FreeResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 100});
     }
 

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -693,8 +693,10 @@ void KqpRm::PoolMemoryAvailability() {
 }
 
 // The quota managers refuse optional requests in advance when the tx availability cannot cover the aligned
-// step (no resource manager round trip), their availability follows the sign of the tx value, and an optional
-// request that fits the availability goes to the resource manager as usual
+// step: no resource manager round trip, even when the resource manager itself would have granted the request.
+// The resource manager records every refusal it handles in TxFailedAllocationSize, so a zero there proves it
+// was not asked. Their availability follows the sign of the tx value, and an optional request that fits goes
+// to the resource manager as usual
 void KqpRm::TaskQuotaManagerOptional() {
     StartRms();
     NKikimr::TActorSystemStub stub;
@@ -709,14 +711,16 @@ void KqpRm::TaskQuotaManagerOptional() {
         UNIT_ASSERT(rm->AllocateResources(*tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .ExternalMemory = initialLimit}));
         UNIT_ASSERT(rm->AllocateResources(*tx, taskId, NRm::TKqpResourcesRequest{.Memory = 100}));
         UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 700);
+        UNIT_ASSERT_VALUES_EQUAL(tx->TxFailedAllocationSize.load(), 0);
         const auto statsBefore = rm->GetLocalResources();
 
-        // task level manager: 1 MB allocation step, the test resource broker cannot grant that much
+        // task level manager: 1 MB allocation step, more than the tx availability
         auto qm = CreateTaskQuotaManager(rm, tx, taskId, initialLimit);
         UNIT_ASSERT(qm->AllocateQuota(50, /* isOptional = */ true)); // fits in the prepaid limit
         UNIT_ASSERT_VALUES_EQUAL(qm->GetMemoryAvailability(), 700 + 50); // tx value plus the local leftover
-        UNIT_ASSERT(!qm->AllocateQuota(1500, /* isOptional = */ true)); // refused in advance
-        UNIT_ASSERT_VALUES_EQUAL(rm->GetLocalResources().Memory, statsBefore.Memory); // no round trip
+        UNIT_ASSERT(!qm->AllocateQuota(1500, /* isOptional = */ true)); // 1 MB step > 700: refused in advance
+        UNIT_ASSERT_VALUES_EQUAL(rm->GetLocalResources().Memory, statsBefore.Memory);
+        UNIT_ASSERT_VALUES_EQUAL(tx->TxFailedAllocationSize.load(), 0); // the resource manager was not asked
         // a negative tx value dominates the local leftover
         tx->TotalMemoryCookie->MemoryAvailability.store(-7);
         UNIT_ASSERT_VALUES_EQUAL(qm->GetMemoryAvailability(), -7);
@@ -724,17 +728,24 @@ void KqpRm::TaskQuotaManagerOptional() {
         qm->FreeQuota(50);
         qm.reset();
 
-        // channel level manager: 16 byte allocation step, the granted path is observable
+        // channel level manager: 16 byte allocation step. The tx reports less than the aligned request although
+        // the resource manager has 700 bytes and would grant it: refused in advance, the resource manager not asked
         auto cm = CreateChannelQuotaManager(rm, tx, 0, 16);
-        tx->TotalMemoryCookie->MemoryAvailability.store(500);
-        UNIT_ASSERT(!cm->AllocateQuota(1500, /* isOptional = */ true)); // 1504 > 500: refused in advance
+        tx->TotalMemoryCookie->MemoryAvailability.store(100);
+        UNIT_ASSERT(!cm->AllocateQuota(200, /* isOptional = */ true)); // 208 > 100: refused in advance
         UNIT_ASSERT_VALUES_EQUAL(rm->GetLocalResources().Memory, statsBefore.Memory);
-        UNIT_ASSERT_VALUES_EQUAL(cm->GetMemoryAvailability(), 500); // nothing prepaid here
+        UNIT_ASSERT_VALUES_EQUAL(tx->TxFailedAllocationSize.load(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(cm->GetMemoryAvailability(), 100); // nothing prepaid here
         tx->TotalMemoryCookie->MemoryAvailability.store(700);
-        UNIT_ASSERT(cm->AllocateQuota(200, /* isOptional = */ true)); // 208 <= 700: granted by the resource manager
+        UNIT_ASSERT(cm->AllocateQuota(200, /* isOptional = */ true)); // 208 <= 700: the same request is granted by the resource manager
         UNIT_ASSERT_VALUES_EQUAL(rm->GetLocalResources().Memory, statsBefore.Memory - 208);
         UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 700 - 208); // the cookie follows the allocation
-        cm->FreeQuota(200);
+        UNIT_ASSERT_VALUES_EQUAL(tx->TxFailedAllocationSize.load(), 0);
+        cm->FreeQuota(200); // the 208 stay prepaid in the channel manager until it dies
+        // a mandatory request beyond the node memory does reach the resource manager and is refused there:
+        // 1500 - 208 prepaid = 1292, aligned to 1296 > 692 left on the node
+        UNIT_ASSERT(!cm->AllocateQuota(1500, /* isOptional = */ false));
+        UNIT_ASSERT_VALUES_EQUAL(tx->TxFailedAllocationSize.load(), 1296);
         cm.reset();
         UNIT_ASSERT_VALUES_EQUAL(rm->GetLocalResources().Memory, statsBefore.Memory);
 

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -307,6 +307,7 @@ public:
         UNIT_TEST(MemoryAvailability);
         UNIT_TEST(PoolMemoryAvailability);
         UNIT_TEST(PoolMemoryAvailabilityAfterRelease);
+        UNIT_TEST(PoolLimitFollowsAllocatingTx);
         UNIT_TEST(SpillingPercentReconfigure);
         UNIT_TEST(TaskQuotaManagerOptional);
         UNIT_TEST(SnapshotSharingByExchanger);
@@ -334,6 +335,7 @@ public:
     void MemoryAvailability();
     void PoolMemoryAvailability();
     void PoolMemoryAvailabilityAfterRelease();
+    void PoolLimitFollowsAllocatingTx();
     void SpillingPercentReconfigure();
     void TaskQuotaManagerOptional();
     void SnapshotSharing();
@@ -733,6 +735,35 @@ void KqpRm::PoolMemoryAvailabilityAfterRelease() {
         rm->FreeResources(*tx2, 1, NRm::TKqpResourcesRequest{.Memory = 10});
         rm->FreeResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 450});
         UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 400);
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
+}
+
+// Constructing a tx of a pool with another percent must not move the pool threshold under the running txs:
+// the pool limit follows the txs that allocate from the pool, not the ones that merely appear
+void KqpRm::PoolLimitFollowsAllocatingTx() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    {
+        auto tx = MakePoolTx(1, rm, /* memoryPoolPercent = */ 50); // pool limit 500, threshold at 400 used
+        UNIT_ASSERT(rm->AllocateResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 450}));
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), -50); // over the pool threshold
+
+        auto other = MakePoolTx(2, rm, /* memoryPoolPercent = */ 90); // the same pool, another percent: nothing moves
+        UNIT_ASSERT(other->PoolMemoryCookie == tx->PoolMemoryCookie);
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), -50);
+        UNIT_ASSERT_VALUES_EQUAL(other->GetMemoryAvailability(), -50);
+
+        // an allocation of the other tx does refresh the pool limit with its percent: limit 900, threshold 720
+        UNIT_ASSERT(rm->AllocateResources(*other, 1, NRm::TKqpResourcesRequest{.Memory = 10}));
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 260); // 900 - 460 - 180, below the node total's 340
+
+        rm->FreeResources(*other, 1, NRm::TKqpResourcesRequest{.Memory = 10});
+        rm->FreeResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 450});
     }
 
     AssertResourceManagerStats(rm, 1000, 100);

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -13,6 +13,10 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/threading/local_executor/local_executor.h>
+#include <util/generic/size_literals.h>
+
+#include <atomic>
+#include <limits>
 
 #ifndef NDEBUG
 const bool DETAILED_LOG = false;
@@ -213,6 +217,10 @@ public:
         return MakeIntrusive<NRm::TTxState>(rm, txId, TInstant::Now(), poolId, memoryPoolPercent, "", false);
     }
 
+    TIntrusivePtr<NRm::TTxState> MakePoolTx(ui64 txId, std::shared_ptr<NRm::IKqpResourceManager> rm, double memoryPoolPercent) {
+        return MakeIntrusive<NRm::TTxState>(rm, txId, TInstant::Now(), "pool", memoryPoolPercent, "db", false);
+    }
+
     void AssertResourceManagerStats(
             std::shared_ptr<NRm::IKqpResourceManager> rm, ui64 scanQueryMemory, ui32 executionUnits) {
         Y_UNUSED(executionUnits);
@@ -295,6 +303,9 @@ public:
         UNIT_TEST(Reduce);
         UNIT_TEST(ConcurrentTasks);
         UNIT_TEST(ConcurrentChannels);
+        UNIT_TEST(MemoryAvailability);
+        UNIT_TEST(PoolMemoryAvailability);
+        UNIT_TEST(TaskQuotaManagerOptional);
         UNIT_TEST(SnapshotSharingByExchanger);
         UNIT_TEST(NodesMembershipByExchanger);
         UNIT_TEST(DisonnectNodes);
@@ -317,6 +328,9 @@ public:
     void Reduce();
     void ConcurrentTasks();
     void ConcurrentChannels();
+    void MemoryAvailability();
+    void PoolMemoryAvailability();
+    void TaskQuotaManagerOptional();
     void SnapshotSharing();
     void SnapshotSharingByExchanger();
     void NodesMembership();
@@ -577,7 +591,7 @@ void KqpRm::ConcurrentChannels() {
                 auto count = 0u;
                 for (auto n = 0u; n < 20u; n++) {
                     for (auto j = 0u; j < 20u; j++) {
-                        if (!qm->AllocateQuota(j * 10u)) {
+                        if (!qm->AllocateQuota(j * 10u, /* isOptional = */ false)) {
                             failedAllocations++;
                             Sleep(TDuration::MilliSeconds(j * 10));
                             break;
@@ -597,16 +611,21 @@ void KqpRm::ConcurrentChannels() {
 
             UNIT_ASSERT_GT(failedAllocations.load(), 0);
 
-            // the channel quota manager exposes the node level memory pressure signal of its tx,
-            // DQ channels 2.0 propagate it to the senders as back pressure. The load above drives
-            // allocations to failure, so the cookie may well be set already - toggle it explicitly.
+            // the channel quota manager exposes the node level memory availability of its tx,
+            // DQ channels 2.0 propagate a negative value to the senders as back pressure. The load above
+            // drives allocations to failure, so the cookie may well be negative already - set it explicitly.
             UNIT_ASSERT(tx->TotalMemoryCookie);
-            const bool reached = tx->TotalMemoryCookie->SpillingPercentReached.load();
-            tx->TotalMemoryCookie->SpillingPercentReached.store(true);
-            UNIT_ASSERT(qm->IsReasonableToUseSpilling());
-            tx->TotalMemoryCookie->SpillingPercentReached.store(false);
-            UNIT_ASSERT_VALUES_EQUAL(qm->IsReasonableToUseSpilling(), tx->IsReasonableToStartSpilling());
-            tx->TotalMemoryCookie->SpillingPercentReached.store(reached);
+            const i64 saved = tx->TotalMemoryCookie->MemoryAvailability.load();
+            tx->TotalMemoryCookie->MemoryAvailability.store(0);
+            const i64 base = qm->GetMemoryAvailability(); // the locally prepaid channel quota
+            tx->TotalMemoryCookie->MemoryAvailability.store(500);
+            UNIT_ASSERT_VALUES_EQUAL(qm->GetMemoryAvailability(), base + 500);
+            UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 500);
+            // a negative node value dominates: prepaid quota must not mask node level memory pressure
+            tx->TotalMemoryCookie->MemoryAvailability.store(-1000000);
+            UNIT_ASSERT_VALUES_EQUAL(qm->GetMemoryAvailability(), -1000000);
+            UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), -1000000);
+            tx->TotalMemoryCookie->MemoryAvailability.store(saved);
         }
 
         AssertResourceManagerStats(rm, 1000, 100);
@@ -614,6 +633,115 @@ void KqpRm::ConcurrentChannels() {
     }
 
     AssertResourceBrokerSensors(0, 0, 0, std::nullopt, 0);
+}
+
+// QueryMemoryLimit = 1000 with the default SpillingPercent = 80: the spilling threshold is at 800 used,
+// the availability is 800 - used and turns negative past it (the old SpillingPercentReached signal)
+void KqpRm::MemoryAvailability() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    {
+        auto tx = MakeTx(1, rm);
+        // nothing allocated yet: no cookie, nothing is known about the node
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), std::numeric_limits<i64>::max());
+
+        UNIT_ASSERT(rm->AllocateResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 100}));
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 700);
+
+        UNIT_ASSERT(rm->AllocateResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 700}));
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 0); // at the threshold: not pressure yet
+
+        UNIT_ASSERT(rm->AllocateResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 1}));
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), -1);
+
+        rm->FreeResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 801});
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 800);
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
+}
+
+// A tx with a resource pool sees the minimum over the node total and its pool: the pool limit is
+// MemoryPoolPercent of the node limit, the spilling threshold applies to each of them
+void KqpRm::PoolMemoryAvailability() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    {
+        auto tx = MakePoolTx(1, rm, /* memoryPoolPercent = */ 50);
+        // pool limit 500, pool threshold at 400 used; node threshold at 800 used
+        UNIT_ASSERT(rm->AllocateResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 100}));
+        UNIT_ASSERT(tx->PoolMemoryCookie);
+        UNIT_ASSERT_VALUES_EQUAL(tx->TotalMemoryCookie->MemoryAvailability.load(), 700);
+        UNIT_ASSERT_VALUES_EQUAL(tx->PoolMemoryCookie->MemoryAvailability.load(), 300);
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 300);
+
+        UNIT_ASSERT(rm->AllocateResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 350}));
+        UNIT_ASSERT_VALUES_EQUAL(tx->TotalMemoryCookie->MemoryAvailability.load(), 350);
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), -50); // the pool is over its threshold
+
+        rm->FreeResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 350});
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 300);
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
+}
+
+// The quota managers refuse optional requests in advance when the tx availability cannot cover the aligned
+// step (no resource manager round trip), their availability follows the sign of the tx value, and an optional
+// request that fits the availability goes to the resource manager as usual
+void KqpRm::TaskQuotaManagerOptional() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    {
+        auto tx = MakeTx(1, rm);
+        const ui64 taskId = 1;
+        const ui64 initialLimit = 100;
+        // the node service prepays the initial limit as external memory before the task starts
+        UNIT_ASSERT(rm->AllocateResources(*tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .ExternalMemory = initialLimit}));
+        UNIT_ASSERT(rm->AllocateResources(*tx, taskId, NRm::TKqpResourcesRequest{.Memory = 100}));
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 700);
+        const auto statsBefore = rm->GetLocalResources();
+
+        // task level manager: 1 MB allocation step, the test resource broker cannot grant that much
+        auto qm = CreateTaskQuotaManager(rm, tx, taskId, initialLimit);
+        UNIT_ASSERT(qm->AllocateQuota(50, /* isOptional = */ true)); // fits in the prepaid limit
+        UNIT_ASSERT_VALUES_EQUAL(qm->GetMemoryAvailability(), 700 + 50); // tx value plus the local leftover
+        UNIT_ASSERT(!qm->AllocateQuota(1500, /* isOptional = */ true)); // refused in advance
+        UNIT_ASSERT_VALUES_EQUAL(rm->GetLocalResources().Memory, statsBefore.Memory); // no round trip
+        // a negative tx value dominates the local leftover
+        tx->TotalMemoryCookie->MemoryAvailability.store(-7);
+        UNIT_ASSERT_VALUES_EQUAL(qm->GetMemoryAvailability(), -7);
+        tx->TotalMemoryCookie->MemoryAvailability.store(700);
+        qm->FreeQuota(50);
+        qm.reset();
+
+        // channel level manager: 16 byte allocation step, the granted path is observable
+        auto cm = CreateChannelQuotaManager(rm, tx, 0, 16);
+        tx->TotalMemoryCookie->MemoryAvailability.store(500);
+        UNIT_ASSERT(!cm->AllocateQuota(1500, /* isOptional = */ true)); // 1504 > 500: refused in advance
+        UNIT_ASSERT_VALUES_EQUAL(rm->GetLocalResources().Memory, statsBefore.Memory);
+        UNIT_ASSERT_VALUES_EQUAL(cm->GetMemoryAvailability(), 500); // nothing prepaid here
+        tx->TotalMemoryCookie->MemoryAvailability.store(700);
+        UNIT_ASSERT(cm->AllocateQuota(200, /* isOptional = */ true)); // 208 <= 700: granted by the resource manager
+        UNIT_ASSERT_VALUES_EQUAL(rm->GetLocalResources().Memory, statsBefore.Memory - 208);
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 700 - 208); // the cookie follows the allocation
+        cm->FreeQuota(200);
+        cm.reset();
+        UNIT_ASSERT_VALUES_EQUAL(rm->GetLocalResources().Memory, statsBefore.Memory);
+
+        rm->FreeResources(*tx, taskId, NRm::TKqpResourcesRequest{.Memory = 100});
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
 }
 
 void KqpRm::SnapshotSharing() {
@@ -908,13 +1036,13 @@ void KqpRm::SpillingPercentAppliedWithoutPoolLimit() {
 
         UNIT_ASSERT(rm->AllocateResources(*tx, 1,
             NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 600}));
-        UNIT_ASSERT(!tx->IsReasonableToStartSpilling());
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 200); // 1000 - 600 - 200, no pressure
 
         SetSpillingPercent(20);
-        UNIT_ASSERT(tx->IsReasonableToStartSpilling());
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), -400); // 1000 - 600 - 800, past the threshold
 
         SetSpillingPercent(80);
-        UNIT_ASSERT(!tx->IsReasonableToStartSpilling());
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 200);
     }
 
     AssertResourceManagerStats(rm, 1000, 100);

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -305,6 +305,7 @@ public:
         UNIT_TEST(ConcurrentChannels);
         UNIT_TEST(MemoryAvailability);
         UNIT_TEST(PoolMemoryAvailability);
+        UNIT_TEST(PoolMemoryAvailabilityAfterRelease);
         UNIT_TEST(TaskQuotaManagerOptional);
         UNIT_TEST(SnapshotSharingByExchanger);
         UNIT_TEST(NodesMembershipByExchanger);
@@ -330,6 +331,7 @@ public:
     void ConcurrentChannels();
     void MemoryAvailability();
     void PoolMemoryAvailability();
+    void PoolMemoryAvailabilityAfterRelease();
     void TaskQuotaManagerOptional();
     void SnapshotSharing();
     void SnapshotSharingByExchanger();
@@ -687,6 +689,43 @@ void KqpRm::PoolMemoryAvailability() {
 
         rm->FreeResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 350});
         UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 300);
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
+}
+
+// The pool resource survives a release down to zero: a tx keeps the pool cookie it got on its first allocation,
+// so that cookie must still be the live one after the pool memory was released and acquired again, and a later
+// tx of the same pool must get the very same cookie
+void KqpRm::PoolMemoryAvailabilityAfterRelease() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    {
+        auto tx = MakePoolTx(1, rm, /* memoryPoolPercent = */ 50); // pool limit 500, pool threshold at 400 used
+        UNIT_ASSERT(rm->AllocateResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 100}));
+        const auto cookie = tx->PoolMemoryCookie;
+        UNIT_ASSERT(cookie);
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 300);
+
+        rm->FreeResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 100}); // the pool is empty now
+        UNIT_ASSERT_VALUES_EQUAL(cookie->MemoryAvailability.load(), 400);
+
+        UNIT_ASSERT(rm->AllocateResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 450})); // over the pool threshold
+        UNIT_ASSERT(tx->PoolMemoryCookie == cookie);
+        UNIT_ASSERT_VALUES_EQUAL(cookie->MemoryAvailability.load(), -50); // the cookie is still the live one
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), -50);
+
+        auto tx2 = MakePoolTx(2, rm, /* memoryPoolPercent = */ 50);
+        UNIT_ASSERT(rm->AllocateResources(*tx2, 1, NRm::TKqpResourcesRequest{.Memory = 10}));
+        UNIT_ASSERT(tx2->PoolMemoryCookie == cookie); // the same resource, the same cookie
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), -60);
+
+        rm->FreeResources(*tx2, 1, NRm::TKqpResourcesRequest{.Memory = 10});
+        rm->FreeResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 450});
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 400);
     }
 
     AssertResourceManagerStats(rm, 1000, 100);

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -647,8 +647,10 @@ void KqpRm::MemoryAvailability() {
 
     {
         auto tx = MakeTx(1, rm);
-        // nothing allocated yet: no cookie, nothing is known about the node
-        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), std::numeric_limits<i64>::max());
+        // the cookies are attached at construction: the node availability is known before anything is allocated
+        UNIT_ASSERT(tx->TotalMemoryCookie);
+        UNIT_ASSERT(!tx->PoolMemoryCookie); // no resource pool
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 800);
 
         UNIT_ASSERT(rm->AllocateResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 100}));
         UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 700);
@@ -676,9 +678,11 @@ void KqpRm::PoolMemoryAvailability() {
 
     {
         auto tx = MakePoolTx(1, rm, /* memoryPoolPercent = */ 50);
-        // pool limit 500, pool threshold at 400 used; node threshold at 800 used
-        UNIT_ASSERT(rm->AllocateResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 100}));
+        // pool limit 500, pool threshold at 400 used; node threshold at 800 used. The pool resource is created
+        // together with the tx, so the pool cookie is there before the first allocation
         UNIT_ASSERT(tx->PoolMemoryCookie);
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 400);
+        UNIT_ASSERT(rm->AllocateResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 100}));
         UNIT_ASSERT_VALUES_EQUAL(tx->TotalMemoryCookie->MemoryAvailability.load(), 700);
         UNIT_ASSERT_VALUES_EQUAL(tx->PoolMemoryCookie->MemoryAvailability.load(), 300);
         UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 300);

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -310,6 +310,7 @@ public:
         UNIT_TEST(PoolLimitFollowsAllocatingTx);
         UNIT_TEST(PoolReleaseMirrorsAcquire);
         UNIT_TEST(SpillingPercentReconfigure);
+        UNIT_TEST(TotalLimitReconfigure);
         UNIT_TEST(TaskQuotaManagerOptional);
         UNIT_TEST(SnapshotSharingByExchanger);
         UNIT_TEST(NodesMembershipByExchanger);
@@ -339,6 +340,7 @@ public:
     void PoolLimitFollowsAllocatingTx();
     void PoolReleaseMirrorsAcquire();
     void SpillingPercentReconfigure();
+    void TotalLimitReconfigure();
     void TaskQuotaManagerOptional();
     void SnapshotSharing();
     void SnapshotSharingByExchanger();
@@ -844,6 +846,44 @@ void KqpRm::SpillingPercentReconfigure() {
         UNIT_ASSERT_VALUES_EQUAL(poolTx->GetMemoryAvailability(), -100); // the pool reads 500 - 0 - 500 = 0, the node total wins
 
         rm->FreeResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 100});
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
+}
+
+// A new node total from the resource broker queue config reaches every pool: a pool is a share of the total,
+// so its limit and threshold move with it, and the running txs of the pool see it through their cookies
+void KqpRm::TotalLimitReconfigure() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    // the resource broker queue config as the resource manager receives it; the handler does not reply, so
+    // dispatch in short slices until the node total shows the new limit
+    auto setTotal = [&](ui64 memory, ui64 expectedFree) {
+        auto response = MakeHolder<TEvResourceBroker::TEvConfigResponse>();
+        response->QueueConfig.ConstructInPlace();
+        response->QueueConfig->MutableLimit()->SetMemory(memory);
+        Runtime->Send(new IEventHandle(ResourceManagers.front(), Runtime->AllocateEdgeActor(), response.Release()));
+        for (int i = 0; i < 100 && rm->GetLocalResources().Memory != expectedFree; ++i) {
+            Runtime->DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(10));
+        }
+        UNIT_ASSERT_VALUES_EQUAL(rm->GetLocalResources().Memory, expectedFree);
+    };
+
+    {
+        auto poolTx = MakePoolTx(1, rm, /* memoryPoolPercent = */ 50); // pool limit 500, threshold at 400 used
+        UNIT_ASSERT(rm->AllocateResources(*poolTx, 1, NRm::TKqpResourcesRequest{.Memory = 450}));
+        UNIT_ASSERT_VALUES_EQUAL(poolTx->GetMemoryAvailability(), -50); // over the pool threshold
+
+        setTotal(2000, /* expectedFree = */ 2000 - 450); // pool limit 1000, threshold at 800; node threshold at 1600
+        UNIT_ASSERT_VALUES_EQUAL(poolTx->GetMemoryAvailability(), 350); // 1000 - 450 - 200, the pool followed
+
+        setTotal(1000, /* expectedFree = */ 1000 - 450); // and back
+        UNIT_ASSERT_VALUES_EQUAL(poolTx->GetMemoryAvailability(), -50);
+
+        rm->FreeResources(*poolTx, 1, NRm::TKqpResourcesRequest{.Memory = 450});
     }
 
     AssertResourceManagerStats(rm, 1000, 100);

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -308,6 +308,7 @@ public:
         UNIT_TEST(PoolMemoryAvailability);
         UNIT_TEST(PoolMemoryAvailabilityAfterRelease);
         UNIT_TEST(PoolLimitFollowsAllocatingTx);
+        UNIT_TEST(PoolReleaseMirrorsAcquire);
         UNIT_TEST(SpillingPercentReconfigure);
         UNIT_TEST(TaskQuotaManagerOptional);
         UNIT_TEST(SnapshotSharingByExchanger);
@@ -336,6 +337,7 @@ public:
     void PoolMemoryAvailability();
     void PoolMemoryAvailabilityAfterRelease();
     void PoolLimitFollowsAllocatingTx();
+    void PoolReleaseMirrorsAcquire();
     void SpillingPercentReconfigure();
     void TaskQuotaManagerOptional();
     void SnapshotSharing();
@@ -764,6 +766,37 @@ void KqpRm::PoolLimitFollowsAllocatingTx() {
 
         rm->FreeResources(*other, 1, NRm::TKqpResourcesRequest{.Memory = 10});
         rm->FreeResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 450});
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
+}
+
+// A tx of a pool without a memory limit (percent -1, the default) takes nothing from the pool and must give
+// nothing back to it either, whatever the txs with a limit have acquired there
+void KqpRm::PoolReleaseMirrorsAcquire() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    {
+        auto limited = MakePoolTx(1, rm, /* memoryPoolPercent = */ 50); // pool limit 500, threshold at 400 used
+        auto unlimited = MakePoolTx(2, rm, /* memoryPoolPercent = */ -1); // the same pool, no pool accounting
+        UNIT_ASSERT(limited->HasMemoryPoolLimit());
+        UNIT_ASSERT(!unlimited->HasMemoryPoolLimit());
+        UNIT_ASSERT(!unlimited->PoolMemoryCookie);
+
+        UNIT_ASSERT(rm->AllocateResources(*limited, 1, NRm::TKqpResourcesRequest{.Memory = 300}));
+        UNIT_ASSERT_VALUES_EQUAL(limited->GetMemoryAvailability(), 100); // 500 - 300 - 100
+
+        UNIT_ASSERT(rm->AllocateResources(*unlimited, 1, NRm::TKqpResourcesRequest{.Memory = 200})); // the node total only
+        UNIT_ASSERT_VALUES_EQUAL(limited->GetMemoryAvailability(), 100); // the pool did not move
+        UNIT_ASSERT_VALUES_EQUAL(unlimited->GetMemoryAvailability(), 300); // 1000 - 500 - 200
+        rm->FreeResources(*unlimited, 1, NRm::TKqpResourcesRequest{.Memory = 200});
+        UNIT_ASSERT_VALUES_EQUAL(limited->GetMemoryAvailability(), 100); // and did not move back either
+
+        rm->FreeResources(*limited, 1, NRm::TKqpResourcesRequest{.Memory = 300});
+        UNIT_ASSERT_VALUES_EQUAL(limited->GetMemoryAvailability(), 400);
     }
 
     AssertResourceManagerStats(rm, 1000, 100);

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -1,3 +1,4 @@
+#include <ydb/core/cms/console/console.h>
 #include <ydb/core/kqp/rm_service/kqp_rm_service.h>
 #include <ydb/core/cms/console/console.h>
 #include <ydb/core/tablet/resource_broker_impl.h>
@@ -306,6 +307,7 @@ public:
         UNIT_TEST(MemoryAvailability);
         UNIT_TEST(PoolMemoryAvailability);
         UNIT_TEST(PoolMemoryAvailabilityAfterRelease);
+        UNIT_TEST(SpillingPercentReconfigure);
         UNIT_TEST(TaskQuotaManagerOptional);
         UNIT_TEST(SnapshotSharingByExchanger);
         UNIT_TEST(NodesMembershipByExchanger);
@@ -332,6 +334,7 @@ public:
     void MemoryAvailability();
     void PoolMemoryAvailability();
     void PoolMemoryAvailabilityAfterRelease();
+    void SpillingPercentReconfigure();
     void TaskQuotaManagerOptional();
     void SnapshotSharing();
     void SnapshotSharingByExchanger();
@@ -730,6 +733,45 @@ void KqpRm::PoolMemoryAvailabilityAfterRelease() {
         rm->FreeResources(*tx2, 1, NRm::TKqpResourcesRequest{.Memory = 10});
         rm->FreeResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 450});
         UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 400);
+    }
+
+    AssertResourceManagerStats(rm, 1000, 100);
+}
+
+// A runtime SpillingPercent change moves the spilling threshold of the node total and of every pool at once,
+// the limits stay as they are, and the running transactions see it through their cookies
+void KqpRm::SpillingPercentReconfigure() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    auto reconfigure = [&](double spillingPercent) {
+        auto request = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+        auto* config = request->Record.MutableConfig()->MutableTableServiceConfig()->MutableResourceManager();
+        config->CopyFrom(MakeKqpResourceManagerConfig());
+        config->SetSpillingPercent(spillingPercent);
+        const TActorId edge = Runtime->AllocateEdgeActor();
+        Runtime->Send(new IEventHandle(ResourceManagers.front(), edge, request.Release()));
+        Runtime->GrabEdgeEvent<NConsole::TEvConsole::TEvConfigNotificationResponse>(edge);
+    };
+
+    {
+        auto tx = MakeTx(1, rm); // node limit 1000, threshold at 800 used
+        auto poolTx = MakePoolTx(2, rm, /* memoryPoolPercent = */ 50); // pool limit 500, threshold at 400 used
+        UNIT_ASSERT(rm->AllocateResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 100}));
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 700);
+        UNIT_ASSERT_VALUES_EQUAL(poolTx->GetMemoryAvailability(), 400);
+
+        reconfigure(100); // the thresholds move up to the limits
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 900);
+        UNIT_ASSERT_VALUES_EQUAL(poolTx->GetMemoryAvailability(), 500);
+
+        reconfigure(50); // and down to half of them
+        UNIT_ASSERT_VALUES_EQUAL(tx->GetMemoryAvailability(), 400);
+        UNIT_ASSERT_VALUES_EQUAL(poolTx->GetMemoryAvailability(), 250);
+
+        rm->FreeResources(*tx, 1, NRm::TKqpResourcesRequest{.Memory = 100});
     }
 
     AssertResourceManagerStats(rm, 1000, 100);

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -831,6 +831,20 @@ void KqpRm::TaskQuotaManagerOptional() {
         // 1500 - 208 prepaid = 1292, aligned to 1296 > 692 left on the node
         UNIT_ASSERT(!cm->AllocateQuota(1500, /* isOptional = */ false));
         UNIT_ASSERT_VALUES_EQUAL(tx->TxFailedAllocationSize.load(), 1296);
+
+        // the resource manager refuses a small request (below 10 steps) that the pre-check let through: a
+        // mandatory one is tolerated as over-quoting, an optional one is refused and the prepaid quota restored
+        UNIT_ASSERT(rm->AllocateResources(*tx, 2, NRm::TKqpResourcesRequest{.Memory = 600})); // 92 bytes left on the node
+        tx->TotalMemoryCookie->MemoryAvailability.store(1'000'000); // the pre-check passes
+        UNIT_ASSERT(!cm->AllocateQuota(300, /* isOptional = */ true)); // 300 - 208 prepaid = 92, aligned to 96 > 92
+        UNIT_ASSERT_VALUES_EQUAL(tx->TxFailedAllocationSize.load(), 96); // refused by the resource manager
+        UNIT_ASSERT_VALUES_EQUAL(cm->GetMemoryAvailability(), 1'000'000 + 208); // the prepaid quota is intact
+        UNIT_ASSERT(cm->AllocateQuota(300, /* isOptional = */ false)); // the mandatory request is over-quoted
+        UNIT_ASSERT_VALUES_EQUAL(cm->GetMemoryAvailability(), 1'000'000 + 208 - 300);
+        cm->FreeQuota(300);
+        UNIT_ASSERT_VALUES_EQUAL(cm->GetMemoryAvailability(), 1'000'000 + 208);
+        tx->TotalMemoryCookie->MemoryAvailability.store(700);
+        rm->FreeResources(*tx, 2, NRm::TKqpResourcesRequest{.Memory = 600});
         cm.reset();
         UNIT_ASSERT_VALUES_EQUAL(rm->GetLocalResources().Memory, statsBefore.Memory);
 

--- a/ydb/core/kqp/ut/channels/dq_channel_service_ut.cpp
+++ b/ydb/core/kqp/ut/channels/dq_channel_service_ut.cpp
@@ -15,6 +15,8 @@
 #include <ydb/library/yql/dq/actors/dq.h>
 #include <util/random/random.h>
 
+#include <atomic>
+
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::KQP_CHANNELS
 
 using namespace NKikimr::NKqp;
@@ -58,7 +60,7 @@ struct TEvTestPrivate {
 // TChannelQuotaManager does with VERIFY) and to leave anything allocated at the end of the test.
 struct TTestQuotaManager : public IMemoryQuotaManager {
 
-    bool AllocateQuota(ui64 memorySize) override {
+    bool AllocateQuota(ui64 memorySize, bool /* isOptional */) override {
         if (Quota.load() + static_cast<i64>(memorySize) > static_cast<i64>(Limit)) {
             return false;
         }
@@ -82,9 +84,10 @@ struct TTestQuotaManager : public IMemoryQuotaManager {
         return Limit;
     }
 
-    // stands for the node level memory pressure signal, see NRm::TTxState::IsReasonableToStartSpilling
-    bool IsReasonableToUseSpilling() const override {
-        return MemoryPressure.load();
+    // stands for the node level memory availability, see NRm::TTxState::GetMemoryAvailability:
+    // negative under memory pressure, otherwise what is left of the limit
+    i64 GetMemoryAvailability() const override {
+        return MemoryPressure.load() ? -1 : static_cast<i64>(Limit) - Quota.load();
     }
 
     TString MemoryConsumptionDetails() const override {

--- a/ydb/core/kqp/ut/join/kqp_block_hash_join_ut.cpp
+++ b/ydb/core/kqp/ut/join/kqp_block_hash_join_ut.cpp
@@ -37,11 +37,13 @@ NKikimrConfig::TAppConfig AppCfgLowComputeLimits(double reasonableTreshold, bool
 }
 
 
-Y_UNIT_TEST_SUITE(KqpBlockHashJoin) {
-    Y_UNIT_TEST(Spilling) {
+// Runs the spilling join under the given resource manager spilling threshold, with the operator memory quota
+// (RFC dq_memory_quota_20) bound or not, and checks whether the compute spilling counters moved.
+void RunSpillingCase(double spillingPercent, bool expectSpilling, bool enableOperatorMemoryQuota) {
         TKikimrSettings settings = TKikimrSettings().SetWithSampleTables(false);
-        settings.AppConfig = AppCfgLowComputeLimits(0.01);
+        settings.AppConfig = AppCfgLowComputeLimits(spillingPercent);
         settings.AppConfig.MutableTableServiceConfig()->SetEnableOlapSink(true);
+        settings.AppConfig.MutableTableServiceConfig()->MutableResourceManager()->SetEnableOperatorMemoryQuota(enableOperatorMemoryQuota);
         TKikimrRunner kikimr(settings);
 
         auto queryClient = kikimr.GetQueryClient();
@@ -123,10 +125,33 @@ Y_UNIT_TEST_SUITE(KqpBlockHashJoin) {
             UNIT_ASSERT_VALUES_EQUAL(resultSet.RowsCount(), expectedRowsCount);
 
             TKqpCounters counters(kikimr.GetTestServer().GetRuntime()->GetAppData().Counters);
-            UNIT_ASSERT(counters.ComputeSpilling.WriteBlobs->Val() > 0);
-            UNIT_ASSERT(counters.ComputeSpilling.ReadBlobs->Val() > 0);
+            if (expectSpilling) {
+                UNIT_ASSERT(counters.ComputeSpilling.WriteBlobs->Val() > 0);
+                UNIT_ASSERT(counters.ComputeSpilling.ReadBlobs->Val() > 0);
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL(counters.ComputeSpilling.WriteBlobs->Val(), 0);
+            }
 
         }
+}
+
+Y_UNIT_TEST_SUITE(KqpBlockHashJoin) {
+    Y_UNIT_TEST(Spilling) {
+        RunSpillingCase(0.01, /* expectSpilling = */ true, /* enableOperatorMemoryQuota = */ false);
+    }
+
+    Y_UNIT_TEST(SpillingWithOperatorMemoryQuota) {
+        // the negative memory availability of the resource manager drives the join to spill
+        RunSpillingCase(0.01, /* expectSpilling = */ true, /* enableOperatorMemoryQuota = */ true);
+    }
+
+    Y_UNIT_TEST(NoSpillingAtHighPercent) {
+        RunSpillingCase(100, /* expectSpilling = */ false, /* enableOperatorMemoryQuota = */ false);
+    }
+
+    Y_UNIT_TEST(NoSpillingAtHighPercentWithOperatorMemoryQuota) {
+        // the availability never turns negative below the spilling threshold: no spilling, optional requests granted
+        RunSpillingCase(100, /* expectSpilling = */ false, /* enableOperatorMemoryQuota = */ true);
     }
     Y_UNIT_TEST_TWIN(BlockHashJoinTest, UseBlockHashJoin) {
         TKikimrSettings settings = TKikimrSettings().SetWithSampleTables(false);

--- a/ydb/core/kqp/ut/join/kqp_block_hash_join_ut.cpp
+++ b/ydb/core/kqp/ut/join/kqp_block_hash_join_ut.cpp
@@ -38,11 +38,14 @@ NKikimrConfig::TAppConfig AppCfgLowComputeLimits(double reasonableTreshold, bool
 
 
 // Runs the spilling join under the given resource manager spilling threshold and checks whether the compute
-// spilling counters moved.
-void RunSpillingCase(double spillingPercent, bool expectSpilling) {
+// spilling counters moved. With enableOperatorMemoryQuota the compute actors bind the operator memory quota
+// (RFC dq_memory_quota_20) for the graph; nothing consumes it until the operator side lands, so the outcome
+// must be the same.
+void RunSpillingCase(double spillingPercent, bool expectSpilling, bool enableOperatorMemoryQuota = false) {
         TKikimrSettings settings = TKikimrSettings().SetWithSampleTables(false);
         settings.AppConfig = AppCfgLowComputeLimits(spillingPercent);
         settings.AppConfig.MutableTableServiceConfig()->SetEnableOlapSink(true);
+        settings.AppConfig.MutableTableServiceConfig()->MutableResourceManager()->SetEnableOperatorMemoryQuota(enableOperatorMemoryQuota);
         TKikimrRunner kikimr(settings);
 
         auto queryClient = kikimr.GetQueryClient();
@@ -143,6 +146,12 @@ Y_UNIT_TEST_SUITE(KqpBlockHashJoin) {
     Y_UNIT_TEST(NoSpillingAtHighPercent) {
         // the availability never turns negative below the spilling threshold: no spilling
         RunSpillingCase(100, /* expectSpilling = */ false);
+    }
+
+    Y_UNIT_TEST(SpillingWithOperatorMemoryQuota) {
+        // smoke test of the flag plumbing: config -> compute actor factory -> memory limits -> the quota bound
+        // around every execution; the join still spills exactly as without the flag
+        RunSpillingCase(0.01, /* expectSpilling = */ true, /* enableOperatorMemoryQuota = */ true);
     }
     Y_UNIT_TEST_TWIN(BlockHashJoinTest, UseBlockHashJoin) {
         TKikimrSettings settings = TKikimrSettings().SetWithSampleTables(false);

--- a/ydb/core/kqp/ut/join/kqp_block_hash_join_ut.cpp
+++ b/ydb/core/kqp/ut/join/kqp_block_hash_join_ut.cpp
@@ -37,13 +37,12 @@ NKikimrConfig::TAppConfig AppCfgLowComputeLimits(double reasonableTreshold, bool
 }
 
 
-// Runs the spilling join under the given resource manager spilling threshold, with the operator memory quota
-// (RFC dq_memory_quota_20) bound or not, and checks whether the compute spilling counters moved.
-void RunSpillingCase(double spillingPercent, bool expectSpilling, bool enableOperatorMemoryQuota) {
+// Runs the spilling join under the given resource manager spilling threshold and checks whether the compute
+// spilling counters moved.
+void RunSpillingCase(double spillingPercent, bool expectSpilling) {
         TKikimrSettings settings = TKikimrSettings().SetWithSampleTables(false);
         settings.AppConfig = AppCfgLowComputeLimits(spillingPercent);
         settings.AppConfig.MutableTableServiceConfig()->SetEnableOlapSink(true);
-        settings.AppConfig.MutableTableServiceConfig()->MutableResourceManager()->SetEnableOperatorMemoryQuota(enableOperatorMemoryQuota);
         TKikimrRunner kikimr(settings);
 
         auto queryClient = kikimr.GetQueryClient();
@@ -137,21 +136,13 @@ void RunSpillingCase(double spillingPercent, bool expectSpilling, bool enableOpe
 
 Y_UNIT_TEST_SUITE(KqpBlockHashJoin) {
     Y_UNIT_TEST(Spilling) {
-        RunSpillingCase(0.01, /* expectSpilling = */ true, /* enableOperatorMemoryQuota = */ false);
-    }
-
-    Y_UNIT_TEST(SpillingWithOperatorMemoryQuota) {
         // the negative memory availability of the resource manager drives the join to spill
-        RunSpillingCase(0.01, /* expectSpilling = */ true, /* enableOperatorMemoryQuota = */ true);
+        RunSpillingCase(0.01, /* expectSpilling = */ true);
     }
 
     Y_UNIT_TEST(NoSpillingAtHighPercent) {
-        RunSpillingCase(100, /* expectSpilling = */ false, /* enableOperatorMemoryQuota = */ false);
-    }
-
-    Y_UNIT_TEST(NoSpillingAtHighPercentWithOperatorMemoryQuota) {
-        // the availability never turns negative below the spilling threshold: no spilling, optional requests granted
-        RunSpillingCase(100, /* expectSpilling = */ false, /* enableOperatorMemoryQuota = */ true);
+        // the availability never turns negative below the spilling threshold: no spilling
+        RunSpillingCase(100, /* expectSpilling = */ false);
     }
     Y_UNIT_TEST_TWIN(BlockHashJoinTest, UseBlockHashJoin) {
         TKikimrSettings settings = TKikimrSettings().SetWithSampleTables(false);

--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -63,6 +63,11 @@ message TTableServiceConfig {
 
         optional uint64 KqpLevelCacheMaxSizeBytes = 32 [default = 0];
         optional uint64 KqpLevelCacheIncreaseBatchSizeBytes = 33 [default = 33554432];
+
+        // Bind the compute actor memory quota to DqHashCombine / DqHashAggregate / DqBlockHashJoin
+        // (RFC dq_memory_quota_20): optional memory requests before growth, numeric memory availability
+        // instead of the allocator yellow zone, explicit give-back. Off: allocator heuristics only.
+        optional bool EnableOperatorMemoryQuota = 34 [default = false];
     }
 
     message TSpillingServiceConfig {
@@ -572,8 +577,8 @@ message TTableServiceConfig {
 
     optional bool UseBlockHashJoinForCross = 145 [default = false, (InvalidateCompileCache) = true];
 
-    // DQ channels 2.0: when the receiver node reports the resource manager spilling signal
-    // (NRm::TTxState::IsReasonableToStartSpilling), shrink the sender inflight window down to
+    // DQ channels 2.0: when the receiver node reports the resource manager memory pressure signal
+    // (NRm::TTxState::GetMemoryAvailability() < 0), shrink the sender inflight window down to
     // the cold inflight value instead of letting channels soak the full per channel limit.
     optional bool EnableSpillingChannelBackpressure = 146 [default = false];
 

--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -64,9 +64,11 @@ message TTableServiceConfig {
         optional uint64 KqpLevelCacheMaxSizeBytes = 32 [default = 0];
         optional uint64 KqpLevelCacheIncreaseBatchSizeBytes = 33 [default = 33554432];
 
-        // Bind the compute actor memory quota to DqHashCombine / DqHashAggregate / DqBlockHashJoin
-        // (RFC dq_memory_quota_20): optional memory requests before growth, numeric memory availability
-        // instead of the allocator yellow zone, explicit give-back. Off: allocator heuristics only.
+        // Bind the compute actor memory quota to the memory hungry operators (RFC dq_memory_quota_20), so that
+        // DqHashCombine / DqHashAggregate / DqBlockHashJoin can request memory before growing, read a numeric
+        // memory availability instead of the allocator yellow zone and give memory back explicitly.
+        // Off: the operators use the allocator heuristics only. Takes effect once the operators consult the
+        // bound quota (the operator side of the RFC); until then the flag only binds the quota.
         optional bool EnableOperatorMemoryQuota = 34 [default = false];
     }
 

--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -49,7 +49,9 @@ message TTableServiceConfig {
         optional TInfoExchangerSettings InfoExchangerSettings = 19;
         optional uint64 KqpPatternCachePatternAccessTimesBeforeTryToCompile = 20 [default = 5];
         optional uint64 KqpPatternCacheCompiledCapacityBytes = 21 [default = 104857600]; // 100 MiB
-        optional double SpillingPercent = 22 [default = 80]; // 100 MiB
+        // Percent of the query memory limit (node total and resource pool) past which the tasks see memory
+        // pressure: spilling, optional memory requests refused, channel back pressure. Above 100 behaves as 100.
+        optional double SpillingPercent = 22 [default = 80];
 
         optional uint64 MinMemAllocSize = 23 [default = 1048576]; // 1 MiB
         optional uint64 MinMemFreeSize = 24  [default = 33554432]; // 32 MiB

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor.h
@@ -289,11 +289,16 @@ struct TGuaranteeQuotaManager : public IMemoryQuotaManager {
         MaxMemorySize = Limit;
     }
 
-    bool AllocateQuota(ui64 memorySize) override {
+    bool AllocateQuota(ui64 memorySize, bool isOptional) override {
         if (Quota + memorySize > Limit) {
             ui64 delta = Quota + memorySize - Limit;
             ui64 alignMask = Step - 1;
             delta = (delta + alignMask) & ~alignMask;
+
+            // optional growth must not push the parent over its target: refuse in advance, do not ask
+            if (isOptional && GetExtraMemoryAvailability() < static_cast<i64>(delta)) {
+                return false;
+            }
 
             if (!AllocateExtraQuota(delta)) {
                 return false;
@@ -309,8 +314,10 @@ struct TGuaranteeQuotaManager : public IMemoryQuotaManager {
         return true;
     }
 
-    bool IsReasonableToUseSpilling() const override {
-        return false;
+    i64 GetMemoryAvailability() const override {
+        // a negative parent value (over target) must not be masked by the locally prepaid leftover
+        const i64 extra = GetExtraMemoryAvailability();
+        return extra < 0 ? extra : AddMemoryAvailability(static_cast<i64>(Limit - Quota), extra);
     }
 
     void FreeQuota(ui64 memorySize) override {
@@ -344,29 +351,17 @@ struct TGuaranteeQuotaManager : public IMemoryQuotaManager {
     virtual void FreeExtraQuota(ui64) {
     }
 
+    // How much more the parent could grant (same sign semantics as GetMemoryAvailability).
+    // Default 0 mirrors AllocateExtraQuota() == false: never over target, nothing beyond Limit.
+    virtual i64 GetExtraMemoryAvailability() const {
+        return 0;
+    }
+
     ui64 Limit;     // current consumption (Quota + leftover from allocation chunk)
     ui64 Guarantee; // do not free memory below this value even if Quota == 0
     ui64 Step;      // allocation chunk size
     ui64 Quota;     // current value
     ui64 MaxMemorySize; // usage peak for statistics
-};
-
-struct TChainedQuotaManager : public TGuaranteeQuotaManager {
-
-    TChainedQuotaManager(IMemoryQuotaManager::TPtr extraQuotaManager, ui64 limit, ui64 guarantee, ui64 step = 1_MB, ui64 quota = 0)
-    : TGuaranteeQuotaManager(limit, guarantee, step, quota)
-    , ExtraQuotaManager(extraQuotaManager) {
-    }
-
-    bool AllocateExtraQuota(ui64 memorySize) override {
-        return ExtraQuotaManager->AllocateQuota(memorySize);
-    }
-
-    void FreeExtraQuota(ui64 memorySize) override {
-        ExtraQuotaManager->FreeQuota(memorySize);
-    }
-
-    IMemoryQuotaManager::TPtr ExtraQuotaManager;
 };
 
 struct TComputeMemoryLimits {
@@ -384,6 +379,10 @@ struct TComputeMemoryLimits {
 
     IMemoryQuotaManager::TPtr MemoryQuotaManager;
     IMemoryQuotaManager::TPtr ChannelQuotaManager;
+
+    // Bind the compute actor memory quota to the memory hungry operators (DqHashCombine, DqHashAggregate,
+    // DqBlockHashJoin), see IDqOperatorMemoryQuota. Off: operators use the allocator heuristics only.
+    bool EnableOperatorMemoryQuota = false;
 };
 
 using TTaskRunnerFactory = std::function<

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor.h
@@ -15,6 +15,7 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
+#include <util/generic/bitops.h>
 
 namespace NYql {
 namespace NDq {
@@ -285,7 +286,7 @@ struct TGuaranteeQuotaManager : public IMemoryQuotaManager {
         : Limit(limit), Guarantee(guarantee), Step(step), Quota(quota) {
         Y_ABORT_UNLESS(Limit >= Guarantee);
         Y_ABORT_UNLESS(Limit >= Quota);
-        Y_ABORT_UNLESS(Step != 0 && (Step & (Step - 1)) == 0, "the allocation step must be a power of two"); // it is used as an alignment mask
+        Y_ABORT_UNLESS(IsPowerOf2(Step), "the allocation step must be a power of two"); // it is used as an alignment mask
         MaxMemorySize = Limit;
     }
 

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor.h
@@ -285,7 +285,7 @@ struct TGuaranteeQuotaManager : public IMemoryQuotaManager {
         : Limit(limit), Guarantee(guarantee), Step(step), Quota(quota) {
         Y_ABORT_UNLESS(Limit >= Guarantee);
         Y_ABORT_UNLESS(Limit >= Quota);
-        Y_ABORT_UNLESS((Step ^ ~Step) + 1 == 0);
+        Y_ABORT_UNLESS(Step != 0 && (Step & (Step - 1)) == 0, "the allocation step must be a power of two"); // it is used as an alignment mask
         MaxMemorySize = Limit;
     }
 

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor.h
@@ -315,9 +315,7 @@ struct TGuaranteeQuotaManager : public IMemoryQuotaManager {
     }
 
     i64 GetMemoryAvailability() const override {
-        // a negative parent value (over target) must not be masked by the locally prepaid leftover
-        const i64 extra = GetExtraMemoryAvailability();
-        return extra < 0 ? extra : AddMemoryAvailability(static_cast<i64>(Limit - Quota), extra);
+        return CombineMemoryAvailability(static_cast<i64>(Limit - Quota), GetExtraMemoryAvailability());
     }
 
     void FreeQuota(ui64 memorySize) override {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -13,6 +13,7 @@
 
 #include <util/generic/ptr.h>
 
+#include <limits>
 #include <memory>
 #include <utility>
 
@@ -41,13 +42,31 @@ struct IMemoryQuotaManager {
     using TPtr = std::shared_ptr<IMemoryQuotaManager>;
     using TWeakPtr = std::weak_ptr<IMemoryQuotaManager>;
     virtual ~IMemoryQuotaManager() = default;
-    virtual bool AllocateQuota(ui64 memorySize) = 0;
+    // isOptional == true: the caller can continue without the memory (e.g. hash table growth that can be
+    // replaced by spilling), the manager MAY refuse in advance even if it has free quota.
+    // isOptional == false: the caller fails without the memory.
+    virtual bool AllocateQuota(ui64 memorySize, bool isOptional) = 0;
     virtual void FreeQuota(ui64 memorySize) = 0;
     virtual ui64 GetCurrentQuota() const = 0;
     virtual ui64 GetMaxMemorySize() const = 0;
-    virtual bool IsReasonableToUseSpilling() const = 0;
+    // > 0: bytes that may still be requested, mandatory or optional;
+    //   0: do not request optional quota, it will most likely be refused;
+    // < 0: total consumption is over target, |value| is the overuse, consumers should give memory back.
+    // The old IsReasonableToUseSpilling() signal is (GetMemoryAvailability() < 0).
+    virtual i64 GetMemoryAvailability() const = 0;
     virtual TString MemoryConsumptionDetails() const = 0;
 };
+
+// Saturating add for availability values: std::numeric_limits<i64>::max() is the "unlimited" sentinel.
+inline i64 AddMemoryAvailability(i64 a, i64 b) {
+    if (b > 0 && a > std::numeric_limits<i64>::max() - b) {
+        return std::numeric_limits<i64>::max();
+    }
+    if (b < 0 && a < std::numeric_limits<i64>::min() - b) {
+        return std::numeric_limits<i64>::min();
+    }
+    return a + b;
+}
 
 // Source/transform.
 // Must be IActor.

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -68,6 +68,12 @@ inline i64 AddMemoryAvailability(i64 a, i64 b) {
     return a + b;
 }
 
+// Availability of a quota manager that keeps a locally prepaid leftover on top of a parent (node level) value:
+// the sum, unless the parent is over target - a negative parent value is never masked by the leftover.
+inline i64 CombineMemoryAvailability(i64 localLeftover, i64 parent) {
+    return parent < 0 ? parent : AddMemoryAvailability(localLeftover, parent);
+}
+
 // Source/transform.
 // Must be IActor.
 //

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -640,6 +640,8 @@ protected:
 
         try {
             if (MemoryQuota) {
+                // everything below dies without an operator quota, maybe under the scope of the current execution
+                MemoryQuota->UnbindOperatorQuota();
                 MemoryQuota->TryReleaseQuota();
             }
 

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -2558,8 +2558,6 @@ public:
             dst->SetMkqlMaxMemoryUsage(memProfileStats->MkqlMaxUsedMemory);
             dst->SetMkqlExtraMemoryBytes(memProfileStats->MkqlExtraMemoryBytes);
             dst->SetMkqlExtraMemoryRequests(memProfileStats->MkqlExtraMemoryRequests);
-            dst->SetMkqlOptionalMemoryRequests(memProfileStats->MkqlOptionalMemoryRequests);
-            dst->SetMkqlOptionalMemoryRefusals(memProfileStats->MkqlOptionalMemoryRefusals);
         }
 
         if (Stat) { // for task_runner_actor

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -394,7 +394,6 @@ protected:
         Y_ASSERT(!Terminated);
 
         auto guard = BindAllocator();
-        auto* alloc = guard.GetMutex();
         // memory hungry operators reach the task memory quota through this thread-local binding
         TDqOperatorMemoryQuotaScope operatorQuotaScope(MemoryQuota ? MemoryQuota->GetOperatorQuota() : nullptr);
 
@@ -407,7 +406,7 @@ protected:
         }
 
         if (MemoryQuota) {
-            MemoryQuota->TryShrinkMemory(alloc);
+            MemoryQuota->TryShrinkMemory();
         }
 
         ReportStats();

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -26,6 +26,7 @@
 #include <ydb/library/yql/dq/actors/dq.h>
 #include <ydb/library/yql/dq/actors/compute/dq_request_context.h>
 #include <ydb/library/yql/dq/runtime/streaming/dq_compute_actor_watermarks.h>
+#include <ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.h>
 
 #include <ydb/library/actors/core/interconnect.h>
 #include <ydb/library/actors/wilson/wilson_span.h>
@@ -394,6 +395,8 @@ protected:
 
         auto guard = BindAllocator();
         auto* alloc = guard.GetMutex();
+        // memory hungry operators reach the task memory quota through this thread-local binding
+        TDqOperatorMemoryQuotaScope operatorQuotaScope(MemoryQuota ? MemoryQuota->GetOperatorQuota() : nullptr);
 
         if (State == NDqProto::COMPUTE_STATE_FINISHED) {
             if (!DoHandleChannelsAfterFinishImpl()) {
@@ -2555,6 +2558,8 @@ public:
             dst->SetMkqlMaxMemoryUsage(memProfileStats->MkqlMaxUsedMemory);
             dst->SetMkqlExtraMemoryBytes(memProfileStats->MkqlExtraMemoryBytes);
             dst->SetMkqlExtraMemoryRequests(memProfileStats->MkqlExtraMemoryRequests);
+            dst->SetMkqlOptionalMemoryRequests(memProfileStats->MkqlOptionalMemoryRequests);
+            dst->SetMkqlOptionalMemoryRefusals(memProfileStats->MkqlOptionalMemoryRefusals);
         }
 
         if (Stat) { // for task_runner_actor

--- a/ydb/library/yql/dq/actors/compute/dq_compute_memory_quota.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_memory_quota.h
@@ -4,6 +4,7 @@
 #include <util/system/mem_info.h>
 #include <ydb/library/services/services.pb.h>
 #include <ydb/library/yql/dq/actors/compute/dq_compute_actor.h>
+#include <ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.h>
 #include <yql/essentials/minikql/mkql_alloc.h>
 #include <yql/essentials/minikql/aligned_page_pool.h>
 
@@ -12,20 +13,27 @@
 #include <util/generic/size_literals.h>
 #include <util/system/types.h>
 
+#include <algorithm>
+#include <limits>
+
 namespace NYql::NDq {
+// ActorSystem is null in standalone unit tests
 #define CAMQ_LOG_T(s) \
-    LOG_TRACE_S(*ActorSystem, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", task: " << TaskId << ". " << s)
+    do { if (ActorSystem) { LOG_TRACE_S(*ActorSystem, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", task: " << TaskId << ". " << s); } } while (0)
 #define CAMQ_LOG_D(s) \
-    LOG_DEBUG_S(*ActorSystem, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", task: " << TaskId << ". " << s)
+    do { if (ActorSystem) { LOG_DEBUG_S(*ActorSystem, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", task: " << TaskId << ". " << s); } } while (0)
 #define CAMQ_LOG_I(s) \
-    LOG_INFO_S(*ActorSystem, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", task: " << TaskId << ". " << s)
+    do { if (ActorSystem) { LOG_INFO_S(*ActorSystem, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", task: " << TaskId << ". " << s); } } while (0)
 #define CAMQ_LOG_W(s) \
-    LOG_WARN_S(*ActorSystem, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", task: " << TaskId << ". " << s)
+    do { if (ActorSystem) { LOG_WARN_S(*ActorSystem, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", task: " << TaskId << ". " << s); } } while (0)
 
     class THardMemoryLimitException : public NKikimr::TMemoryLimitExceededException {
     };
 
-    class TDqMemoryQuota {
+    // Bridge between the MKQL allocator of a task and IMemoryQuotaManager (RFC dq_memory_quota_20, section 2).
+    // Also the operator-facing IDqOperatorMemoryQuota: the owner binds it to the executing thread with
+    // TDqOperatorMemoryQuotaScope around graph execution (see GetOperatorQuota).
+    class TDqMemoryQuota final : public IDqOperatorMemoryQuota {
     public:
         TDqMemoryQuota(::NMonitoring::TDynamicCounters::TCounterPtr& mkqlMemoryQuota, ui64 initialMkqlMemoryLimit, const NYql::NDq::TComputeMemoryLimits& memoryLimits, NYql::NDq::TTxId txId, ui64 taskId, bool profileStats, NActors::TActorSystem* actorSystem)
             : MkqlMemoryQuota(mkqlMemoryQuota)
@@ -38,12 +46,10 @@ namespace NYql::NDq {
             , ActorSystem(actorSystem) {
 
             auto memoryLimit = initialMkqlMemoryLimit;
-            if (!MemoryLimits.MemoryQuotaManager->AllocateQuota(memoryLimit)) {
-                // we don't have API call to discover current limit available in MemoryQuotaManager
-                // but at this point it'll match GetMaxMemorySize(), so we can use it as guranteed limit
-                // and allocation should never fail anymore
+            if (!MemoryLimits.MemoryQuotaManager->AllocateQuota(memoryLimit, /* isOptional = */ false)) {
+                // fall back to the guaranteed part of the quota manager, this allocation should never fail
                 memoryLimit = std::min(InitialMkqlMemoryLimit, MemoryLimits.MemoryQuotaManager->GetMaxMemorySize());
-                if (!MemoryLimits.MemoryQuotaManager->AllocateQuota(memoryLimit)) {
+                if (!MemoryLimits.MemoryQuotaManager->AllocateQuota(memoryLimit, /* isOptional = */ false)) {
                     CAMQ_LOG_W("[Mem] initial memory allocation of " << memoryLimit << " failed, starting with 0");
                     return;
                 }
@@ -59,8 +65,9 @@ namespace NYql::NDq {
         }
 
         void TrySetIncreaseMemoryLimitCallback(NKikimr::NMiniKQL::TScopedAlloc* alloc) {
+            Alloc = alloc;
             alloc->Ref().SetIncreaseMemoryLimitCallback([this, alloc](ui64 limit, ui64 required) {
-                RequestExtraMemory(required - limit, alloc);
+                RequestExtraMemory(required - limit, /* isOptional = */ false, alloc);
             });
         }
 
@@ -70,8 +77,9 @@ namespace NYql::NDq {
             const ui64 limitRSS = std::numeric_limits<ui64>::max();
             const ui64 criticalRSSValue = limitRSS / 100 * 80;
 
+            Alloc = alloc;
             alloc->Ref().SetIncreaseMemoryLimitCallback([this, alloc](ui64 limit, ui64 required) {
-                RequestExtraMemory(required - limit, alloc);
+                RequestExtraMemory(required - limit, /* isOptional = */ false, alloc);
 
                 ui64 currentRSS = NMemInfo::GetMemInfo().RSS;
                 if (currentRSS > criticalRSSValue) {
@@ -80,8 +88,64 @@ namespace NYql::NDq {
             });
         }
 
+        // Raise the MKQL memory limit by `memory` (rounded up to MB / MinMemAllocSize), returns true on success.
+        // Mandatory (isOptional == false): the per-task hard limit throws THardMemoryLimitException; a refusal of the
+        //   quota manager is logged and the limit stays, the allocator then throws TMemoryLimitExceededException itself.
+        // Optional: never throws, false when refused by the hard limit or by the quota manager.
+        bool RequestExtraMemory(ui64 memory, bool isOptional, NKikimr::NMiniKQL::TScopedAlloc* alloc) {
+            memory = std::max(AlignMemorySizeToMbBoundary(memory), MemoryLimits.MinMemAllocSize);
+
+            bool granted = false;
+            if (MemoryLimits.MkqlProgramHardMemoryLimit && MkqlMemoryLimit + memory > MemoryLimits.MkqlProgramHardMemoryLimit) {
+                if (!isOptional) {
+                    throw THardMemoryLimitException();
+                }
+                CAMQ_LOG_D("[Mem] optional memory " << memory << " refused by hard limit " << MemoryLimits.MkqlProgramHardMemoryLimit);
+            } else if (MemoryLimits.MemoryQuotaManager->AllocateQuota(memory, isOptional)) {
+                MkqlMemoryLimit += memory;
+                if (MkqlMemoryQuota) {
+                    MkqlMemoryQuota->Add(memory);
+                }
+                CAMQ_LOG_D("[Mem] " << (isOptional ? "optional " : "") << "memory " << memory << " granted, new limit: " << MkqlMemoryLimit);
+                alloc->SetLimit(MkqlMemoryLimit);
+                granted = true;
+            } else if (isOptional) {
+                CAMQ_LOG_D("[Mem] optional memory " << memory << " NOT granted");
+            } else {
+                CAMQ_LOG_W("[Mem] memory " << memory << " NOT granted");
+            }
+
+            // negative availability is the memory pressure signal of the quota manager (former IsReasonableToUseSpilling)
+            alloc->SetMaximumLimitValueReached(MemoryLimits.MemoryQuotaManager->GetMemoryAvailability() < 0);
+
+            if (Y_UNLIKELY(ProfileStats)) {
+                if (isOptional) {
+                    ProfileStats->MkqlOptionalMemoryRequests++;
+                    if (granted) {
+                        ProfileStats->MkqlExtraMemoryBytes += memory;
+                    } else {
+                        ProfileStats->MkqlOptionalMemoryRefusals++;
+                    }
+                } else {
+                    ProfileStats->MkqlExtraMemoryBytes += memory;
+                    ProfileStats->MkqlExtraMemoryRequests++;
+                }
+            }
+            return granted;
+        }
+
+        // Explicit give-back: release free pages and return the unused part of the limit to the quota manager.
+        // GetUsed() excludes free pages, so MkqlMemoryLimit - used is what can be returned after ReleaseFreePages().
+        // Two triggers: enough cached free pages, or a grown limit with enough unused part - blocks larger than a
+        // page are malloc-backed (sized allocators) and their release never produces free pages. Neither fires while
+        // the limit is still the initial one and the page cache is small: the shrink never goes below the initial
+        // limit, so releasing the pages would only make the next execution take them from the global pool again.
         void TryShrinkMemory(NKikimr::NMiniKQL::TScopedAlloc* alloc) {
-            if (alloc->GetAllocated() - alloc->GetUsed() > MemoryLimits.MinMemFreeSize) {
+            const ui64 used = alloc->GetUsed();
+            const bool cachedPages = alloc->GetAllocated() - used > MemoryLimits.MinMemFreeSize;
+            const bool grownLimit = MkqlMemoryLimit > InitialMkqlMemoryLimit && MkqlMemoryLimit > used
+                && MkqlMemoryLimit - used > MemoryLimits.MinMemFreeSize;
+            if (cachedPages || grownLimit) {
                 alloc->ReleaseFreePages();
                 auto newLimit = std::max(alloc->GetAllocated(), InitialMkqlMemoryLimit);
                 if (MkqlMemoryLimit > newLimit) {
@@ -106,12 +170,39 @@ namespace NYql::NDq {
             }
         }
 
+        // IDqOperatorMemoryQuota: operators call these inside a bound scope, on the thread that runs the graph
+        // under this quota's allocator. Silent no-ops otherwise (operators then fall back to the allocator heuristics).
+        bool RequestExtraMemory(ui64 bytes, bool isOptional) override {
+            if (!IsBoundAllocator()) {
+                return false;
+            }
+            return RequestExtraMemory(bytes, isOptional, Alloc);
+        }
+
+        i64 GetMemoryAvailability() const override {
+            return MemoryLimits.MemoryQuotaManager->GetMemoryAvailability();
+        }
+
+        void TryShrinkMemory() override {
+            if (IsBoundAllocator()) {
+                TryShrinkMemory(Alloc);
+            }
+        }
+
+        // What the owner binds for the operators, nullptr when the operator memory quota is disabled
+        // or the allocator is not attached yet
+        IDqOperatorMemoryQuota* GetOperatorQuota() {
+            return (MemoryLimits.EnableOperatorMemoryQuota && Alloc) ? this : nullptr;
+        }
+
     public:
         struct TProfileStats
         {
             ui64 MkqlMaxUsedMemory = 0;
             ui64 MkqlExtraMemoryBytes = 0;
             ui32 MkqlExtraMemoryRequests = 0;
+            ui32 MkqlOptionalMemoryRequests = 0;
+            ui32 MkqlOptionalMemoryRefusals = 0;
         };
 
         const TProfileStats* GetProfileStats() const {
@@ -137,36 +228,8 @@ namespace NYql::NDq {
         }
 
     private:
-        void RequestExtraMemory(ui64 memory, NKikimr::NMiniKQL::TScopedAlloc* alloc) {
-            memory = std::max(AlignMemorySizeToMbBoundary(memory), MemoryLimits.MinMemAllocSize);
-
-            if (MemoryLimits.MkqlProgramHardMemoryLimit && MkqlMemoryLimit + memory > MemoryLimits.MkqlProgramHardMemoryLimit) {
-                throw THardMemoryLimitException();
-            }
-
-            if (MemoryLimits.MemoryQuotaManager->AllocateQuota(memory)) {
-                MkqlMemoryLimit += memory;
-                if (MkqlMemoryQuota) {
-                    MkqlMemoryQuota->Add(memory);
-                }
-                CAMQ_LOG_D("[Mem] memory " << memory << " granted, new limit: " << MkqlMemoryLimit);
-                alloc->SetLimit(MkqlMemoryLimit);
-            } else {
-                CAMQ_LOG_W("[Mem] memory " << memory << " NOT granted");
-                //            throw yexception() << "Can not allocate extra memory, limit: " << MkqlMemoryLimit
-                //                << ", requested: " << memory << ", host: " << HostName();
-            }
-
-            if (MemoryLimits.MemoryQuotaManager->IsReasonableToUseSpilling()) {
-                alloc->SetMaximumLimitValueReached(true);
-            } else {
-                alloc->SetMaximumLimitValueReached(false);
-            }
-
-            if (Y_UNLIKELY(ProfileStats)) {
-                ProfileStats->MkqlExtraMemoryBytes += memory;
-                ProfileStats->MkqlExtraMemoryRequests++;
-            }
+        bool IsBoundAllocator() const {
+            return Alloc && NKikimr::NMiniKQL::TlsAllocState == &Alloc->Ref();
         }
 
         ui64 AlignMemorySizeToMbBoundary(ui64 memory) {
@@ -184,5 +247,6 @@ namespace NYql::NDq {
         const ui64 TaskId;
         THolder<TProfileStats> ProfileStats;
         NActors::TActorSystem* ActorSystem;
+        NKikimr::NMiniKQL::TScopedAlloc* Alloc = nullptr; // attached by TrySetIncreaseMemoryLimitCallback[WithRSSControl]
     };
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/actors/compute/dq_compute_memory_quota.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_memory_quota.h
@@ -60,7 +60,7 @@ namespace NYql::NDq {
             }
         }
 
-        // The attached allocator holds a callback into this object: detach before dying. Every owner keeps the
+        // The bound allocator holds a callback into this object: detach before dying. Every owner keeps the
         // allocator alive longer than the quota (a shared_ptr declared before it, see the compute actor and the
         // task runner actor), so the allocator is still there to be detached from.
         ~TDqMemoryQuota() {
@@ -73,35 +73,79 @@ namespace NYql::NDq {
             return MkqlMemoryLimit;
         }
 
-        void TrySetIncreaseMemoryLimitCallback(NKikimr::NMiniKQL::TScopedAlloc* alloc) {
+        // The allocator this quota manages: every other call works on it. Bound once by the owner, right after
+        // the allocator is created and before anything runs under it; the quota is inert until then.
+        void BindScopedAlloc(NKikimr::NMiniKQL::TScopedAlloc* alloc) {
+            Y_ABORT_UNLESS(alloc);
+            Y_ABORT_UNLESS(!Alloc || Alloc == alloc, "the memory quota is already bound to another allocator");
             Alloc = alloc;
-            alloc->Ref().SetIncreaseMemoryLimitCallback([this, alloc](ui64 limit, ui64 required) {
-                RequestExtraMemory(required - limit, /* isOptional = */ false, alloc);
+        }
+
+        void TrySetIncreaseMemoryLimitCallback() {
+            Y_ABORT_UNLESS(Alloc, "bind the allocator first");
+            Alloc->Ref().SetIncreaseMemoryLimitCallback([this](ui64 limit, ui64 required) {
+                DoRequestExtraMemory(required - limit, /* isOptional = */ false);
             });
         }
 
         // This callback is created for testing purposes and will be enabled only with spilling.
         // Most likely this callback will be removed after KIKIMR-21481.
-        void TrySetIncreaseMemoryLimitCallbackWithRSSControl(NKikimr::NMiniKQL::TScopedAlloc* alloc) {
+        void TrySetIncreaseMemoryLimitCallbackWithRSSControl() {
+            Y_ABORT_UNLESS(Alloc, "bind the allocator first");
             const ui64 limitRSS = std::numeric_limits<ui64>::max();
             const ui64 criticalRSSValue = limitRSS / 100 * 80;
 
-            Alloc = alloc;
-            alloc->Ref().SetIncreaseMemoryLimitCallback([this, alloc](ui64 limit, ui64 required) {
-                RequestExtraMemory(required - limit, /* isOptional = */ false, alloc);
+            Alloc->Ref().SetIncreaseMemoryLimitCallback([this](ui64 limit, ui64 required) {
+                DoRequestExtraMemory(required - limit, /* isOptional = */ false);
 
                 ui64 currentRSS = NMemInfo::GetMemInfo().RSS;
                 if (currentRSS > criticalRSSValue) {
-                    alloc->SetMaximumLimitValueReached(true);
+                    Alloc->SetMaximumLimitValueReached(true);
                 }
             });
         }
 
-        // Raise the MKQL memory limit by `memory` (rounded up to MB / MinMemAllocSize), returns true on success.
-        // Mandatory (isOptional == false): the per-task hard limit throws THardMemoryLimitException; a refusal of the
-        //   quota manager is logged and the limit stays, the allocator then throws TMemoryLimitExceededException itself.
-        // Optional: never throws, false when refused by the hard limit or by the quota manager.
-        bool RequestExtraMemory(ui64 memory, bool isOptional, NKikimr::NMiniKQL::TScopedAlloc* alloc) {
+        // IDqOperatorMemoryQuota, also the owner's entry points. They work on the bound allocator and only from
+        // the thread that has it bound (the owner under its allocator guard, an operator inside a bound scope);
+        // silent no-ops otherwise, operators then fall back to the allocator heuristics.
+        //
+        // RequestExtraMemory: raise the MKQL memory limit by `bytes` (rounded up to MB / MinMemAllocSize), true on
+        // success. Mandatory (isOptional == false): the per-task hard limit throws THardMemoryLimitException; a
+        // refusal of the quota manager is logged and the limit stays, the allocator then throws
+        // TMemoryLimitExceededException itself. Optional: never throws, false when refused by the hard limit or
+        // by the quota manager.
+        bool RequestExtraMemory(ui64 bytes, bool isOptional) override {
+            if (!IsBoundAllocator()) {
+                return false;
+            }
+            return DoRequestExtraMemory(bytes, isOptional);
+        }
+
+        i64 GetMemoryAvailability() const override {
+            return MemoryLimits.MemoryQuotaManager->GetMemoryAvailability();
+        }
+
+        // Explicit give-back: release free pages and return the unused part of the limit to the quota manager.
+        // GetUsed() excludes free pages, so MkqlMemoryLimit - used is what can be returned after ReleaseFreePages().
+        // Two triggers: enough cached free pages, or a grown limit with enough unused part - blocks larger than a
+        // page are malloc-backed (sized allocators) and their release never produces free pages. Neither fires while
+        // the limit is still the initial one and the page cache is small: the shrink never goes below the initial
+        // limit, so releasing the pages would only make the next execution take them from the global pool again.
+        void TryShrinkMemory() override {
+            if (IsBoundAllocator()) {
+                DoTryShrinkMemory();
+            }
+        }
+
+        // What the owner binds for the operators, nullptr when the operator memory quota is disabled
+        // or the allocator is not bound yet
+        IDqOperatorMemoryQuota* GetOperatorQuota() {
+            return (MemoryLimits.EnableOperatorMemoryQuota && Alloc) ? this : nullptr;
+        }
+
+    private:
+        bool DoRequestExtraMemory(ui64 memory, bool isOptional) {
+            auto* alloc = Alloc;
             memory = std::max(AlignMemorySizeToMbBoundary(memory), MemoryLimits.MinMemAllocSize);
 
             bool granted = false;
@@ -135,13 +179,8 @@ namespace NYql::NDq {
             return granted;
         }
 
-        // Explicit give-back: release free pages and return the unused part of the limit to the quota manager.
-        // GetUsed() excludes free pages, so MkqlMemoryLimit - used is what can be returned after ReleaseFreePages().
-        // Two triggers: enough cached free pages, or a grown limit with enough unused part - blocks larger than a
-        // page are malloc-backed (sized allocators) and their release never produces free pages. Neither fires while
-        // the limit is still the initial one and the page cache is small: the shrink never goes below the initial
-        // limit, so releasing the pages would only make the next execution take them from the global pool again.
-        void TryShrinkMemory(NKikimr::NMiniKQL::TScopedAlloc* alloc) {
+        void DoTryShrinkMemory() {
+            auto* alloc = Alloc;
             const ui64 used = alloc->GetUsed();
             const bool cachedPages = alloc->GetAllocated() - used > MemoryLimits.MinMemFreeSize;
             const bool grownLimit = MkqlMemoryLimit > InitialMkqlMemoryLimit && MkqlMemoryLimit > used
@@ -169,31 +208,6 @@ namespace NYql::NDq {
                     CAMQ_LOG_T("Peak memory usage: " << currentUsedMemory);
                 }
             }
-        }
-
-        // IDqOperatorMemoryQuota: operators call these inside a bound scope, on the thread that runs the graph
-        // under this quota's allocator. Silent no-ops otherwise (operators then fall back to the allocator heuristics).
-        bool RequestExtraMemory(ui64 bytes, bool isOptional) override {
-            if (!IsBoundAllocator()) {
-                return false;
-            }
-            return RequestExtraMemory(bytes, isOptional, Alloc);
-        }
-
-        i64 GetMemoryAvailability() const override {
-            return MemoryLimits.MemoryQuotaManager->GetMemoryAvailability();
-        }
-
-        void TryShrinkMemory() override {
-            if (IsBoundAllocator()) {
-                TryShrinkMemory(Alloc);
-            }
-        }
-
-        // What the owner binds for the operators, nullptr when the operator memory quota is disabled
-        // or the allocator is not attached yet
-        IDqOperatorMemoryQuota* GetOperatorQuota() {
-            return (MemoryLimits.EnableOperatorMemoryQuota && Alloc) ? this : nullptr;
         }
 
     public:
@@ -246,6 +260,6 @@ namespace NYql::NDq {
         const ui64 TaskId;
         THolder<TProfileStats> ProfileStats;
         NActors::TActorSystem* ActorSystem;
-        NKikimr::NMiniKQL::TScopedAlloc* Alloc = nullptr; // attached by TrySetIncreaseMemoryLimitCallback[WithRSSControl]
+        NKikimr::NMiniKQL::TScopedAlloc* Alloc = nullptr; // set by BindScopedAlloc
     };
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/actors/compute/dq_compute_memory_quota.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_memory_quota.h
@@ -60,6 +60,15 @@ namespace NYql::NDq {
             }
         }
 
+        // The attached allocator holds a callback into this object: detach before dying. Every owner keeps the
+        // allocator alive longer than the quota (a shared_ptr declared before it, see the compute actor and the
+        // task runner actor), so the allocator is still there to be detached from.
+        ~TDqMemoryQuota() {
+            if (Alloc) {
+                Alloc->Ref().SetIncreaseMemoryLimitCallback({});
+            }
+        }
+
         ui64 GetMkqlMemoryLimit() const {
             return MkqlMemoryLimit;
         }

--- a/ydb/library/yql/dq/actors/compute/dq_compute_memory_quota.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_memory_quota.h
@@ -119,17 +119,9 @@ namespace NYql::NDq {
             alloc->SetMaximumLimitValueReached(MemoryLimits.MemoryQuotaManager->GetMemoryAvailability() < 0);
 
             if (Y_UNLIKELY(ProfileStats)) {
-                if (isOptional) {
-                    ProfileStats->MkqlOptionalMemoryRequests++;
-                    if (granted) {
-                        ProfileStats->MkqlExtraMemoryBytes += memory;
-                    } else {
-                        ProfileStats->MkqlOptionalMemoryRefusals++;
-                    }
-                } else {
-                    ProfileStats->MkqlExtraMemoryBytes += memory;
-                    ProfileStats->MkqlExtraMemoryRequests++;
-                }
+                // every request counts, mandatory or optional, granted or not
+                ProfileStats->MkqlExtraMemoryBytes += memory;
+                ProfileStats->MkqlExtraMemoryRequests++;
             }
             return granted;
         }
@@ -201,8 +193,6 @@ namespace NYql::NDq {
             ui64 MkqlMaxUsedMemory = 0;
             ui64 MkqlExtraMemoryBytes = 0;
             ui32 MkqlExtraMemoryRequests = 0;
-            ui32 MkqlOptionalMemoryRequests = 0;
-            ui32 MkqlOptionalMemoryRefusals = 0;
         };
 
         const TProfileStats* GetProfileStats() const {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_memory_quota.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_memory_quota.h
@@ -60,13 +60,22 @@ namespace NYql::NDq {
             }
         }
 
-        // The bound allocator holds a callback into this object: detach before dying. Every owner keeps the
-        // allocator alive longer than the quota (a shared_ptr declared before it, see the compute actor and the
-        // task runner actor), so the allocator is still there to be detached from.
+        // The bound allocator holds a callback into this object and the executing thread may hold the operator
+        // binding: detach from both before dying. Every owner keeps the allocator alive longer than the quota
+        // (a shared_ptr declared before it, see the compute actor and the task runner actor), so the allocator
+        // is still there to be detached from.
         ~TDqMemoryQuota() {
+            UnbindOperatorQuota();
             if (Alloc) {
                 Alloc->Ref().SetIncreaseMemoryLimitCallback({});
             }
+        }
+
+        // Take the operator binding of the executing thread away before the graph is torn down, so that the
+        // operators see no quota while they die (see IDqOperatorMemoryQuota): the owner may terminate from
+        // inside an execution, i.e. under the scope it bound for that execution.
+        void UnbindOperatorQuota() {
+            UnbindDqOperatorMemoryQuota(this);
         }
 
         ui64 GetMkqlMemoryLimit() const {

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -376,7 +376,8 @@ protected:
         auto* alloc = guard.GetMutex();
         alloc->SetLimit(this->MemoryQuota->GetMkqlMemoryLimit());
 
-        this->MemoryQuota->TrySetIncreaseMemoryLimitCallback(alloc);
+        this->MemoryQuota->BindScopedAlloc(alloc);
+        this->MemoryQuota->TrySetIncreaseMemoryLimitCallback();
 
         TDqTaskRunnerMemoryLimits limits;
         limits.ChannelBufferSize = this->MemoryLimits.ChannelBufferSize;

--- a/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
@@ -196,11 +196,11 @@ Y_UNIT_TEST_SUITE(TDqMemoryQuotaTest) {
         UNIT_ASSERT(!env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ false, &env.Alloc));
         UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 50_MB);
 
+        // every request counts, granted or not: two optional and one mandatory, 10 MB each
         const auto* stats = env.Quota.GetProfileStats();
         UNIT_ASSERT(stats);
-        UNIT_ASSERT_VALUES_EQUAL(stats->MkqlOptionalMemoryRequests, 2);
-        UNIT_ASSERT_VALUES_EQUAL(stats->MkqlOptionalMemoryRefusals, 1);
-        UNIT_ASSERT_VALUES_EQUAL(stats->MkqlExtraMemoryRequests, 1);
+        UNIT_ASSERT_VALUES_EQUAL(stats->MkqlExtraMemoryRequests, 3);
+        UNIT_ASSERT_VALUES_EQUAL(stats->MkqlExtraMemoryBytes, 30_MB);
     }
 
     Y_UNIT_TEST(HardLimit) {

--- a/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
@@ -337,6 +337,29 @@ Y_UNIT_TEST_SUITE(TDqMemoryQuotaTest) {
         UNIT_ASSERT_VALUES_EQUAL(env.Manager->Freed, 0);
     }
 
+    // The quota detaches from the allocator when it dies: the allocator must not call a dead quota to raise its
+    // limit, exceeding the limit throws instead
+    Y_UNIT_TEST(DestructorDetachesFromAllocator) {
+        TScopedAlloc alloc(__LOCATION__, NKikimr::TAlignedPagePoolCounters(), /* supportsSizedAllocators = */ true);
+        auto manager = std::make_shared<TStubQuotaManager>();
+        ::NMonitoring::TDynamicCounters::TCounterPtr counter;
+        {
+            TDqMemoryQuota quota(counter, 40_MB, MakeLimits(manager), TTxId{ui64(1)}, 1, /* profileStats = */ false, /* actorSystem = */ nullptr);
+            alloc.SetLimit(quota.GetMkqlMemoryLimit());
+            quota.TrySetIncreaseMemoryLimitCallback(&alloc);
+            // attached: a block beyond the limit grows it through the quota
+            void* block = MKQLAllocWithSize(64_MB, EMemorySubPool::Default);
+            UNIT_ASSERT(block);
+            MKQLFreeWithSize(block, 64_MB, EMemorySubPool::Default);
+            UNIT_ASSERT_GE(quota.GetMkqlMemoryLimit(), 64_MB);
+            quota.TryShrinkMemory(&alloc);
+            UNIT_ASSERT_VALUES_EQUAL(quota.GetMkqlMemoryLimit(), 40_MB);
+        }
+        // detached: the same block hits the allocator limit and nothing raises it
+        UNIT_ASSERT_VALUES_EQUAL(alloc.GetLimit(), 40_MB);
+        UNIT_ASSERT_EXCEPTION(MKQLAllocWithSize(64_MB, EMemorySubPool::Default), NKikimr::TMemoryLimitExceededException);
+    }
+
     Y_UNIT_TEST(GuaranteeManagerNegativeParentDominates) {
         struct TParentedManager : public TGuaranteeQuotaManager {
             TParentedManager()

--- a/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
@@ -411,7 +411,7 @@ Y_UNIT_TEST_SUITE(TDqMemoryQuotaTest) {
             quota.Destroy(); // the destructor does it on its own
             UNIT_ASSERT(GetDqOperatorMemoryQuota() == nullptr);
         }
-        UNIT_ASSERT(GetDqOperatorMemoryQuota() == nullptr); // the scope restored what was bound before it
+        UNIT_ASSERT(GetDqOperatorMemoryQuota() == nullptr); // the scope cleared the binding on exit
     }
 
     Y_UNIT_TEST(GuaranteeManagerNegativeParentDominates) {

--- a/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
@@ -382,6 +382,38 @@ Y_UNIT_TEST_SUITE(TDqMemoryQuotaTest) {
         UNIT_ASSERT_VALUES_EQUAL(CombineMemoryAvailability(100, std::numeric_limits<i64>::max()), std::numeric_limits<i64>::max());
     }
 
+    // The owner may tear the quota down while the execution scope is still bound (termination from inside the
+    // execution): the binding must never outlive the quota, and another quota's teardown must leave it alone
+    Y_UNIT_TEST(TeardownUnbindsOperatorQuota) {
+        TScopedAlloc alloc(__LOCATION__, NKikimr::TAlignedPagePoolCounters(), /* supportsSizedAllocators = */ true);
+        auto manager = std::make_shared<TStubQuotaManager>();
+        ::NMonitoring::TDynamicCounters::TCounterPtr counter;
+        auto makeQuota = [&](ui64 taskId) {
+            auto quota = MakeHolder<TDqMemoryQuota>(counter, 40_MB, MakeLimits(manager), TTxId{ui64(1)}, taskId, /* profileStats = */ false, /* actorSystem = */ nullptr);
+            quota->BindScopedAlloc(&alloc);
+            return quota;
+        };
+        auto quota = makeQuota(1);
+        auto other = makeQuota(2);
+        UNIT_ASSERT(GetDqOperatorMemoryQuota() == nullptr);
+        {
+            TDqOperatorMemoryQuotaScope scope(quota->GetOperatorQuota());
+            UNIT_ASSERT(GetDqOperatorMemoryQuota() == quota.Get());
+            other->UnbindOperatorQuota(); // not the bound one
+            UNIT_ASSERT(GetDqOperatorMemoryQuota() == quota.Get());
+            quota->UnbindOperatorQuota(); // explicit, before the graph is torn down
+            UNIT_ASSERT(GetDqOperatorMemoryQuota() == nullptr);
+        }
+        UNIT_ASSERT(GetDqOperatorMemoryQuota() == nullptr);
+        {
+            TDqOperatorMemoryQuotaScope scope(quota->GetOperatorQuota());
+            UNIT_ASSERT(GetDqOperatorMemoryQuota() == quota.Get());
+            quota.Destroy(); // the destructor does it on its own
+            UNIT_ASSERT(GetDqOperatorMemoryQuota() == nullptr);
+        }
+        UNIT_ASSERT(GetDqOperatorMemoryQuota() == nullptr); // the scope restored what was bound before it
+    }
+
     Y_UNIT_TEST(GuaranteeManagerNegativeParentDominates) {
         struct TParentedManager : public TGuaranteeQuotaManager {
             TParentedManager()

--- a/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
@@ -1,0 +1,382 @@
+#include <ydb/library/yql/dq/actors/compute/dq_compute_actor.h>
+#include <ydb/library/yql/dq/actors/compute/dq_compute_memory_quota.h>
+#include <ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.h>
+
+#include <yql/essentials/minikql/mkql_alloc.h>
+
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/ptr.h>
+#include <util/generic/size_literals.h>
+
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace NYql::NDq {
+
+namespace {
+
+using namespace NKikimr::NMiniKQL;
+
+// Scripted IMemoryQuotaManager: counts requests, refuses on demand, reports a scripted availability
+struct TStubQuotaManager : public IMemoryQuotaManager {
+    struct TRequest {
+        ui64 Size;
+        bool Optional;
+    };
+
+    bool AllocateQuota(ui64 memorySize, bool isOptional) override {
+        Requests.push_back({memorySize, isOptional});
+        if (RefuseNext > 0) {
+            RefuseNext--;
+            return false;
+        }
+        if (RefuseAll || (isOptional && RefuseOptional)) {
+            return false;
+        }
+        Quota += memorySize;
+        return true;
+    }
+
+    void FreeQuota(ui64 memorySize) override {
+        Freed += memorySize;
+        Quota -= memorySize;
+    }
+
+    ui64 GetCurrentQuota() const override {
+        return Quota;
+    }
+
+    ui64 GetMaxMemorySize() const override {
+        return MaxMemorySize;
+    }
+
+    i64 GetMemoryAvailability() const override {
+        return Availability;
+    }
+
+    TString MemoryConsumptionDetails() const override {
+        return TString();
+    }
+
+    ui64 Quota = 0;
+    ui64 Freed = 0;
+    bool RefuseAll = false;
+    bool RefuseOptional = false;
+    ui32 RefuseNext = 0; // refuse this many requests, whatever they are, then behave as scripted
+    ui64 MaxMemorySize = 1_GB;
+    i64 Availability = 1_GB;
+    std::vector<TRequest> Requests;
+};
+
+TComputeMemoryLimits MakeLimits(IMemoryQuotaManager::TPtr manager, ui64 hardLimit = 0, bool enableOperatorQuota = true) {
+    TComputeMemoryLimits limits;
+    limits.MkqlLightProgramMemoryLimit = 40_MB;
+    limits.MkqlHeavyProgramMemoryLimit = 60_MB;
+    limits.MkqlProgramHardMemoryLimit = hardLimit;
+    limits.MinMemAllocSize = 1_MB;
+    limits.MinMemFreeSize = 32_MB;
+    limits.MemoryQuotaManager = std::move(manager);
+    limits.EnableOperatorMemoryQuota = enableOperatorQuota;
+    return limits;
+}
+
+// the compute actor allocator: sized allocators on, so blocks larger than a page are malloc-backed
+struct TQuotaEnv {
+    TQuotaEnv(ui64 hardLimit = 0, bool enableOperatorQuota = true)
+        : Alloc(__LOCATION__, NKikimr::TAlignedPagePoolCounters(), /* supportsSizedAllocators = */ true) // acquired by this thread
+        , Manager(std::make_shared<TStubQuotaManager>())
+        , Quota(Counter, 40_MB, MakeLimits(Manager, hardLimit, enableOperatorQuota), TTxId{ui64(1)}, 1, /* profileStats = */ true, /* actorSystem = */ nullptr)
+    {
+        Alloc.SetLimit(Quota.GetMkqlMemoryLimit());
+    }
+
+    void Bind() {
+        Quota.TrySetIncreaseMemoryLimitCallback(&Alloc);
+    }
+
+    TScopedAlloc Alloc;
+    std::shared_ptr<TStubQuotaManager> Manager;
+    ::NMonitoring::TDynamicCounters::TCounterPtr Counter;
+    TDqMemoryQuota Quota;
+};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TDqMemoryQuotaTest) {
+
+    Y_UNIT_TEST(InitialLimit) {
+        TQuotaEnv env;
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB);
+        UNIT_ASSERT_VALUES_EQUAL(env.Manager->Quota, 40_MB);
+        UNIT_ASSERT_VALUES_EQUAL(env.Manager->Requests.size(), 1);
+        UNIT_ASSERT(!env.Manager->Requests[0].Optional);
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMemoryAvailability(), 1_GB); // forwarded from the manager
+    }
+
+    // The initial allocation is mandatory; when the manager refuses it, the quota falls back to the manager's
+    // GetMaxMemorySize() (the guaranteed part of a fresh TGuaranteeQuotaManager), capped by the initial limit,
+    // and starts with 0 when that is refused too. The MkqlMemoryQuota counter follows the granted limit.
+    Y_UNIT_TEST(InitialLimitFallsBackToMaxMemorySize) {
+        struct TObserved {
+            ui64 Limit;
+            ui64 QuotaAfterConstruction;
+            i64 CounterAfterConstruction;
+            i64 CounterAfterRelease;
+            std::shared_ptr<TStubQuotaManager> Manager;
+        };
+        auto construct = [](ui64 maxMemorySize, bool refuseAll) {
+            auto manager = std::make_shared<TStubQuotaManager>();
+            manager->MaxMemorySize = maxMemorySize;
+            manager->RefuseNext = 1; // the initial request is refused once
+            manager->RefuseAll = refuseAll;
+            auto counters = MakeIntrusive<::NMonitoring::TDynamicCounters>();
+            auto counter = counters->GetCounter("MkqlMemoryQuota");
+            TDqMemoryQuota quota(counter, 40_MB, MakeLimits(manager), TTxId{ui64(1)}, 1, /* profileStats = */ false, /* actorSystem = */ nullptr);
+            TObserved observed{quota.GetMkqlMemoryLimit(), manager->Quota, counter->Val(), 0, manager};
+            quota.TryReleaseQuota(); // gives the granted limit back to the manager and takes it off the counter
+            observed.CounterAfterRelease = counter->Val();
+            return observed;
+        };
+        {
+            const auto o = construct(10_MB, /* refuseAll = */ false); // the fallback is below the initial limit
+            UNIT_ASSERT_VALUES_EQUAL(o.Limit, 10_MB);
+            UNIT_ASSERT_VALUES_EQUAL(o.Manager->Requests.size(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(o.Manager->Requests[0].Size, 40_MB);
+            UNIT_ASSERT(!o.Manager->Requests[0].Optional);
+            UNIT_ASSERT_VALUES_EQUAL(o.Manager->Requests[1].Size, 10_MB);
+            UNIT_ASSERT(!o.Manager->Requests[1].Optional);
+            UNIT_ASSERT_VALUES_EQUAL(o.QuotaAfterConstruction, 10_MB);
+            UNIT_ASSERT_VALUES_EQUAL(o.CounterAfterConstruction, 10_MB);
+            UNIT_ASSERT_VALUES_EQUAL(o.CounterAfterRelease, 0);
+            UNIT_ASSERT_VALUES_EQUAL(o.Manager->Freed, 10_MB);
+            UNIT_ASSERT_VALUES_EQUAL(o.Manager->Quota, 0);
+        }
+        {
+            const auto o = construct(1_GB, /* refuseAll = */ false); // capped by the initial limit
+            UNIT_ASSERT_VALUES_EQUAL(o.Limit, 40_MB);
+            UNIT_ASSERT_VALUES_EQUAL(o.Manager->Requests.size(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(o.Manager->Requests[1].Size, 40_MB);
+            UNIT_ASSERT_VALUES_EQUAL(o.QuotaAfterConstruction, 40_MB);
+            UNIT_ASSERT_VALUES_EQUAL(o.CounterAfterConstruction, 40_MB);
+            UNIT_ASSERT_VALUES_EQUAL(o.CounterAfterRelease, 0);
+            UNIT_ASSERT_VALUES_EQUAL(o.Manager->Freed, 40_MB);
+        }
+        {
+            const auto o = construct(10_MB, /* refuseAll = */ true); // the fallback is refused too: start with 0
+            UNIT_ASSERT_VALUES_EQUAL(o.Limit, 0);
+            UNIT_ASSERT_VALUES_EQUAL(o.Manager->Requests.size(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(o.Manager->Requests[1].Size, 10_MB);
+            UNIT_ASSERT_VALUES_EQUAL(o.QuotaAfterConstruction, 0);
+            UNIT_ASSERT_VALUES_EQUAL(o.CounterAfterConstruction, 0);
+            UNIT_ASSERT_VALUES_EQUAL(o.CounterAfterRelease, 0);
+            UNIT_ASSERT_VALUES_EQUAL(o.Manager->Freed, 0);
+        }
+    }
+
+    Y_UNIT_TEST(OptionalGrantedAndRefused) {
+        TQuotaEnv env;
+        env.Bind();
+
+        UNIT_ASSERT(env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ true, &env.Alloc));
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 50_MB);
+        UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetLimit(), 50_MB);
+        UNIT_ASSERT(env.Manager->Requests.back().Optional);
+
+        env.Manager->RefuseOptional = true;
+        UNIT_ASSERT(!env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ true, &env.Alloc)); // no throw
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 50_MB);
+        UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetLimit(), 50_MB);
+
+        // a mandatory refusal does not throw here either: the allocator throws when the limit is not raised
+        env.Manager->RefuseAll = true;
+        UNIT_ASSERT(!env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ false, &env.Alloc));
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 50_MB);
+
+        const auto* stats = env.Quota.GetProfileStats();
+        UNIT_ASSERT(stats);
+        UNIT_ASSERT_VALUES_EQUAL(stats->MkqlOptionalMemoryRequests, 2);
+        UNIT_ASSERT_VALUES_EQUAL(stats->MkqlOptionalMemoryRefusals, 1);
+        UNIT_ASSERT_VALUES_EQUAL(stats->MkqlExtraMemoryRequests, 1);
+    }
+
+    Y_UNIT_TEST(HardLimit) {
+        TQuotaEnv env(/* hardLimit = */ 45_MB);
+        env.Bind();
+        UNIT_ASSERT(!env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ true, &env.Alloc)); // refused, no throw
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB);
+        UNIT_ASSERT_EXCEPTION(env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ false, &env.Alloc), THardMemoryLimitException);
+        UNIT_ASSERT(env.Quota.RequestExtraMemory(4_MB, /* isOptional = */ true, &env.Alloc)); // still fits
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 44_MB);
+    }
+
+    Y_UNIT_TEST(MaximumLimitFlagFollowsAvailability) {
+        TQuotaEnv env;
+        env.Bind();
+        env.Manager->Availability = -1;
+        UNIT_ASSERT(env.Quota.RequestExtraMemory(1_MB, /* isOptional = */ true, &env.Alloc));
+        UNIT_ASSERT(env.Alloc.Ref().GetMaximumLimitValueReached()); // the old IsReasonableToUseSpilling signal
+        env.Manager->Availability = 1;
+        UNIT_ASSERT(env.Quota.RequestExtraMemory(1_MB, /* isOptional = */ true, &env.Alloc));
+        UNIT_ASSERT(!env.Alloc.Ref().GetMaximumLimitValueReached());
+        env.Manager->Availability = 0; // zero is not pressure, just "do not ask for optional quota"
+        UNIT_ASSERT(env.Quota.RequestExtraMemory(1_MB, /* isOptional = */ false, &env.Alloc));
+        UNIT_ASSERT(!env.Alloc.Ref().GetMaximumLimitValueReached());
+    }
+
+    Y_UNIT_TEST(OperatorQuotaBinding) {
+        TQuotaEnv env;
+        UNIT_ASSERT(env.Quota.GetOperatorQuota() == nullptr); // no allocator attached yet
+        env.Bind();
+        IDqOperatorMemoryQuota* operatorQuota = env.Quota.GetOperatorQuota();
+        UNIT_ASSERT(operatorQuota == &env.Quota);
+
+        // the operator-facing methods work on the attached allocator (TScopedAlloc binds itself to the thread)
+        UNIT_ASSERT(operatorQuota->RequestExtraMemory(10_MB, /* isOptional = */ true));
+        UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetLimit(), 50_MB);
+        UNIT_ASSERT_VALUES_EQUAL(operatorQuota->GetMemoryAvailability(), 1_GB);
+        operatorQuota->TryShrinkMemory(); // the granted memory is unused: it goes back, down to the initial limit
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB);
+        UNIT_ASSERT_VALUES_EQUAL(env.Manager->Freed, 10_MB);
+        UNIT_ASSERT(operatorQuota->RequestExtraMemory(10_MB, /* isOptional = */ true));
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 50_MB);
+
+        // and are no-ops when another allocator is bound to the thread
+        {
+            TScopedAlloc other(__LOCATION__);
+            UNIT_ASSERT(!operatorQuota->RequestExtraMemory(10_MB, /* isOptional = */ true));
+            operatorQuota->TryShrinkMemory();
+            UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 50_MB);
+        }
+    }
+
+    Y_UNIT_TEST(OperatorQuotaDisabled) {
+        TQuotaEnv env(/* hardLimit = */ 0, /* enableOperatorQuota = */ false);
+        env.Bind();
+        UNIT_ASSERT(env.Quota.GetOperatorQuota() == nullptr);
+    }
+
+    Y_UNIT_TEST(ShrinkReturnsMallocBackedBlocks) {
+        TQuotaEnv env;
+        env.Bind();
+
+        // a block larger than a page is malloc-backed: its release produces no free pages, only a lower
+        // TotalAllocated, so the shrink gate must look at the unused part of the limit
+        const size_t blockSize = 64_MB;
+        void* block = MKQLAllocWithSize(blockSize, EMemorySubPool::Default);
+        UNIT_ASSERT(block);
+        // grown through the mandatory callback, which asks for the missing part of the block only
+        const ui64 grownLimit = env.Quota.GetMkqlMemoryLimit();
+        UNIT_ASSERT_GE(grownLimit, blockSize);
+        UNIT_ASSERT_VALUES_EQUAL(env.Manager->Freed, 0);
+
+        MKQLFreeWithSize(block, blockSize, EMemorySubPool::Default);
+        UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetAllocated() - env.Alloc.GetUsed(), 0); // no free pages appeared
+
+        env.Quota.TryShrinkMemory(&env.Alloc);
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB); // back to the initial limit
+        UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetLimit(), 40_MB);
+        UNIT_ASSERT_VALUES_EQUAL(env.Manager->Freed, grownLimit - 40_MB);
+    }
+
+    // Page-backed blocks (at most a page each): every one takes its own 64 KB page and freeing it leaves the page
+    // cached in the allocator, so GetAllocated() - GetUsed() is the cache size
+    std::vector<void*> AllocatePageBlocks(size_t count) {
+        std::vector<void*> blocks;
+        blocks.reserve(count);
+        for (size_t i = 0; i < count; ++i) {
+            blocks.push_back(MKQLAllocWithSize(60_KB, EMemorySubPool::Default));
+        }
+        return blocks;
+    }
+
+    void FreePageBlocks(const std::vector<void*>& blocks) {
+        for (void* block : blocks) {
+            MKQLFreeWithSize(block, 60_KB, EMemorySubPool::Default);
+        }
+    }
+
+    // The limit is still the initial one and the page cache is small: nothing could be given back (the shrink
+    // never goes below the initial limit), so the cached pages must stay with the task instead of being pushed
+    // to the global pool on every execution
+    Y_UNIT_TEST(ShrinkKeepsSmallPageCacheUnderInitialLimit) {
+        TQuotaEnv env;
+        env.Bind();
+
+        FreePageBlocks(AllocatePageBlocks(16));
+        const ui64 cached = env.Alloc.GetAllocated() - env.Alloc.GetUsed();
+        UNIT_ASSERT_GE(cached, 15 * 64_KB);
+        UNIT_ASSERT_LT(cached, 32_MB);
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB); // never grew
+        const ui64 allocatedBefore = env.Alloc.GetAllocated();
+
+        env.Quota.TryShrinkMemory(&env.Alloc);
+        UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetAllocated(), allocatedBefore); // the cache is kept
+        UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetAllocated() - env.Alloc.GetUsed(), cached);
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB);
+        UNIT_ASSERT_VALUES_EQUAL(env.Manager->Freed, 0);
+    }
+
+    // A page cache above MinMemFreeSize is released even under the initial limit (the classic trigger),
+    // the limit itself stays at the initial value
+    Y_UNIT_TEST(ShrinkReleasesLargePageCacheUnderInitialLimit) {
+        TQuotaEnv env;
+        env.Bind();
+
+        FreePageBlocks(AllocatePageBlocks(560)); // 35 MB of pages, within the 40 MB initial limit
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB);
+        UNIT_ASSERT_GT(env.Alloc.GetAllocated() - env.Alloc.GetUsed(), 32_MB);
+
+        env.Quota.TryShrinkMemory(&env.Alloc);
+        UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetAllocated() - env.Alloc.GetUsed(), 0); // the cache went to the global pool
+        UNIT_ASSERT_LT(env.Alloc.GetAllocated(), 1_MB);
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB); // never below the initial limit
+        UNIT_ASSERT_VALUES_EQUAL(env.Manager->Freed, 0);
+    }
+
+    Y_UNIT_TEST(GuaranteeManagerNegativeParentDominates) {
+        struct TParentedManager : public TGuaranteeQuotaManager {
+            TParentedManager()
+                : TGuaranteeQuotaManager(30_MB, 30_MB)
+            {
+            }
+
+            bool AllocateExtraQuota(ui64 size) override {
+                ExtraRequests++;
+                return ExtraGranted && (Extra -= size, true);
+            }
+
+            i64 GetExtraMemoryAvailability() const override {
+                return Extra;
+            }
+
+            i64 Extra = -1;
+            bool ExtraGranted = true;
+            size_t ExtraRequests = 0;
+        };
+
+        TParentedManager manager;
+        UNIT_ASSERT(manager.AllocateQuota(1_MB, /* isOptional = */ false)); // fits in the guarantee
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetMemoryAvailability(), -1); // the local leftover does not mask node pressure
+
+        manager.Extra = 5_MB;
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetMemoryAvailability(), i64(29_MB + 5_MB));
+
+        // an optional request beyond the limit is refused in advance when the parent cannot cover the delta
+        manager.Extra = 0;
+        UNIT_ASSERT(!manager.AllocateQuota(40_MB, /* isOptional = */ true));
+        UNIT_ASSERT_VALUES_EQUAL(manager.ExtraRequests, 0);
+        // a mandatory one still asks the parent
+        manager.Extra = 100_MB;
+        UNIT_ASSERT(manager.AllocateQuota(40_MB, /* isOptional = */ false));
+        UNIT_ASSERT_VALUES_EQUAL(manager.ExtraRequests, 1);
+        // unlimited parents saturate instead of overflowing
+        manager.Extra = std::numeric_limits<i64>::max();
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetMemoryAvailability(), std::numeric_limits<i64>::max());
+    }
+}
+
+} // namespace NYql::NDq

--- a/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
@@ -373,6 +373,15 @@ Y_UNIT_TEST_SUITE(TDqMemoryQuotaTest) {
         UNIT_ASSERT_EXCEPTION(MKQLAllocWithSize(64_MB, EMemorySubPool::Default), NKikimr::TMemoryLimitExceededException);
     }
 
+    // The rule shared by the quota managers: the local leftover adds to the parent value, a negative parent wins
+    Y_UNIT_TEST(CombineMemoryAvailability) {
+        UNIT_ASSERT_VALUES_EQUAL(CombineMemoryAvailability(100, 5), 105);
+        UNIT_ASSERT_VALUES_EQUAL(CombineMemoryAvailability(100, 0), 100);
+        UNIT_ASSERT_VALUES_EQUAL(CombineMemoryAvailability(100, -5), -5);
+        UNIT_ASSERT_VALUES_EQUAL(CombineMemoryAvailability(0, -5), -5);
+        UNIT_ASSERT_VALUES_EQUAL(CombineMemoryAvailability(100, std::numeric_limits<i64>::max()), std::numeric_limits<i64>::max());
+    }
+
     Y_UNIT_TEST(GuaranteeManagerNegativeParentDominates) {
         struct TParentedManager : public TGuaranteeQuotaManager {
             TParentedManager()

--- a/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_compute_memory_quota_ut.cpp
@@ -95,7 +95,8 @@ struct TQuotaEnv {
     }
 
     void Bind() {
-        Quota.TrySetIncreaseMemoryLimitCallback(&Alloc);
+        Quota.BindScopedAlloc(&Alloc);
+        Quota.TrySetIncreaseMemoryLimitCallback();
     }
 
     TScopedAlloc Alloc;
@@ -177,23 +178,34 @@ Y_UNIT_TEST_SUITE(TDqMemoryQuotaTest) {
         }
     }
 
+    // Without a bound allocator the quota is inert: nothing to grow or shrink, nothing for the operators
+    Y_UNIT_TEST(UnboundQuotaIsInert) {
+        TQuotaEnv env;
+        UNIT_ASSERT(!env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ true));
+        UNIT_ASSERT(!env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ false));
+        env.Quota.TryShrinkMemory();
+        UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB);
+        UNIT_ASSERT_VALUES_EQUAL(env.Manager->Requests.size(), 1); // the initial allocation only
+        UNIT_ASSERT(env.Quota.GetOperatorQuota() == nullptr);
+    }
+
     Y_UNIT_TEST(OptionalGrantedAndRefused) {
         TQuotaEnv env;
         env.Bind();
 
-        UNIT_ASSERT(env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ true, &env.Alloc));
+        UNIT_ASSERT(env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ true));
         UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 50_MB);
         UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetLimit(), 50_MB);
         UNIT_ASSERT(env.Manager->Requests.back().Optional);
 
         env.Manager->RefuseOptional = true;
-        UNIT_ASSERT(!env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ true, &env.Alloc)); // no throw
+        UNIT_ASSERT(!env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ true)); // no throw
         UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 50_MB);
         UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetLimit(), 50_MB);
 
         // a mandatory refusal does not throw here either: the allocator throws when the limit is not raised
         env.Manager->RefuseAll = true;
-        UNIT_ASSERT(!env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ false, &env.Alloc));
+        UNIT_ASSERT(!env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ false));
         UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 50_MB);
 
         // every request counts, granted or not: two optional and one mandatory, 10 MB each
@@ -206,10 +218,10 @@ Y_UNIT_TEST_SUITE(TDqMemoryQuotaTest) {
     Y_UNIT_TEST(HardLimit) {
         TQuotaEnv env(/* hardLimit = */ 45_MB);
         env.Bind();
-        UNIT_ASSERT(!env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ true, &env.Alloc)); // refused, no throw
+        UNIT_ASSERT(!env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ true)); // refused, no throw
         UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB);
-        UNIT_ASSERT_EXCEPTION(env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ false, &env.Alloc), THardMemoryLimitException);
-        UNIT_ASSERT(env.Quota.RequestExtraMemory(4_MB, /* isOptional = */ true, &env.Alloc)); // still fits
+        UNIT_ASSERT_EXCEPTION(env.Quota.RequestExtraMemory(10_MB, /* isOptional = */ false), THardMemoryLimitException);
+        UNIT_ASSERT(env.Quota.RequestExtraMemory(4_MB, /* isOptional = */ true)); // still fits
         UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 44_MB);
     }
 
@@ -217,19 +229,19 @@ Y_UNIT_TEST_SUITE(TDqMemoryQuotaTest) {
         TQuotaEnv env;
         env.Bind();
         env.Manager->Availability = -1;
-        UNIT_ASSERT(env.Quota.RequestExtraMemory(1_MB, /* isOptional = */ true, &env.Alloc));
+        UNIT_ASSERT(env.Quota.RequestExtraMemory(1_MB, /* isOptional = */ true));
         UNIT_ASSERT(env.Alloc.Ref().GetMaximumLimitValueReached()); // the old IsReasonableToUseSpilling signal
         env.Manager->Availability = 1;
-        UNIT_ASSERT(env.Quota.RequestExtraMemory(1_MB, /* isOptional = */ true, &env.Alloc));
+        UNIT_ASSERT(env.Quota.RequestExtraMemory(1_MB, /* isOptional = */ true));
         UNIT_ASSERT(!env.Alloc.Ref().GetMaximumLimitValueReached());
         env.Manager->Availability = 0; // zero is not pressure, just "do not ask for optional quota"
-        UNIT_ASSERT(env.Quota.RequestExtraMemory(1_MB, /* isOptional = */ false, &env.Alloc));
+        UNIT_ASSERT(env.Quota.RequestExtraMemory(1_MB, /* isOptional = */ false));
         UNIT_ASSERT(!env.Alloc.Ref().GetMaximumLimitValueReached());
     }
 
     Y_UNIT_TEST(OperatorQuotaBinding) {
         TQuotaEnv env;
-        UNIT_ASSERT(env.Quota.GetOperatorQuota() == nullptr); // no allocator attached yet
+        UNIT_ASSERT(env.Quota.GetOperatorQuota() == nullptr); // no allocator bound yet
         env.Bind();
         IDqOperatorMemoryQuota* operatorQuota = env.Quota.GetOperatorQuota();
         UNIT_ASSERT(operatorQuota == &env.Quota);
@@ -276,7 +288,7 @@ Y_UNIT_TEST_SUITE(TDqMemoryQuotaTest) {
         MKQLFreeWithSize(block, blockSize, EMemorySubPool::Default);
         UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetAllocated() - env.Alloc.GetUsed(), 0); // no free pages appeared
 
-        env.Quota.TryShrinkMemory(&env.Alloc);
+        env.Quota.TryShrinkMemory();
         UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB); // back to the initial limit
         UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetLimit(), 40_MB);
         UNIT_ASSERT_VALUES_EQUAL(env.Manager->Freed, grownLimit - 40_MB);
@@ -313,7 +325,7 @@ Y_UNIT_TEST_SUITE(TDqMemoryQuotaTest) {
         UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB); // never grew
         const ui64 allocatedBefore = env.Alloc.GetAllocated();
 
-        env.Quota.TryShrinkMemory(&env.Alloc);
+        env.Quota.TryShrinkMemory();
         UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetAllocated(), allocatedBefore); // the cache is kept
         UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetAllocated() - env.Alloc.GetUsed(), cached);
         UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB);
@@ -330,7 +342,7 @@ Y_UNIT_TEST_SUITE(TDqMemoryQuotaTest) {
         UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB);
         UNIT_ASSERT_GT(env.Alloc.GetAllocated() - env.Alloc.GetUsed(), 32_MB);
 
-        env.Quota.TryShrinkMemory(&env.Alloc);
+        env.Quota.TryShrinkMemory();
         UNIT_ASSERT_VALUES_EQUAL(env.Alloc.GetAllocated() - env.Alloc.GetUsed(), 0); // the cache went to the global pool
         UNIT_ASSERT_LT(env.Alloc.GetAllocated(), 1_MB);
         UNIT_ASSERT_VALUES_EQUAL(env.Quota.GetMkqlMemoryLimit(), 40_MB); // never below the initial limit
@@ -346,13 +358,14 @@ Y_UNIT_TEST_SUITE(TDqMemoryQuotaTest) {
         {
             TDqMemoryQuota quota(counter, 40_MB, MakeLimits(manager), TTxId{ui64(1)}, 1, /* profileStats = */ false, /* actorSystem = */ nullptr);
             alloc.SetLimit(quota.GetMkqlMemoryLimit());
-            quota.TrySetIncreaseMemoryLimitCallback(&alloc);
+            quota.BindScopedAlloc(&alloc);
+            quota.TrySetIncreaseMemoryLimitCallback();
             // attached: a block beyond the limit grows it through the quota
             void* block = MKQLAllocWithSize(64_MB, EMemorySubPool::Default);
             UNIT_ASSERT(block);
             MKQLFreeWithSize(block, 64_MB, EMemorySubPool::Default);
             UNIT_ASSERT_GE(quota.GetMkqlMemoryLimit(), 64_MB);
-            quota.TryShrinkMemory(&alloc);
+            quota.TryShrinkMemory();
             UNIT_ASSERT_VALUES_EQUAL(quota.GetMkqlMemoryLimit(), 40_MB);
         }
         // detached: the same block hits the allocator limit and nothing raises it

--- a/ydb/library/yql/dq/actors/compute/ut/ya.make
+++ b/ydb/library/yql/dq/actors/compute/ut/ya.make
@@ -12,6 +12,7 @@ ENDIF()
 SRCS(
     dq_compute_actor_async_input_helper_ut.cpp
     dq_compute_actor_channels_ut.cpp
+    dq_compute_memory_quota_ut.cpp
     dq_compute_issues_buffer_ut.cpp
     mock_lookup_factory.cpp
 )
@@ -27,6 +28,7 @@ PEERDIR(
     ydb/library/yql/dq/actors/compute/ut/proto
     ydb/library/yql/dq/actors/input_transforms
     ydb/library/yql/dq/actors/task_runner
+    ydb/library/yql/dq/comp_nodes
     ydb/library/yql/dq/runtime/streaming
     ydb/library/yql/dq/tasks
     ydb/library/yql/dq/transform

--- a/ydb/library/yql/dq/actors/compute/ut/ya.make
+++ b/ydb/library/yql/dq/actors/compute/ut/ya.make
@@ -28,7 +28,6 @@ PEERDIR(
     ydb/library/yql/dq/actors/compute/ut/proto
     ydb/library/yql/dq/actors/input_transforms
     ydb/library/yql/dq/actors/task_runner
-    ydb/library/yql/dq/comp_nodes
     ydb/library/yql/dq/runtime/streaming
     ydb/library/yql/dq/tasks
     ydb/library/yql/dq/transform

--- a/ydb/library/yql/dq/actors/compute/ya.make
+++ b/ydb/library/yql/dq/actors/compute/ya.make
@@ -24,6 +24,7 @@ PEERDIR(
     ydb/library/yql/dq/actors/compute/events
     ydb/library/yql/dq/actors/spilling
     ydb/library/yql/dq/common
+    ydb/library/yql/dq/comp_nodes/operator_memory_quota
     ydb/library/yql/dq/proto
     ydb/library/yql/dq/runtime
     ydb/library/yql/dq/runtime/streaming

--- a/ydb/library/yql/dq/actors/protos/dq_stats.proto
+++ b/ydb/library/yql/dq/actors/protos/dq_stats.proto
@@ -318,6 +318,8 @@ message TDqComputeActorStats {
     uint64 MkqlMaxMemoryUsage = 102;       // MKQL allocations stats
     uint64 MkqlExtraMemoryBytes = 103;
     uint32 MkqlExtraMemoryRequests = 104;
+    uint32 MkqlOptionalMemoryRequests = 105;
+    uint32 MkqlOptionalMemoryRefusals = 106;
 
     google.protobuf.Any Extra = 200;
 }

--- a/ydb/library/yql/dq/actors/protos/dq_stats.proto
+++ b/ydb/library/yql/dq/actors/protos/dq_stats.proto
@@ -318,8 +318,6 @@ message TDqComputeActorStats {
     uint64 MkqlMaxMemoryUsage = 102;       // MKQL allocations stats
     uint64 MkqlExtraMemoryBytes = 103;
     uint32 MkqlExtraMemoryRequests = 104;
-    uint32 MkqlOptionalMemoryRequests = 105;
-    uint32 MkqlOptionalMemoryRefusals = 106;
 
     google.protobuf.Any Extra = 200;
 }

--- a/ydb/library/yql/dq/actors/task_runner/task_runner_actor_local.cpp
+++ b/ydb/library/yql/dq/actors/task_runner/task_runner_actor_local.cpp
@@ -217,7 +217,7 @@ private:
         }
 
         if (MemoryQuota) {
-            MemoryQuota->TryShrinkMemory(guard.GetMutex());
+            MemoryQuota->TryShrinkMemory();
         }
 
         {
@@ -465,10 +465,11 @@ private:
 
         auto guard = TaskRunner->BindAllocator(MemoryQuota ? TMaybe<ui64>(MemoryQuota->GetMkqlMemoryLimit()) : Nothing());
         if (MemoryQuota) {
+            MemoryQuota->BindScopedAlloc(guard.GetMutex());
             if (settings.GetEnableSpilling()) {
-                MemoryQuota->TrySetIncreaseMemoryLimitCallbackWithRSSControl(guard.GetMutex());
+                MemoryQuota->TrySetIncreaseMemoryLimitCallbackWithRSSControl();
             } else {
-                MemoryQuota->TrySetIncreaseMemoryLimitCallback(guard.GetMutex());
+                MemoryQuota->TrySetIncreaseMemoryLimitCallback();
             }
         }
 

--- a/ydb/library/yql/dq/actors/task_runner/task_runner_actor_local.cpp
+++ b/ydb/library/yql/dq/actors/task_runner/task_runner_actor_local.cpp
@@ -11,6 +11,8 @@
 
 #include <ydb/library/yql/dq/actors/compute/dq_compute_memory_quota.h>
 
+#include <ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.h>
+
 #include <ydb/library/yql/dq/actors/task_runner/task_runner_actor.h>
 
 #include <ydb/library/yql/dq/runtime/dq_tasks_runner.h>
@@ -165,6 +167,8 @@ private:
 
     void OnContinueRun(TEvContinueRun::TPtr& ev) {
         auto guard = TaskRunner->BindAllocator(MemoryQuota ? MemoryQuota->GetMkqlMemoryLimit() : ev->Get()->MemLimit);
+        // memory hungry operators reach the task memory quota through this thread-local binding
+        TDqOperatorMemoryQuotaScope operatorQuotaScope(MemoryQuota ? MemoryQuota->GetOperatorQuota() : nullptr);
         const auto& inputMap = ev->Get()->AskFreeSpace
             ? Inputs
             : ev->Get()->InputChannels;
@@ -540,8 +544,8 @@ private:
     TVector<ui32> Sources;
     TVector<ui32> Sinks;
     TVector<ui32> Outputs;
+    THolder<TDqMemoryQuota> MemoryQuota; // declared before TaskRunner: the graph must die before its quota
     TIntrusivePtr<NDq::IDqTaskRunner> TaskRunner;
-    THolder<TDqMemoryQuota> MemoryQuota;
     ui64 ActorElapsedTicks = 0;
     bool HasActiveCheckpoint = false;
     ui32 UnsentCheckpoints = 0;

--- a/ydb/library/yql/dq/actors/task_runner/task_runner_actor_local.cpp
+++ b/ydb/library/yql/dq/actors/task_runner/task_runner_actor_local.cpp
@@ -127,6 +127,7 @@ private:
 
     void PassAway() override {
         if (MemoryQuota) {
+            MemoryQuota->UnbindOperatorQuota(); // the graph dies without a quota, maybe under the execution scope
             MemoryQuota->TryReleaseQuota();
         }
         TaskRunner.Reset();

--- a/ydb/library/yql/dq/actors/task_runner/ya.make
+++ b/ydb/library/yql/dq/actors/task_runner/ya.make
@@ -7,6 +7,7 @@ SRCS(
 
 PEERDIR(
     ydb/library/actors/core
+    ydb/library/yql/dq/comp_nodes/operator_memory_quota
     ydb/library/yql/dq/runtime
     ydb/library/yql/dq/common
     ydb/library/yql/dq/proto

--- a/ydb/library/yql/dq/common/dq_resource_quoter.h
+++ b/ydb/library/yql/dq/common/dq_resource_quoter.h
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <ydb/library/yql/dq/common/dq_common.h>
+
 #include <util/generic/hash.h>
 #include <util/system/mutex.h>
 #include <util/system/types.h>
+
+#include <atomic>
+#include <functional>
 
 namespace NYql::NDq {
 
@@ -25,22 +30,25 @@ public:
         return Limit;
     }
 
+    // The totals are lock-free snapshots: read by every task of the node on its memory hot path
+    // (see TMemoryQuotaManager::GetExtraMemoryAvailability in the local worker manager). They may lag a
+    // concurrent Allocate / Free by one step, the decision itself is always taken under the lock.
     ui64 GetAllocatedTotal() const {
-        TGuard<TMutex> lock(Mutex);
-        return Allocated;
+        return Allocated.load(std::memory_order_relaxed);
     }
 
     ui64 GetFreeTotal() const {
-        TGuard<TMutex> lock(Mutex);
-        return Limit > Allocated ? Limit - Allocated : 0;
+        const ui64 allocated = Allocated.load(std::memory_order_relaxed);
+        return Limit > allocated ? Limit - allocated : 0;
     }
 
     bool Allocate(const NDq::TTxId& txId, ui64 taskId, ui64 size) {
         TGuard<TMutex> lock(Mutex);
-        if (Limit && Allocated + size > Limit) {
+        const ui64 allocated = Allocated.load(std::memory_order_relaxed);
+        if (Limit && allocated + size > Limit) {
             return false;
         }
-        Allocated += size;
+        Allocated.store(allocated + size, std::memory_order_relaxed);
 
         auto& txMap = ResourceMap[txId];
         auto itt = txMap.find(taskId);
@@ -80,7 +88,7 @@ public:
             }
         }
 
-        Y_ABORT_UNLESS(Allocated >= size);
+        Y_ABORT_UNLESS(GetAllocatedTotal() >= size);
 
         itt->second.Size -= size;
         if (itt->second.Size == 0) {
@@ -90,7 +98,7 @@ public:
             }
         }
 
-        Allocated -= size;
+        Allocated.fetch_sub(size, std::memory_order_relaxed);
         Notify();
     }
 
@@ -112,8 +120,8 @@ public:
         if (itx != ResourceMap.end()) {
             auto itt = itx->second.find(taskId);
             if (itt != itx->second.end()) {
-                Y_ABORT_UNLESS(Allocated >= itt->second.Size);
-                Allocated -= itt->second.Size;
+                Y_ABORT_UNLESS(GetAllocatedTotal() >= itt->second.Size);
+                Allocated.fetch_sub(itt->second.Size, std::memory_order_relaxed);
                 itx->second.erase(itt);
                 if (itx->second.size() == 0) {
                     ResourceMap.erase(itx);
@@ -132,14 +140,14 @@ public:
 private:
     ui64 Limit;
     bool Strict;
-    ui64 Allocated = 0;
+    std::atomic<ui64> Allocated = 0; // written under Mutex only, read lock-free by the totals
     TMutex Mutex;
     THashMap<NDq::TTxId, THashMap<ui64, TTransactionTaskInfo>> ResourceMap;
     TNotifyCallback Cb;
 
     void Notify() const {
         if (Cb) {
-            Cb(Limit, Allocated);
+            Cb(Limit, GetAllocatedTotal());
         }
     }
 };

--- a/ydb/library/yql/dq/common/dq_resource_quoter.h
+++ b/ydb/library/yql/dq/common/dq_resource_quoter.h
@@ -8,6 +8,7 @@
 
 #include <atomic>
 #include <functional>
+#include <limits>
 
 namespace NYql::NDq {
 
@@ -40,6 +41,15 @@ public:
     ui64 GetFreeTotal() const {
         const ui64 allocated = Allocated.load(std::memory_order_relaxed);
         return Limit > allocated ? Limit - allocated : 0;
+    }
+
+    // Bytes that may still be allocated, in the signed convention of the memory quota managers: i64 max for a
+    // quoter without a limit (Limit == 0, which Allocate() never refuses), otherwise Limit - allocated.
+    i64 GetMemoryAvailability() const {
+        if (!Limit) {
+            return std::numeric_limits<i64>::max();
+        }
+        return static_cast<i64>(Limit) - static_cast<i64>(GetAllocatedTotal());
     }
 
     bool Allocate(const NDq::TTxId& txId, ui64 taskId, ui64 size) {

--- a/ydb/library/yql/dq/common/ut/dq_resource_quoter_ut.cpp
+++ b/ydb/library/yql/dq/common/ut/dq_resource_quoter_ut.cpp
@@ -3,6 +3,7 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <atomic>
+#include <limits>
 #include <thread>
 #include <vector>
 
@@ -23,6 +24,7 @@ Y_UNIT_TEST_SUITE(TDqResourceQuoterTest) {
 
         UNIT_ASSERT(!quoter.Allocate(TTxId{ui64(1)}, 1, 701)); // over the limit, nothing changes
         UNIT_ASSERT_VALUES_EQUAL(quoter.GetFreeTotal(), 700);
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetMemoryAvailability(), 700);
         UNIT_ASSERT(quoter.Allocate(TTxId{ui64(2)}, 7, 700));
         UNIT_ASSERT_VALUES_EQUAL(quoter.GetFreeTotal(), 0);
 
@@ -33,12 +35,13 @@ Y_UNIT_TEST_SUITE(TDqResourceQuoterTest) {
         UNIT_ASSERT_VALUES_EQUAL(quoter.GetFreeTotal(), 1000);
     }
 
-    // Limit == 0 never refuses; the free total reads as 0 then and the callers treat that limit as unlimited
+    // Limit == 0 never refuses and reports an unlimited availability (the raw free total reads as 0 then)
     Y_UNIT_TEST(UnlimitedQuoter) {
         TResourceQuoter quoter(0);
         UNIT_ASSERT(quoter.Allocate(TTxId{ui64(1)}, 1, ui64(1) << 40));
         UNIT_ASSERT_VALUES_EQUAL(quoter.GetAllocatedTotal(), ui64(1) << 40);
         UNIT_ASSERT_VALUES_EQUAL(quoter.GetFreeTotal(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetMemoryAvailability(), std::numeric_limits<i64>::max());
     }
 
     // The totals are read without the lock: concurrent allocations and releases must never make them

--- a/ydb/library/yql/dq/common/ut/dq_resource_quoter_ut.cpp
+++ b/ydb/library/yql/dq/common/ut/dq_resource_quoter_ut.cpp
@@ -1,0 +1,77 @@
+#include <ydb/library/yql/dq/common/dq_resource_quoter.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+namespace NYql::NDq {
+
+Y_UNIT_TEST_SUITE(TDqResourceQuoterTest) {
+
+    Y_UNIT_TEST(Totals) {
+        TResourceQuoter quoter(1000);
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetLimit(), 1000);
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetAllocatedTotal(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetFreeTotal(), 1000);
+
+        UNIT_ASSERT(quoter.Allocate(TTxId{ui64(1)}, 1, 300));
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetAllocatedTotal(), 300);
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetFreeTotal(), 700);
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetAllocated(TTxId{ui64(1)}, 1), 300);
+
+        UNIT_ASSERT(!quoter.Allocate(TTxId{ui64(1)}, 1, 701)); // over the limit, nothing changes
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetFreeTotal(), 700);
+        UNIT_ASSERT(quoter.Allocate(TTxId{ui64(2)}, 7, 700));
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetFreeTotal(), 0);
+
+        quoter.Free(TTxId{ui64(1)}, 1, 300);
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetFreeTotal(), 300);
+        quoter.Free(TTxId{ui64(2)}, 7); // the whole task
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetAllocatedTotal(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetFreeTotal(), 1000);
+    }
+
+    // Limit == 0 never refuses; the free total reads as 0 then and the callers treat that limit as unlimited
+    Y_UNIT_TEST(UnlimitedQuoter) {
+        TResourceQuoter quoter(0);
+        UNIT_ASSERT(quoter.Allocate(TTxId{ui64(1)}, 1, ui64(1) << 40));
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetAllocatedTotal(), ui64(1) << 40);
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetFreeTotal(), 0);
+    }
+
+    // The totals are read without the lock: concurrent allocations and releases must never make them
+    // exceed the limit and must leave them exact at the end
+    Y_UNIT_TEST(ConcurrentTotals) {
+        constexpr ui64 limit = 1000;
+        constexpr size_t threadCount = 8;
+        constexpr size_t iterations = 20000;
+        TResourceQuoter quoter(limit);
+        std::atomic<bool> inconsistent{false};
+
+        std::vector<std::thread> threads;
+        for (size_t i = 0; i < threadCount; ++i) {
+            threads.emplace_back([&, txId = ui64(i + 1)] {
+                for (size_t j = 0; j < iterations; ++j) {
+                    const ui64 size = 1 + j % 7;
+                    if (quoter.Allocate(TTxId{txId}, 0, size)) {
+                        if (quoter.GetAllocatedTotal() > limit || quoter.GetFreeTotal() > limit) {
+                            inconsistent = true;
+                        }
+                        quoter.Free(TTxId{txId}, 0, size);
+                    }
+                }
+            });
+        }
+        for (auto& thread : threads) {
+            thread.join();
+        }
+
+        UNIT_ASSERT(!inconsistent);
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetAllocatedTotal(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(quoter.GetFreeTotal(), limit);
+    }
+}
+
+} // namespace NYql::NDq

--- a/ydb/library/yql/dq/common/ut/ya.make
+++ b/ydb/library/yql/dq/common/ut/ya.make
@@ -1,0 +1,11 @@
+UNITTEST_FOR(ydb/library/yql/dq/common)
+
+SRCS(
+    dq_resource_quoter_ut.cpp
+)
+
+PEERDIR(
+    library/cpp/testing/unittest
+)
+
+END()

--- a/ydb/library/yql/dq/common/ya.make
+++ b/ydb/library/yql/dq/common/ya.make
@@ -20,3 +20,7 @@ SRCS(
 GENERATE_ENUM_SERIALIZATION(dq_common.h)
 
 END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.cpp
+++ b/ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.cpp
@@ -1,0 +1,27 @@
+#include "dq_operator_memory_quota.h"
+
+#include <util/system/tls.h>
+
+namespace NYql::NDq {
+
+namespace {
+
+Y_POD_STATIC_THREAD(IDqOperatorMemoryQuota*) TlsOperatorMemoryQuota;
+
+} // namespace
+
+IDqOperatorMemoryQuota* GetDqOperatorMemoryQuota() {
+    return TlsOperatorMemoryQuota;
+}
+
+TDqOperatorMemoryQuotaScope::TDqOperatorMemoryQuotaScope(IDqOperatorMemoryQuota* quota)
+    : Previous(TlsOperatorMemoryQuota)
+{
+    TlsOperatorMemoryQuota = quota;
+}
+
+TDqOperatorMemoryQuotaScope::~TDqOperatorMemoryQuotaScope() {
+    TlsOperatorMemoryQuota = Previous;
+}
+
+} // namespace NYql::NDq

--- a/ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.cpp
+++ b/ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.cpp
@@ -14,6 +14,12 @@ IDqOperatorMemoryQuota* GetDqOperatorMemoryQuota() {
     return TlsOperatorMemoryQuota;
 }
 
+void UnbindDqOperatorMemoryQuota(const IDqOperatorMemoryQuota* quota) {
+    if (TlsOperatorMemoryQuota == quota) {
+        TlsOperatorMemoryQuota = nullptr;
+    }
+}
+
 TDqOperatorMemoryQuotaScope::TDqOperatorMemoryQuotaScope(IDqOperatorMemoryQuota* quota)
     : Previous(TlsOperatorMemoryQuota)
 {

--- a/ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.cpp
+++ b/ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.cpp
@@ -1,6 +1,7 @@
 #include "dq_operator_memory_quota.h"
 
 #include <util/system/tls.h>
+#include <util/system/yassert.h>
 
 namespace NYql::NDq {
 
@@ -20,14 +21,16 @@ void UnbindDqOperatorMemoryQuota(const IDqOperatorMemoryQuota* quota) {
     }
 }
 
-TDqOperatorMemoryQuotaScope::TDqOperatorMemoryQuotaScope(IDqOperatorMemoryQuota* quota)
-    : Previous(TlsOperatorMemoryQuota)
-{
+TDqOperatorMemoryQuotaScope::TDqOperatorMemoryQuotaScope(IDqOperatorMemoryQuota* quota) {
+    // One scope per execution, opened by the owner of the computation graph. A nested scope would have to
+    // restore the outer binding on exit, and UnbindDqOperatorMemoryQuota cannot reach a saved value: a quota
+    // torn down inside the inner scope would come back as a dangling pointer.
+    Y_ABORT_UNLESS(!TlsOperatorMemoryQuota, "operator memory quota scopes must not nest");
     TlsOperatorMemoryQuota = quota;
 }
 
 TDqOperatorMemoryQuotaScope::~TDqOperatorMemoryQuotaScope() {
-    TlsOperatorMemoryQuota = Previous;
+    TlsOperatorMemoryQuota = nullptr;
 }
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.h
+++ b/ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <util/system/types.h>
+
+namespace NYql::NDq {
+
+// Operator-facing view of the compute actor memory quota (RFC dq_memory_quota_20, section 3).
+// Implemented by TDqMemoryQuota (ydb/library/yql/dq/actors/compute/dq_compute_memory_quota.h).
+// Not thread safe: only the thread that runs the computation graph (the one that bound it) may use it.
+class IDqOperatorMemoryQuota {
+public:
+    virtual ~IDqOperatorMemoryQuota() = default;
+
+    // Raise the MKQL allocator limit by at least `bytes` (the owner rounds up to its allocation step).
+    // isOptional == true : never throws; the quota manager may refuse in advance even if free quota exists,
+    //                      the caller must be able to continue without the memory (spill, drain, shrink).
+    // isOptional == false: same semantics as the implicit allocator callback.
+    // Returns true when the limit was raised.
+    virtual bool RequestExtraMemory(ui64 bytes, bool isOptional) = 0;
+
+    // > 0: bytes that may still be requested; 0: do not request optional memory;
+    // < 0: over target, please give |value| bytes back (free memory, then call TryShrinkMemory()).
+    virtual i64 GetMemoryAvailability() const = 0;
+
+    // Release free allocator pages and return the unused part of the limit to the quota manager.
+    virtual void TryShrinkMemory() = 0;
+};
+
+// Quota bound to the current thread by the owner of the computation graph (compute actor or task runner
+// actor) for the duration of graph execution. nullptr when unbound: literal executer, unit tests, YQL DQ
+// workers, graph construction and teardown. Operators must then fall back to the allocator heuristics
+// (TlsAllocState->IsMemoryYellowZoneEnabled() / GetMaximumLimitValueReached()).
+IDqOperatorMemoryQuota* GetDqOperatorMemoryQuota();
+
+// RAII binding, nestable: the destructor restores the previously bound quota. `quota` may be nullptr.
+class TDqOperatorMemoryQuotaScope {
+public:
+    explicit TDqOperatorMemoryQuotaScope(IDqOperatorMemoryQuota* quota);
+    ~TDqOperatorMemoryQuotaScope();
+
+    TDqOperatorMemoryQuotaScope(const TDqOperatorMemoryQuotaScope&) = delete;
+    TDqOperatorMemoryQuotaScope& operator=(const TDqOperatorMemoryQuotaScope&) = delete;
+
+private:
+    IDqOperatorMemoryQuota* const Previous;
+};
+
+} // namespace NYql::NDq

--- a/ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.h
+++ b/ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.h
@@ -32,6 +32,11 @@ public:
 // (TlsAllocState->IsMemoryYellowZoneEnabled() / GetMaximumLimitValueReached()).
 IDqOperatorMemoryQuota* GetDqOperatorMemoryQuota();
 
+// For the owner tearing a quota down while a scope is still active (termination from inside an execution):
+// clears the binding if it points at `quota`, a no-op otherwise. The active scope restores its own previous
+// value on exit as usual, so do not nest scopes of a quota that may die inside the inner scope.
+void UnbindDqOperatorMemoryQuota(const IDqOperatorMemoryQuota* quota);
+
 // RAII binding, nestable: the destructor restores the previously bound quota. `quota` may be nullptr.
 class TDqOperatorMemoryQuotaScope {
 public:

--- a/ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.h
+++ b/ydb/library/yql/dq/comp_nodes/operator_memory_quota/dq_operator_memory_quota.h
@@ -33,11 +33,14 @@ public:
 IDqOperatorMemoryQuota* GetDqOperatorMemoryQuota();
 
 // For the owner tearing a quota down while a scope is still active (termination from inside an execution):
-// clears the binding if it points at `quota`, a no-op otherwise. The active scope restores its own previous
-// value on exit as usual, so do not nest scopes of a quota that may die inside the inner scope.
+// clears the binding if it points at `quota`, a no-op otherwise. The scope clears the binding on exit in any
+// case, so an unbind under an active scope needs nothing else.
 void UnbindDqOperatorMemoryQuota(const IDqOperatorMemoryQuota* quota);
 
-// RAII binding, nestable: the destructor restores the previously bound quota. `quota` may be nullptr.
+// RAII binding for one graph execution, opened by the owner at the top of it. NOT nestable: the destructor
+// clears the binding instead of restoring an outer one, and the constructor aborts on a nested scope - a
+// restored binding could point at a quota that UnbindDqOperatorMemoryQuota tore down inside the inner scope.
+// `quota` may be nullptr.
 class TDqOperatorMemoryQuotaScope {
 public:
     explicit TDqOperatorMemoryQuotaScope(IDqOperatorMemoryQuota* quota);
@@ -45,9 +48,6 @@ public:
 
     TDqOperatorMemoryQuotaScope(const TDqOperatorMemoryQuotaScope&) = delete;
     TDqOperatorMemoryQuotaScope& operator=(const TDqOperatorMemoryQuotaScope&) = delete;
-
-private:
-    IDqOperatorMemoryQuota* const Previous;
 };
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/comp_nodes/operator_memory_quota/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/operator_memory_quota/ya.make
@@ -1,0 +1,7 @@
+LIBRARY()
+
+SRCS(
+    dq_operator_memory_quota.cpp
+)
+
+END()

--- a/ydb/library/yql/dq/comp_nodes/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/ya.make
@@ -13,6 +13,7 @@ RECURSE(
     llvm16
     no_llvm
     hash_join_utils
+    operator_memory_quota
 )
 
 RECURSE_FOR_TESTS(

--- a/ydb/library/yql/dq/runtime/dq_channel_service.cpp
+++ b/ydb/library/yql/dq/runtime/dq_channel_service.cpp
@@ -182,7 +182,7 @@ void TLocalBuffer::PushDataChunk(TDataChunk&& data) {
             fillLevel = Storage->IsFull() ? EDqFillLevel::HardLimit : EDqFillLevel::SoftLimit;
         } else {
             // allocate quota before the chunk is counted as inflight to keep InflightBytes always allocated
-            if (QuotaManager && !QuotaManager->AllocateQuota(data.Bytes)) {
+            if (QuotaManager && !QuotaManager->AllocateQuota(data.Bytes, /* isOptional = */ false)) {
                 AbortChannelByMemoryLimit(data.Bytes);
                 return;
             }
@@ -192,7 +192,7 @@ void TLocalBuffer::PushDataChunk(TDataChunk&& data) {
             fillLevel = InflightBytes.load() >= maxInflightBytes ? EDqFillLevel::SoftLimit : EDqFillLevel::NoLimit;
         }
     } else {
-        if (QuotaManager && !QuotaManager->AllocateQuota(data.Bytes)) {
+        if (QuotaManager && !QuotaManager->AllocateQuota(data.Bytes, /* isOptional = */ false)) {
             AbortChannelByMemoryLimit(data.Bytes);
             return;
         }
@@ -280,7 +280,7 @@ bool TLocalBuffer::Pop(TDataChunk& data) {
             auto bytes = SpilledChunkBytes.front();
             // quota for a spilled chunk is allocated as soon as it is counted as inflight (and released on pop),
             // no matter whether it is loaded right here or via LoadingQueue
-            if (QuotaManager && !QuotaManager->AllocateQuota(bytes)) {
+            if (QuotaManager && !QuotaManager->AllocateQuota(bytes, /* isOptional = */ false)) {
                 AbortChannelByMemoryLimit(bytes);
                 break;
             }
@@ -862,7 +862,7 @@ bool TInputDescriptor::PushDataChunk(TDataChunk&& data) {
 
     RefreshMemoryPressure();
 
-    if (QuotaManager && !QuotaManager->AllocateQuota(data.Bytes)) {
+    if (QuotaManager && !QuotaManager->AllocateQuota(data.Bytes, /* isOptional = */ false)) {
         AbortChannelByMemoryLimit(data.Bytes);
         return false;
     }
@@ -1985,7 +1985,7 @@ std::shared_ptr<TInputDescriptor> TNodeState::GetOrCreateInputDescriptor(const T
             if (result->QuotaManager) {
                 result->QuotaManager->FreeQuota(result->QueueBytes);
             }
-            if (quotaManager && !quotaManager->AllocateQuota(result->QueueBytes)) {
+            if (quotaManager && !quotaManager->AllocateQuota(result->QueueBytes, /* isOptional = */ false)) {
                 result->AbortChannelByMemoryLimit(result->QueueBytes);
                 quotaManager = nullptr;
             }

--- a/ydb/library/yql/dq/runtime/dq_channel_service.h
+++ b/ydb/library/yql/dq/runtime/dq_channel_service.h
@@ -133,7 +133,7 @@ inline NActors::TActorId MakeChannelServiceActorID(ui32 nodeId) {
 }
 
 struct TDqChannelLimits {
-    // Node level memory back pressure: report IMemoryQuotaManager::IsReasonableToUseSpilling of the
+    // Node level memory back pressure: report a negative IMemoryQuotaManager::GetMemoryAvailability of the
     // receiver side to the sender and keep the channel at the cold inflight window while it is set.
     // Off by default, the cold window is then used only until the 1st peer pop, as before.
     bool EnableSpillingChannelBackpressure = false;

--- a/ydb/library/yql/dq/runtime/dq_channel_service_impl.h
+++ b/ydb/library/yql/dq/runtime/dq_channel_service_impl.h
@@ -10,6 +10,8 @@
 
 #include <ydb/library/actors/core/interconnect.h>
 
+#include <atomic>
+
 // Flow control design principles
 //
 // 1. There are several ui64 counters which grow monotonically
@@ -244,7 +246,7 @@ public:
     // quota manager, no TEvChannelUpdateV2 round trip as for TOutputDescriptor. Must be called
     // under Mutex, together with the Max/Min getters below, to keep the window consistent
     void RefreshMemoryPressure() {
-        MemoryPressure.store(EnableSpillingBackpressure && QuotaManager && QuotaManager->IsReasonableToUseSpilling());
+        MemoryPressure.store(EnableSpillingBackpressure && QuotaManager && QuotaManager->GetMemoryAvailability() < 0);
     }
 
     ui64 GetMaxInflightBytes() const {
@@ -327,7 +329,7 @@ public:
 
     // must be called only if IsQuotaAssigned() is true
     bool AllocateQuota(ui64 bytes) {
-        return QuotaManager->AllocateQuota(bytes);
+        return QuotaManager->AllocateQuota(bytes, /* isOptional = */ false);
     }
 
     // must be called only for the bytes allocated by AllocateQuota
@@ -527,7 +529,7 @@ public:
 
     // Must be called under QueueMutex - QuotaManager is (re)assigned under the same mutex
     void RefreshMemoryPressure() {
-        MemoryPressure.store(EnableSpillingBackpressure && QuotaManager && QuotaManager->IsReasonableToUseSpilling());
+        MemoryPressure.store(EnableSpillingBackpressure && QuotaManager && QuotaManager->GetMemoryAvailability() < 0);
     }
 
     bool IsFinished();

--- a/ydb/library/yql/dq/runtime/dq_input_channel.cpp
+++ b/ydb/library/yql/dq/runtime/dq_input_channel.cpp
@@ -156,7 +156,7 @@ public:
         if (Y_UNLIKELY(data.Proto.GetChunks() == 0)) {
             return;
         }
-        if (QuotaManager && !QuotaManager->AllocateQuota(data.Size())) {
+        if (QuotaManager && !QuotaManager->AllocateQuota(data.Size(), /* isOptional = */ false)) {
             throw NKikimr::TMemoryLimitExceededException();
         }
         StoredSerializedBytes += data.Size();

--- a/ydb/library/yql/dq/runtime/dq_input_impl.h
+++ b/ydb/library/yql/dq/runtime/dq_input_impl.h
@@ -166,7 +166,7 @@ public:
         Y_ABORT_UNLESS(batch.Width() == GetWidth());
 
         ui64 rows = GetRowsCount(batch);
-        if (QuotaManager && !QuotaManager->AllocateQuota(space)) {
+        if (QuotaManager && !QuotaManager->AllocateQuota(space, /* isOptional = */ false)) {
             throw NKikimr::TMemoryLimitExceededException();
         }
         StoredBytes += space;

--- a/ydb/library/yql/dq/runtime/dq_output_channel.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_channel.cpp
@@ -105,7 +105,7 @@ public:
         if (QuotaManager) {
             size_t storedSize = PackedDataSize + Packer.PackedSizeEstimate();
             if (QuotedSize < storedSize) {
-                if (!QuotaManager->AllocateQuota(storedSize - QuotedSize)) {
+                if (!QuotaManager->AllocateQuota(storedSize - QuotedSize, /* isOptional = */ false)) {
                     throw NKikimr::TMemoryLimitExceededException();
                 }
             } else if (QuotedSize > storedSize) {

--- a/ydb/library/yql/providers/dq/actors/worker_actor.cpp
+++ b/ydb/library/yql/providers/dq/actors/worker_actor.cpp
@@ -22,6 +22,8 @@
 #include <util/string/split.h>
 #include <util/stream/output.h>
 
+#include <limits>
+
 using namespace NYql::NDq;
 using namespace NYql::NDq::NTaskRunnerActor;
 using namespace NYql::NDqProto;
@@ -70,7 +72,7 @@ struct TSinkInfo {
 };
 
 class TDummyMemoryQuotaManager: public IMemoryQuotaManager {
-    bool AllocateQuota(ui64) override {
+    bool AllocateQuota(ui64, bool) override {
         return true;
     }
 
@@ -88,8 +90,8 @@ class TDummyMemoryQuotaManager: public IMemoryQuotaManager {
         return TString();
     }
 
-    bool IsReasonableToUseSpilling() const override {
-        return false;
+    i64 GetMemoryAvailability() const override {
+        return std::numeric_limits<i64>::max();
     }
 };
 

--- a/ydb/library/yql/providers/dq/worker_manager/local_worker_manager.cpp
+++ b/ydb/library/yql/providers/dq/worker_manager/local_worker_manager.cpp
@@ -23,7 +23,6 @@
 #include <util/random/random.h>
 #include <util/system/rusage.h>
 
-#include <limits>
 
 using namespace NActors;
 
@@ -63,10 +62,7 @@ struct TMemoryQuotaManager : public NYql::NDq::TGuaranteeQuotaManager {
     }
 
     i64 GetExtraMemoryAvailability() const override {
-        // a lock-free snapshot of the node quoter. TResourceQuoter::Allocate treats Limit == 0 as unlimited,
-        // but GetFreeTotal() returns 0 then
-        const ui64 limit = NodeQuoter->GetLimit();
-        return limit ? static_cast<i64>(NodeQuoter->GetFreeTotal()) : std::numeric_limits<i64>::max();
+        return NodeQuoter->GetMemoryAvailability(); // a lock-free snapshot, unlimited for a quoter without a limit
     }
 
     std::shared_ptr<NDq::TResourceQuoter> NodeQuoter;

--- a/ydb/library/yql/providers/dq/worker_manager/local_worker_manager.cpp
+++ b/ydb/library/yql/providers/dq/worker_manager/local_worker_manager.cpp
@@ -23,6 +23,8 @@
 #include <util/random/random.h>
 #include <util/system/rusage.h>
 
+#include <limits>
+
 using namespace NActors;
 
 namespace NYql::NDqs {
@@ -58,6 +60,12 @@ struct TMemoryQuotaManager : public NYql::NDq::TGuaranteeQuotaManager {
 
     void FreeExtraQuota(ui64 extraSize) override {
         NodeQuoter->Free(TxId, 0, extraSize);
+    }
+
+    i64 GetExtraMemoryAvailability() const override {
+        // TResourceQuoter::Allocate treats Limit == 0 as unlimited, but GetFreeTotal() returns 0 then
+        const ui64 limit = NodeQuoter->GetLimit();
+        return limit ? static_cast<i64>(NodeQuoter->GetFreeTotal()) : std::numeric_limits<i64>::max();
     }
 
     std::shared_ptr<NDq::TResourceQuoter> NodeQuoter;

--- a/ydb/library/yql/providers/dq/worker_manager/local_worker_manager.cpp
+++ b/ydb/library/yql/providers/dq/worker_manager/local_worker_manager.cpp
@@ -63,7 +63,8 @@ struct TMemoryQuotaManager : public NYql::NDq::TGuaranteeQuotaManager {
     }
 
     i64 GetExtraMemoryAvailability() const override {
-        // TResourceQuoter::Allocate treats Limit == 0 as unlimited, but GetFreeTotal() returns 0 then
+        // a lock-free snapshot of the node quoter. TResourceQuoter::Allocate treats Limit == 0 as unlimited,
+        // but GetFreeTotal() returns 0 then
         const ui64 limit = NodeQuoter->GetLimit();
         return limit ? static_cast<i64>(NodeQuoter->GetFreeTotal()) : std::numeric_limits<i64>::max();
     }

--- a/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
@@ -54,6 +54,7 @@
 #include <util/system/fstat.h>
 
 #include <algorithm>
+#include <atomic>
 #include <queue>
 
 #undef THROW
@@ -1579,7 +1580,7 @@ public:
 
         // Arrow blocks are currently not limited by mem quoter, so we use rough buffer quotation
         // After exact mem control implementation, this allocation should be deleted
-        if (!MemoryQuotaManager->AllocateQuota(ReadActorFactoryCfg.DataInflight)) {
+        if (!MemoryQuotaManager->AllocateQuota(ReadActorFactoryCfg.DataInflight, /* isOptional = */ false)) {
             TIssues issues;
             issues.AddIssue(TIssue{TStringBuilder() << "OutOfMemory - can't allocate " << ReadActorFactoryCfg.DataInflight << "b read buffer"});
             OnFatalError(std::move(issues), NYql::NDqProto::StatusIds::OVERLOADED);

--- a/ydb/library/yql/providers/solomon/actors/dq_solomon_read_actor.cpp
+++ b/ydb/library/yql/providers/solomon/actors/dq_solomon_read_actor.cpp
@@ -166,7 +166,7 @@ public:
     }
 
     void Bootstrap() {
-        if (!MemoryQuotaManager->AllocateQuota(MaxDataInflightBytes + MaxMetadataInflightBytes)) {
+        if (!MemoryQuotaManager->AllocateQuota(MaxDataInflightBytes + MaxMetadataInflightBytes, /* isOptional = */ false)) {
             TIssues issues;
             issues.AddIssue(TIssue{TStringBuilder() << "OutOfMemory - can't allocate " << MaxDataInflightBytes + MaxMetadataInflightBytes << "b read buffer"});
             Send(ComputeActorId, new TEvAsyncInputError(InputIndex, issues, NYql::NDqProto::StatusIds::BAD_REQUEST));


### PR DESCRIPTION
Part 1 of https://github.com/ydb-platform/ydb/pull/52082 (RFC dq_memory_quota_20):

- IMemoryQuotaManager: AllocateQuota(size, isOptional), GetMemoryAvailability() instead of IsReasonableToUseSpilling(); TGuaranteeQuotaManager refuses optional requests the parent cannot cover, TChainedQuotaManager removed
- resource manager: TMemoryResourceCookie carries a numeric MemoryAvailability (Limit - Used - OverLimit) instead of the SpillingPercentReached flag
- TDqMemoryQuota: optional extra memory requests, explicit give-back, implements the operator-facing IDqOperatorMemoryQuota bound to the executing thread by the compute actor / task runner actor (TDqOperatorMemoryQuotaScope)
- new interface library ydb/library/yql/dq/comp_nodes/operator_memory_quota
- TableServiceConfig.ResourceManager.EnableOperatorMemoryQuota (off by default)
- unit tests: TDqMemoryQuotaTest, KqpRm memory availability, operator quota binding

The operator side (DqHashCombine / DqBlockHashJoin in comp_nodes, combiner_perf, KqpHashCombine tests) follows in a separate part.

<img width="1146" height="628" alt="image" src="https://github.com/user-attachments/assets/93fe7b30-b50a-4dd4-a013-3c15ee573d91" />

Left side - current main. Right side - this PR + changes in DqHashAggregation which are not committed there

```diff
diff --git a/ydb/tests/tools/kqprun/configuration/app_config.conf b/ydb/tests/tools/kqprun/configuration/app_config.conf
index d242f737c76..f1c75682c60 100644
--- a/ydb/tests/tools/kqprun/configuration/app_config.conf
+++ b/ydb/tests/tools/kqprun/configuration/app_config.conf
@@ -233,7 +233,8 @@ ResourceBrokerConfig {
     Weight: 30

     Limit {
-      Memory: 64424509440
+      Memory: 5000000000
     }
   }

@@ -264,6 +266,8 @@ TableServiceConfig {

   ResourceManager {
     QueryMemoryLimit: 64424509440
+    SpillingPercent: 95
+    EnableOperatorMemoryQuota: true
   }
```

```bash
./kqprun -G 2735 -M 18765 --storage-path tpch100n --dedicated tpch100:1
```

```sql
-- TPC-H Scale 10000 Query 18

pragma ydb.OverridePlanner = @@ [
    { "tx": 0, "stage": 0, "tasks": 20 },
    { "tx": 0, "stage": 1, "tasks": 20 },
    { "tx": 0, "stage": 2, "tasks": 20 },

    { "tx": 0, "stage": 3, "tasks": 200 },

    { "tx": 0, "stage": 4, "tasks": 40 },
    { "tx": 0, "stage": 5, "tasks": 45 },
    { "tx": 0, "stage": 6, "tasks": 45 },
    { "tx": 0, "stage": 7, "tasks": 1 }
] @@;

$in = (
        select
            l_orderkey,
            sum(l_quantity) as sum_l_quantity
        from
            `lineitem`
        group by
            l_orderkey having
                sum(l_quantity) > 300
        );
        $join1 = (
                select
                    c.c_name as c_name,
                    c.c_custkey as c_custkey,
                    o.o_orderkey as o_orderkey,
                    o.o_orderdate as o_orderdate,
                    o.o_totalprice as o_totalprice
                from
                    `customer` as c
                join
                    `orders` as o
                on
                    c.c_custkey = o.o_custkey
        );
        select
            j.c_name as c_name,
            j.c_custkey as c_custkey,
            j.o_orderkey as o_orderkey,
            j.o_orderdate as o_orderdate,
            j.o_totalprice as o_totalprice,
            sum(i.sum_l_quantity) as sum_l_quantity
        from
            $join1 as j
        join
            $in as i
        on
            i.l_orderkey = j.o_orderkey
        group by
            j.c_name,
            j.c_custkey,
            j.o_orderkey,
            j.o_orderdate,
            j.o_totalprice
        order by
            o_totalprice desc,
            o_orderdate,
            o_orderkey
        limit 100;
```

1. Run kqprun with TPC-H scale 100 data set with single node (and a lot of CPU)
2. Set Limit of queue_kqp_resource_manager RB queue to 1/2/3/4/5GB
3. Run TPC-H Q18 with fixed tasks per stage, vary stage 3 task count in [1..200]
4. If 10/10 test succeded - it's GREEN, single fail - repeat, otherwise is RED
5. Black/yellow squares mark tens