### PR TITLE
Replace subcolumn paths trie with canonized path checking.

### DIFF
--- a/ydb/core/formats/arrow/accessor/sub_columns/README.md
+++ b/ydb/core/formats/arrow/accessor/sub_columns/README.md
@@ -1,0 +1,26 @@
+# Subcolumns
+
+## Classes
+
+[`TSubColumnsArray`](accessor.h#L22) is a fully loaded JSON column. It stores separated, frequently used paths in `TColumnsData` as regular column arrays, and the remaining paths in `TOthersData` as a sparse representation.
+
+[`TSubColumnsPartialArray`](partial.h#L44) has metadata for all subcolumns, and actual data for specific separated ones or Others as a whole is loaded on request.
+
+[`TJsonPathAccessor`](json_value_path.h#L51) is an application of JSONPath to column. Its result can be retrieved via `VisitValues` method. It can be in invalid state (no internal array) - for now invalid accessors seem to never be created.
+
+[`TDictStats`](stats.h#L20) describes the stored paths in separated/others. It resolves a requested JSONPath to a `TResolvedPath`, which identifies the stored column, its value type, and the suffix that remains to be evaluated.
+
+## JSON_VALUE resolution
+
+[`TSubColumnsArray::GetPathAccessor()`](accessor.h#L115) resolves the requested JSONPath against the separated and Others stats before constructing an accessor. The source-selection algorithm is [`ResolveBestPath`](stats.h#L316).
+
+1. TDictStats selects the best match among its paths and represents it as a `TResolvedPath`. A path may be matched by partially, for example, path `$.a.b[0]` may be matched by subcolumn `a` with suffix `.b[0]`, or by subcolumn `a.b` with suffix `[0]`. Matches are compared by the length of matched path prefix.
+2. Matches between separated and others are compared and the best one is selected, the result is represented as a `TResolvedPathMatch` (`TResolvedPath` + where did it come from).
+3. `TColumnsData` constructs a `TJsonPathAccessor` over its stored subcolumn, or `TOthersData` constructs a `TJsonPathAccessor` holding a sparse array for requested key.
+4. Resulting values are retrieved via `TJsonPathAccessor::VisitValues()`, which applies the remaining path suffix over its stored array. For example, applying `[0]` to `[[1, 2], [3, 4 ]]` produces `[1, 3]` sequence.
+
+If no stored path matches a valid request, the result is a valid, row-aligned accessor with `recordsCount` NULL values. This preserves SQL `JSON_VALUE` semantics and row cardinality for filters and expressions.
+
+An invalid JSONPath returns a failed `TConclusion`.
+
+For a partial array, `GetPathAccessor()` resolves only among loaded data. A valid path absent from header stats returns the same row-aligned all-NULL accessor as a full array. A path that matches header stats but has not been loaded violates the fetch contract. Fetch planning and accessor lookup must use the same canonical path resolution.

--- a/ydb/core/formats/arrow/accessor/sub_columns/accessor.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/accessor.cpp
@@ -202,9 +202,9 @@ const NJson::TJsonValue& TJsonRestorer::GetResult() const {
 
 void TJsonRestorer::SetValueByPath(const TString& path, const NJson::TJsonValue& jsonValue) {
     // Path may be empty (for backward compatibility), so make it $."" in this case
-    auto splitResult = NSubColumns::SplitJsonPath(NSubColumns::ToJsonPath(path.empty() ? "\"\"" : path), NSubColumns::TJsonPathSplitSettings{.FillTypes = true});
-    AFL_VERIFY(splitResult.IsSuccess())("error", splitResult.GetErrorMessage())("path", path);
-    const auto [pathItems, pathTypes, _] = splitResult.DetachResult();
+    auto parsedResult = NSubColumns::ParseJsonPath(NSubColumns::ToJsonPath(path.empty() ? "\"\"" : path));
+    AFL_VERIFY(parsedResult.IsSuccess())("error", parsedResult.GetErrorMessage())("path", path);
+    const auto [pathItems, pathTypes, _] = parsedResult.DetachResult().Items;
     AFL_VERIFY(pathItems.size() > 0);
     AFL_VERIFY(pathItems.size() == pathTypes.size());
     NJson::TJsonValue* current = &Result;

--- a/ydb/core/formats/arrow/accessor/sub_columns/accessor.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/accessor.h
@@ -113,15 +113,18 @@ public:
     }
 
     TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> GetPathAccessor(const std::string_view svPath, const ui32 recordsCount) const {
-        auto columnsResult = ColumnsData.GetPathAccessor(svPath);
-        if (columnsResult.IsFail()) {
-            return columnsResult;
+        auto pathResult = NSubColumns::ResolveBestPath(ColumnsData.GetStats(), OthersData.GetStats(), svPath);
+        if (pathResult.IsFail()) {
+            return TConclusionStatus::Fail(pathResult.GetErrorMessage());
         }
-        auto othersResult = OthersData.GetPathAccessor(svPath, recordsCount);
-        if (othersResult.IsFail()) {
-            return othersResult;
+        auto path = pathResult.DetachResult();
+        if (path && path->IsColumn) {
+            return ColumnsData.GetPathAccessor(std::move(path->Path));
         }
-        return NSubColumns::TJsonPathAccessor::SelectBestMatch(columnsResult.DetachResult(), othersResult.DetachResult());
+        if (path) {
+            return OthersData.GetPathAccessor(std::move(path->Path), recordsCount);
+        }
+        return NSubColumns::TOthersData::BuildEmptyPathAccessor(recordsCount);
     }
 };
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/accessor.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/accessor.h
@@ -113,11 +113,15 @@ public:
     }
 
     TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> GetPathAccessor(const std::string_view svPath, const ui32 recordsCount) const {
-        auto accResult = ColumnsData.GetPathAccessor(svPath);
-        if (accResult.IsFail() || accResult.GetResult()->IsValid()) {
-            return accResult;
+        auto columnsResult = ColumnsData.GetPathAccessor(svPath);
+        if (columnsResult.IsFail()) {
+            return columnsResult;
         }
-        return OthersData.GetPathAccessor(svPath, recordsCount);
+        auto othersResult = OthersData.GetPathAccessor(svPath, recordsCount);
+        if (othersResult.IsFail()) {
+            return othersResult;
+        }
+        return NSubColumns::TJsonPathAccessor::SelectBestMatch(columnsResult.DetachResult(), othersResult.DetachResult());
     }
 };
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/accessor.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/accessor.h
@@ -74,8 +74,8 @@ public:
     }
 
     bool HasSubColumn(const TString& subColumnName) const {
-        return ColumnsData.GetStats().GetKeyIndexOptional(std::string_view(subColumnName.data(), subColumnName.size())) ||
-               OthersData.GetStats().GetKeyIndexOptional(std::string_view(subColumnName.data(), subColumnName.size()));
+        return ColumnsData.GetStats().GetKeyOrPrefixIndexOptional(std::string_view(subColumnName.data(), subColumnName.size())) ||
+               OthersData.GetStats().GetKeyOrPrefixIndexOptional(std::string_view(subColumnName.data(), subColumnName.size()));
     }
 
     void StoreSourceString(const TString& sourceDeserializationString) {

--- a/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
@@ -19,17 +19,9 @@ private:
     YDB_READONLY_DEF(std::shared_ptr<TGeneralContainer>, Records);
 
 public:
-    TConclusion<std::shared_ptr<TJsonPathAccessor>> GetPathAccessor(const std::string_view path) const {
-        auto pathInfoResult = Stats.ResolvePath(path);
-        if (pathInfoResult.IsFail()) {
-            return TConclusionStatus::Fail(pathInfoResult.GetErrorMessage());
-        }
-        auto pathInfo = pathInfoResult.DetachResult();
-        if (!pathInfo) {
-            return std::make_shared<TJsonPathAccessor>(nullptr, TString{}, EValueType::BinaryJson);
-        }
+    std::shared_ptr<TJsonPathAccessor> GetPathAccessor(TDictStats::TResolvedPath path) const {
         return std::make_shared<TJsonPathAccessor>(
-            Records->GetColumnVerified(pathInfo->ColumnIndex), std::move(pathInfo->RemainingPath), pathInfo->ValueType);
+            Records->GetColumnVerified(path.ColumnIndex), std::move(path.RemainingPath), path.ValueType);
     }
 
     NJson::TJsonValue DebugJson() const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
@@ -20,12 +20,16 @@ private:
 
 public:
     TConclusion<std::shared_ptr<TJsonPathAccessor>> GetPathAccessor(const std::string_view path) const {
-        auto jsonPathAccessorTrie = std::make_shared<NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie>();
-        for (ui32 i = 0; i < Stats.GetColumnsCount(); ++i) {
-            auto insertResult = jsonPathAccessorTrie->Insert(ToJsonPath(Stats.GetColumnName(i)), Records->GetColumnVerified(i), Stats.GetValueType(i));
-            AFL_VERIFY(insertResult.IsSuccess())("error", insertResult.GetErrorMessage());
+        auto pathInfoResult = Stats.ResolvePath(path);
+        if (pathInfoResult.IsFail()) {
+            return TConclusionStatus::Fail(pathInfoResult.GetErrorMessage());
         }
-        return jsonPathAccessorTrie->GetAccessor(path);
+        auto pathInfo = pathInfoResult.DetachResult();
+        if (!pathInfo) {
+            return std::make_shared<TJsonPathAccessor>(nullptr, TString{}, EValueType::BinaryJson);
+        }
+        return std::make_shared<TJsonPathAccessor>(
+            Records->GetColumnVerified(pathInfo->ColumnIndex), std::move(pathInfo->RemainingPath), pathInfo->ValueType);
     }
 
     NJson::TJsonValue DebugJson() const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/direct_builder.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/direct_builder.cpp
@@ -127,23 +127,12 @@ TOthersData TDataBuilder::MergeOthers(const std::vector<TColumnElements*>& other
     return othersBuilder->Finish(TOthersData::TFinishContext(BuildStats(otherKeys, Settings, recordsCount, false)));
 }
 
-std::string BuildString(const TStringBuf currentPrefix, const TStringBuf key) {
-    TStringBuilder builder;
-    const auto escapedKey = QuoteJsonItem(key);
-    if (currentPrefix.size()) {
-        builder << currentPrefix << ".";
-    }
-    builder << escapedKey;
-
-    return builder;
-}
-
 TStringBuf TDataBuilder::AddKeyOwn(const TStringBuf currentPrefix, std::string&& key) {
     auto it = StorageHash.find(TStorageAddress(currentPrefix, TStringBuf(key.data(), key.size())));
     if (it == StorageHash.end()) {
         Storage.emplace_back(std::move(key));
         TStringBuf sbKey(Storage.back().data(), Storage.back().size());
-        it = StorageHash.emplace(TStorageAddress(currentPrefix, sbKey), BuildString(currentPrefix, sbKey)).first;
+        it = StorageHash.emplace(TStorageAddress(currentPrefix, sbKey), BuildSubcolumnName(currentPrefix, sbKey)).first;
     }
     return TStringBuf(it->second.data(), it->second.size());
 }
@@ -152,7 +141,7 @@ TStringBuf TDataBuilder::AddKey(const TStringBuf currentPrefix, const TStringBuf
     TStorageAddress keyAddress(currentPrefix, key);
     auto it = StorageHash.find(keyAddress);
     if (it == StorageHash.end()) {
-        it = StorageHash.emplace(keyAddress, BuildString(currentPrefix, key)).first;
+        it = StorageHash.emplace(keyAddress, BuildSubcolumnName(currentPrefix, key)).first;
     }
     return TStringBuf(it->second.data(), it->second.size());
 }

--- a/ydb/core/formats/arrow/accessor/sub_columns/header.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/header.h
@@ -49,8 +49,8 @@ public:
     }
 
     bool HasSubColumn(const TString& subColumnName) const {
-        return ColumnStats.GetKeyIndexOptional(std::string_view(subColumnName.data(), subColumnName.size())) ||
-               OtherStats.GetKeyIndexOptional(std::string_view(subColumnName.data(), subColumnName.size()));
+        return ColumnStats.GetKeyOrPrefixIndexOptional(std::string_view(subColumnName.data(), subColumnName.size())) ||
+               OtherStats.GetKeyOrPrefixIndexOptional(std::string_view(subColumnName.data(), subColumnName.size()));
     }
 
     TConstructorContainer GetAccessorConstructor(const ui32 colIndex, const TEncodingParams& encodingParams) const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
@@ -113,6 +113,14 @@ TConclusion<TSplittedJsonPath> SplitJsonPath(TJsonPathBuf jsonPath, const TJsonP
     return result;
 }
 
+TConclusion<TParsedJsonPath> ParseJsonPath(const TJsonPathBuf jsonPath) {
+    auto result = SplitJsonPath(jsonPath, TJsonPathSplitSettings{.FillTypes = true, .FillStartPositions = true});
+    if (result.IsFail()) {
+        return TConclusionStatus::Fail(result.GetErrorMessage());
+    }
+    return TParsedJsonPath{jsonPath, result.DetachResult()};
+}
+
 TConclusionStatus ValidateJsonPath(TJsonPathBuf jsonPath) {
     const auto result = SplitJsonPath(jsonPath, TJsonPathSplitSettings{.FillTypes = false, .FillStartPositions = false});
     if (result.IsSuccess()) {

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
@@ -31,6 +31,15 @@ TString QuoteJsonItem(TStringBuf item) {
     return builder;
 }
 
+TString BuildSubcolumnName(const TStringBuf currentPrefix, const TStringBuf item) {
+    TStringBuilder builder;
+    if (currentPrefix) {
+        builder << currentPrefix << ".";
+    }
+    builder << QuoteJsonItem(item);
+    return builder;
+}
+
 TJsonPath ToJsonPath(TStringBuf path) {
     if (!path.StartsWith('"')) {
         return TString("$.") + QuoteJsonItem(path);
@@ -111,10 +120,7 @@ TString ToSubcolumnName(TStringBuf path) {
         if (pathTypes[i] == NYql::NJsonPath::EJsonPathItemType::ArrayAccess) {
             result.append(pathItems[i]);
         } else {
-            if (!result.empty()) {
-                result.append(".");
-            }
-            result.append(QuoteJsonItem(pathItems[i]));
+            result = BuildSubcolumnName(result, pathItems[i]);
         }
     }
 
@@ -200,61 +206,6 @@ void TJsonPathAccessor::VisitValues(const TValuesVisitor& visitor) const {
             }
         }
     });
-}
-
-TConclusionStatus TJsonPathAccessorTrie::Insert(TJsonPathBuf jsonPath, std::shared_ptr<IChunkedArray> accessor, const EValueType valueType,
-    const std::optional<ui64>& cookie) {
-    auto splittedPathResult = NSubColumns::SplitJsonPath(jsonPath, NSubColumns::TJsonPathSplitSettings{.FillTypes = true, .FillStartPositions = false});
-    if (!splittedPathResult.IsSuccess()) {
-        return splittedPathResult;
-    }
-
-    auto [pathItems, pathTypes, _] = splittedPathResult.DetachResult();
-    AFL_VERIFY(pathItems.size() == pathTypes.size());
-
-    auto currentNode = &Root;
-    for (decltype(pathItems)::size_type i = 0; i < pathItems.size(); ++i) {
-        AFL_VERIFY(pathTypes[i] == NYql::NJsonPath::EJsonPathItemType::MemberAccess);
-        if (auto found = currentNode->Children.find(pathItems[i]); found != currentNode->Children.end()) {
-            currentNode = found->second.get();
-        } else {
-            currentNode = currentNode->Children.emplace(pathItems[i], std::make_unique<TrieNode>()).first->second.get();
-        }
-    }
-
-    AFL_VERIFY(!currentNode->Accessor);
-
-    currentNode->Accessor = std::move(accessor);
-    currentNode->ValueType = valueType;
-    currentNode->Cookie = cookie;
-
-    return TConclusionStatus::Success();
-}
-
-TConclusion<std::shared_ptr<TJsonPathAccessor>> TJsonPathAccessorTrie::GetAccessor(TJsonPathBuf jsonPath) const {
-    auto splittedPathResult = SplitJsonPath(jsonPath, NSubColumns::TJsonPathSplitSettings{.FillTypes = false, .FillStartPositions = true});
-    if (!splittedPathResult.IsSuccess()) {
-        return splittedPathResult;
-    }
-
-    auto [pathItems, _, startPositions] = splittedPathResult.DetachResult();
-    AFL_VERIFY(pathItems.size() == startPositions.size());
-    auto currentNode = &Root;
-    for (decltype(pathItems)::size_type i = 0; i < pathItems.size(); ++i) {
-        if (auto found = currentNode->Children.find(pathItems[i]); found != currentNode->Children.end()) {
-            currentNode = found->second.get();
-        } else if (currentNode->Accessor || currentNode->Cookie) {
-            auto remainingPath = jsonPath.substr(startPositions[i]);
-            // strict is required, because there is a memory problem in NYql::NJsonPath::ExecuteJsonPath with lax and BinaryJson
-            return std::make_shared<TJsonPathAccessor>(currentNode->Accessor,
-                remainingPath.empty() ? TString{} : "strict $" + TString(remainingPath.data(), remainingPath.size()),
-                currentNode->ValueType, currentNode->Cookie);
-        } else {
-            return std::make_shared<TJsonPathAccessor>(nullptr, TString{}, EValueType::BinaryJson);
-        }
-    }
-
-    return std::make_shared<TJsonPathAccessor>(currentNode->Accessor, TString{}, currentNode->ValueType, currentNode->Cookie);
 }
 
 } // namespace NKikimr::NArrow::NAccessor::NSubColumns

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
@@ -39,7 +39,7 @@ TString QuoteJsonItem(const TStringBuf item) {
 }
 
 void AppendSubcolumnName(TString& currentPrefix, const TStringBuf item) {
-    if (currentPrefix) {
+    if (!currentPrefix.empty()) {
         currentPrefix.append(".");
     }
     AppendQuotedJsonItem(currentPrefix, item);

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
@@ -11,33 +11,49 @@
 
 namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
-TString QuoteJsonItem(TStringBuf item) {
-    TStringBuilder builder;
+namespace {
 
-    builder << '"';
+void AppendQuotedJsonItem(TString& result, const TStringBuf item) {
+    result.append("\"");
 
     for (char ch : item) {
         if (ch == '"') {
-            builder << "\\\"";
+            result.append("\\\"");
         } else if (ch == '\\') {
-            builder << "\\\\";
+            result.append("\\\\");
         } else {
-            builder << ch;
+            result.append(1, ch);
         }
     }
 
-    builder << '"';
+    result.append("\"");
+}
 
-    return builder;
+}
+
+TString QuoteJsonItem(const TStringBuf item) {
+    TString result;
+    result.reserve(item.size() + 2);
+    AppendQuotedJsonItem(result, item);
+    return result;
+}
+
+void AppendSubcolumnName(TString& currentPrefix, const TStringBuf item) {
+    if (currentPrefix) {
+        currentPrefix.append(".");
+    }
+    AppendQuotedJsonItem(currentPrefix, item);
 }
 
 TString BuildSubcolumnName(const TStringBuf currentPrefix, const TStringBuf item) {
-    TStringBuilder builder;
-    if (currentPrefix) {
-        builder << currentPrefix << ".";
-    }
-    builder << QuoteJsonItem(item);
-    return builder;
+    TString result(currentPrefix);
+    AppendSubcolumnName(result, item);
+    return result;
+}
+
+size_t EstimateSubcolumnNameSize(const TStringBuf path, const size_t pathItemsCount) {
+    // Every canonical member adds a pair of quotes.
+    return path.size() + 2 * pathItemsCount;
 }
 
 TJsonPath ToJsonPath(TStringBuf path) {
@@ -115,12 +131,12 @@ TString ToSubcolumnName(TStringBuf path) {
     }
     auto [pathItems, pathTypes, _] = pathItemsResult.DetachResult();
     TString result;
-    result.reserve(path.size() + 2 * pathItems.size());
+    result.reserve(EstimateSubcolumnNameSize(path, pathItems.size()));
     for (decltype(pathItems)::size_type i = 0; i < pathItems.size(); ++i) {
         if (pathTypes[i] == NYql::NJsonPath::EJsonPathItemType::ArrayAccess) {
             result.append(pathItems[i]);
         } else {
-            result = BuildSubcolumnName(result, pathItems[i]);
+            AppendSubcolumnName(result, pathItems[i]);
         }
     }
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
@@ -63,6 +63,13 @@ TJsonPath ToJsonPath(TStringBuf path) {
     return TString("$.") + path;
 }
 
+namespace {
+
+struct TJsonPathSplitSettings {
+    bool FillTypes = false;
+    bool FillStartPositions = false;
+};
+
 TConclusion<TSplittedJsonPath> SplitJsonPath(TJsonPathBuf jsonPath, const TJsonPathSplitSettings& settings) {
     NYql::TIssues issues;
     auto path = NYql::NJsonPath::ParseJsonPath(jsonPath, issues, 5);
@@ -113,6 +120,8 @@ TConclusion<TSplittedJsonPath> SplitJsonPath(TJsonPathBuf jsonPath, const TJsonP
     return result;
 }
 
+} // namespace
+
 TConclusion<TParsedJsonPath> ParseJsonPath(const TJsonPathBuf jsonPath) {
     auto result = SplitJsonPath(jsonPath, TJsonPathSplitSettings{.FillTypes = true, .FillStartPositions = true});
     if (result.IsFail()) {
@@ -130,9 +139,9 @@ TConclusionStatus ValidateJsonPath(TJsonPathBuf jsonPath) {
 }
 
 TString ToSubcolumnName(TStringBuf path) {
-    auto pathItemsResult = SplitJsonPath(path, NSubColumns::TJsonPathSplitSettings{.FillTypes = true, .FillStartPositions = false});
+    auto pathItemsResult = SplitJsonPath(path, TJsonPathSplitSettings{.FillTypes = true, .FillStartPositions = false});
     if (pathItemsResult.IsFail()) {
-        pathItemsResult = SplitJsonPath(ToJsonPath(path), NSubColumns::TJsonPathSplitSettings{.FillTypes = true, .FillStartPositions = false});
+        pathItemsResult = SplitJsonPath(ToJsonPath(path), TJsonPathSplitSettings{.FillTypes = true, .FillStartPositions = false});
         if (pathItemsResult.IsFail()) {
             return TString(path);
         }

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
@@ -160,12 +160,10 @@ TString ToSubcolumnName(TStringBuf path) {
     return result;
 }
 
-TJsonPathAccessor::TJsonPathAccessor(std::shared_ptr<IChunkedArray> accessor, TString remainingPath, const EValueType valueType,
-    const std::optional<ui64>& cookie)
+TJsonPathAccessor::TJsonPathAccessor(std::shared_ptr<IChunkedArray> accessor, TString remainingPath, const EValueType valueType)
     : ChunkedArrayAccessor(std::move(accessor))
     , RemainingPath(std::move(remainingPath))
-    , ValueType(valueType)
-    , Cookie(cookie) {
+    , ValueType(valueType) {
     if (!RemainingPath.empty()) {
         NYql::TIssues issues;
         RemainingPathPtr = NYql::NJsonPath::ParseJsonPath(RemainingPath, issues, 5);

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
@@ -7,7 +7,6 @@
 #include <yql/essentials/minikql/jsonpath/parser/parser.h>
 #include <ydb/library/accessor/accessor.h>
 
-#include <util/generic/map.h>
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 
@@ -21,6 +20,7 @@ using TJsonPath = TString;
 using TJsonPathBuf = TStringBuf;
 
 TString QuoteJsonItem(TStringBuf item);
+TString BuildSubcolumnName(TStringBuf currentPrefix, TStringBuf item);
 TJsonPath ToJsonPath(TStringBuf path);
 
 struct TSplittedJsonPath {
@@ -69,22 +69,6 @@ public:
     ui64 GetRecordsCount() const {
         return ChunkedArrayAccessor ? ChunkedArrayAccessor->GetRecordsCount() : 0;
     }
-};
-
-class TJsonPathAccessorTrie {
-    struct TrieNode {
-        TMap<TString, std::unique_ptr<TrieNode>> Children;
-        std::shared_ptr<IChunkedArray> Accessor;
-        EValueType ValueType = EValueType::BinaryJson;
-        std::optional<ui64> Cookie;
-    };
-
-    TrieNode Root;
-
-public:
-    TConclusionStatus Insert(TJsonPathBuf jsonPath, std::shared_ptr<IChunkedArray> accessor, const EValueType valueType,
-        const std::optional<ui64>& cookie = std::nullopt);
-    TConclusion<std::shared_ptr<TJsonPathAccessor>> GetAccessor(TJsonPathBuf jsonPath) const;
 };
 
 } // namespace NKikimr::NArrow::NAccessor::NSubColumns

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
@@ -31,6 +31,11 @@ struct TSplittedJsonPath {
     TVector<TJsonPathBuf::size_type> StartPositions;
 };
 
+struct TParsedJsonPath {
+    TJsonPathBuf Source;
+    TSplittedJsonPath Items;
+};
+
 struct TJsonPathSplitSettings {
     bool FillTypes = false;
     bool FillStartPositions = false;
@@ -38,6 +43,7 @@ struct TJsonPathSplitSettings {
 
 
 TConclusion<TSplittedJsonPath> SplitJsonPath(TJsonPathBuf jsonPath, const TJsonPathSplitSettings& settings = {});
+TConclusion<TParsedJsonPath> ParseJsonPath(TJsonPathBuf jsonPath);
 
 TConclusionStatus ValidateJsonPath(TJsonPathBuf jsonPath);
 
@@ -66,18 +72,6 @@ public:
 
     bool IsValid() const {
         return ChunkedArrayAccessor != nullptr || Cookie.has_value();
-    }
-
-    static bool IsBetterMatch(const TStringBuf firstRemainingPath, const TStringBuf secondRemainingPath) {
-        return firstRemainingPath.size() <= secondRemainingPath.size();
-    }
-
-    static std::shared_ptr<TJsonPathAccessor> SelectBestMatch(
-        const std::shared_ptr<TJsonPathAccessor>& first, const std::shared_ptr<TJsonPathAccessor>& second) {
-        if (!second || !second->IsValid() || (first && first->IsValid() && IsBetterMatch(first->RemainingPath, second->RemainingPath))) {
-            return first;
-        }
-        return second;
     }
 
     ui64 GetRecordsCount() const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
@@ -68,6 +68,18 @@ public:
         return ChunkedArrayAccessor != nullptr || Cookie.has_value();
     }
 
+    static bool IsBetterMatch(const TStringBuf firstRemainingPath, const TStringBuf secondRemainingPath) {
+        return firstRemainingPath.size() <= secondRemainingPath.size();
+    }
+
+    static std::shared_ptr<TJsonPathAccessor> SelectBestMatch(
+        const std::shared_ptr<TJsonPathAccessor>& first, const std::shared_ptr<TJsonPathAccessor>& second) {
+        if (!second || !second->IsValid() || (first && first->IsValid() && IsBetterMatch(first->RemainingPath, second->RemainingPath))) {
+            return first;
+        }
+        return second;
+    }
+
     ui64 GetRecordsCount() const {
         return ChunkedArrayAccessor ? ChunkedArrayAccessor->GetRecordsCount() : 0;
     }

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
@@ -36,13 +36,6 @@ struct TParsedJsonPath {
     TSplittedJsonPath Items;
 };
 
-struct TJsonPathSplitSettings {
-    bool FillTypes = false;
-    bool FillStartPositions = false;
-};
-
-
-TConclusion<TSplittedJsonPath> SplitJsonPath(TJsonPathBuf jsonPath, const TJsonPathSplitSettings& settings = {});
 TConclusion<TParsedJsonPath> ParseJsonPath(TJsonPathBuf jsonPath);
 
 TConclusionStatus ValidateJsonPath(TJsonPathBuf jsonPath);

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
@@ -51,20 +51,18 @@ class TJsonPathAccessor {
     YDB_READONLY_DEF(std::shared_ptr<IChunkedArray>, ChunkedArrayAccessor);
     YDB_READONLY_DEF(TString, RemainingPath);
     YDB_READONLY(EValueType, ValueType, EValueType::BinaryJson);
-    YDB_READONLY_DEF(std::optional<ui64>, Cookie);
     NYql::NJsonPath::TJsonPathPtr RemainingPathPtr;
 
 public:
     using TValuesVisitor = std::function<void(const std::optional<TStringBuf>& value)>;
 
-    TJsonPathAccessor(std::shared_ptr<IChunkedArray> accessor, TString remainingPath, const EValueType valueType,
-        const std::optional<ui64>& cookie = std::nullopt);
+    TJsonPathAccessor(std::shared_ptr<IChunkedArray> accessor, TString remainingPath, EValueType valueType);
 
     std::shared_ptr<IChunkedArray> GetNativeStringArray() const;
     void VisitValues(const TValuesVisitor& visitor) const;
 
     bool IsValid() const {
-        return ChunkedArrayAccessor != nullptr || Cookie.has_value();
+        return ChunkedArrayAccessor != nullptr;
     }
 
     ui64 GetRecordsCount() const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
@@ -20,7 +20,9 @@ using TJsonPath = TString;
 using TJsonPathBuf = TStringBuf;
 
 TString QuoteJsonItem(TStringBuf item);
+void AppendSubcolumnName(TString& currentPrefix, TStringBuf item);
 TString BuildSubcolumnName(TStringBuf currentPrefix, TStringBuf item);
+size_t EstimateSubcolumnNameSize(TStringBuf path, size_t pathItemsCount);
 TJsonPath ToJsonPath(TStringBuf path);
 
 struct TSplittedJsonPath {

--- a/ydb/core/formats/arrow/accessor/sub_columns/others_storage.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/others_storage.cpp
@@ -248,29 +248,18 @@ TOthersData TOthersData::BuildEmpty() {
 }
 
 TConclusion<std::shared_ptr<TJsonPathAccessor>> TOthersData::GetPathAccessor(const std::string_view path, const ui32 recordsCount) const {
-    auto jsonPathAccessorTrie = std::make_shared<NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie>();
-    for (ui32 i = 0; i < Stats.GetColumnsCount(); ++i) {
-        auto insertResult = jsonPathAccessorTrie->Insert(ToJsonPath(Stats.GetColumnName(i)), nullptr, OthersExplicitBinaryJson, i);
-        AFL_VERIFY(insertResult.IsSuccess())("error", insertResult.GetErrorMessage());
+    auto pathInfoResult = Stats.ResolvePath(path);
+    if (pathInfoResult.IsFail()) {
+        return TConclusionStatus::Fail(pathInfoResult.GetErrorMessage());
     }
-    auto accessorResult = jsonPathAccessorTrie->GetAccessor(path);
-    if (accessorResult.IsFail()) {
-        return accessorResult;
-    }
-
-    auto accessor = accessorResult.DetachResult();
-    if (!accessor) {
-        return std::shared_ptr<TJsonPathAccessor>{};
-    }
-
-    auto idx = accessor->GetCookie();
-    if (!idx) {
+    auto pathInfo = pathInfoResult.DetachResult();
+    if (!pathInfo) {
         return std::make_shared<TJsonPathAccessor>(
             std::make_shared<TSparsedArray>(nullptr, arrow::binary(), recordsCount), TString{}, OthersExplicitBinaryJson);
     }
     TColumnFilter filter = TColumnFilter::BuildAllowFilter();
     for (TIterator it(Records); it.IsValid(); it.Next()) {
-        filter.Add(it.GetKeyIndex() == *idx);
+        filter.Add(it.GetKeyIndex() == pathInfo->ColumnIndex);
     }
     auto recordsFiltered = NArrow::ApplyFilter(filter, Records);
     auto table = recordsFiltered->BuildTableVerified(std::set<std::string>({ "record_idx", "value" }));
@@ -278,7 +267,7 @@ TConclusion<std::shared_ptr<TJsonPathAccessor>> TOthersData::GetPathAccessor(con
     TSparsedArray::TBuilder builder(nullptr, arrow::binary());
     auto batch = ToBatch(table);
     builder.AddChunk(recordsCount, batch->GetColumnByName("record_idx"), batch->GetColumnByName("value"));
-    return std::make_shared<TJsonPathAccessor>(builder.Finish(), accessor->GetRemainingPath(), OthersExplicitBinaryJson);
+    return std::make_shared<TJsonPathAccessor>(builder.Finish(), std::move(pathInfo->RemainingPath), OthersExplicitBinaryJson);
 }
 
 NArrow::NAccessor::TJsonValueView TOthersData::TIterator::GetValue() const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/others_storage.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/others_storage.cpp
@@ -247,19 +247,15 @@ TOthersData TOthersData::BuildEmpty() {
     return result;
 }
 
-TConclusion<std::shared_ptr<TJsonPathAccessor>> TOthersData::GetPathAccessor(const std::string_view path, const ui32 recordsCount) const {
-    auto pathInfoResult = Stats.ResolvePath(path);
-    if (pathInfoResult.IsFail()) {
-        return TConclusionStatus::Fail(pathInfoResult.GetErrorMessage());
-    }
-    auto pathInfo = pathInfoResult.DetachResult();
-    if (!pathInfo) {
-        return std::make_shared<TJsonPathAccessor>(
-            std::make_shared<TSparsedArray>(nullptr, arrow::binary(), recordsCount), TString{}, OthersExplicitBinaryJson);
-    }
+std::shared_ptr<TJsonPathAccessor> TOthersData::BuildEmptyPathAccessor(const ui32 recordsCount) {
+    return std::make_shared<TJsonPathAccessor>(
+        std::make_shared<TSparsedArray>(nullptr, arrow::binary(), recordsCount), TString{}, OthersExplicitBinaryJson);
+}
+
+std::shared_ptr<TJsonPathAccessor> TOthersData::GetPathAccessor(TDictStats::TResolvedPath path, const ui32 recordsCount) const {
     TColumnFilter filter = TColumnFilter::BuildAllowFilter();
     for (TIterator it(Records); it.IsValid(); it.Next()) {
-        filter.Add(it.GetKeyIndex() == pathInfo->ColumnIndex);
+        filter.Add(it.GetKeyIndex() == path.ColumnIndex);
     }
     auto recordsFiltered = NArrow::ApplyFilter(filter, Records);
     auto table = recordsFiltered->BuildTableVerified(std::set<std::string>({ "record_idx", "value" }));
@@ -267,7 +263,7 @@ TConclusion<std::shared_ptr<TJsonPathAccessor>> TOthersData::GetPathAccessor(con
     TSparsedArray::TBuilder builder(nullptr, arrow::binary());
     auto batch = ToBatch(table);
     builder.AddChunk(recordsCount, batch->GetColumnByName("record_idx"), batch->GetColumnByName("value"));
-    return std::make_shared<TJsonPathAccessor>(builder.Finish(), std::move(pathInfo->RemainingPath), OthersExplicitBinaryJson);
+    return std::make_shared<TJsonPathAccessor>(builder.Finish(), std::move(path.RemainingPath), OthersExplicitBinaryJson);
 }
 
 NArrow::NAccessor::TJsonValueView TOthersData::TIterator::GetValue() const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/others_storage.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/others_storage.h
@@ -20,7 +20,8 @@ private:
     YDB_READONLY_DEF(std::shared_ptr<TGeneralContainer>, Records);
 
 public:
-    TConclusion<std::shared_ptr<TJsonPathAccessor>> GetPathAccessor(const std::string_view path, const ui32 recordsCount) const;
+    static std::shared_ptr<TJsonPathAccessor> BuildEmptyPathAccessor(ui32 recordsCount);
+    std::shared_ptr<TJsonPathAccessor> GetPathAccessor(TDictStats::TResolvedPath path, ui32 recordsCount) const;
 
     NJson::TJsonValue DebugJson() const {
         NJson::TJsonValue result = NJson::JSON_MAP;

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
@@ -1,10 +1,6 @@
 #include "constructor.h"
 #include "partial.h"
 
-#include <ydb/core/formats/arrow/accessor/plain/accessor.h>
-
-#include <ydb/library/formats/arrow/simple_arrays_cache.h>
-
 namespace NKikimr::NArrow::NAccessor {
 
 void TSubColumnsPartialArray::InitOthers(const TString& blob, const TChunkConstructionData& externalInfo,
@@ -28,19 +24,19 @@ TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> TSubColumnsPartialA
         return TConclusionStatus::Fail(pathInfoResult.GetErrorMessage());
     }
     auto pathInfo = pathInfoResult.DetachResult();
-    if (pathInfo && PartialColumnsData.HasColumn(pathInfo->ColumnIndex)) {
-        return std::make_shared<NSubColumns::TJsonPathAccessor>(PartialColumnsData.GetAccessorVerified(pathInfo->ColumnIndex),
-            std::move(pathInfo->RemainingPath), pathInfo->ValueType);
+    const auto columnsAccessor = pathInfo
+        ? std::make_shared<NSubColumns::TJsonPathAccessor>(PartialColumnsData.GetAccessorVerified(pathInfo->ColumnIndex),
+              std::move(pathInfo->RemainingPath), pathInfo->ValueType)
+        : std::make_shared<NSubColumns::TJsonPathAccessor>(nullptr, TString{}, NSubColumns::EValueType::BinaryJson);
+    if (!OthersData) {
+        AFL_VERIFY(!GetBestPathSource(svPath).IsOther);
+        return columnsAccessor;
     }
-
-    if (OthersData) {
-        return OthersData->GetPathAccessor(svPath, recordsCount);
+    auto othersResult = OthersData->GetPathAccessor(svPath, recordsCount);
+    if (othersResult.IsFail()) {
+        return TConclusionStatus::Fail(othersResult.GetErrorMessage());
     }
-
-    AFL_VERIFY(!Header.GetOtherStats().GetKeyIndexOptional(svPath));
-    return std::make_shared<NSubColumns::TJsonPathAccessor>(
-        std::make_shared<TTrivialArray>(TThreadSimpleArraysCache::GetNull(arrow::binary(), recordsCount)), TString{},
-        NSubColumns::EValueType::BinaryJson);
+    return NSubColumns::TJsonPathAccessor::SelectBestMatch(columnsAccessor, othersResult.DetachResult());
 }
 
 }   // namespace NKikimr::NArrow::NAccessor

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
@@ -51,6 +51,7 @@ TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> TSubColumnsPartialA
     if (headerOthersResult.IsFail()) {
         return TConclusionStatus::Fail(headerOthersResult.GetErrorMessage());
     }
+    // A matching path must be loaded before accessor creation.
     AFL_VERIFY(!headerColumnsResult.DetachResult());
     AFL_VERIFY(!headerOthersResult.DetachResult());
     return NSubColumns::TOthersData::BuildEmptyPathAccessor(recordsCount);

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
@@ -52,6 +52,7 @@ TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> TSubColumnsPartialA
         return TConclusionStatus::Fail(headerOthersResult.GetErrorMessage());
     }
     // A matching path must be loaded before accessor creation.
+    // Fetch planning and lookup use the same canonical path resolution.
     AFL_VERIFY(!headerColumnsResult.DetachResult());
     AFL_VERIFY(!headerOthersResult.DetachResult());
     return NSubColumns::TOthersData::BuildEmptyPathAccessor(recordsCount);

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
@@ -20,7 +20,7 @@ TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> TSubColumnsPartialA
         return TConclusionStatus::Fail(parsedResult.GetErrorMessage());
     }
     const auto parsedPath = parsedResult.DetachResult();
-    auto headerStats = Header.GetColumnStats();
+    const auto& headerStats = Header.GetColumnStats();
     auto columnsResult = headerStats.ResolvePath(parsedPath, [this](const ui32 columnIndex) {
         return PartialColumnsData.HasColumn(columnIndex);
     });

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
@@ -15,28 +15,35 @@ void TSubColumnsPartialArray::InitOthers(const TString& blob, const TChunkConstr
 }
 
 TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> TSubColumnsPartialArray::GetPathAccessor(const std::string_view svPath, const ui32 recordsCount) const {
+    auto parsedResult = NSubColumns::ParseJsonPath(svPath);
+    if (parsedResult.IsFail()) {
+        return TConclusionStatus::Fail(parsedResult.GetErrorMessage());
+    }
+    const auto parsedPath = parsedResult.DetachResult();
     auto headerStats = Header.GetColumnStats();
-    // Resolve only among requested columns
-    auto pathInfoResult = headerStats.ResolvePath(svPath, [this](const ui32 columnIndex) {
+    auto columnsResult = headerStats.ResolvePath(parsedPath, [this](const ui32 columnIndex) {
         return PartialColumnsData.HasColumn(columnIndex);
     });
-    if (pathInfoResult.IsFail()) {
-        return TConclusionStatus::Fail(pathInfoResult.GetErrorMessage());
+    if (columnsResult.IsFail()) {
+        return TConclusionStatus::Fail(columnsResult.GetErrorMessage());
     }
-    auto pathInfo = pathInfoResult.DetachResult();
-    const auto columnsAccessor = pathInfo
-        ? std::make_shared<NSubColumns::TJsonPathAccessor>(PartialColumnsData.GetAccessorVerified(pathInfo->ColumnIndex),
-              std::move(pathInfo->RemainingPath), pathInfo->ValueType)
-        : std::make_shared<NSubColumns::TJsonPathAccessor>(nullptr, TString{}, NSubColumns::EValueType::BinaryJson);
-    if (!OthersData) {
-        AFL_VERIFY(!GetBestPathSource(svPath).IsOther);
-        return columnsAccessor;
+    auto columnsPath = columnsResult.DetachResult();
+    std::optional<NSubColumns::TDictStats::TResolvedPath> othersPath;
+    if (OthersData) {
+        auto othersResult = Header.GetOtherStats().ResolvePath(parsedPath);
+        if (othersResult.IsFail()) {
+            return TConclusionStatus::Fail(othersResult.GetErrorMessage());
+        }
+        othersPath = othersResult.DetachResult();
     }
-    auto othersResult = OthersData->GetPathAccessor(svPath, recordsCount);
-    if (othersResult.IsFail()) {
-        return TConclusionStatus::Fail(othersResult.GetErrorMessage());
+    if (othersPath && (!columnsPath || !NSubColumns::TDictStats::TResolvedPath::IsBetterMatch(*columnsPath, *othersPath))) {
+        return OthersData->GetPathAccessor(std::move(*othersPath), recordsCount);
     }
-    return NSubColumns::TJsonPathAccessor::SelectBestMatch(columnsAccessor, othersResult.DetachResult());
+    if (columnsPath) {
+        return std::make_shared<NSubColumns::TJsonPathAccessor>(PartialColumnsData.GetAccessorVerified(columnsPath->ColumnIndex),
+            std::move(columnsPath->RemainingPath), columnsPath->ValueType);
+    }
+    return NSubColumns::TOthersData::BuildEmptyPathAccessor(recordsCount);
 }
 
 }   // namespace NKikimr::NArrow::NAccessor

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
@@ -19,19 +19,18 @@ void TSubColumnsPartialArray::InitOthers(const TString& blob, const TChunkConstr
 }
 
 TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> TSubColumnsPartialArray::GetPathAccessor(const std::string_view svPath, const ui32 recordsCount) const {
-    auto jsonPathAccessorTrie = std::make_shared<NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie>();
     auto headerStats = Header.GetColumnStats();
-    for (ui32 i = 0; i < headerStats.GetDataNamesCount(); ++i) {
-        if (PartialColumnsData.HasColumn(i)) {
-            auto insertResult = jsonPathAccessorTrie->Insert(
-                NSubColumns::ToJsonPath(headerStats.GetColumnName(i)), PartialColumnsData.GetAccessorVerified(i), headerStats.GetValueType(i));
-            AFL_VERIFY(insertResult.IsSuccess())("error", insertResult.GetErrorMessage());
-        }
+    // Resolve only among requested columns
+    auto pathInfoResult = headerStats.ResolvePath(svPath, [this](const ui32 columnIndex) {
+        return PartialColumnsData.HasColumn(columnIndex);
+    });
+    if (pathInfoResult.IsFail()) {
+        return TConclusionStatus::Fail(pathInfoResult.GetErrorMessage());
     }
-
-    auto accessorResult = jsonPathAccessorTrie->GetAccessor(svPath);
-    if (accessorResult.IsSuccess() && accessorResult.GetResult()->IsValid()) {
-        return accessorResult;
+    auto pathInfo = pathInfoResult.DetachResult();
+    if (pathInfo && PartialColumnsData.HasColumn(pathInfo->ColumnIndex)) {
+        return std::make_shared<NSubColumns::TJsonPathAccessor>(PartialColumnsData.GetAccessorVerified(pathInfo->ColumnIndex),
+            std::move(pathInfo->RemainingPath), pathInfo->ValueType);
     }
 
     if (OthersData) {

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.cpp
@@ -36,13 +36,23 @@ TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> TSubColumnsPartialA
         }
         othersPath = othersResult.DetachResult();
     }
-    if (othersPath && (!columnsPath || !NSubColumns::TDictStats::TResolvedPath::IsBetterMatch(*columnsPath, *othersPath))) {
+    if (othersPath && (!columnsPath || !NSubColumns::TDictStats::TResolvedPath::IsBetterOrEqualMatchThan(*columnsPath, *othersPath))) {
         return OthersData->GetPathAccessor(std::move(*othersPath), recordsCount);
     }
     if (columnsPath) {
         return std::make_shared<NSubColumns::TJsonPathAccessor>(PartialColumnsData.GetAccessorVerified(columnsPath->ColumnIndex),
             std::move(columnsPath->RemainingPath), columnsPath->ValueType);
     }
+    auto headerColumnsResult = Header.GetColumnStats().ResolvePath(parsedPath);
+    if (headerColumnsResult.IsFail()) {
+        return TConclusionStatus::Fail(headerColumnsResult.GetErrorMessage());
+    }
+    auto headerOthersResult = Header.GetOtherStats().ResolvePath(parsedPath);
+    if (headerOthersResult.IsFail()) {
+        return TConclusionStatus::Fail(headerOthersResult.GetErrorMessage());
+    }
+    AFL_VERIFY(!headerColumnsResult.DetachResult());
+    AFL_VERIFY(!headerOthersResult.DetachResult());
     return NSubColumns::TOthersData::BuildEmptyPathAccessor(recordsCount);
 }
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.h
@@ -97,11 +97,6 @@ protected:
     }
 
 public:
-    struct TPathSource {
-        std::optional<ui32> ColumnIndex;
-        bool IsOther = false;
-    };
-
     TSubColumnsPartialArray(TSubColumnsHeader&& header, const ui32 recordsCount, const std::shared_ptr<arrow::DataType>& dataType,
         const NSubColumns::TSettings& settings)
         : TBase(recordsCount, EType::SubColumnsPartialArray, dataType)
@@ -136,25 +131,13 @@ public:
 
     TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> GetPathAccessor(const std::string_view svPath, const ui32 recordsCount) const;
 
-    TPathSource GetBestPathSource(const NSubColumns::TJsonPathBuf path) const {
-        auto columnsResult = Header.GetColumnStats().ResolvePath(path);
-        AFL_VERIFY(columnsResult.IsSuccess())("path", path)("error", columnsResult.GetErrorMessage());
-        auto othersResult = Header.GetOtherStats().ResolvePath(path);
-        AFL_VERIFY(othersResult.IsSuccess())("path", path)("error", othersResult.GetErrorMessage());
-        const auto columnsPath = columnsResult.DetachResult();
-        const auto othersPath = othersResult.DetachResult();
-        if (!othersPath || (columnsPath && NSubColumns::TJsonPathAccessor::IsBetterMatch(columnsPath->RemainingPath, othersPath->RemainingPath))) {
-            return { columnsPath ? std::optional<ui32>(columnsPath->ColumnIndex) : std::nullopt, false };
-        }
-        return { std::nullopt, true };
-    }
-
     bool NeedFetch(const std::string_view colName) const {
-        const auto source = GetBestPathSource(NSubColumns::ToJsonPath(colName));
-        if (source.ColumnIndex) {
-            return !PartialColumnsData.HasColumn(*source.ColumnIndex);
+        const auto path = NSubColumns::ResolveBestPath(
+            Header.GetColumnStats(), Header.GetOtherStats(), NSubColumns::ToJsonPath(colName)).DetachResult();
+        if (path && path->IsColumn) {
+            return !PartialColumnsData.HasColumn(path->Path.ColumnIndex);
         }
-        return source.IsOther && !OthersData;
+        return path && !OthersData;
     }
 
     void AddColumn(const TString& columnName, const std::shared_ptr<IChunkedArray>& arr) {

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.h
@@ -132,16 +132,17 @@ public:
     TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> GetPathAccessor(const std::string_view svPath, const ui32 recordsCount) const;
 
     bool NeedFetch(const std::string_view colName) const {
-        const auto path = NSubColumns::ResolveBestPath(
-            Header.GetColumnStats(), Header.GetOtherStats(), NSubColumns::ToJsonPath(colName)).DetachResult();
+        auto pathResult = NSubColumns::ResolveBestPath(Header.GetColumnStats(), Header.GetOtherStats(), NSubColumns::ToJsonPath(colName));
+        AFL_VERIFY(pathResult.IsSuccess())("column", colName)("error", pathResult.GetErrorMessage());
+        const auto path = pathResult.DetachResult();
         if (path && path->IsColumn) {
             return !PartialColumnsData.HasColumn(path->Path.ColumnIndex);
         }
         return path && !OthersData;
     }
 
-    void AddColumn(const TString& columnName, const std::shared_ptr<IChunkedArray>& arr) {
-        PartialColumnsData.AddColumn(Header.GetColumnStats().GetExactKeyIndexVerified(std::string_view(columnName.data(), columnName.size())), arr);
+    void AddColumn(const ui32 columnIndex, const std::shared_ptr<IChunkedArray>& arr) {
+        PartialColumnsData.AddColumn(columnIndex, arr);
     }
 
     bool HasOthers() const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.h
@@ -158,7 +158,7 @@ public:
     }
 
     void AddColumn(const TString& columnName, const std::shared_ptr<IChunkedArray>& arr) {
-        PartialColumnsData.AddColumn(Header.GetColumnStats().GetKeyIndexVerified(std::string_view(columnName.data(), columnName.size())), arr);
+        PartialColumnsData.AddColumn(Header.GetColumnStats().GetExactKeyIndexVerified(std::string_view(columnName.data(), columnName.size())), arr);
     }
 
     bool HasOthers() const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.h
@@ -97,6 +97,11 @@ protected:
     }
 
 public:
+    struct TPathSource {
+        std::optional<ui32> ColumnIndex;
+        bool IsOther = false;
+    };
+
     TSubColumnsPartialArray(TSubColumnsHeader&& header, const ui32 recordsCount, const std::shared_ptr<arrow::DataType>& dataType,
         const NSubColumns::TSettings& settings)
         : TBase(recordsCount, EType::SubColumnsPartialArray, dataType)
@@ -131,13 +136,25 @@ public:
 
     TConclusion<std::shared_ptr<NSubColumns::TJsonPathAccessor>> GetPathAccessor(const std::string_view svPath, const ui32 recordsCount) const;
 
-    bool NeedFetch(const std::string_view colName) const {
-        if (auto idx = Header.GetColumnStats().GetKeyIndexOptional(colName)) {
-            return !PartialColumnsData.HasColumn(*idx);
-        } else if (auto idx = Header.GetOtherStats().GetKeyIndexOptional(colName)) {
-            return !OthersData;
+    TPathSource GetBestPathSource(const NSubColumns::TJsonPathBuf path) const {
+        auto columnsResult = Header.GetColumnStats().ResolvePath(path);
+        AFL_VERIFY(columnsResult.IsSuccess())("path", path)("error", columnsResult.GetErrorMessage());
+        auto othersResult = Header.GetOtherStats().ResolvePath(path);
+        AFL_VERIFY(othersResult.IsSuccess())("path", path)("error", othersResult.GetErrorMessage());
+        const auto columnsPath = columnsResult.DetachResult();
+        const auto othersPath = othersResult.DetachResult();
+        if (!othersPath || (columnsPath && NSubColumns::TJsonPathAccessor::IsBetterMatch(columnsPath->RemainingPath, othersPath->RemainingPath))) {
+            return { columnsPath ? std::optional<ui32>(columnsPath->ColumnIndex) : std::nullopt, false };
         }
-        return false;
+        return { std::nullopt, true };
+    }
+
+    bool NeedFetch(const std::string_view colName) const {
+        const auto source = GetBestPathSource(NSubColumns::ToJsonPath(colName));
+        if (source.ColumnIndex) {
+            return !PartialColumnsData.HasColumn(*source.ColumnIndex);
+        }
+        return source.IsOther && !OthersData;
     }
 
     void AddColumn(const TString& columnName, const std::shared_ptr<IChunkedArray>& arr) {
@@ -150,10 +167,6 @@ public:
 
     void InitOthers(const TString& blob, const TChunkConstructionData& externalInfo, const std::shared_ptr<NArrow::TColumnFilter>& applyFilter,
         const bool deserialize);
-
-    bool IsOtherColumn(const TString& colName) const {
-        return !!Header.GetOtherStats().GetKeyIndexOptional(std::string_view(colName.data(), colName.size()));
-    }
 
     NSubColumns::TReadRange GetColumnReadRange(const ui32 colIndex) const {
         return Header.GetColumnReadRange(colIndex);

--- a/ydb/core/formats/arrow/accessor/sub_columns/stats.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/stats.cpp
@@ -95,6 +95,11 @@ TDictStats::TDictStats(const std::shared_ptr<arrow::RecordBatch>& original)
     DataSize = std::static_pointer_cast<arrow::UInt32Array>(Original->column(2));
     AccessorType = std::static_pointer_cast<arrow::UInt8Array>(Original->column(3));
     ValueType = std::static_pointer_cast<arrow::UInt8Array>(Original->column(4));
+    ColumnIndexes.reserve(DataNames->length());
+    for (ui32 i = 0; i < DataNames->length(); ++i) {
+        const auto insertResult = ColumnIndexes.emplace(GetColumnName(i), i);
+        AFL_VERIFY(insertResult.second)("name", GetColumnName(i));
+    }
 }
 
 TConstructorContainer TDictStats::GetAccessorConstructor(const ui32 columnIndex, const TEncodingParams& encodingParams) const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/stats.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/stats.h
@@ -27,6 +27,10 @@ public:
 
         bool operator==(const TResolvedPath&) const = default;
 
+        static bool IsBetterMatch(const TResolvedPath& first, const TResolvedPath& second) {
+            return first.RemainingPath.size() <= second.RemainingPath.size();
+        }
+
         friend IOutputStream& operator<<(IOutputStream& out, const TResolvedPath& pathInfo) {
             return out << "{ " << pathInfo.ColumnIndex << ", " << static_cast<ui32>(pathInfo.ValueType) << ", " << pathInfo.RemainingPath << " }";
         }
@@ -82,17 +86,13 @@ public:
     static TDictStats DeserializeFromBlob(const TString& blob);
 
     template <class TColumnPredicate>
-    TConclusion<std::optional<TResolvedPath>> ResolvePath(const TJsonPathBuf jsonPath, const TColumnPredicate& isColumnAvailable) const {
-        auto splitResult = SplitJsonPath(jsonPath, TJsonPathSplitSettings{.FillTypes = true, .FillStartPositions = true});
-        if (splitResult.IsFail()) {
-            return TConclusionStatus::Fail(splitResult.GetErrorMessage());
-        }
-        const auto [pathItems, pathTypes, startPositions] = splitResult.DetachResult();
+    TConclusion<std::optional<TResolvedPath>> ResolvePath(const TParsedJsonPath& jsonPath, const TColumnPredicate& isColumnAvailable) const {
+        const auto& [pathItems, pathTypes, startPositions] = jsonPath.Items;
         AFL_VERIFY(pathItems.size() == pathTypes.size());
         AFL_VERIFY(pathItems.size() == startPositions.size());
 
         TString columnName;
-        columnName.reserve(EstimateSubcolumnNameSize(jsonPath, pathItems.size()));
+        columnName.reserve(EstimateSubcolumnNameSize(jsonPath.Source, pathItems.size()));
         std::optional<ui32> columnIndex;
         ui32 matchedItemsCount = 0;
         for (ui32 i = 0; i < pathItems.size(); ++i) {
@@ -112,9 +112,24 @@ public:
         TString remainingPath;
         // strict is required, because there is a memory problem in NYql::NJsonPath::ExecuteJsonPath with lax and BinaryJson
         if (matchedItemsCount < startPositions.size()) {
-            remainingPath = "strict $" + TString(jsonPath.data() + startPositions[matchedItemsCount], jsonPath.size() - startPositions[matchedItemsCount]);
+            remainingPath = "strict $" + TString(jsonPath.Source.data() + startPositions[matchedItemsCount], jsonPath.Source.size() - startPositions[matchedItemsCount]);
         }
         return std::optional<TResolvedPath>(TResolvedPath{ *columnIndex, GetValueType(*columnIndex), std::move(remainingPath) });
+    }
+
+    template <class TColumnPredicate>
+    TConclusion<std::optional<TResolvedPath>> ResolvePath(const TJsonPathBuf jsonPath, const TColumnPredicate& isColumnAvailable) const {
+        auto parsed = ParseJsonPath(jsonPath);
+        if (parsed.IsFail()) {
+            return TConclusionStatus::Fail(parsed.GetErrorMessage());
+        }
+        return ResolvePath(parsed.GetResult(), isColumnAvailable);
+    }
+
+    TConclusion<std::optional<TResolvedPath>> ResolvePath(const TParsedJsonPath& jsonPath) const {
+        return ResolvePath(jsonPath, [](const ui32) {
+            return true;
+        });
     }
 
     TConclusion<std::optional<TResolvedPath>> ResolvePath(const TJsonPathBuf jsonPath) const {
@@ -290,4 +305,32 @@ public:
 
     TDictStats(const std::shared_ptr<arrow::RecordBatch>& original);
 };
+
+struct TResolvedPathMatch {
+    TDictStats::TResolvedPath Path;
+    bool IsColumn = false;
+};
+
+inline TConclusion<std::optional<TResolvedPathMatch>> ResolveBestPath(
+    const TDictStats& columnsStats, const TDictStats& othersStats, const TJsonPathBuf path) {
+    auto parsed = ParseJsonPath(path);
+    if (parsed.IsFail()) {
+        return TConclusionStatus::Fail(parsed.GetErrorMessage());
+    }
+    auto columnsResult = columnsStats.ResolvePath(parsed.GetResult());
+    if (columnsResult.IsFail()) {
+        return TConclusionStatus::Fail(columnsResult.GetErrorMessage());
+    }
+    auto othersResult = othersStats.ResolvePath(parsed.GetResult());
+    if (othersResult.IsFail()) {
+        return TConclusionStatus::Fail(othersResult.GetErrorMessage());
+    }
+    const auto columnsPath = columnsResult.DetachResult();
+    const auto othersPath = othersResult.DetachResult();
+    if (!othersPath || (columnsPath && TDictStats::TResolvedPath::IsBetterMatch(*columnsPath, *othersPath))) {
+        return columnsPath ? std::optional<TResolvedPathMatch>(TResolvedPathMatch{ *columnsPath, true }) : std::nullopt;
+    }
+    return TResolvedPathMatch{ *othersPath, false };
+}
+
 }   // namespace NKikimr::NArrow::NAccessor::NSubColumns

--- a/ydb/core/formats/arrow/accessor/sub_columns/stats.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/stats.h
@@ -27,7 +27,7 @@ public:
 
         bool operator==(const TResolvedPath&) const = default;
 
-        static bool IsBetterMatch(const TResolvedPath& first, const TResolvedPath& second) {
+        static bool IsBetterOrEqualMatchThan(const TResolvedPath& first, const TResolvedPath& second) {
             return first.RemainingPath.size() <= second.RemainingPath.size();
         }
 
@@ -327,7 +327,7 @@ inline TConclusion<std::optional<TResolvedPathMatch>> ResolveBestPath(
     }
     const auto columnsPath = columnsResult.DetachResult();
     const auto othersPath = othersResult.DetachResult();
-    if (!othersPath || (columnsPath && TDictStats::TResolvedPath::IsBetterMatch(*columnsPath, *othersPath))) {
+    if (!othersPath || (columnsPath && TDictStats::TResolvedPath::IsBetterOrEqualMatchThan(*columnsPath, *othersPath))) {
         return columnsPath ? std::optional<TResolvedPathMatch>(TResolvedPathMatch{ *columnsPath, true }) : std::nullopt;
     }
     return TResolvedPathMatch{ *othersPath, false };

--- a/ydb/core/formats/arrow/accessor/sub_columns/stats.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/stats.h
@@ -8,36 +8,46 @@
 #include <ydb/library/accessor/accessor.h>
 #include <ydb/library/actors/core/log.h>
 
+#include <library/cpp/containers/absl/flat_hash_map.h>
+
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/array_binary.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/builder_base.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/record_batch.h>
 #include <util/generic/string.h>
+#include <util/stream/output.h>
 
 namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
 class TDictStats {
-private:
-    using TJsonPathAccessorTriePtr = std::shared_ptr<NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie>;
+public:
+    struct TResolvedPath {
+        ui32 ColumnIndex;
+        EValueType ValueType;
+        TString RemainingPath;
 
+        bool operator==(const TResolvedPath&) const = default;
+
+        friend IOutputStream& operator<<(IOutputStream& out, const TResolvedPath& pathInfo) {
+            return out << "{ " << pathInfo.ColumnIndex << ", " << static_cast<ui32>(pathInfo.ValueType) << ", " << pathInfo.RemainingPath << " }";
+        }
+    };
+
+private:
     std::shared_ptr<arrow::RecordBatch> Original;
     std::shared_ptr<arrow::BinaryArray> DataNames;
     std::shared_ptr<arrow::UInt32Array> DataRecordsCount;
     std::shared_ptr<arrow::UInt32Array> DataSize;
     std::shared_ptr<arrow::UInt8Array> AccessorType;
     std::shared_ptr<arrow::UInt8Array> ValueType;
-    TJsonPathAccessorTriePtr CachedJsonPathAccessorTrie;
+    // keys are references to DataNames array values
+    absl::flat_hash_map<std::string_view, ui32> ColumnIndexes;
 
-    TJsonPathAccessorTriePtr GenerateJsonPathAccessorTrie() const {
-        auto jsonPathAccessorTrie = std::make_shared<NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie>();
-        for (ui32 i = 0; i < DataNames->length(); ++i) {
-            const auto arrView = DataNames->GetView(i);
-            auto insertResult = jsonPathAccessorTrie->Insert(ToJsonPath(TStringBuf(arrView.data(), arrView.size())), nullptr, OthersExplicitBinaryJson, i);
-            AFL_VERIFY(insertResult.IsSuccess())("key_name", TStringBuf(arrView.data(), arrView.size()))
-                ("json_path", ToJsonPath(TStringBuf(arrView.data(), arrView.size())))
-                ("error", insertResult.GetErrorMessage());
+    std::optional<ui32> GetColumnIndexOptional(const std::string_view name) const {
+        const auto it = ColumnIndexes.find(name);
+        if (it != ColumnIndexes.end()) {
+            return it->second;
         }
-
-        return jsonPathAccessorTrie;
+        return std::nullopt;
     }
 
 public:
@@ -65,21 +75,55 @@ public:
     // and the legacy (4-column) layout via try-decode-fallback.
     static TDictStats DeserializeFromBlob(const TString& blob);
 
-    void CreateJsonPathAccessorTrieCache() {
-        CachedJsonPathAccessorTrie = GenerateJsonPathAccessorTrie();
+    template <class TColumnPredicate>
+    TConclusion<std::optional<TResolvedPath>> ResolvePath(const TJsonPathBuf jsonPath, const TColumnPredicate& isColumnAvailable) const {
+        auto splitResult = SplitJsonPath(jsonPath, TJsonPathSplitSettings{.FillTypes = true, .FillStartPositions = true});
+        if (splitResult.IsFail()) {
+            return TConclusionStatus::Fail(splitResult.GetErrorMessage());
+        }
+        const auto [pathItems, pathTypes, startPositions] = splitResult.DetachResult();
+        AFL_VERIFY(pathItems.size() == pathTypes.size());
+        AFL_VERIFY(pathItems.size() == startPositions.size());
+
+        TString columnName;
+        std::optional<ui32> columnIndex;
+        ui32 matchedItemsCount = 0;
+        for (ui32 i = 0; i < pathItems.size(); ++i) {
+            if (pathTypes[i] != NYql::NJsonPath::EJsonPathItemType::MemberAccess) {
+                break;
+            }
+            columnName = BuildSubcolumnName(columnName, pathItems[i]);
+            if (auto index = GetColumnIndexOptional(columnName); index && isColumnAvailable(*index)) {
+                columnIndex = index;
+                matchedItemsCount = i + 1;
+            }
+        }
+        if (!columnIndex) {
+            return std::optional<TResolvedPath>();
+        }
+
+        TString remainingPath;
+        // strict is required, because there is a memory problem in NYql::NJsonPath::ExecuteJsonPath with lax and BinaryJson
+        if (matchedItemsCount < startPositions.size()) {
+            remainingPath = "strict $" + TString(jsonPath.data() + startPositions[matchedItemsCount], jsonPath.size() - startPositions[matchedItemsCount]);
+        }
+        return std::optional<TResolvedPath>(TResolvedPath{ *columnIndex, GetValueType(*columnIndex), std::move(remainingPath) });
+    }
+
+    TConclusion<std::optional<TResolvedPath>> ResolvePath(const TJsonPathBuf jsonPath) const {
+        return ResolvePath(jsonPath, [](const ui32) {
+            return true;
+        });
     }
 
     std::optional<ui32> GetKeyIndexOptional(const std::string_view keyName) const {
-        auto accessorResult = CachedJsonPathAccessorTrie ? CachedJsonPathAccessorTrie->GetAccessor(ToJsonPath(keyName))
-                                                         : GenerateJsonPathAccessorTrie()->GetAccessor(ToJsonPath(keyName));
-        AFL_VERIFY(accessorResult.IsSuccess())("keyName", keyName)("jsonPath", ToJsonPath(keyName))("error", accessorResult.GetErrorMessage());
-
-        auto accessor = accessorResult.DetachResult();
-        if (!accessor) {
+        auto pathInfoResult = ResolvePath(ToJsonPath(keyName));
+        AFL_VERIFY(pathInfoResult.IsSuccess())("keyName", keyName)("jsonPath", ToJsonPath(keyName))("error", pathInfoResult.GetErrorMessage());
+        auto pathInfo = pathInfoResult.DetachResult();
+        if (!pathInfo) {
             return std::nullopt;
         }
-
-        return accessor->GetCookie();
+        return pathInfo->ColumnIndex;
     }
 
     ui32 GetKeyIndexVerified(const std::string_view keyName) const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/stats.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/stats.h
@@ -140,7 +140,9 @@ public:
 
     std::optional<ui32> GetKeyOrPrefixIndexOptional(const std::string_view keyName) const {
         auto pathInfoResult = ResolvePath(ToJsonPath(keyName));
-        AFL_VERIFY(pathInfoResult.IsSuccess())("keyName", keyName)("jsonPath", ToJsonPath(keyName))("error", pathInfoResult.GetErrorMessage());
+        if (pathInfoResult.IsFail()) {
+            return std::nullopt;
+        }
         auto pathInfo = pathInfoResult.DetachResult();
         if (!pathInfo) {
             return std::nullopt;

--- a/ydb/core/formats/arrow/accessor/sub_columns/stats.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/stats.h
@@ -138,6 +138,7 @@ public:
         });
     }
 
+    // Returns the longest stored member-wise prefix; malformed paths do not match.
     std::optional<ui32> GetKeyOrPrefixIndexOptional(const std::string_view keyName) const {
         auto pathInfoResult = ResolvePath(ToJsonPath(keyName));
         if (pathInfoResult.IsFail()) {

--- a/ydb/core/formats/arrow/accessor/sub_columns/stats.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/stats.h
@@ -42,7 +42,8 @@ private:
     // keys are references to DataNames array values
     absl::flat_hash_map<std::string_view, ui32> ColumnIndexes;
 
-    std::optional<ui32> GetColumnIndexOptional(const std::string_view name) const {
+public:
+    std::optional<ui32> GetExactKeyIndexOptional(const std::string_view name) const {
         const auto it = ColumnIndexes.find(name);
         if (it != ColumnIndexes.end()) {
             return it->second;
@@ -50,7 +51,12 @@ private:
         return std::nullopt;
     }
 
-public:
+    ui32 GetExactKeyIndexVerified(const std::string_view keyName) const {
+        const auto idx = GetExactKeyIndexOptional(keyName);
+        AFL_VERIFY(idx.has_value());
+        return *idx;
+    }
+
     ui32 GetFilledValuesCount() const {
         ui32 result = 0;
         for (ui32 i = 0; i < (ui32)DataRecordsCount->length(); ++i) {
@@ -94,7 +100,7 @@ public:
                 break;
             }
             AppendSubcolumnName(columnName, pathItems[i]);
-            if (auto index = GetColumnIndexOptional(columnName); index && isColumnAvailable(*index)) {
+            if (auto index = GetExactKeyIndexOptional(columnName); index && isColumnAvailable(*index)) {
                 columnIndex = index;
                 matchedItemsCount = i + 1;
             }
@@ -117,7 +123,7 @@ public:
         });
     }
 
-    std::optional<ui32> GetKeyIndexOptional(const std::string_view keyName) const {
+    std::optional<ui32> GetKeyOrPrefixIndexOptional(const std::string_view keyName) const {
         auto pathInfoResult = ResolvePath(ToJsonPath(keyName));
         AFL_VERIFY(pathInfoResult.IsSuccess())("keyName", keyName)("jsonPath", ToJsonPath(keyName))("error", pathInfoResult.GetErrorMessage());
         auto pathInfo = pathInfoResult.DetachResult();
@@ -125,13 +131,6 @@ public:
             return std::nullopt;
         }
         return pathInfo->ColumnIndex;
-    }
-
-    ui32 GetKeyIndexVerified(const std::string_view keyName) const {
-        auto idx = GetKeyIndexOptional(keyName);
-        AFL_VERIFY(idx.has_value());
-
-        return idx.value();
     }
 
     class TRTStatsValue {

--- a/ydb/core/formats/arrow/accessor/sub_columns/stats.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/stats.h
@@ -86,13 +86,14 @@ public:
         AFL_VERIFY(pathItems.size() == startPositions.size());
 
         TString columnName;
+        columnName.reserve(EstimateSubcolumnNameSize(jsonPath, pathItems.size()));
         std::optional<ui32> columnIndex;
         ui32 matchedItemsCount = 0;
         for (ui32 i = 0; i < pathItems.size(); ++i) {
             if (pathTypes[i] != NYql::NJsonPath::EJsonPathItemType::MemberAccess) {
                 break;
             }
-            columnName = BuildSubcolumnName(columnName, pathItems[i]);
+            AppendSubcolumnName(columnName, pathItems[i]);
             if (auto index = GetColumnIndexOptional(columnName); index && isColumnAvailable(*index)) {
                 columnIndex = index;
                 matchedItemsCount = i + 1;

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -571,9 +571,8 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         NSubColumns::TColumnsData columns(stats, records);
 
         const auto check = [&](const TStringBuf path, const std::optional<TStringBuf> expected) {
-            auto accessorResult = columns.GetPathAccessor(path);
-            UNIT_ASSERT_C(accessorResult.IsSuccess(), accessorResult.GetErrorMessage());
-            const auto accessor = accessorResult.DetachResult();
+            const auto pathInfo = ResolvePathVerified(stats, path);
+            const auto accessor = columns.GetPathAccessor(pathInfo);
             accessor->VisitValues([&](const std::optional<TStringBuf>& value) {
                 UNIT_ASSERT_VALUES_EQUAL_C(value, expected, path);
             });

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -298,7 +298,7 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         UNIT_ASSERT(invalidResult.GetErrorMessage().Contains("Unsupported path"));
     }
 
-    Y_UNIT_TEST(SplitJsonPath) {
+    Y_UNIT_TEST(ParseJsonPath) {
         TString path = R"($.a."b".'c'.'d"'."'"."\"".""."."[0,2].b[0].c[3][4].d[2 to 5].e[last])";
         TVector<TString> expectedItems = {"a", "b", "c", "d\"", "'", "\"", "", ".", "[0,2]", "b", "[0]", "c", "[3]", "[4]", "d", "[2 to 5]", "e", "[last]"};
         using enum NYql::NJsonPath::EJsonPathItemType;
@@ -306,9 +306,9 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
             MemberAccess, ArrayAccess, MemberAccess, ArrayAccess, ArrayAccess, MemberAccess, ArrayAccess, MemberAccess, ArrayAccess};
         TVector<NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathBuf::size_type> expectedStartPositions = {1, 3, 7, 11, 16, 20, 25, 28, 32, 37, 39, 42, 44, 47, 50, 52, 60, 62};
 
-        auto result = NKikimr::NArrow::NAccessor::NSubColumns::SplitJsonPath(path, NSubColumns::TJsonPathSplitSettings{.FillTypes = true, .FillStartPositions = true});
+        auto result = NKikimr::NArrow::NAccessor::NSubColumns::ParseJsonPath(path);
         UNIT_ASSERT_C(result.IsSuccess(), result.GetErrorMessage());
-        const auto [pathItems, pathTypes, startPositions] = result.DetachResult();
+        const auto [pathItems, pathTypes, startPositions] = result.DetachResult().Items;
 
         UNIT_ASSERT_VALUES_EQUAL(expectedItems, pathItems);
         UNIT_ASSERT_EQUAL(expectedTypes, pathTypes);

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -383,6 +383,36 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
             std::make_shared<arrow::BinaryScalar>(std::make_shared<arrow::Buffer>((const ui8*)binaryJson.data(), binaryJson.size()), arrow::binary())));
     }
 
+    void CheckMostSpecificStoredPath(const std::initializer_list<std::pair<TStringBuf, TStringBuf>>& columns, const TStringBuf otherName,
+        const TStringBuf otherValue, const TStringBuf path, const TStringBuf expected) {
+        auto columnsBuilder = NSubColumns::TDictStats::MakeBuilder();
+        for (const auto& [name, _] : columns) {
+            columnsBuilder.Add(TString(name), 1, 1, IChunkedArray::EType::Array, NSubColumns::EValueType::BinaryJson);
+        }
+        auto columnsStats = columnsBuilder.Finish();
+        auto columnsRecords = std::make_shared<TGeneralContainer>(1);
+        ui32 index = 0;
+        for (const auto& [_, value] : columns) {
+            columnsRecords->AddField(columnsStats.GetField(index++), CreateTrivialArrayAccessor(value)).Validate();
+        }
+
+        auto othersStats = BuildStats({ { otherName, NSubColumns::EValueType::BinaryJson } });
+        const auto binaryJsonResult = NBinaryJson::SerializeToBinaryJson(otherValue);
+        UNIT_ASSERT(std::holds_alternative<NBinaryJson::TBinaryJson>(binaryJsonResult));
+        const auto& binaryJson = std::get<NBinaryJson::TBinaryJson>(binaryJsonResult);
+        auto othersBuilder = NSubColumns::TOthersData::MakeMergedBuilder();
+        othersBuilder->Add(0, 0, std::string_view(binaryJson.data(), binaryJson.size()));
+        auto others = othersBuilder->Finish(NSubColumns::TOthersData::TFinishContext(othersStats));
+
+        TSubColumnsArray array(
+            NSubColumns::TColumnsData(columnsStats, columnsRecords), std::move(others), arrow::binary(), 1, NSubColumns::TSettings());
+        auto accessorResult = array.GetPathAccessor(path, 1);
+        UNIT_ASSERT_C(accessorResult.IsSuccess(), accessorResult.GetErrorMessage());
+        accessorResult.DetachResult()->VisitValues([expected](const std::optional<TStringBuf>& value) {
+            UNIT_ASSERT_VALUES_EQUAL(value, expected);
+        });
+    }
+
     void CheckValueByPath(const std::shared_ptr<IChunkedArray>& accessor, TStringBuf path, std::optional<TStringBuf> expected) {
         static const auto stats = BuildStats({ { R"("a")", NSubColumns::EValueType::BinaryJson } });
         auto pathInfo = ResolvePathVerified(stats, path);
@@ -591,6 +621,17 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         accessorResult.DetachResult()->VisitValues([](const std::optional<TStringBuf>& value) {
             UNIT_ASSERT_VALUES_EQUAL(value, "value");
         });
+    }
+
+    Y_UNIT_TEST(JsonPathAccessorPreferBestMatchOthers) {
+        // Others have an exact match while separated only a prefix
+        CheckMostSpecificStoredPath({ { R"("a")", R"({"b":"columns"})" }, { R"("a"."b"."c")", R"("descendant")" } }, R"("a"."b")",
+            R"("others")", "$.a.b", "others");
+    }
+
+    // Others have an exact match while separated only a prefix
+    Y_UNIT_TEST(JsonPathAccessorPreferBestMatchSeparated) {
+        CheckMostSpecificStoredPath({ { R"("a"."b")", R"("columns")" } }, R"("a")", R"({"c":"others"})", "$.a.b", "columns");
     }
 };
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -296,6 +296,9 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         const auto invalidResult = NSubColumns::ValidateJsonPath(R"("deployment.environment")");
         UNIT_ASSERT(invalidResult.IsFail());
         UNIT_ASSERT(invalidResult.GetErrorMessage().Contains("Unsupported path"));
+
+        const auto stats = BuildStats({ { R"("a")", NSubColumns::EValueType::BinaryJson } });
+        UNIT_ASSERT(!stats.GetKeyOrPrefixIndexOptional("\""));
     }
 
     Y_UNIT_TEST(ParseJsonPath) {

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -6,8 +6,6 @@
 #include <ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
 #include <ydb/core/formats/arrow/serializer/abstract.h>
-#include <ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/sub_column.h>
-
 #include <ydb/core/formats/arrow/accessor/sub_columns/ut_common/ut_helpers.h>
 
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/builder_binary.h>
@@ -658,20 +656,6 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         CheckMostSpecificStoredPath({ { R"("a"."b")", R"("columns")" } }, R"("a")", R"({"c":"others"})", "$.a.b", "columns");
     }
 
-    Y_UNIT_TEST(SubColumnDataExtractorUsesExactStoredPath) {
-        auto array = BuildArrayWithStoredPaths(
-            { { R"("a")", R"("columns")" }, { R"("a"."b"."c")", R"("descendant")" } }, R"("a"."b")", R"("others")");
-        NOlap::NIndexes::TSubColumnDataExtractor extractor;
-        NJson::TJsonValue config(NJson::JSON_MAP);
-        config.InsertValue("sub_column_name", R"("a"."b")");
-        UNIT_ASSERT(extractor.DeserializeFromJson(config).IsSuccess());
-
-        TString result;
-        extractor.VisitAll(array, {}, [&result](const NArrow::NAccessor::TJsonValueView& value, ui64) {
-            result = value.ToJsonValue().GetString();
-        });
-        UNIT_ASSERT_VALUES_EQUAL(result, "others");
-    }
 };
 
 Y_UNIT_TEST_SUITE(SubColumnsDictStats) {

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -6,6 +6,7 @@
 #include <ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
 #include <ydb/core/formats/arrow/serializer/abstract.h>
+#include <ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/sub_column.h>
 
 #include <ydb/core/formats/arrow/accessor/sub_columns/ut_common/ut_helpers.h>
 
@@ -36,7 +37,7 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         UNIT_ASSERT_C(pathInfoResult.IsSuccess(), pathInfoResult.GetErrorMessage());
         const auto pathInfo = pathInfoResult.DetachResult();
         UNIT_ASSERT_C(pathInfo, path);
-        const auto keyIndex = stats.GetKeyIndexOptional(NSubColumns::ToSubcolumnName(path));
+        const auto keyIndex = stats.GetKeyOrPrefixIndexOptional(NSubColumns::ToSubcolumnName(path));
         UNIT_ASSERT_C(keyIndex, path);
         UNIT_ASSERT_VALUES_EQUAL(*keyIndex, pathInfo->ColumnIndex);
         return *pathInfo;
@@ -46,7 +47,7 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         auto pathInfoResult = stats.ResolvePath(path);
         UNIT_ASSERT_C(pathInfoResult.IsSuccess(), pathInfoResult.GetErrorMessage());
         UNIT_ASSERT_C(!pathInfoResult.DetachResult(), path);
-        UNIT_ASSERT_C(!stats.GetKeyIndexOptional(NSubColumns::ToSubcolumnName(path)), path);
+        UNIT_ASSERT_C(!stats.GetKeyOrPrefixIndexOptional(NSubColumns::ToSubcolumnName(path)), path);
     }
 
     NSubColumns::TDictStats BuildStats(const std::initializer_list<std::pair<TStringBuf, NSubColumns::EValueType>>& columns) {
@@ -389,8 +390,8 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
             std::make_shared<arrow::BinaryScalar>(std::make_shared<arrow::Buffer>((const ui8*)binaryJson.data(), binaryJson.size()), arrow::binary())));
     }
 
-    void CheckMostSpecificStoredPath(const std::initializer_list<std::pair<TStringBuf, TStringBuf>>& columns, const TStringBuf otherName,
-        const TStringBuf otherValue, const TStringBuf path, const TStringBuf expected) {
+    std::shared_ptr<TSubColumnsArray> BuildArrayWithStoredPaths(const std::initializer_list<std::pair<TStringBuf, TStringBuf>>& columns,
+        const TStringBuf otherName, const TStringBuf otherValue) {
         auto columnsBuilder = NSubColumns::TDictStats::MakeBuilder();
         for (const auto& [name, _] : columns) {
             columnsBuilder.Add(TString(name), 1, 1, IChunkedArray::EType::Array, NSubColumns::EValueType::BinaryJson);
@@ -410,9 +411,14 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         othersBuilder->Add(0, 0, std::string_view(binaryJson.data(), binaryJson.size()));
         auto others = othersBuilder->Finish(NSubColumns::TOthersData::TFinishContext(othersStats));
 
-        TSubColumnsArray array(
+        return std::make_shared<TSubColumnsArray>(
             NSubColumns::TColumnsData(columnsStats, columnsRecords), std::move(others), arrow::binary(), 1, NSubColumns::TSettings());
-        auto accessorResult = array.GetPathAccessor(path, 1);
+    }
+
+    void CheckMostSpecificStoredPath(const std::initializer_list<std::pair<TStringBuf, TStringBuf>>& columns, const TStringBuf otherName,
+        const TStringBuf otherValue, const TStringBuf path, const TStringBuf expected) {
+        auto array = BuildArrayWithStoredPaths(columns, otherName, otherValue);
+        auto accessorResult = array->GetPathAccessor(path, 1);
         UNIT_ASSERT_C(accessorResult.IsSuccess(), accessorResult.GetErrorMessage());
         accessorResult.DetachResult()->VisitValues([expected](const std::optional<TStringBuf>& value) {
             UNIT_ASSERT_VALUES_EQUAL(value, expected);
@@ -629,6 +635,16 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         });
     }
 
+    Y_UNIT_TEST(PartialArrayFetchesMoreSpecificOthersPath) {
+        auto header = NSubColumns::TSubColumnsHeader(
+            BuildStats({ { R"("a")", NSubColumns::EValueType::BinaryJson }, { R"("a"."b"."c")", NSubColumns::EValueType::BinaryJson } }),
+            BuildStats({ { R"("a"."b")", NSubColumns::EValueType::BinaryJson } }), NKikimrArrowAccessorProto::TSubColumnsAccessor(), 0);
+        TSubColumnsPartialArray partial(std::move(header), 1, arrow::binary(), NSubColumns::TSettings());
+        partial.AddColumn(R"("a")", CreateTrivialArrayAccessor(R"({"b":"columns"})"));
+
+        UNIT_ASSERT(!partial.HasSubColumnData(R"("a"."b")"));
+    }
+
     Y_UNIT_TEST(JsonPathAccessorPreferBestMatchOthers) {
         // Others have an exact match while separated only a prefix
         CheckMostSpecificStoredPath({ { R"("a")", R"({"b":"columns"})" }, { R"("a"."b"."c")", R"("descendant")" } }, R"("a"."b")",
@@ -638,6 +654,21 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
     // Others have an exact match while separated only a prefix
     Y_UNIT_TEST(JsonPathAccessorPreferBestMatchSeparated) {
         CheckMostSpecificStoredPath({ { R"("a"."b")", R"("columns")" } }, R"("a")", R"({"c":"others"})", "$.a.b", "columns");
+    }
+
+    Y_UNIT_TEST(SubColumnDataExtractorUsesExactStoredPath) {
+        auto array = BuildArrayWithStoredPaths(
+            { { R"("a")", R"("columns")" }, { R"("a"."b"."c")", R"("descendant")" } }, R"("a"."b")", R"("others")");
+        NOlap::NIndexes::TSubColumnDataExtractor extractor;
+        NJson::TJsonValue config(NJson::JSON_MAP);
+        config.InsertValue("sub_column_name", R"("a"."b")");
+        UNIT_ASSERT(extractor.DeserializeFromJson(config).IsSuccess());
+
+        TString result;
+        extractor.VisitAll(array, {}, [&result](const NArrow::NAccessor::TJsonValueView& value, ui64) {
+            result = value.ToJsonValue().GetString();
+        });
+        UNIT_ASSERT_VALUES_EQUAL(result, "others");
     }
 };
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -606,6 +606,25 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         UNIT_ASSERT(!partial.HasSubColumnData(R"("a"."b")"));
     }
 
+    Y_UNIT_TEST(JsonPathAccessorReturnsNullForMissingPath) {
+        auto array = BuildArrayWithStoredPaths({ { R"("a")", R"("columns")" } }, R"("b")", R"("others")");
+        auto accessorResult = array->GetPathAccessor("$.missing", 1);
+        UNIT_ASSERT_C(accessorResult.IsSuccess(), accessorResult.GetErrorMessage());
+        accessorResult.DetachResult()->VisitValues([](const std::optional<TStringBuf>& value) {
+            UNIT_ASSERT(!value);
+        });
+
+        auto header = NSubColumns::TSubColumnsHeader(
+            BuildStats({ { R"("a")", NSubColumns::EValueType::BinaryJson } }), NSubColumns::TDictStats::BuildEmpty(),
+            NKikimrArrowAccessorProto::TSubColumnsAccessor(), 0);
+        TSubColumnsPartialArray partial(std::move(header), 1, arrow::binary(), NSubColumns::TSettings());
+        accessorResult = partial.GetPathAccessor("$.missing", 1);
+        UNIT_ASSERT_C(accessorResult.IsSuccess(), accessorResult.GetErrorMessage());
+        accessorResult.DetachResult()->VisitValues([](const std::optional<TStringBuf>& value) {
+            UNIT_ASSERT(!value);
+        });
+    }
+
     Y_UNIT_TEST(JsonPathAccessorPreferBestMatchOthers) {
         // Others have an exact match while separated only a prefix
         CheckMostSpecificStoredPath({ { R"("a")", R"({"b":"columns"})" }, { R"("a"."b"."c")", R"("descendant")" } }, R"("a"."b")",

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -625,7 +625,7 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
             BuildStats({ { R"("a")", NSubColumns::EValueType::BinaryJson }, { R"("a"."b")", NSubColumns::EValueType::BinaryJson } }),
             NSubColumns::TDictStats::BuildEmpty(), NKikimrArrowAccessorProto::TSubColumnsAccessor(), 0);
         TSubColumnsPartialArray partial(std::move(header), 1, arrow::binary(), NSubColumns::TSettings());
-        partial.AddColumn(R"("a")", CreateTrivialArrayAccessor(R"({"b":{"c":"value"}})"));
+        partial.AddColumn(partial.GetHeader().GetColumnStats().GetExactKeyIndexVerified(R"("a")"), CreateTrivialArrayAccessor(R"({"b":{"c":"value"}})"));
 
         auto accessorResult = partial.GetPathAccessor("$.a.b.c", 1);
         UNIT_ASSERT_C(accessorResult.IsSuccess(), accessorResult.GetErrorMessage());
@@ -634,12 +634,12 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         });
     }
 
-    Y_UNIT_TEST(PartialArrayFetchesMoreSpecificOthersPath) {
+    Y_UNIT_TEST(PartialArrayNeedsFetchForMoreSpecificOthersPath) {
         auto header = NSubColumns::TSubColumnsHeader(
             BuildStats({ { R"("a")", NSubColumns::EValueType::BinaryJson }, { R"("a"."b"."c")", NSubColumns::EValueType::BinaryJson } }),
             BuildStats({ { R"("a"."b")", NSubColumns::EValueType::BinaryJson } }), NKikimrArrowAccessorProto::TSubColumnsAccessor(), 0);
         TSubColumnsPartialArray partial(std::move(header), 1, arrow::binary(), NSubColumns::TSettings());
-        partial.AddColumn(R"("a")", CreateTrivialArrayAccessor(R"({"b":"columns"})"));
+        partial.AddColumn(partial.GetHeader().GetColumnStats().GetExactKeyIndexVerified(R"("a")"), CreateTrivialArrayAccessor(R"({"b":"columns"})"));
 
         UNIT_ASSERT(!partial.HasSubColumnData(R"("a"."b")"));
     }

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -17,6 +17,7 @@
 #include <yql/essentials/types/binary_json/write.h>
 
 #include <regex>
+#include <utility>
 
 using NKikimr::NArrow::NAccessor::NSubColumns::NTesting::PrintBinaryJsons;
 
@@ -24,9 +25,26 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
     using namespace NKikimr::NArrow::NAccessor;
     using namespace NKikimr::NArrow;
     using namespace NKikimr;
+    using TResolvedPath = NSubColumns::TDictStats::TResolvedPath;
 
     std::string PrepareToCompare(const std::string& str) {
         return std::regex_replace(str, std::regex(" |\\n"), "");
+    }
+
+    TResolvedPath ResolvePathVerified(const NSubColumns::TDictStats& stats, TStringBuf path) {
+        auto pathInfoResult = stats.ResolvePath(path);
+        UNIT_ASSERT_C(pathInfoResult.IsSuccess(), pathInfoResult.GetErrorMessage());
+        const auto pathInfo = pathInfoResult.DetachResult();
+        UNIT_ASSERT_C(pathInfo, path);
+        return *pathInfo;
+    }
+
+    NSubColumns::TDictStats BuildStats(const std::initializer_list<std::pair<TStringBuf, NSubColumns::EValueType>>& columns) {
+        auto builder = NSubColumns::TDictStats::MakeBuilder();
+        for (const auto& [name, valueType] : columns) {
+            builder.Add(TString(name), 1, 1, IChunkedArray::EType::Array, valueType);
+        }
+        return builder.Finish();
     }
 
     Y_UNIT_TEST(EmptyOthers){
@@ -286,66 +304,73 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         UNIT_ASSERT_VALUES_EQUAL(expectedStartPositions, startPositions);
     }
 
-    Y_UNIT_TEST(JsonPathTrie) {
-        TVector<TString> testPaths = {"$.a.b", "$.b", "$.c.d"};
-        TVector<std::shared_ptr<IChunkedArray>> testAccessors;
-        TVector<ui64> testCookies;
-        NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie jsonPathAccessorTrie;
+    Y_UNIT_TEST(JsonPathResolutionHandlesMultipleRequestedPaths) {
+        auto stats = BuildStats({
+            { R"("a"."b")", NSubColumns::EValueType::BinaryJson },
+            { R"("b")", NSubColumns::EValueType::BinaryJson },
+            { R"("c"."d")", NSubColumns::EValueType::BinaryJson },
+        });
 
-        {
-            ui64 testCookie = 0;
-            for (const auto& path : testPaths) {
-                testAccessors.emplace_back(TTrivialArray::BuildEmpty(std::make_shared<arrow::BinaryType>()));
-                testCookies.emplace_back(testCookie++);
-                UNIT_ASSERT(jsonPathAccessorTrie.Insert(path, testAccessors.back(), NSubColumns::EValueType::BinaryJson, testCookies.back()).IsSuccess());
-            }
+        UNIT_ASSERT_VALUES_EQUAL(ResolvePathVerified(stats, "$.a.b"), (TResolvedPath{0, NSubColumns::EValueType::BinaryJson, ""}));
+        UNIT_ASSERT_VALUES_EQUAL(ResolvePathVerified(stats, "$.b"), (TResolvedPath{1, NSubColumns::EValueType::BinaryJson, ""}));
+        UNIT_ASSERT_VALUES_EQUAL(ResolvePathVerified(stats, "$.c.d"), (TResolvedPath{2, NSubColumns::EValueType::BinaryJson, ""}));
+        UNIT_ASSERT_VALUES_EQUAL(ResolvePathVerified(stats, "$.a.b.e"), (TResolvedPath{0, NSubColumns::EValueType::BinaryJson, "strict $.e"}));
+        UNIT_ASSERT_VALUES_EQUAL(ResolvePathVerified(stats, "$.b.\"\".g[3].h"), (TResolvedPath{1, NSubColumns::EValueType::BinaryJson, "strict $.\"\".g[3].h"}));
+        UNIT_ASSERT_VALUES_EQUAL(ResolvePathVerified(stats, "$.c.d[54]"), (TResolvedPath{2, NSubColumns::EValueType::BinaryJson, "strict $[54]"}));
+
+        for (const auto& path : { "$.a", "$.\"\"", "$.c" }) {
+            auto pathInfoResult = stats.ResolvePath(path);
+            UNIT_ASSERT_C(pathInfoResult.IsSuccess(), pathInfoResult.GetErrorMessage());
+            UNIT_ASSERT_C(!pathInfoResult.DetachResult(), path);
         }
+    }
 
-        {
-            for (decltype(testPaths)::size_type i = 0; i < testPaths.size(); ++i) {
-                auto jsonPathAccessorResult = jsonPathAccessorTrie.GetAccessor(testPaths[i]);
-                UNIT_ASSERT_C(jsonPathAccessorResult.IsSuccess(), testPaths[i] + " error: " + jsonPathAccessorResult.GetErrorMessage());
-                auto jsonPathAccessor = jsonPathAccessorResult.DetachResult();
-                UNIT_ASSERT(jsonPathAccessor->IsValid());
-                UNIT_ASSERT_VALUES_EQUAL(testAccessors[i].get(), jsonPathAccessor->GetChunkedArrayAccessor().get());
-                UNIT_ASSERT_VALUES_EQUAL(testCookies[i], jsonPathAccessor->GetCookie());
-                UNIT_ASSERT_VALUES_EQUAL(TString{}, jsonPathAccessor->GetRemainingPath());
-            }
-        }
+    Y_UNIT_TEST(JsonPathResolutionUsesLongestPrefix) {
+        auto stats = BuildStats({ { R"("a")", NSubColumns::EValueType::BinaryJson }, { R"("a"."b")", NSubColumns::EValueType::String } });
 
-        {
-            TVector<TString> testShortPaths = {"$.a", "$.\"\"", "$.c"};
-            for (const auto& path : testShortPaths) {
-                auto jsonPathAccessorResult = jsonPathAccessorTrie.GetAccessor(path);
-                UNIT_ASSERT_C(jsonPathAccessorResult.IsSuccess(), path + " error: " + jsonPathAccessorResult.GetErrorMessage());
-                auto jsonPathAccessor = jsonPathAccessorResult.DetachResult();
-                UNIT_ASSERT(!jsonPathAccessor->IsValid());
-                UNIT_ASSERT_VALUES_EQUAL(nullptr, jsonPathAccessor->GetChunkedArrayAccessor().get());
-                UNIT_ASSERT_VALUES_EQUAL(std::optional<ui64>{}, jsonPathAccessor->GetCookie());
-                UNIT_ASSERT_VALUES_EQUAL(TString{}, jsonPathAccessor->GetRemainingPath());
-            }
-        }
+        UNIT_ASSERT_VALUES_EQUAL(ResolvePathVerified(stats, "$.a.b.c"), (TResolvedPath{1, NSubColumns::EValueType::String, "strict $.c"}));
+    }
 
-        {
-            TVector<TString> testLongPaths = {"$.a.b.e", "$.b.\"\".g[3].h", "$.c.d[54]"};
-            TVector<TString> testLongRemainingPaths = {"strict $.e", "strict $.\"\".g[3].h", "strict $[54]"};
-            for (decltype(testPaths)::size_type i = 0; i < testPaths.size(); ++i) {
-                auto jsonPathAccessorResult = jsonPathAccessorTrie.GetAccessor(testLongPaths[i]);
-                UNIT_ASSERT_C(jsonPathAccessorResult.IsSuccess(), testPaths[i] + " error: " + jsonPathAccessorResult.GetErrorMessage());
-                auto jsonPathAccessor = jsonPathAccessorResult.DetachResult();
-                UNIT_ASSERT(jsonPathAccessor->IsValid());
-                UNIT_ASSERT_VALUES_EQUAL(testAccessors[i].get(), jsonPathAccessor->GetChunkedArrayAccessor().get());
-                UNIT_ASSERT_VALUES_EQUAL(testCookies[i], jsonPathAccessor->GetCookie());
-                UNIT_ASSERT_VALUES_EQUAL(testLongRemainingPaths[i], jsonPathAccessor->GetRemainingPath());
-            }
-        }
 
-        {
-            TVector<TString> testInvalidPaths = {"$.a.b.[2]", "$.b.", "$.c[]"};
-            for (decltype(testPaths)::size_type i = 0; i < testPaths.size(); ++i) {
-                auto jsonPathAccessorResult = jsonPathAccessorTrie.GetAccessor(testInvalidPaths[i]);
-                UNIT_ASSERT(jsonPathAccessorResult.IsFail());
-            }
+
+    Y_UNIT_TEST(JsonPathResolutionMatchesExactPath) {
+        auto stats = BuildStats({ { R"("a"."b")", NSubColumns::EValueType::String } });
+
+        UNIT_ASSERT_VALUES_EQUAL(ResolvePathVerified(stats, "$.a.b"), (TResolvedPath{0, NSubColumns::EValueType::String, ""}));
+    }
+
+    Y_UNIT_TEST(JsonPathResolutionReturnsNoMatch) {
+        auto stats = BuildStats({ { R"("a")", NSubColumns::EValueType::BinaryJson } });
+
+        auto pathInfoResult = stats.ResolvePath("$.b");
+        UNIT_ASSERT_C(pathInfoResult.IsSuccess(), pathInfoResult.GetErrorMessage());
+        UNIT_ASSERT(!pathInfoResult.DetachResult());
+    }
+
+    Y_UNIT_TEST(JsonPathResolutionMatchesQuotedMember) {
+        auto stats = BuildStats({ { R"("a.b")", NSubColumns::EValueType::String } });
+
+        UNIT_ASSERT_VALUES_EQUAL(ResolvePathVerified(stats, "$.\"a.b\".c"), (TResolvedPath{0, NSubColumns::EValueType::String, "strict $.c"}));
+    }
+
+    Y_UNIT_TEST(JsonPathResolutionRetainsArraySuffix) {
+        auto stats = BuildStats({ { R"("a")", NSubColumns::EValueType::BinaryJson } });
+
+        UNIT_ASSERT_VALUES_EQUAL(ResolvePathVerified(stats, "$.a[0].b"), (TResolvedPath{0, NSubColumns::EValueType::BinaryJson, "strict $[0].b"}));
+    }
+
+    Y_UNIT_TEST(JsonPathResolutionMatchesAncestorBeforeUnstoredDescendant) {
+        auto stats = BuildStats({ { R"("d")", NSubColumns::EValueType::BinaryJson }, { R"("d"."e"."f")", NSubColumns::EValueType::BinaryJson } });
+
+        // A descendant stored path does not prevent selecting the longest stored ancestor.
+        UNIT_ASSERT_VALUES_EQUAL(ResolvePathVerified(stats, "$.d.e"), (TResolvedPath{0, NSubColumns::EValueType::BinaryJson, "strict $.e"}));
+    }
+
+    Y_UNIT_TEST(JsonPathResolutionRejectsInvalidPaths) {
+        auto stats = NSubColumns::TDictStats::BuildEmpty();
+
+        for (const auto& path : { "$.a.b.[2]", "$.b.", "$.c[]" }) {
+            UNIT_ASSERT(stats.ResolvePath(path).IsFail());
         }
     }
 
@@ -358,108 +383,95 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
             std::make_shared<arrow::BinaryScalar>(std::make_shared<arrow::Buffer>((const ui8*)binaryJson.data(), binaryJson.size()), arrow::binary())));
     }
 
-    void CheckValueByPath(const NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie& jsonPathAccessorTrie, TStringBuf path, std::optional<TStringBuf> expected) {
-        auto jsonPathAccessorResult = jsonPathAccessorTrie.GetAccessor(path);
-        UNIT_ASSERT_C(jsonPathAccessorResult.IsSuccess(), TString(path) + " error: " + jsonPathAccessorResult.GetErrorMessage());
-        auto jsonPathAccessor = jsonPathAccessorResult.DetachResult();
-        UNIT_ASSERT(jsonPathAccessor->IsValid());
+    void CheckValueByPath(const std::shared_ptr<IChunkedArray>& accessor, TStringBuf path, std::optional<TStringBuf> expected) {
+        static const auto stats = BuildStats({ { R"("a")", NSubColumns::EValueType::BinaryJson } });
+        auto pathInfo = ResolvePathVerified(stats, path);
+        NSubColumns::TJsonPathAccessor jsonPathAccessor(accessor, std::move(pathInfo.RemainingPath), pathInfo.ValueType);
 
         int callsCount = 0;
-        jsonPathAccessor->VisitValues([&](const std::optional<TStringBuf>& value) {
+        jsonPathAccessor.VisitValues([&](const std::optional<TStringBuf>& value) {
             UNIT_ASSERT_VALUES_EQUAL_C(expected, value, TString(path));
-            callsCount++;
-            UNIT_ASSERT_VALUES_EQUAL(1, callsCount);
+            ++callsCount;
         });
+        UNIT_ASSERT_VALUES_EQUAL(callsCount, 1);
     }
 
     Y_UNIT_TEST(JsonPathAccessorObject) {
         auto accessor = CreateTrivialArrayAccessor(
             R"({"root_integer": 1, "root_string": "a", "root_true": true, "root_false": false, "root_null": null, "root_object": {"a": "b"}, "root_array": ["a", 1, true, false, null, {}, [], [1, 2]]})");
-
-        NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie jsonPathAccessorTrie;
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.a", accessor, NSubColumns::EValueType::BinaryJson).IsSuccess());
-
         // Non-existing paths and root path must return std::nullopt and called only once for our binary JSON
         // Object, array, null must return std::nullopt
         {
             for (const auto& path : {"$.a", "$.a[0]", "$.a.h", "$.a.e.p", "$.a.f.z", "$.a.root_object", "$.a.root_array", "$.a.root_null", "$.a.root_array[4]", "$.a.root_array[5]",
                      "$.a.root_array[6]", "$.a.root_array[7]", "$.a.root_array[7][4]", "$.a.root_array[10]"}) {
-                CheckValueByPath(jsonPathAccessorTrie, path, std::nullopt);
+                CheckValueByPath(accessor, path, std::nullopt);
             }
         }
 
         // Root scalars
         {
-            CheckValueByPath(jsonPathAccessorTrie, "$.a.root_string", "a");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a.root_integer", "1");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a.root_true", "true");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a.root_false", "false");
+            CheckValueByPath(accessor, "$.a.root_string", "a");
+            CheckValueByPath(accessor, "$.a.root_integer", "1");
+            CheckValueByPath(accessor, "$.a.root_true", "true");
+            CheckValueByPath(accessor, "$.a.root_false", "false");
         }
 
         // Non-root scalars
         {
-            CheckValueByPath(jsonPathAccessorTrie, "$.a.root_object.a", "b");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a.root_array[0]", "a");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a.root_array[1]", "1");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a.root_array[2]", "true");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a.root_array[3]", "false");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a.root_array[7][0]", "1");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a.root_array[7][1]", "2");
+            CheckValueByPath(accessor, "$.a.root_object.a", "b");
+            CheckValueByPath(accessor, "$.a.root_array[0]", "a");
+            CheckValueByPath(accessor, "$.a.root_array[1]", "1");
+            CheckValueByPath(accessor, "$.a.root_array[2]", "true");
+            CheckValueByPath(accessor, "$.a.root_array[3]", "false");
+            CheckValueByPath(accessor, "$.a.root_array[7][0]", "1");
+            CheckValueByPath(accessor, "$.a.root_array[7][1]", "2");
         }
 
         // Different quotes
         {
             for (const auto& path : {"$.a.root_integer", "$.a.\"root_integer\"", "$.a.'root_integer'", "$.\"a\".root_integer", "$.\"a\".\"root_integer\"", "$.\"a\".'root_integer'",
                      "$.'a'.root_integer", "$.'a'.\"root_integer\"", "$.'a'.'root_integer'"}) {
-                CheckValueByPath(jsonPathAccessorTrie, path, "1");
+                CheckValueByPath(accessor, path, "1");
             }
         }
     }
 
     Y_UNIT_TEST(JsonPathAccessorTopLevelNull) {
         auto accessor = CreateTrivialArrayAccessor("null");
-
-        NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie jsonPathAccessorTrie;
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.a", accessor, NSubColumns::EValueType::BinaryJson).IsSuccess());
-
-        CheckValueByPath(jsonPathAccessorTrie, "$.a", std::nullopt);
-        CheckValueByPath(jsonPathAccessorTrie, "$.a.b", std::nullopt);
-        CheckValueByPath(jsonPathAccessorTrie, "$.a.b.c", std::nullopt);
+        CheckValueByPath(accessor, "$.a", std::nullopt);
+        CheckValueByPath(accessor, "$.a.b", std::nullopt);
+        CheckValueByPath(accessor, "$.a.b.c", std::nullopt);
     }
 
     Y_UNIT_TEST(JsonPathAccessorArray) {
         auto accessor = CreateTrivialArrayAccessor(R"(["a", 1, true, false, null, {"a": "b"}, {}, [1,2], []])");
-
-        NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie jsonPathAccessorTrie;
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.a", accessor, NSubColumns::EValueType::BinaryJson).IsSuccess());
-
         // Non-existing paths and root path must return std::nullopt and called only once for our binary JSON
         // Object, array, null must return std::nullopt
         {
             for (const auto& path : {"$.a", "$.a[100]", "$.a.h", "$.a.e.p", "$.a[4]", "$.a[5]", "$.a[6]", "$.a[7]", "$.a[7][10]", "$.a[8]", "$.a[8][0]"}) {
-                CheckValueByPath(jsonPathAccessorTrie, path, std::nullopt);
+                CheckValueByPath(accessor, path, std::nullopt);
             }
         }
 
         // Root scalars
         {
-            CheckValueByPath(jsonPathAccessorTrie, "$.a[0]", "a");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a[1]", "1");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a[2]", "true");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a[3]", "false");
+            CheckValueByPath(accessor, "$.a[0]", "a");
+            CheckValueByPath(accessor, "$.a[1]", "1");
+            CheckValueByPath(accessor, "$.a[2]", "true");
+            CheckValueByPath(accessor, "$.a[3]", "false");
         }
 
         // Non-root scalars
         {
-            CheckValueByPath(jsonPathAccessorTrie, "$.a[5].a", "b");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a[7][0]", "1");
-            CheckValueByPath(jsonPathAccessorTrie, "$.a[7][1]", "2");
+            CheckValueByPath(accessor, "$.a[5].a", "b");
+            CheckValueByPath(accessor, "$.a[7][0]", "1");
+            CheckValueByPath(accessor, "$.a[7][1]", "2");
         }
 
         // Different quotes
         {
             for (const auto& path : {"$.a[1]", "$.\"a\"[1]", "$.'a'[1]"}) {
-                CheckValueByPath(jsonPathAccessorTrie, path, "1");
+                CheckValueByPath(accessor, path, "1");
             }
         }
     }
@@ -472,20 +484,16 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
             const auto& scalarJson = scalarJsons[i];
             const auto& expectedValue = expectedValues[i];
             auto accessor = CreateTrivialArrayAccessor(scalarJson);
-
-            NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie jsonPathAccessorTrie;
-            UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.a", accessor, NSubColumns::EValueType::BinaryJson).IsSuccess());
-
             // Non-existing paths must return std::nullopt and called only once for our binary JSON
             {
                 for (const auto& path : {"$.a.h", "$.a.e[3]", "$.a[4]"}) {
-                    CheckValueByPath(jsonPathAccessorTrie, path, std::nullopt);
+                    CheckValueByPath(accessor, path, std::nullopt);
                 }
             }
 
             // Existing path should return expected value
             {
-                CheckValueByPath(jsonPathAccessorTrie, "$.a", expectedValue);
+                CheckValueByPath(accessor, "$.a", expectedValue);
             }
         }
     }
@@ -496,41 +504,59 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         auto accessorTopScalar2 = CreateTrivialArrayAccessor("2");
         auto accessorTopScalar3 = CreateTrivialArrayAccessor("3");
         auto accessorTopArray = CreateTrivialArrayAccessor("[3,4]");
+        auto stats = BuildStats({
+            { R"("a")", NSubColumns::EValueType::BinaryJson },
+            { R"("a"."b")", NSubColumns::EValueType::BinaryJson },
+            { R"("b")", NSubColumns::EValueType::BinaryJson },
+            { R"("d"."e"."f")", NSubColumns::EValueType::BinaryJson },
+            { R"("d"."e"."g")", NSubColumns::EValueType::BinaryJson },
+            { R"("d"."e"."h")", NSubColumns::EValueType::BinaryJson },
+            { R"("d"."i"."j")", NSubColumns::EValueType::BinaryJson },
+            { R"("d"."i")", NSubColumns::EValueType::BinaryJson },
+            { R"("d")", NSubColumns::EValueType::BinaryJson },
+            { R"("k")", NSubColumns::EValueType::BinaryJson },
+            { R"("k"."l")", NSubColumns::EValueType::BinaryJson },
+            { R"("k"."m")", NSubColumns::EValueType::BinaryJson },
+        });
+        auto records = std::make_shared<TGeneralContainer>(1);
+        const std::vector<std::shared_ptr<IChunkedArray>> accessors = {
+            accessorTopObject, accessorTopScalar2, accessorTopArray, accessorTopScalar1, accessorTopScalar2, accessorTopScalar3,
+            accessorTopScalar1, accessorTopScalar2, accessorTopArray, accessorTopScalar1, accessorTopObject, accessorTopArray,
+        };
+        for (ui32 i = 0; i < accessors.size(); ++i) {
+            records->AddField(stats.GetField(i), accessors[i]).Validate();
+        }
+        NSubColumns::TColumnsData columns(stats, records);
 
-        NKikimr::NArrow::NAccessor::NSubColumns::TJsonPathAccessorTrie jsonPathAccessorTrie;
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.a", accessorTopObject, NSubColumns::EValueType::BinaryJson).IsSuccess());
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.a.b", accessorTopScalar2, NSubColumns::EValueType::BinaryJson).IsSuccess());
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.b", accessorTopArray, NSubColumns::EValueType::BinaryJson).IsSuccess());
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.d.e.f", accessorTopScalar1, NSubColumns::EValueType::BinaryJson).IsSuccess());
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.d.e.g", accessorTopScalar2, NSubColumns::EValueType::BinaryJson).IsSuccess());
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.d.e.h", accessorTopScalar3, NSubColumns::EValueType::BinaryJson).IsSuccess());
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.d.i.j", accessorTopScalar1, NSubColumns::EValueType::BinaryJson).IsSuccess());
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.d.i", accessorTopScalar2, NSubColumns::EValueType::BinaryJson).IsSuccess());
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.d", accessorTopArray, NSubColumns::EValueType::BinaryJson).IsSuccess());
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.k", accessorTopScalar1, NSubColumns::EValueType::BinaryJson).IsSuccess());
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.k.l", accessorTopObject, NSubColumns::EValueType::BinaryJson).IsSuccess());
-        UNIT_ASSERT(jsonPathAccessorTrie.Insert("$.k.m", accessorTopArray, NSubColumns::EValueType::BinaryJson).IsSuccess());
+        const auto check = [&](const TStringBuf path, const std::optional<TStringBuf> expected) {
+            auto accessorResult = columns.GetPathAccessor(path);
+            UNIT_ASSERT_C(accessorResult.IsSuccess(), accessorResult.GetErrorMessage());
+            const auto accessor = accessorResult.DetachResult();
+            accessor->VisitValues([&](const std::optional<TStringBuf>& value) {
+                UNIT_ASSERT_VALUES_EQUAL_C(value, expected, path);
+            });
+        };
 
-        CheckValueByPath(jsonPathAccessorTrie, "$.a", std::nullopt);
-        CheckValueByPath(jsonPathAccessorTrie, "$.a.data", "1");
-        CheckValueByPath(jsonPathAccessorTrie, "$.a.b", "2");
-        CheckValueByPath(jsonPathAccessorTrie, "$.b", std::nullopt);
-        CheckValueByPath(jsonPathAccessorTrie, "$.b[0]", "3");
-        CheckValueByPath(jsonPathAccessorTrie, "$.b[1]", "4");
-        CheckValueByPath(jsonPathAccessorTrie, "$.d.e.f", "1");
-        CheckValueByPath(jsonPathAccessorTrie, "$.d.e.g", "2");
-        CheckValueByPath(jsonPathAccessorTrie, "$.d.e.h", "3");
-        CheckValueByPath(jsonPathAccessorTrie, "$.d.i.j", "1");
-        CheckValueByPath(jsonPathAccessorTrie, "$.d.i", "2");
-        CheckValueByPath(jsonPathAccessorTrie, "$.d", std::nullopt);
-        CheckValueByPath(jsonPathAccessorTrie, "$.d[0]", "3");
-        CheckValueByPath(jsonPathAccessorTrie, "$.d[1]", "4");
-        CheckValueByPath(jsonPathAccessorTrie, "$.k", "1");
-        CheckValueByPath(jsonPathAccessorTrie, "$.k.l", std::nullopt);
-        CheckValueByPath(jsonPathAccessorTrie, "$.k.l.data", "1");
-        CheckValueByPath(jsonPathAccessorTrie, "$.k.m", std::nullopt);
-        CheckValueByPath(jsonPathAccessorTrie, "$.k.m[0]", "3");
-        CheckValueByPath(jsonPathAccessorTrie, "$.k.m[1]", "4");
+        check("$.a", std::nullopt);
+        check("$.a.data", "1");
+        check("$.a.b", "2");
+        check("$.b", std::nullopt);
+        check("$.b[0]", "3");
+        check("$.b[1]", "4");
+        check("$.d.e.f", "1");
+        check("$.d.e.g", "2");
+        check("$.d.e.h", "3");
+        check("$.d.i.j", "1");
+        check("$.d.i", "2");
+        check("$.d", std::nullopt);
+        check("$.d[0]", "3");
+        check("$.d[1]", "4");
+        check("$.k", "1");
+        check("$.k.l", std::nullopt);
+        check("$.k.l.data", "1");
+        check("$.k.m", std::nullopt);
+        check("$.k.m[0]", "3");
+        check("$.k.m[1]", "4");
     }
 
     Y_UNIT_TEST(SubColumnNameFromDifferentPaths) {
@@ -551,6 +577,20 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
             expected[str] = 1;
             UNIT_ASSERT_VALUES_EQUAL(expected, restorer.GetResult());
         }
+    }
+
+    Y_UNIT_TEST(PartialJsonPathAccessorResolvesToAddedColumn) {
+        auto header = NSubColumns::TSubColumnsHeader(
+            BuildStats({ { R"("a")", NSubColumns::EValueType::BinaryJson }, { R"("a"."b")", NSubColumns::EValueType::BinaryJson } }),
+            NSubColumns::TDictStats::BuildEmpty(), NKikimrArrowAccessorProto::TSubColumnsAccessor(), 0);
+        TSubColumnsPartialArray partial(std::move(header), 1, arrow::binary(), NSubColumns::TSettings());
+        partial.AddColumn(R"("a")", CreateTrivialArrayAccessor(R"({"b":{"c":"value"}})"));
+
+        auto accessorResult = partial.GetPathAccessor("$.a.b.c", 1);
+        UNIT_ASSERT_C(accessorResult.IsSuccess(), accessorResult.GetErrorMessage());
+        accessorResult.DetachResult()->VisitValues([](const std::optional<TStringBuf>& value) {
+            UNIT_ASSERT_VALUES_EQUAL(value, "value");
+        });
     }
 };
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -36,7 +36,17 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         UNIT_ASSERT_C(pathInfoResult.IsSuccess(), pathInfoResult.GetErrorMessage());
         const auto pathInfo = pathInfoResult.DetachResult();
         UNIT_ASSERT_C(pathInfo, path);
+        const auto keyIndex = stats.GetKeyIndexOptional(NSubColumns::ToSubcolumnName(path));
+        UNIT_ASSERT_C(keyIndex, path);
+        UNIT_ASSERT_VALUES_EQUAL(*keyIndex, pathInfo->ColumnIndex);
         return *pathInfo;
+    }
+
+    void CheckPathHasNoMatch(const NSubColumns::TDictStats& stats, TStringBuf path) {
+        auto pathInfoResult = stats.ResolvePath(path);
+        UNIT_ASSERT_C(pathInfoResult.IsSuccess(), pathInfoResult.GetErrorMessage());
+        UNIT_ASSERT_C(!pathInfoResult.DetachResult(), path);
+        UNIT_ASSERT_C(!stats.GetKeyIndexOptional(NSubColumns::ToSubcolumnName(path)), path);
     }
 
     NSubColumns::TDictStats BuildStats(const std::initializer_list<std::pair<TStringBuf, NSubColumns::EValueType>>& columns) {
@@ -319,9 +329,7 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         UNIT_ASSERT_VALUES_EQUAL(ResolvePathVerified(stats, "$.c.d[54]"), (TResolvedPath{2, NSubColumns::EValueType::BinaryJson, "strict $[54]"}));
 
         for (const auto& path : { "$.a", "$.\"\"", "$.c" }) {
-            auto pathInfoResult = stats.ResolvePath(path);
-            UNIT_ASSERT_C(pathInfoResult.IsSuccess(), pathInfoResult.GetErrorMessage());
-            UNIT_ASSERT_C(!pathInfoResult.DetachResult(), path);
+            CheckPathHasNoMatch(stats, path);
         }
     }
 
@@ -342,9 +350,7 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
     Y_UNIT_TEST(JsonPathResolutionReturnsNoMatch) {
         auto stats = BuildStats({ { R"("a")", NSubColumns::EValueType::BinaryJson } });
 
-        auto pathInfoResult = stats.ResolvePath("$.b");
-        UNIT_ASSERT_C(pathInfoResult.IsSuccess(), pathInfoResult.GetErrorMessage());
-        UNIT_ASSERT(!pathInfoResult.DetachResult());
+        CheckPathHasNoMatch(stats, "$.b");
     }
 
     Y_UNIT_TEST(JsonPathResolutionMatchesQuotedMember) {

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sub_columns.cpp
@@ -18,6 +18,9 @@
 #include <regex>
 #include <utility>
 
+using NKikimr::NArrow::NAccessor::NSubColumns::NTesting::BuildArrayWithStoredPaths;
+using NKikimr::NArrow::NAccessor::NSubColumns::NTesting::BuildStats;
+using NKikimr::NArrow::NAccessor::NSubColumns::NTesting::CreateTrivialArrayAccessor;
 using NKikimr::NArrow::NAccessor::NSubColumns::NTesting::PrintBinaryJsons;
 
 Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
@@ -46,14 +49,6 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         UNIT_ASSERT_C(pathInfoResult.IsSuccess(), pathInfoResult.GetErrorMessage());
         UNIT_ASSERT_C(!pathInfoResult.DetachResult(), path);
         UNIT_ASSERT_C(!stats.GetKeyOrPrefixIndexOptional(NSubColumns::ToSubcolumnName(path)), path);
-    }
-
-    NSubColumns::TDictStats BuildStats(const std::initializer_list<std::pair<TStringBuf, NSubColumns::EValueType>>& columns) {
-        auto builder = NSubColumns::TDictStats::MakeBuilder();
-        for (const auto& [name, valueType] : columns) {
-            builder.Add(TString(name), 1, 1, IChunkedArray::EType::Array, valueType);
-        }
-        return builder.Finish();
     }
 
     Y_UNIT_TEST(EmptyOthers){
@@ -380,40 +375,6 @@ Y_UNIT_TEST_SUITE(SubColumnsArrayAccessor) {
         for (const auto& path : { "$.a.b.[2]", "$.b.", "$.c[]" }) {
             UNIT_ASSERT(stats.ResolvePath(path).IsFail());
         }
-    }
-
-    std::shared_ptr<TTrivialArray> CreateTrivialArrayAccessor(TStringBuf data) {
-        auto binaryJsonResult = NBinaryJson::SerializeToBinaryJson(data);
-        UNIT_ASSERT(std::holds_alternative<NBinaryJson::TBinaryJson>(binaryJsonResult));
-
-        auto binaryJson = std::get<NBinaryJson::TBinaryJson>(binaryJsonResult);
-        return std::make_shared<TTrivialArray>(NKikimr::NArrow::NAccessor::TTrivialArray::BuildArrayFromScalar(
-            std::make_shared<arrow::BinaryScalar>(std::make_shared<arrow::Buffer>((const ui8*)binaryJson.data(), binaryJson.size()), arrow::binary())));
-    }
-
-    std::shared_ptr<TSubColumnsArray> BuildArrayWithStoredPaths(const std::initializer_list<std::pair<TStringBuf, TStringBuf>>& columns,
-        const TStringBuf otherName, const TStringBuf otherValue) {
-        auto columnsBuilder = NSubColumns::TDictStats::MakeBuilder();
-        for (const auto& [name, _] : columns) {
-            columnsBuilder.Add(TString(name), 1, 1, IChunkedArray::EType::Array, NSubColumns::EValueType::BinaryJson);
-        }
-        auto columnsStats = columnsBuilder.Finish();
-        auto columnsRecords = std::make_shared<TGeneralContainer>(1);
-        ui32 index = 0;
-        for (const auto& [_, value] : columns) {
-            columnsRecords->AddField(columnsStats.GetField(index++), CreateTrivialArrayAccessor(value)).Validate();
-        }
-
-        auto othersStats = BuildStats({ { otherName, NSubColumns::EValueType::BinaryJson } });
-        const auto binaryJsonResult = NBinaryJson::SerializeToBinaryJson(otherValue);
-        UNIT_ASSERT(std::holds_alternative<NBinaryJson::TBinaryJson>(binaryJsonResult));
-        const auto& binaryJson = std::get<NBinaryJson::TBinaryJson>(binaryJsonResult);
-        auto othersBuilder = NSubColumns::TOthersData::MakeMergedBuilder();
-        othersBuilder->Add(0, 0, std::string_view(binaryJson.data(), binaryJson.size()));
-        auto others = othersBuilder->Finish(NSubColumns::TOthersData::TFinishContext(othersStats));
-
-        return std::make_shared<TSubColumnsArray>(
-            NSubColumns::TColumnsData(columnsStats, columnsRecords), std::move(others), arrow::binary(), 1, NSubColumns::TSettings());
     }
 
     void CheckMostSpecificStoredPath(const std::initializer_list<std::pair<TStringBuf, TStringBuf>>& columns, const TStringBuf otherName,

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ya.make
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ya.make
@@ -8,7 +8,6 @@ PEERDIR(
     yql/essentials/public/udf/service/stub
     yql/essentials/sql/pg_dummy
     ydb/core/formats/arrow
-    ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor
 )
 
 SRCS(

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ya.make
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ya.make
@@ -8,6 +8,7 @@ PEERDIR(
     yql/essentials/public/udf/service/stub
     yql/essentials/sql/pg_dummy
     ydb/core/formats/arrow
+    ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor
 )
 
 SRCS(

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut_common/ut_helpers.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut_common/ut_helpers.cpp
@@ -1,0 +1,78 @@
+#include "ut_helpers.h"
+
+#include <ydb/core/formats/arrow/accessor/plain/accessor.h>
+
+#include <contrib/libs/apache/arrow/cpp/src/arrow/array/array_binary.h>
+#include <contrib/libs/apache/arrow/cpp/src/arrow/array/builder_binary.h>
+
+#include <ydb/library/actors/core/log.h>
+
+#include <yql/essentials/types/binary_json/write.h>
+
+namespace NKikimr::NArrow::NAccessor::NSubColumns::NTesting {
+
+TString PrintBinaryJsons(const std::shared_ptr<arrow::ChunkedArray>& array) {
+    TStringBuilder sb;
+    sb << "[";
+    for (auto&& i : array->chunks()) {
+        sb << "[";
+        AFL_VERIFY(i->type()->id() == arrow::binary()->id());
+        auto views = std::static_pointer_cast<arrow::BinaryArray>(i);
+        for (ui32 r = 0; r < views->length(); ++r) {
+            if (views->IsNull(r)) {
+                sb << "null";
+            } else {
+                sb << NKikimr::NBinaryJson::SerializeToJson(TStringBuf(views->GetView(r).data(), views->GetView(r).size()));
+            }
+            if (r + 1 != views->length()) {
+                sb << ",";
+            }
+        }
+        sb << "]";
+    }
+    sb << "]";
+    return sb;
+}
+
+std::shared_ptr<TTrivialArray> CreateTrivialArrayAccessor(const TStringBuf data) {
+    auto binaryJsonResult = NBinaryJson::SerializeToBinaryJson(data);
+    AFL_VERIFY(std::holds_alternative<NBinaryJson::TBinaryJson>(binaryJsonResult));
+    const auto binaryJson = std::get<NBinaryJson::TBinaryJson>(binaryJsonResult);
+    return std::make_shared<TTrivialArray>(TTrivialArray::BuildArrayFromScalar(std::make_shared<arrow::BinaryScalar>(
+        std::make_shared<arrow::Buffer>((const ui8*)binaryJson.data(), binaryJson.size()), arrow::binary())));
+}
+
+TDictStats BuildStats(const std::initializer_list<std::pair<TStringBuf, EValueType>>& columns) {
+    auto builder = TDictStats::MakeBuilder();
+    for (const auto& [name, valueType] : columns) {
+        builder.Add(TString(name), 1, 1, IChunkedArray::EType::Array, valueType);
+    }
+    return builder.Finish();
+}
+
+std::shared_ptr<TSubColumnsArray> BuildArrayWithStoredPaths(const std::initializer_list<std::pair<TStringBuf, TStringBuf>>& columns,
+    const TStringBuf otherName, const TStringBuf otherValue) {
+    auto columnsBuilder = TDictStats::MakeBuilder();
+    for (const auto& [name, _] : columns) {
+        columnsBuilder.Add(TString(name), 1, 1, IChunkedArray::EType::Array, EValueType::BinaryJson);
+    }
+    auto columnsStats = columnsBuilder.Finish();
+    auto columnsRecords = std::make_shared<NArrow::TGeneralContainer>(1);
+    ui32 index = 0;
+    for (const auto& [_, value] : columns) {
+        columnsRecords->AddField(columnsStats.GetField(index++), CreateTrivialArrayAccessor(value)).Validate();
+    }
+
+    auto othersStats = BuildStats({ { otherName, EValueType::BinaryJson } });
+    auto binaryJsonResult = NBinaryJson::SerializeToBinaryJson(otherValue);
+    AFL_VERIFY(std::holds_alternative<NBinaryJson::TBinaryJson>(binaryJsonResult));
+    const auto& binaryJson = std::get<NBinaryJson::TBinaryJson>(binaryJsonResult);
+    auto othersBuilder = TOthersData::MakeMergedBuilder();
+    othersBuilder->Add(0, 0, std::string_view(binaryJson.data(), binaryJson.size()));
+    auto others = othersBuilder->Finish(TOthersData::TFinishContext(othersStats));
+
+    return std::make_shared<TSubColumnsArray>(
+        TColumnsData(std::move(columnsStats), columnsRecords), std::move(others), arrow::binary(), 1, TSettings());
+}
+
+}   // namespace NKikimr::NArrow::NAccessor::NSubColumns::NTesting

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut_common/ut_helpers.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut_common/ut_helpers.h
@@ -1,37 +1,21 @@
 #pragma once
 
-#include <contrib/libs/apache/arrow/cpp/src/arrow/array/array_binary.h>
+#include <ydb/core/formats/arrow/accessor/common/chunk_data.h>
+#include <ydb/core/formats/arrow/accessor/sub_columns/accessor.h>
+
 #include <contrib/libs/apache/arrow/cpp/src/arrow/chunked_array.h>
-
-#include <ydb/library/actors/core/log.h>
-
-#include <yql/essentials/types/binary_json/read.h>
 
 #include <util/generic/string.h>
 
 namespace NKikimr::NArrow::NAccessor::NSubColumns::NTesting {
 
-inline TString PrintBinaryJsons(const std::shared_ptr<arrow::ChunkedArray>& array) {
-    TStringBuilder sb;
-    sb << "[";
-    for (auto&& i : array->chunks()) {
-        sb << "[";
-        AFL_VERIFY(i->type()->id() == arrow::binary()->id());
-        auto views = std::static_pointer_cast<arrow::BinaryArray>(i);
-        for (ui32 r = 0; r < views->length(); ++r) {
-            if (views->IsNull(r)) {
-                sb << "null";
-            } else {
-                sb << NKikimr::NBinaryJson::SerializeToJson(TStringBuf(views->GetView(r).data(), views->GetView(r).size()));
-            }
-            if (r + 1 != views->length()) {
-                sb << ",";
-            }
-        }
-        sb << "]";
-    }
-    sb << "]";
-    return sb;
-}
+TString PrintBinaryJsons(const std::shared_ptr<arrow::ChunkedArray>& array);
+
+std::shared_ptr<TTrivialArray> CreateTrivialArrayAccessor(TStringBuf data);
+
+TDictStats BuildStats(const std::initializer_list<std::pair<TStringBuf, EValueType>>& columns);
+
+std::shared_ptr<TSubColumnsArray> BuildArrayWithStoredPaths(const std::initializer_list<std::pair<TStringBuf, TStringBuf>>& columns,
+    TStringBuf otherName, TStringBuf otherValue);
 
 }   // namespace NKikimr::NArrow::NAccessor::NSubColumns::NTesting

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut_common/ya.make
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut_common/ya.make
@@ -2,12 +2,16 @@ LIBRARY()
 
 SRCS(
     ut_helpers.h
+    ut_helpers.cpp
 )
 
 PEERDIR(
     ydb/core/formats/arrow
+    ydb/core/formats/arrow/accessor/sub_columns
     ydb/library/actors/core
     yql/essentials/types/binary_json
 )
+
+YQL_LAST_ABI_VERSION()
 
 END()

--- a/ydb/core/kqp/ut/olap/types/json_ut.cpp
+++ b/ydb/core/kqp/ut/olap/types/json_ut.cpp
@@ -172,6 +172,72 @@ Y_UNIT_TEST_SUITE(KqpOlapJson) {
         Variator::ToExecutor(Variator::SingleScript(__SCRIPT_CONTENT)).Execute();
     }
 
+    // Complex JSON paths are processed on compaction and query. The second portion encodes `a`
+    // and `slash/key` differently to verify both decode to the first portion's keys.
+    TString scriptComplexPathVariants = R"(
+        SCHEMA:
+        CREATE TABLE `/Root/ColumnTable` (
+            Col1 Uint64 NOT NULL,
+            Col2 JsonDocument,
+            PRIMARY KEY (Col1)
+        )
+        PARTITION BY HASH(Col1)
+        WITH (STORE = COLUMN, AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = $$1|2$$);
+        ------
+        SCHEMA:
+        ALTER OBJECT `/Root/ColumnTable` (TYPE TABLE) SET (ACTION=UPSERT_OPTIONS, `SCAN_READER_POLICY_NAME`=`SIMPLE`)
+        ------
+        SCHEMA:
+        ALTER OBJECT `/Root/ColumnTable` (TYPE TABLE) SET (ACTION=ALTER_COLUMN, NAME=Col2, `DATA_ACCESSOR_CONSTRUCTOR.CLASS_NAME`=`SUB_COLUMNS`,
+                    `FORCE_SIMD_PARSING`=`$$true|false$$`, `COLUMNS_LIMIT`=`$$0|1|1024$$`, `OTHERS_ALLOWED_FRACTION`=`$$0|0.5$$`)
+        ------
+        DATA:
+        REPLACE INTO `/Root/ColumnTable` (Col1, Col2) VALUES
+            (1u, JsonDocument(@@{"a":{"b":"nested"},"a.b":"flat","a[0]":{"b":"literal"},"a":[{"b":"array"}],"":{"x":"empty"},
+                "q\"u":{"b":"quote"},"slash/key":{"b":"slash"},"?":{"x":"question"}}@@));
+        ------
+        DATA:
+        REPLACE INTO `/Root/ColumnTable` (Col1, Col2) VALUES
+            (1u, JsonDocument(@@{"\u0061":{"b":"merged_nested"},"a.b":"merged_flat","a[0]":{"b":"merged_literal"},"\u0061":[{"b":"merged_array"}],"":{"x":"merged_empty"},
+                "q\"u":{"b":"merged_quote"},"slash\/key":{"b":"merged_slash"},"?":{"x":"merged_question"}}@@));
+        ------
+        ONE_COMPACTION
+        ------
+        READ: SELECT Col1 FROM `/Root/ColumnTable` WHERE JSON_VALUE(Col2, "$.a.b") = "merged_nested";
+        EXPECTED: [[1u]]
+        ------
+        READ: SELECT Col1 FROM `/Root/ColumnTable` WHERE JSON_VALUE(Col2, "$.\"a\".\"b\"") = "merged_nested";
+        EXPECTED: [[1u]]
+        ------
+        READ: SELECT Col1 FROM `/Root/ColumnTable` WHERE JSON_VALUE(Col2, "$.'a'.'b'") = "merged_nested";
+        EXPECTED: [[1u]]
+        ------
+        READ: SELECT Col1 FROM `/Root/ColumnTable` WHERE JSON_VALUE(Col2, "$.\"a.b\"") = "merged_flat";
+        EXPECTED: [[1u]]
+        ------
+        READ: SELECT Col1 FROM `/Root/ColumnTable` WHERE JSON_VALUE(Col2, "$.\"a[0]\".b") = "merged_literal";
+        EXPECTED: [[1u]]
+        ------
+        READ: SELECT Col1 FROM `/Root/ColumnTable` WHERE JSON_VALUE(Col2, "$.a[0].b") = "merged_array";
+        EXPECTED: [[1u]]
+        ------
+        READ: SELECT Col1 FROM `/Root/ColumnTable` WHERE JSON_VALUE(Col2, "$.\"\".x") = "merged_empty";
+        EXPECTED: [[1u]]
+        ------
+        READ: SELECT Col1 FROM `/Root/ColumnTable` WHERE JSON_VALUE(Col2, @@$."q\"u".b@@) = "merged_quote";
+        EXPECTED: [[1u]]
+        ------
+        READ: SELECT Col1 FROM `/Root/ColumnTable` WHERE JSON_VALUE(Col2, @@$."slash/key".b@@) = "merged_slash";
+        EXPECTED: [[1u]]
+        ------
+        READ: SELECT Col1 FROM `/Root/ColumnTable` WHERE JSON_VALUE(Col2, "$.\"?\".x") = "merged_question";
+        EXPECTED: [[1u]]
+
+    )";
+    Y_UNIT_TEST_STRING_VARIATOR(ComplexPathVariants, scriptComplexPathVariants) {
+        Variator::ToExecutor(Variator::SingleScript(__SCRIPT_CONTENT)).Execute();
+    }
+
     Y_UNIT_TEST_STRING_VARIATOR(FilterVariants, NSubColumnsScenarios::Filter(false)) {
         Variator::ToExecutor(Variator::SingleScript(__SCRIPT_CONTENT)).Execute();
     }

--- a/ydb/core/kqp/ut/olap/types/json_ut.cpp
+++ b/ydb/core/kqp/ut/olap/types/json_ut.cpp
@@ -175,6 +175,8 @@ Y_UNIT_TEST_SUITE(KqpOlapJson) {
     // Complex JSON paths are processed on compaction and query. The second portion encodes `a`
     // and `slash/key` differently to verify both decode to the first portion's keys.
     TString scriptComplexPathVariants = R"(
+        STOP_COMPACTION
+        ------
         SCHEMA:
         CREATE TABLE `/Root/ColumnTable` (
             Col1 Uint64 NOT NULL,

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/logic.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/logic.cpp
@@ -30,7 +30,6 @@ void TSubColumnsMerger::DoStart(const std::vector<std::shared_ptr<NArrow::NAcces
     AFL_VERIFY(statRecordsCount);
     auto commonStats = TDictStats::Merge(stats, GetSettings(), statRecordsCount);
     ResultColumnStats = commonStats.SelectSeparatedColumns(GetSettings(), statRecordsCount);
-    ResultColumnStats->CreateJsonPathAccessorTrieCache();
     RemapKeyIndex.RegisterColumnStats(*ResultColumnStats);
     for (auto&& i : OrderedIterators) {
         i.Start();

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.cpp
@@ -34,17 +34,15 @@ void TRemapColumns::StartSourceChunk(const ui32 sourceIdx, const TDictStats& sou
     auto& remapSourceInfo = RemapInfo[sourceIdx];
     remapSourceInfo.resize(2);
     auto& remapSourceInfoColumns = remapSourceInfo[1];
-    AFL_VERIFY(ResultColumnStats);
     for (ui32 i = 0; i < sourceColumnStats.GetColumnsCount(); ++i) {
         if (remapSourceInfoColumns.size() <= i) {
             remapSourceInfoColumns.resize((i + 1) * 2);
         }
         AFL_VERIFY(!remapSourceInfoColumns[i]);
-        if (auto commonKeyIndex = ResultColumnStats->GetKeyIndexOptional(sourceColumnStats.GetColumnName(i))) {
-            remapSourceInfoColumns[i] = TRemapInfo(*commonKeyIndex, true);
+        if (const auto it = ResultColumnKeyIndex.find(sourceColumnStats.GetColumnName(i)); it != ResultColumnKeyIndex.end()) {
+            remapSourceInfoColumns[i] = TRemapInfo(it->second, true);
         } else {
-            commonKeyIndex = RegisterNewOtherIndex(sourceColumnStats.GetColumnName(i));
-            remapSourceInfoColumns[i] = TRemapInfo(*commonKeyIndex, false);
+            remapSourceInfoColumns[i] = TRemapInfo(RegisterNewOtherIndex(sourceColumnStats.GetColumnName(i)), false);
         }
     }
     auto& remapSourceInfoOthers = remapSourceInfo[0];
@@ -53,11 +51,10 @@ void TRemapColumns::StartSourceChunk(const ui32 sourceIdx, const TDictStats& sou
             remapSourceInfoOthers.resize((i + 1) * 2);
         }
         AFL_VERIFY(!remapSourceInfoOthers[i]);
-        if (auto commonKeyIndex = ResultColumnStats->GetKeyIndexOptional(sourceOtherStats.GetColumnName(i))) {
-            remapSourceInfoOthers[i] = TRemapInfo(*commonKeyIndex, true);
+        if (const auto it = ResultColumnKeyIndex.find(sourceOtherStats.GetColumnName(i)); it != ResultColumnKeyIndex.end()) {
+            remapSourceInfoOthers[i] = TRemapInfo(it->second, true);
         } else {
-            commonKeyIndex = RegisterNewOtherIndex(sourceOtherStats.GetColumnName(i));
-            remapSourceInfoOthers[i] = TRemapInfo(*commonKeyIndex, false);
+            remapSourceInfoOthers[i] = TRemapInfo(RegisterNewOtherIndex(sourceOtherStats.GetColumnName(i)), false);
         }
     }
 }

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.cpp
@@ -27,6 +27,7 @@ TRemapColumns::TOthersData::TFinishContext TRemapColumns::BuildRemapInfo(
 }
 
 void TRemapColumns::StartSourceChunk(const ui32 sourceIdx, const TDictStats& sourceColumnStats, const TDictStats& sourceOtherStats) {
+    AFL_VERIFY(ColumnStatsRegistered);
     if (RemapInfo.size() <= sourceIdx) {
         RemapInfo.resize((sourceIdx + 1) * 2);
     }

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.h
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.h
@@ -6,6 +6,8 @@
 #include <ydb/core/tx/columnshard/engines/changes/compaction/abstract/merger.h>
 #include <ydb/core/tx/columnshard/engines/storage/chunks/column.h>
 
+#include <util/generic/hash.h>
+
 namespace NKikimr::NOlap::NCompaction::NSubColumns {
 
 class TRemapColumns {
@@ -50,8 +52,8 @@ private:
         }
     };
 
-    const TDictStats* ResultColumnStats = nullptr;
     std::vector<std::vector<std::vector<std::optional<TRemapInfo>>>> RemapInfo;
+    THashMap<std::string_view, ui32> ResultColumnKeyIndex;
     std::map<TString, ui32> TemporaryKeyIndex;
 
     ui32 RegisterNewOtherIndex(const TString& keyName) {
@@ -69,7 +71,9 @@ public:
         const std::vector<TDictStats::TRTStatsValue>& statsByKeyIndex, const TSettings& settings, const ui32 recordsCount) const;
 
     void RegisterColumnStats(const TDictStats& resultColumnStats) {
-        ResultColumnStats = &resultColumnStats;
+        for (ui32 i = 0; i < resultColumnStats.GetColumnsCount(); ++i) {
+            AFL_VERIFY(ResultColumnKeyIndex.emplace(resultColumnStats.GetColumnName(i), i).second);
+        }
     }
 
     void StartSourceChunk(const ui32 sourceIdx, const TDictStats& sourceColumnStats, const TDictStats& sourceOtherStats);

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.h
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/remap.h
@@ -53,8 +53,9 @@ private:
     };
 
     std::vector<std::vector<std::vector<std::optional<TRemapInfo>>>> RemapInfo;
-    THashMap<std::string_view, ui32> ResultColumnKeyIndex;
+    THashMap<TString, ui32> ResultColumnKeyIndex;
     std::map<TString, ui32> TemporaryKeyIndex;
+    bool ColumnStatsRegistered = false;
 
     ui32 RegisterNewOtherIndex(const TString& keyName) {
         return TemporaryKeyIndex.emplace(keyName, TemporaryKeyIndex.size()).first->second;
@@ -71,6 +72,8 @@ public:
         const std::vector<TDictStats::TRTStatsValue>& statsByKeyIndex, const TSettings& settings, const ui32 recordsCount) const;
 
     void RegisterColumnStats(const TDictStats& resultColumnStats) {
+        AFL_VERIFY(!ColumnStatsRegistered);
+        ColumnStatsRegistered = true;
         for (ui32 i = 0; i < resultColumnStats.GetColumnsCount(); ++i) {
             AFL_VERIFY(ResultColumnKeyIndex.emplace(resultColumnStats.GetColumnName(i), i).second);
         }

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/ut/ut_merger.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/ut/ut_merger.cpp
@@ -175,4 +175,46 @@ Y_UNIT_TEST_SUITE(SubColumnsCompaction) {
         UNIT_ASSERT_VALUES_EQUAL(values, "xxxx;<null>;yyyy;<null>;");
         UNIT_ASSERT_VALUES_EQUAL(RenderDocs(merged), RenderDocs(BuildChunk(docs, settings)));
     }
+
+    // Bug-triggering scenario:
+    // Source portions expose an ancestor and its child as separated columns.
+    // The unselected path must move to Others in merged portion; it must never be remapped to the selected path.
+    Y_UNIT_TEST(ChildAndAncestorPathMix) {
+        auto settings = MakeSettings();
+        settings.SetColumnsLimit(1);
+        const std::vector<TString> ancestorDocs = {
+            R"({"a":["xxxxxxxxxxxxxxxx"]})",
+            R"({"a":["yyyyyyyyyyyyyyyy"]})",
+        };
+        const std::vector<TString> childDocs = {
+            R"({"a":{"b":1}})",
+            R"({"a":{"b":2}})",
+        };
+
+        {
+            auto merged = MergeChunks({ BuildChunk(ancestorDocs, settings), BuildChunk(childDocs, settings) }, settings);
+            const auto& stats = merged->GetColumnsData().GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetColumnsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetColumnNameString(0), R"("a")");
+            UNIT_ASSERT_VALUES_EQUAL(
+                RenderDocs(merged), R"({"a":["xxxxxxxxxxxxxxxx"]};{"a":["yyyyyyyyyyyyyyyy"]};{"a":{"b":1}};{"a":{"b":2}};)");
+        }
+
+        const std::vector<TString> scalarAncestorDocs = {
+            R"({"a":1})",
+            R"({"a":2})",
+        };
+        const std::vector<TString> largeChildDocs = {
+            R"({"a":{"b":"xxxxxxxxxxxxxxxx"}})",
+            R"({"a":{"b":"yyyyyyyyyyyyyyyy"}})",
+        };
+
+        {
+            auto merged = MergeChunks({ BuildChunk(scalarAncestorDocs, settings), BuildChunk(largeChildDocs, settings) }, settings);
+            const auto& stats = merged->GetColumnsData().GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetColumnsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetColumnNameString(0), R"("a"."b")");
+            UNIT_ASSERT_VALUES_EQUAL(RenderDocs(merged), R"({"a":1};{"a":2};{"a":{"b":"xxxxxxxxxxxxxxxx"}};{"a":{"b":"yyyyyyyyyyyyyyyy"}};)");
+        }
+    }
 }

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/ut/ut_merger.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/ut/ut_merger.cpp
@@ -217,4 +217,54 @@ Y_UNIT_TEST_SUITE(SubColumnsCompaction) {
             UNIT_ASSERT_VALUES_EQUAL(RenderDocs(merged), R"({"a":1};{"a":2};{"a":{"b":"xxxxxxxxxxxxxxxx"}};{"a":{"b":"yyyyyyyyyyyyyyyy"}};)");
         }
     }
+
+    Y_UNIT_TEST(PromotesOthersKeyToSelectedColumn) {
+        auto settings = MakeSettings();
+        settings.SetColumnsLimit(1);
+        // "b" is selected in the source, leaving "a" in Others; larger aggregate "a" is selected after merging.
+        const TString largeA(128, 'a');
+        const TString mediumB(64, 'b');
+        const std::vector<TString> othersDocs = {
+            TStringBuilder() << R"({"a":1,"b":")" << mediumB << R"("})",
+            TStringBuilder() << R"({"a":2,"b":")" << mediumB << R"("})",
+        };
+        const std::vector<TString> columnDocs = {
+            TStringBuilder() << R"({"a":")" << largeA << R"("})",
+            TStringBuilder() << R"({"a":")" << largeA << R"("})",
+        };
+
+        auto othersChunk = BuildChunk(othersDocs, settings);
+        UNIT_ASSERT_VALUES_EQUAL(othersChunk->GetColumnsData().GetStats().GetColumnNameString(0), R"("b")");
+        UNIT_ASSERT_VALUES_EQUAL(othersChunk->GetOthersData().GetStats().GetColumnNameString(0), R"("a")");
+
+        auto merged = MergeChunks({ othersChunk, BuildChunk(columnDocs, settings) }, settings);
+        UNIT_ASSERT_VALUES_EQUAL(merged->GetColumnsData().GetStats().GetColumnNameString(0), R"("a")");
+        UNIT_ASSERT_VALUES_EQUAL(
+            RenderDocs(merged), RenderDocs(BuildChunk({ othersDocs[0], othersDocs[1], columnDocs[0], columnDocs[1] }, settings)));
+    }
+
+    Y_UNIT_TEST(KeepsQuotedAndNestedNamesDistinct) {
+        auto settings = MakeSettings();
+        settings.SetColumnsLimit(1);
+        // "z" is selected in the source, leaving flat "a.b" in Others; larger nested "a"."b" is selected after merging.
+        const TString largeB(128, 'b');
+        const TString mediumZ(64, 'z');
+        const std::vector<TString> flatDocs = {
+            TStringBuilder() << R"({"a.b":1,"z":")" << mediumZ << R"("})",
+            TStringBuilder() << R"({"a.b":2,"z":")" << mediumZ << R"("})",
+        };
+        const std::vector<TString> nestedDocs = {
+            TStringBuilder() << R"({"a":{"b":")" << largeB << R"("}})",
+            TStringBuilder() << R"({"a":{"b":")" << largeB << R"("}})",
+        };
+
+        auto flatChunk = BuildChunk(flatDocs, settings);
+        UNIT_ASSERT_VALUES_EQUAL(flatChunk->GetColumnsData().GetStats().GetColumnNameString(0), R"("z")");
+        UNIT_ASSERT_VALUES_EQUAL(flatChunk->GetOthersData().GetStats().GetColumnNameString(0), R"("a.b")");
+
+        auto merged = MergeChunks({ flatChunk, BuildChunk(nestedDocs, settings) }, settings);
+        UNIT_ASSERT_VALUES_EQUAL(merged->GetColumnsData().GetStats().GetColumnNameString(0), R"("a"."b")");
+        UNIT_ASSERT_VALUES_EQUAL(
+            RenderDocs(merged), RenderDocs(BuildChunk({ flatDocs[0], flatDocs[1], nestedDocs[0], nestedDocs[1] }, settings)));
+    }
 }

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
@@ -102,8 +102,8 @@ public:
         AFL_VERIFY(!HeaderRange);
         if (!!PartialArray) {
             for (auto&& subColumnName : subColumns) {
-                auto pathResult = NSubColumns::ResolveBestPath(PartialArray->GetHeader().GetColumnStats(),
-                    PartialArray->GetHeader().GetOtherStats(), NSubColumns::ToJsonPath(subColumnName));
+                auto pathResult = NArrow::NAccessor::NSubColumns::ResolveBestPath(PartialArray->GetHeader().GetColumnStats(),
+                    PartialArray->GetHeader().GetOtherStats(), NArrow::NAccessor::NSubColumns::ToJsonPath(subColumnName));
                 AFL_VERIFY(pathResult.IsSuccess())("subColumnName", subColumnName)("error", pathResult.GetErrorMessage());
                 const auto path = pathResult.DetachResult();
                 if (path && path->IsColumn) {

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
@@ -107,6 +107,9 @@ public:
                 AFL_VERIFY(pathResult.IsSuccess())("subColumnName", subColumnName)("error", pathResult.GetErrorMessage());
                 const auto path = pathResult.DetachResult();
                 if (path && path->IsColumn) {
+                    if (Chunks.contains(path->Path.ColumnIndex)) {
+                        continue;
+                    }
                     auto colBlobRange = PartialArray->GetColumnReadRange(path->Path.ColumnIndex);
                     const TBlobRange subRange = FullChunkRange.BuildSubset(colBlobRange.GetOffset(), colBlobRange.GetSize());
                     reading->AddRange(subRange);

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
@@ -102,13 +102,15 @@ public:
         AFL_VERIFY(!HeaderRange);
         if (!!PartialArray) {
             for (auto&& subColumnName : subColumns) {
-                const auto source = PartialArray->GetBestPathSource(NSubColumns::ToJsonPath(subColumnName));
-                if (source.ColumnIndex) {
-                    auto colBlobRange = PartialArray->GetColumnReadRange(*source.ColumnIndex);
+                const auto path = NSubColumns::ResolveBestPath(PartialArray->GetHeader().GetColumnStats(),
+                    PartialArray->GetHeader().GetOtherStats(), NSubColumns::ToJsonPath(subColumnName))
+                                      .DetachResult();
+                if (path && path->IsColumn) {
+                    auto colBlobRange = PartialArray->GetColumnReadRange(path->Path.ColumnIndex);
                     const TBlobRange subRange = FullChunkRange.BuildSubset(colBlobRange.GetOffset(), colBlobRange.GetSize());
                     reading->AddRange(subRange);
-                    AddFetchData(subColumnName, subRange, *source.ColumnIndex);
-                } else if (!PartialArray->HasOthers() && !OthersReadData && source.IsOther) {
+                    AddFetchData(subColumnName, subRange, path->Path.ColumnIndex);
+                } else if (!PartialArray->HasOthers() && !OthersReadData && path) {
                     auto readRange = PartialArray->GetHeader().GetOthersReadRange();
                     OthersReadData = FullChunkRange.BuildSubset(readRange.GetOffset(), readRange.GetSize());
                     reading->AddRange(*OthersReadData);

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
@@ -102,12 +102,13 @@ public:
         AFL_VERIFY(!HeaderRange);
         if (!!PartialArray) {
             for (auto&& subColumnName : subColumns) {
-                if (auto colIndex = PartialArray->GetHeader().GetColumnStats().GetKeyIndexOptional(subColumnName)) {
-                    auto colBlobRange = PartialArray->GetColumnReadRange(*colIndex);
+                const auto source = PartialArray->GetBestPathSource(NSubColumns::ToJsonPath(subColumnName));
+                if (source.ColumnIndex) {
+                    auto colBlobRange = PartialArray->GetColumnReadRange(*source.ColumnIndex);
                     const TBlobRange subRange = FullChunkRange.BuildSubset(colBlobRange.GetOffset(), colBlobRange.GetSize());
                     reading->AddRange(subRange);
-                    AddFetchData(subColumnName, subRange, *colIndex);
-                } else if (!PartialArray->HasOthers() && !OthersReadData && PartialArray->IsOtherColumn(subColumnName)) {
+                    AddFetchData(subColumnName, subRange, *source.ColumnIndex);
+                } else if (!PartialArray->HasOthers() && !OthersReadData && source.IsOther) {
                     auto readRange = PartialArray->GetHeader().GetOthersReadRange();
                     OthersReadData = FullChunkRange.BuildSubset(readRange.GetOffset(), readRange.GetSize());
                     reading->AddRange(*OthersReadData);

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
@@ -178,7 +178,8 @@ public:
     }
 
     void AddFetchData(const TBlobRange& subRange, const ui32 colIndex) {
-        Chunks.try_emplace(colIndex, subRange, colIndex);
+        const auto insertResult = Chunks.try_emplace(colIndex, subRange, colIndex);
+        AFL_VERIFY(insertResult.second);
     }
 };
 

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
@@ -48,7 +48,7 @@ class TColumnChunkRestoreInfo {
 private:
     const NArrow::NAccessor::TChunkConstructionData ChunkExternalInfo;
     const NArrow::NAccessor::NSubColumns::TSettings Settings;
-    THashMap<TString, TSubColumnChunkRestoreInfo> Chunks;
+    THashMap<ui32, TSubColumnChunkRestoreInfo> Chunks;
     YDB_ACCESSOR_DEF(std::optional<TBlobRange>, HeaderRange);
     std::shared_ptr<NArrow::NAccessor::TSubColumnsPartialArray> PartialArray;
     YDB_READONLY_DEF(TBlobRange, FullChunkRange);
@@ -91,9 +91,9 @@ public:
                             : std::make_shared<NArrow::NAccessor::TDeserializeChunkedArray>(
                                   GetRecordsCount(), columnLoader, i.second.GetBlobDataVerified(), true, additionalData);
             if (applyFilter) {
-                PartialArray->AddColumn(i.first, applyFilter->Apply(arrOriginal));
+                PartialArray->AddColumn(i.second.GetColumnIdx(), applyFilter->Apply(arrOriginal));
             } else {
-                PartialArray->AddColumn(i.first, arrOriginal);
+                PartialArray->AddColumn(i.second.GetColumnIdx(), arrOriginal);
             }
         }
     }
@@ -102,14 +102,15 @@ public:
         AFL_VERIFY(!HeaderRange);
         if (!!PartialArray) {
             for (auto&& subColumnName : subColumns) {
-                const auto path = NSubColumns::ResolveBestPath(PartialArray->GetHeader().GetColumnStats(),
-                    PartialArray->GetHeader().GetOtherStats(), NSubColumns::ToJsonPath(subColumnName))
-                                      .DetachResult();
+                auto pathResult = NSubColumns::ResolveBestPath(PartialArray->GetHeader().GetColumnStats(),
+                    PartialArray->GetHeader().GetOtherStats(), NSubColumns::ToJsonPath(subColumnName));
+                AFL_VERIFY(pathResult.IsSuccess())("subColumnName", subColumnName)("error", pathResult.GetErrorMessage());
+                const auto path = pathResult.DetachResult();
                 if (path && path->IsColumn) {
                     auto colBlobRange = PartialArray->GetColumnReadRange(path->Path.ColumnIndex);
                     const TBlobRange subRange = FullChunkRange.BuildSubset(colBlobRange.GetOffset(), colBlobRange.GetSize());
                     reading->AddRange(subRange);
-                    AddFetchData(subColumnName, subRange, path->Path.ColumnIndex);
+                    AddFetchData(subRange, path->Path.ColumnIndex);
                 } else if (!PartialArray->HasOthers() && !OthersReadData && path) {
                     auto readRange = PartialArray->GetHeader().GetOthersReadRange();
                     OthersReadData = FullChunkRange.BuildSubset(readRange.GetOffset(), readRange.GetSize());
@@ -165,17 +166,16 @@ public:
         return result;
     }
 
-    const THashMap<TString, TSubColumnChunkRestoreInfo>& GetChunks() const {
+    const THashMap<ui32, TSubColumnChunkRestoreInfo>& GetChunks() const {
         return Chunks;
     }
 
-    THashMap<TString, TSubColumnChunkRestoreInfo>& MutableChunks() {
+    THashMap<ui32, TSubColumnChunkRestoreInfo>& MutableChunks() {
         return Chunks;
     }
 
-    void AddFetchData(const TString& subColName, const TBlobRange& subRange, const ui32 colIndex) {
-        const std::string_view keyName(subColName.data(), subColName.size());
-        AFL_VERIFY(Chunks.emplace(subColName, TSubColumnChunkRestoreInfo(subRange, colIndex)).second);
+    void AddFetchData(const TBlobRange& subRange, const ui32 colIndex) {
+        Chunks.try_emplace(colIndex, subRange, colIndex);
     }
 };
 
@@ -287,7 +287,7 @@ private:
                         source->AddBytesRead(blobBytes);
                     }
                 }
-                for (auto&& [subColName, chunkData] : i.MutableChunks()) {
+                for (auto&& [columnIndex, chunkData] : i.MutableChunks()) {
                     if (!!chunkData.GetBlobRangeOptional()) {
                         const auto dataStart = TInstant::Now();
                         chunkData.SetBlobData(blobs.ExtractVerified(*StorageId, *chunkData.GetBlobRangeOptional()));
@@ -296,11 +296,11 @@ private:
                             auto columnLoader = source->GetSourceSchema()->GetColumnLoaderVerified(GetEntityId());
                             TString columnName = columnLoader->GetField() ? TString(columnLoader->GetField()->name()) : TString("unknown");
                             const ui64 blobBytes = chunkData.GetBlobDataVerified().size();
-                            const ui32 colIndex = i.GetPartialArray()->GetHeader().GetColumnStats().GetExactKeyIndexVerified(subColName);
-                            const ui64 rawBytes = i.GetPartialArray()->GetHeader().GetColumnStats().GetColumnSize(colIndex);
+                            const ui64 rawBytes = i.GetPartialArray()->GetHeader().GetColumnStats().GetColumnSize(columnIndex);
                             LWTRACK(SubColumnsDataRead, source->GetDataSourceOrbit(), source->GetRawPathId(), source->GetTabletId(),
-                                source->GetTxId(), source->GetDeprecatedPortionId(), GetEntityId(), columnName, dataDuration, subColName,
-                                chunkIndex, blobBytes, rawBytes);
+                                source->GetTxId(), source->GetDeprecatedPortionId(), GetEntityId(), columnName, dataDuration,
+                                i.GetPartialArray()->GetHeader().GetColumnStats().GetColumnNameString(columnIndex), chunkIndex, blobBytes,
+                                rawBytes);
                             source->AddBytesRead(blobBytes);
                         }
                     }

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/sub_columns_fetching.h
@@ -294,7 +294,7 @@ private:
                             auto columnLoader = source->GetSourceSchema()->GetColumnLoaderVerified(GetEntityId());
                             TString columnName = columnLoader->GetField() ? TString(columnLoader->GetField()->name()) : TString("unknown");
                             const ui64 blobBytes = chunkData.GetBlobDataVerified().size();
-                            const ui32 colIndex = i.GetPartialArray()->GetHeader().GetColumnStats().GetKeyIndexVerified(subColName);
+                            const ui32 colIndex = i.GetPartialArray()->GetHeader().GetColumnStats().GetExactKeyIndexVerified(subColName);
                             const ui64 rawBytes = i.GetPartialArray()->GetHeader().GetColumnStats().GetColumnSize(colIndex);
                             LWTRACK(SubColumnsDataRead, source->GetDataSourceOrbit(), source->GetRawPathId(), source->GetTabletId(),
                                 source->GetTxId(), source->GetDeprecatedPortionId(), GetEntityId(), columnName, dataDuration, subColName,

--- a/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/sub_column.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/sub_column.cpp
@@ -4,19 +4,35 @@
 
 namespace NKikimr::NOlap::NIndexes {
 
+namespace {
+
+std::optional<NArrow::NAccessor::NSubColumns::TResolvedPathMatch> ResolveIndexPath(
+    const NArrow::NAccessor::TSubColumnsArray& subColumns, const TStringBuf keyName) {
+    auto result = NArrow::NAccessor::NSubColumns::ResolveBestPath(
+        subColumns.GetColumnsData().GetStats(), subColumns.GetOthersData().GetStats(), NArrow::NAccessor::NSubColumns::ToJsonPath(keyName));
+    AFL_VERIFY(result.IsSuccess())("key", keyName)("error", result.GetErrorMessage());
+    auto path = result.DetachResult();
+    if (!path || path->Path.RemainingPath) {
+        return std::nullopt;
+    }
+    return path;
+}
+
+}   // namespace
+
 void TSubColumnDataExtractor::DoVisitAll(const std::shared_ptr<NArrow::NAccessor::IChunkedArray>& dataArray,
     const TChunkVisitor& /*chunkVisitor*/, const TRecordVisitor& recordVisitor) const {
     AFL_VERIFY(dataArray->GetType() == NArrow::NAccessor::IChunkedArray::EType::SubColumnsArray);
     const auto subColumns = std::static_pointer_cast<NArrow::NAccessor::TSubColumnsArray>(dataArray);
-    if (auto idxColumn = subColumns->GetColumnsData().GetStats().GetExactKeyIndexOptional(SubColumnName)) {
-        auto iterator = subColumns->GetColumnsData().BuildIterator(*idxColumn);
+    if (const auto path = ResolveIndexPath(*subColumns, SubColumnName); path && path->IsColumn) {
+        auto iterator = subColumns->GetColumnsData().BuildIterator(path->Path.ColumnIndex);
         for (; iterator.IsValid(); iterator.Next()) {
             recordVisitor(iterator.GetValue(), 0);
         }
-    } else if (auto idxColumn = subColumns->GetOthersData().GetStats().GetExactKeyIndexOptional(SubColumnName)) {
+    } else if (const auto path = ResolveIndexPath(*subColumns, SubColumnName)) {
         auto iterator = subColumns->GetOthersData().BuildIterator();
         for (; iterator.IsValid(); iterator.Next()) {
-            if (iterator.GetKeyIndex() != *idxColumn) {
+            if (iterator.GetKeyIndex() != path->Path.ColumnIndex) {
                 continue;
             }
             recordVisitor(iterator.GetValue(), 0);
@@ -28,12 +44,12 @@ THashMap<ui64, ui32> TSubColumnDataExtractor::DoGetIndexHitsCount(const std::sha
     AFL_VERIFY(dataArray->GetType() == NArrow::NAccessor::IChunkedArray::EType::SubColumnsArray);
     const auto subColumns = std::static_pointer_cast<NArrow::NAccessor::TSubColumnsArray>(dataArray);
     THashMap<ui64, ui32> result;
-    if (auto idxColumn = subColumns->GetColumnsData().GetStats().GetExactKeyIndexOptional(SubColumnName)) {
+    if (const auto path = ResolveIndexPath(*subColumns, SubColumnName); path && path->IsColumn) {
         result.emplace(NRequest::TOriginalDataAddress::CalcSubColumnHash(SubColumnName),
-            subColumns->GetColumnsData().GetStats().GetColumnRecordsCount(*idxColumn));
-    } else if (auto idxColumn = subColumns->GetOthersData().GetStats().GetExactKeyIndexOptional(SubColumnName)) {
+            subColumns->GetColumnsData().GetStats().GetColumnRecordsCount(path->Path.ColumnIndex));
+    } else if (const auto path = ResolveIndexPath(*subColumns, SubColumnName)) {
         result.emplace(NRequest::TOriginalDataAddress::CalcSubColumnHash(SubColumnName),
-            subColumns->GetOthersData().GetStats().GetColumnRecordsCount(*idxColumn));
+            subColumns->GetOthersData().GetStats().GetColumnRecordsCount(path->Path.ColumnIndex));
     }
     return result;
 }

--- a/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/sub_column.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/sub_column.cpp
@@ -8,12 +8,12 @@ void TSubColumnDataExtractor::DoVisitAll(const std::shared_ptr<NArrow::NAccessor
     const TChunkVisitor& /*chunkVisitor*/, const TRecordVisitor& recordVisitor) const {
     AFL_VERIFY(dataArray->GetType() == NArrow::NAccessor::IChunkedArray::EType::SubColumnsArray);
     const auto subColumns = std::static_pointer_cast<NArrow::NAccessor::TSubColumnsArray>(dataArray);
-    if (auto idxColumn = subColumns->GetColumnsData().GetStats().GetKeyIndexOptional(SubColumnName)) {
+    if (auto idxColumn = subColumns->GetColumnsData().GetStats().GetExactKeyIndexOptional(SubColumnName)) {
         auto iterator = subColumns->GetColumnsData().BuildIterator(*idxColumn);
         for (; iterator.IsValid(); iterator.Next()) {
             recordVisitor(iterator.GetValue(), 0);
         }
-    } else if (auto idxColumn = subColumns->GetOthersData().GetStats().GetKeyIndexOptional(SubColumnName)) {
+    } else if (auto idxColumn = subColumns->GetOthersData().GetStats().GetExactKeyIndexOptional(SubColumnName)) {
         auto iterator = subColumns->GetOthersData().BuildIterator();
         for (; iterator.IsValid(); iterator.Next()) {
             if (iterator.GetKeyIndex() != *idxColumn) {
@@ -28,10 +28,10 @@ THashMap<ui64, ui32> TSubColumnDataExtractor::DoGetIndexHitsCount(const std::sha
     AFL_VERIFY(dataArray->GetType() == NArrow::NAccessor::IChunkedArray::EType::SubColumnsArray);
     const auto subColumns = std::static_pointer_cast<NArrow::NAccessor::TSubColumnsArray>(dataArray);
     THashMap<ui64, ui32> result;
-    if (auto idxColumn = subColumns->GetColumnsData().GetStats().GetKeyIndexOptional(SubColumnName)) {
+    if (auto idxColumn = subColumns->GetColumnsData().GetStats().GetExactKeyIndexOptional(SubColumnName)) {
         result.emplace(NRequest::TOriginalDataAddress::CalcSubColumnHash(SubColumnName),
             subColumns->GetColumnsData().GetStats().GetColumnRecordsCount(*idxColumn));
-    } else if (auto idxColumn = subColumns->GetOthersData().GetStats().GetKeyIndexOptional(SubColumnName)) {
+    } else if (auto idxColumn = subColumns->GetOthersData().GetStats().GetExactKeyIndexOptional(SubColumnName)) {
         result.emplace(NRequest::TOriginalDataAddress::CalcSubColumnHash(SubColumnName),
             subColumns->GetOthersData().GetStats().GetColumnRecordsCount(*idxColumn));
     }

--- a/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/sub_column.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/sub_column.cpp
@@ -12,7 +12,7 @@ std::optional<NArrow::NAccessor::NSubColumns::TResolvedPathMatch> ResolveIndexPa
         subColumns.GetColumnsData().GetStats(), subColumns.GetOthersData().GetStats(), NArrow::NAccessor::NSubColumns::ToJsonPath(keyName));
     AFL_VERIFY(result.IsSuccess())("key", keyName)("error", result.GetErrorMessage());
     auto path = result.DetachResult();
-    if (!path || path->Path.RemainingPath) {
+    if (!path || !path->Path.RemainingPath.empty()) {
         return std::nullopt;
     }
     return path;

--- a/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/sub_column.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/sub_column.cpp
@@ -24,12 +24,13 @@ void TSubColumnDataExtractor::DoVisitAll(const std::shared_ptr<NArrow::NAccessor
     const TChunkVisitor& /*chunkVisitor*/, const TRecordVisitor& recordVisitor) const {
     AFL_VERIFY(dataArray->GetType() == NArrow::NAccessor::IChunkedArray::EType::SubColumnsArray);
     const auto subColumns = std::static_pointer_cast<NArrow::NAccessor::TSubColumnsArray>(dataArray);
-    if (const auto path = ResolveIndexPath(*subColumns, SubColumnName); path && path->IsColumn) {
+    const auto path = ResolveIndexPath(*subColumns, SubColumnName);
+    if (path && path->IsColumn) {
         auto iterator = subColumns->GetColumnsData().BuildIterator(path->Path.ColumnIndex);
         for (; iterator.IsValid(); iterator.Next()) {
             recordVisitor(iterator.GetValue(), 0);
         }
-    } else if (const auto path = ResolveIndexPath(*subColumns, SubColumnName)) {
+    } else if (path) {
         auto iterator = subColumns->GetOthersData().BuildIterator();
         for (; iterator.IsValid(); iterator.Next()) {
             if (iterator.GetKeyIndex() != path->Path.ColumnIndex) {
@@ -44,10 +45,11 @@ THashMap<ui64, ui32> TSubColumnDataExtractor::DoGetIndexHitsCount(const std::sha
     AFL_VERIFY(dataArray->GetType() == NArrow::NAccessor::IChunkedArray::EType::SubColumnsArray);
     const auto subColumns = std::static_pointer_cast<NArrow::NAccessor::TSubColumnsArray>(dataArray);
     THashMap<ui64, ui32> result;
-    if (const auto path = ResolveIndexPath(*subColumns, SubColumnName); path && path->IsColumn) {
+    const auto path = ResolveIndexPath(*subColumns, SubColumnName);
+    if (path && path->IsColumn) {
         result.emplace(NRequest::TOriginalDataAddress::CalcSubColumnHash(SubColumnName),
             subColumns->GetColumnsData().GetStats().GetColumnRecordsCount(path->Path.ColumnIndex));
-    } else if (const auto path = ResolveIndexPath(*subColumns, SubColumnName)) {
+    } else if (path) {
         result.emplace(NRequest::TOriginalDataAddress::CalcSubColumnHash(SubColumnName),
             subColumns->GetOthersData().GetStats().GetColumnRecordsCount(path->Path.ColumnIndex));
     }

--- a/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/ut/ut_sub_column.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/ut/ut_sub_column.cpp
@@ -1,0 +1,68 @@
+#include <ydb/core/formats/arrow/accessor/common/chunk_data.h>
+#include <ydb/core/formats/arrow/accessor/plain/accessor.h>
+#include <ydb/core/formats/arrow/accessor/sub_columns/accessor.h>
+#include <ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/sub_column.h>
+
+#include <contrib/libs/apache/arrow/cpp/src/arrow/array/builder_binary.h>
+#include <library/cpp/testing/unittest/registar.h>
+#include <yql/essentials/types/binary_json/write.h>
+
+namespace NKikimr::NOlap::NIndexes {
+
+namespace {
+
+using namespace NArrow::NAccessor;
+using namespace NArrow::NAccessor::NSubColumns;
+
+std::shared_ptr<TTrivialArray> MakeBinaryJsonArray(const TStringBuf data) {
+    auto binaryJsonResult = NBinaryJson::SerializeToBinaryJson(data);
+    UNIT_ASSERT(std::holds_alternative<NBinaryJson::TBinaryJson>(binaryJsonResult));
+    const auto binaryJson = std::get<NBinaryJson::TBinaryJson>(binaryJsonResult);
+    return std::make_shared<TTrivialArray>(TTrivialArray::BuildArrayFromScalar(std::make_shared<arrow::BinaryScalar>(
+        std::make_shared<arrow::Buffer>((const ui8*)binaryJson.data(), binaryJson.size()), arrow::binary())));
+}
+
+TDictStats MakeStats(const std::initializer_list<TStringBuf>& names) {
+    auto builder = TDictStats::MakeBuilder();
+    for (const auto& name : names) {
+        builder.Add(TString(name), 1, 1, IChunkedArray::EType::Array, EValueType::BinaryJson);
+    }
+    return builder.Finish();
+}
+
+std::shared_ptr<TSubColumnsArray> MakeArray() {
+    auto columnsStats = MakeStats({ R"("a")", R"("a"."b"."c")" });
+    auto columnsRecords = std::make_shared<NArrow::TGeneralContainer>(1);
+    columnsRecords->AddField(columnsStats.GetField(0), MakeBinaryJsonArray(R"("columns")")).Validate();
+    columnsRecords->AddField(columnsStats.GetField(1), MakeBinaryJsonArray(R"("descendant")")).Validate();
+
+    auto othersStats = MakeStats({ R"("a"."b")" });
+    auto binaryJsonResult = NBinaryJson::SerializeToBinaryJson(R"("others")");
+    UNIT_ASSERT(std::holds_alternative<NBinaryJson::TBinaryJson>(binaryJsonResult));
+    const auto& binaryJson = std::get<NBinaryJson::TBinaryJson>(binaryJsonResult);
+    auto othersBuilder = TOthersData::MakeMergedBuilder();
+    othersBuilder->Add(0, 0, std::string_view(binaryJson.data(), binaryJson.size()));
+    auto others = othersBuilder->Finish(TOthersData::TFinishContext(othersStats));
+
+    return std::make_shared<TSubColumnsArray>(
+        TColumnsData(std::move(columnsStats), columnsRecords), std::move(others), arrow::binary(), 1, TSettings());
+}
+
+}   // namespace
+
+Y_UNIT_TEST_SUITE(TSubColumnDataExtractorTests) {
+    Y_UNIT_TEST(UsesExactStoredPath) {
+        TSubColumnDataExtractor extractor;
+        NJson::TJsonValue config(NJson::JSON_MAP);
+        config.InsertValue("sub_column_name", R"("a"."b")");
+        UNIT_ASSERT(extractor.DeserializeFromJson(config).IsSuccess());
+
+        TString result;
+        extractor.VisitAll(MakeArray(), {}, [&result](const NArrow::NAccessor::TJsonValueView& value, ui64) {
+            result = value.ToJsonValue().GetString();
+        });
+        UNIT_ASSERT_VALUES_EQUAL(result, "others");
+    }
+}
+
+}   // namespace NKikimr::NOlap::NIndexes

--- a/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/ut/ut_sub_column.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/ut/ut_sub_column.cpp
@@ -1,54 +1,9 @@
-#include <ydb/core/formats/arrow/accessor/common/chunk_data.h>
-#include <ydb/core/formats/arrow/accessor/plain/accessor.h>
-#include <ydb/core/formats/arrow/accessor/sub_columns/accessor.h>
+#include <ydb/core/formats/arrow/accessor/sub_columns/ut_common/ut_helpers.h>
 #include <ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/sub_column.h>
 
-#include <contrib/libs/apache/arrow/cpp/src/arrow/array/builder_binary.h>
 #include <library/cpp/testing/unittest/registar.h>
-#include <yql/essentials/types/binary_json/write.h>
 
 namespace NKikimr::NOlap::NIndexes {
-
-namespace {
-
-using namespace NArrow::NAccessor;
-using namespace NArrow::NAccessor::NSubColumns;
-
-std::shared_ptr<TTrivialArray> MakeBinaryJsonArray(const TStringBuf data) {
-    auto binaryJsonResult = NBinaryJson::SerializeToBinaryJson(data);
-    UNIT_ASSERT(std::holds_alternative<NBinaryJson::TBinaryJson>(binaryJsonResult));
-    const auto binaryJson = std::get<NBinaryJson::TBinaryJson>(binaryJsonResult);
-    return std::make_shared<TTrivialArray>(TTrivialArray::BuildArrayFromScalar(std::make_shared<arrow::BinaryScalar>(
-        std::make_shared<arrow::Buffer>((const ui8*)binaryJson.data(), binaryJson.size()), arrow::binary())));
-}
-
-TDictStats MakeStats(const std::initializer_list<TStringBuf>& names) {
-    auto builder = TDictStats::MakeBuilder();
-    for (const auto& name : names) {
-        builder.Add(TString(name), 1, 1, IChunkedArray::EType::Array, EValueType::BinaryJson);
-    }
-    return builder.Finish();
-}
-
-std::shared_ptr<TSubColumnsArray> MakeArray() {
-    auto columnsStats = MakeStats({ R"("a")", R"("a"."b"."c")" });
-    auto columnsRecords = std::make_shared<NArrow::TGeneralContainer>(1);
-    columnsRecords->AddField(columnsStats.GetField(0), MakeBinaryJsonArray(R"("columns")")).Validate();
-    columnsRecords->AddField(columnsStats.GetField(1), MakeBinaryJsonArray(R"("descendant")")).Validate();
-
-    auto othersStats = MakeStats({ R"("a"."b")" });
-    auto binaryJsonResult = NBinaryJson::SerializeToBinaryJson(R"("others")");
-    UNIT_ASSERT(std::holds_alternative<NBinaryJson::TBinaryJson>(binaryJsonResult));
-    const auto& binaryJson = std::get<NBinaryJson::TBinaryJson>(binaryJsonResult);
-    auto othersBuilder = TOthersData::MakeMergedBuilder();
-    othersBuilder->Add(0, 0, std::string_view(binaryJson.data(), binaryJson.size()));
-    auto others = othersBuilder->Finish(TOthersData::TFinishContext(othersStats));
-
-    return std::make_shared<TSubColumnsArray>(
-        TColumnsData(std::move(columnsStats), columnsRecords), std::move(others), arrow::binary(), 1, TSettings());
-}
-
-}   // namespace
 
 Y_UNIT_TEST_SUITE(TSubColumnDataExtractorTests) {
     Y_UNIT_TEST(UsesExactStoredPath) {
@@ -58,9 +13,11 @@ Y_UNIT_TEST_SUITE(TSubColumnDataExtractorTests) {
         UNIT_ASSERT(extractor.DeserializeFromJson(config).IsSuccess());
 
         TString result;
-        extractor.VisitAll(MakeArray(), {}, [&result](const NArrow::NAccessor::TJsonValueView& value, ui64) {
-            result = value.ToJsonValue().GetString();
-        });
+        extractor.VisitAll(NArrow::NAccessor::NSubColumns::NTesting::BuildArrayWithStoredPaths(
+                               { { R"("a")", R"("columns")" }, { R"("a"."b"."c")", R"("descendant")" } }, R"("a"."b")", R"("others")"),
+            {}, [&result](const NArrow::NAccessor::TJsonValueView& value, ui64) {
+                result = value.ToJsonValue().GetString();
+            });
         UNIT_ASSERT_VALUES_EQUAL(result, "others");
     }
 }

--- a/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/ut/ya.make
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/ut/ya.make
@@ -1,0 +1,15 @@
+UNITTEST_FOR(ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor)
+
+SRCS(
+    ut_sub_column.cpp
+)
+
+PEERDIR(
+    ydb/core/formats/arrow/accessor/sub_columns
+    yql/essentials/public/udf/service/stub
+    yql/essentials/sql/pg_dummy
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/ut/ya.make
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/ut/ya.make
@@ -5,7 +5,7 @@ SRCS(
 )
 
 PEERDIR(
-    ydb/core/formats/arrow/accessor/sub_columns
+    ydb/core/formats/arrow/accessor/sub_columns/ut_common
     yql/essentials/public/udf/service/stub
     yql/essentials/sql/pg_dummy
 )

--- a/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/ya.make
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/ya.make
@@ -11,6 +11,7 @@ PEERDIR(
     ydb/core/formats/arrow
     ydb/core/protos
     ydb/core/formats/arrow/accessor/sub_columns
+    ydb/core/tx/columnshard/engines/scheme/indexes/abstract
 )
 
 YQL_LAST_ABI_VERSION()


### PR DESCRIPTION
Trie building took ~10% cpu on queries with simple LIKE/ILIKE filters and about 10 subcolumns.
In compaction, use only exact paths, do not resolve anything. That also fixes a bug with merging data from "a.b" into "a".

In scan, parse the user-provided path and compare its canonical form with stored column names. Canonization is done by the same code on write and scan paths. Add an integration test to verify that.

Reworked selection between separated and others - in baseline, separated were selected if there was any match in them, even if others had a better match. Now we check both separated and others and select whichever match is better. Same algorithm on all paths - indexing, fetching, retrieving fetched data.

Added README.md with desciption of JSON_VALUE handling.