### PR TITLE
[PQ] Survive corrupt Kafka batches and raise tablet batching coverage

### DIFF
--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
@@ -55,6 +55,24 @@ TString CompressPayload(TStringBuf data, NPersQueueCommon::ECodec codec) {
     }
 }
 
+ui64 RecordOffset(ui64 baseOffset, i64 offsetDelta, ui64 parentOffset) {
+    // Kafka encodes offsetDelta as a signed varint, but a valid RecordBatch uses
+    // non-negative deltas (0, 1, ...). A negative value is corrupt client data;
+    // adding it to ui64 would wrap instead of failing.
+    Y_ENSURE(offsetDelta >= 0,
+        "negative kafka record offset delta"
+        << " offset_delta=" << offsetDelta
+        << " base_offset=" << baseOffset
+        << " offset=" << parentOffset);
+    const ui64 offset = baseOffset + static_cast<ui64>(offsetDelta);
+    Y_ENSURE(offset >= baseOffset,
+        "kafka record offset overflow"
+        << " offset_delta=" << offsetDelta
+        << " base_offset=" << baseOffset
+        << " offset=" << parentOffset);
+    return offset;
+}
+
 } // namespace
 
 TVector<TReadResult> TKafkaBatchCutter::Cut(const TBatchCutterData& data, const ui64 readStartOffset) const {
@@ -94,7 +112,7 @@ TVector<TReadResult> TKafkaBatchCutter::Cut(const TBatchCutterData& data, const 
 
     const ui64 baseOffset = data.ReadResult.GetOffset();
     for (size_t i = 0; i < batch.Records.size(); ++i) {
-        const auto offset = baseOffset + batch.Records[i].OffsetDelta;
+        const ui64 offset = RecordOffset(baseOffset, batch.Records[i].OffsetDelta, data.ReadResult.GetOffset());
         if (offset < readStartOffset) {
             continue;
         }
@@ -151,7 +169,7 @@ THashMap<TString, ui64> TKafkaBatchCutter::GetKeys(const TBatchCutterData& data,
     const auto batch = NKafka::ReadKafkaRecordBatch(dataChunk.GetData());
     const ui64 baseOffset = data.ReadResult.GetOffset();
     for (const auto& record : batch.Records) {
-        const auto offset = baseOffset + record.OffsetDelta;
+        const ui64 offset = RecordOffset(baseOffset, record.OffsetDelta, data.ReadResult.GetOffset());
         if (offset < readStartOffset) {
             continue;
         }

--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
@@ -137,13 +137,7 @@ std::expected<TVector<TReadResult>, TString> TKafkaBatchCutter::Cut(const TBatch
                 itemChunk.ClearData();
             }
             TString serializedChunk;
-            if (!itemChunk.SerializeToString(&serializedChunk)) {
-                return std::unexpected(TStringBuilder()
-                    << "failed to serialize data chunk"
-                    << " offset=" << *offset
-                    << " seq_no=" << seqNo
-                    << " codec=" << static_cast<int>(codec));
-            }
+            Y_PROTOBUF_SUPPRESS_NODISCARD itemChunk.SerializeToString(&serializedChunk);
             item.SetData(std::move(serializedChunk));
 
             if (record.Key) {

--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
@@ -2,15 +2,11 @@
 
 #include <ydb/core/persqueue/public/codecs/kafka.h>
 #include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
-#include <ydb/core/persqueue/public/write_meta/write_meta.h>
-#include <ydb/core/protos/grpc_pq_old.pb.h>
 #include <ydb/public/api/protos/draft/persqueue_common.pb.h>
-#include <ydb/public/api/protos/ydb_topic.pb.h>
 
 #include <library/cpp/streams/zstd/zstd.h>
 
 #include <util/generic/yexception.h>
-#include <util/stream/mem.h>
 #include <util/stream/output.h>
 #include <util/stream/zlib.h>
 
@@ -29,10 +25,6 @@ NPersQueueCommon::ECodec ToDataChunkCodec(NKafka::ECompressionType compressionTy
 }
 
 TString CompressPayload(TStringBuf data, NPersQueueCommon::ECodec codec) {
-    if (codec == NPersQueueCommon::RAW) {
-        return TString(data);
-    }
-
     TString result;
     TStringOutput output(result);
     switch (codec) {
@@ -51,7 +43,7 @@ TString CompressPayload(TStringBuf data, NPersQueueCommon::ECodec codec) {
             return result;
         }
         default:
-            ythrow yexception() << "unsupported message codec: " << static_cast<int>(codec);
+            return TString(data);
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
@@ -61,41 +61,41 @@ TString UnexpectedCodecError(const TBatchCutterData& data) {
         << " offset=" << data.ReadResult.GetOffset();
 }
 
-TString TryRecordOffset(ui64 baseOffset, i64 offsetDelta, ui64 parentOffset, ui64& offset) {
+std::expected<ui64, TString> TryRecordOffset(ui64 baseOffset, i64 offsetDelta, ui64 parentOffset) {
     // Kafka encodes offsetDelta as a signed varint, but a valid RecordBatch uses
     // non-negative deltas (0, 1, ...). A negative or overflowing value is corrupt client data.
     if (offsetDelta < 0) {
-        return TStringBuilder() << "negative kafka record offset delta"
+        return std::unexpected(TStringBuilder() << "negative kafka record offset delta"
             << " offset_delta=" << offsetDelta
             << " base_offset=" << baseOffset
-            << " offset=" << parentOffset;
+            << " offset=" << parentOffset);
     }
-    offset = baseOffset + static_cast<ui64>(offsetDelta);
+    const ui64 offset = baseOffset + static_cast<ui64>(offsetDelta);
     if (offset < baseOffset) {
-        return TStringBuilder() << "kafka record offset overflow"
+        return std::unexpected(TStringBuilder() << "kafka record offset overflow"
             << " offset_delta=" << offsetDelta
             << " base_offset=" << baseOffset
-            << " offset=" << parentOffset;
+            << " offset=" << parentOffset);
     }
-    return {};
+    return offset;
 }
 
 } // namespace
 
-TCutOutcome TKafkaBatchCutter::Cut(const TBatchCutterData& data, const ui64 readStartOffset) const {
+std::expected<TVector<TReadResult>, TString> TKafkaBatchCutter::Cut(const TBatchCutterData& data, const ui64 readStartOffset) const {
     const auto& dataChunk = data.DataChunk;
     if (dataChunk.GetChunkType() != NKikimrPQClient::TDataChunk::REGULAR) {
-        return TCutOutcome{.Records = {data.ReadResult}};
+        return TVector<TReadResult>{data.ReadResult};
     }
 
     if (TString error = UnexpectedCodecError(data); !error.empty()) {
-        return TCutOutcome{.Error = std::move(error)};
+        return std::unexpected(std::move(error));
     }
 
     try {
         const auto batch = NKafka::ReadKafkaRecordBatch(dataChunk.GetData());
         if (batch.Records.empty()) {
-            return TCutOutcome{.Records = {data.ReadResult}};
+            return TVector<TReadResult>{data.ReadResult};
         }
 
         const auto codec = ToDataChunkCodec(batch.CompressionType());
@@ -115,11 +115,11 @@ TCutOutcome TKafkaBatchCutter::Cut(const TBatchCutterData& data, const ui64 read
 
         const ui64 baseOffset = data.ReadResult.GetOffset();
         for (size_t i = 0; i < batch.Records.size(); ++i) {
-            ui64 offset = 0;
-            if (TString error = TryRecordOffset(baseOffset, batch.Records[i].OffsetDelta, data.ReadResult.GetOffset(), offset); !error.empty()) {
-                return TCutOutcome{.Error = std::move(error)};
+            auto offset = TryRecordOffset(baseOffset, batch.Records[i].OffsetDelta, data.ReadResult.GetOffset());
+            if (!offset) {
+                return std::unexpected(std::move(offset).error());
             }
-            if (offset < readStartOffset) {
+            if (*offset < readStartOffset) {
                 continue;
             }
 
@@ -127,7 +127,7 @@ TCutOutcome TKafkaBatchCutter::Cut(const TBatchCutterData& data, const ui64 read
             const ui64 seqNo = NKafka::GetRecordSeqNo(batch, i, record);
 
             TReadResult item(itemTemplate);
-            item.SetOffset(offset);
+            item.SetOffset(*offset);
             item.SetSeqNo(seqNo);
 
             itemChunk.SetSeqNo(seqNo);
@@ -138,11 +138,11 @@ TCutOutcome TKafkaBatchCutter::Cut(const TBatchCutterData& data, const ui64 read
             }
             TString serializedChunk;
             if (!itemChunk.SerializeToString(&serializedChunk)) {
-                return TCutOutcome{.Error = TStringBuilder()
+                return std::unexpected(TStringBuilder()
                     << "failed to serialize data chunk"
-                    << " offset=" << offset
+                    << " offset=" << *offset
                     << " seq_no=" << seqNo
-                    << " codec=" << static_cast<int>(codec)};
+                    << " codec=" << static_cast<int>(codec));
             }
             item.SetData(std::move(serializedChunk));
 
@@ -156,20 +156,20 @@ TCutOutcome TKafkaBatchCutter::Cut(const TBatchCutterData& data, const ui64 read
             result.push_back(std::move(item));
         }
 
-        return TCutOutcome{.Records = std::move(result)};
+        return result;
     } catch (const std::exception& e) {
-        return TCutOutcome{.Error = TString(e.what())};
+        return std::unexpected(TString(e.what()));
     }
 }
 
-TKeysOutcome TKafkaBatchCutter::GetKeys(const TBatchCutterData& data, const ui64 readStartOffset) const {
+std::expected<THashMap<TString, ui64>, TString> TKafkaBatchCutter::GetKeys(const TBatchCutterData& data, const ui64 readStartOffset) const {
     const auto& dataChunk = data.DataChunk;
     if (dataChunk.GetChunkType() != NKikimrPQClient::TDataChunk::REGULAR) {
-        return {};
+        return THashMap<TString, ui64>{};
     }
 
     if (TString error = UnexpectedCodecError(data); !error.empty()) {
-        return TKeysOutcome{.Error = std::move(error)};
+        return std::unexpected(std::move(error));
     }
 
     try {
@@ -177,11 +177,11 @@ TKeysOutcome TKafkaBatchCutter::GetKeys(const TBatchCutterData& data, const ui64
         const ui64 baseOffset = data.ReadResult.GetOffset();
         THashMap<TString, ui64> result;
         for (const auto& record : batch.Records) {
-            ui64 offset = 0;
-            if (TString error = TryRecordOffset(baseOffset, record.OffsetDelta, data.ReadResult.GetOffset(), offset); !error.empty()) {
-                return TKeysOutcome{.Error = std::move(error)};
+            auto offset = TryRecordOffset(baseOffset, record.OffsetDelta, data.ReadResult.GetOffset());
+            if (!offset) {
+                return std::unexpected(std::move(offset).error());
             }
-            if (offset < readStartOffset) {
+            if (*offset < readStartOffset) {
                 continue;
             }
 
@@ -191,12 +191,12 @@ TKeysOutcome TKafkaBatchCutter::GetKeys(const TBatchCutterData& data, const ui64
 
             TString key;
             key.assign(record.Key->data(), record.Key->size());
-            result[key] = offset;
+            result[key] = *offset;
         }
 
-        return TKeysOutcome{.Keys = std::move(result)};
+        return result;
     } catch (const std::exception& e) {
-        return TKeysOutcome{.Error = TString(e.what())};
+        return std::unexpected(TString(e.what()));
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
@@ -6,9 +6,11 @@
 
 #include <library/cpp/streams/zstd/zstd.h>
 
-#include <util/generic/yexception.h>
+#include <exception>
+
 #include <util/stream/output.h>
 #include <util/stream/zlib.h>
+#include <util/string/builder.h>
 
 namespace NKikimr::NPQ::NBatching {
 namespace {
@@ -47,135 +49,155 @@ TString CompressPayload(TStringBuf data, NPersQueueCommon::ECodec codec) {
     }
 }
 
-ui64 RecordOffset(ui64 baseOffset, i64 offsetDelta, ui64 parentOffset) {
+TString UnexpectedCodecError(const TBatchCutterData& data) {
+    const auto& dataChunk = data.DataChunk;
+    if (dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec()) {
+        return {};
+    }
+    return TStringBuilder() << "unexpected data chunk codec for kafka batch cutter"
+        << " has_codec=" << dataChunk.HasCodec()
+        << " codec=" << (dataChunk.HasCodec() ? static_cast<int>(dataChunk.GetCodec()) : -1)
+        << " expected_codec=" << static_cast<int>(KafkaBatchCodec())
+        << " offset=" << data.ReadResult.GetOffset();
+}
+
+TString TryRecordOffset(ui64 baseOffset, i64 offsetDelta, ui64 parentOffset, ui64& offset) {
     // Kafka encodes offsetDelta as a signed varint, but a valid RecordBatch uses
-    // non-negative deltas (0, 1, ...). A negative value is corrupt client data;
-    // adding it to ui64 would wrap instead of failing.
-    Y_ENSURE(offsetDelta >= 0,
-        "negative kafka record offset delta"
-        << " offset_delta=" << offsetDelta
-        << " base_offset=" << baseOffset
-        << " offset=" << parentOffset);
-    const ui64 offset = baseOffset + static_cast<ui64>(offsetDelta);
-    Y_ENSURE(offset >= baseOffset,
-        "kafka record offset overflow"
-        << " offset_delta=" << offsetDelta
-        << " base_offset=" << baseOffset
-        << " offset=" << parentOffset);
-    return offset;
+    // non-negative deltas (0, 1, ...). A negative or overflowing value is corrupt client data.
+    if (offsetDelta < 0) {
+        return TStringBuilder() << "negative kafka record offset delta"
+            << " offset_delta=" << offsetDelta
+            << " base_offset=" << baseOffset
+            << " offset=" << parentOffset;
+    }
+    offset = baseOffset + static_cast<ui64>(offsetDelta);
+    if (offset < baseOffset) {
+        return TStringBuilder() << "kafka record offset overflow"
+            << " offset_delta=" << offsetDelta
+            << " base_offset=" << baseOffset
+            << " offset=" << parentOffset;
+    }
+    return {};
 }
 
 } // namespace
 
-TVector<TReadResult> TKafkaBatchCutter::Cut(const TBatchCutterData& data, const ui64 readStartOffset) const {
+TCutOutcome TKafkaBatchCutter::Cut(const TBatchCutterData& data, const ui64 readStartOffset) const {
     const auto& dataChunk = data.DataChunk;
     if (dataChunk.GetChunkType() != NKikimrPQClient::TDataChunk::REGULAR) {
-        return {data.ReadResult};
+        return TCutOutcome{.Records = {data.ReadResult}};
     }
 
-    // Bad on-disk/client data: throw yexception (catchable in UT and callers), not AFL_ENSURE
-    // which aborts outside an actor activation context.
-    Y_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec(),
-        "unexpected data chunk codec for kafka batch cutter"
-        << " has_codec=" << dataChunk.HasCodec()
-        << " codec=" << (dataChunk.HasCodec() ? static_cast<int>(dataChunk.GetCodec()) : -1)
-        << " expected_codec=" << static_cast<int>(KafkaBatchCodec())
-        << " offset=" << data.ReadResult.GetOffset());
-
-    const auto batch = NKafka::ReadKafkaRecordBatch(dataChunk.GetData());
-    if (batch.Records.empty()) {
-        return {data.ReadResult};
+    if (TString error = UnexpectedCodecError(data); !error.empty()) {
+        return TCutOutcome{.Error = std::move(error)};
     }
 
-    const auto codec = ToDataChunkCodec(batch.CompressionType());
-
-    TVector<TReadResult> result;
-    result.reserve(batch.Records.size());
-
-    TReadResult itemTemplate(data.ReadResult);
-    itemTemplate.ClearData();
-    itemTemplate.SetLogicalMessageCount(1);
-    itemTemplate.SetIsBatch(false);
-    itemTemplate.ClearUncompressedSize();
-
-    NKikimrPQClient::TDataChunk itemChunk(dataChunk);
-    itemChunk.ClearData();
-    itemChunk.SetCodec(codec);
-
-    const ui64 baseOffset = data.ReadResult.GetOffset();
-    for (size_t i = 0; i < batch.Records.size(); ++i) {
-        const ui64 offset = RecordOffset(baseOffset, batch.Records[i].OffsetDelta, data.ReadResult.GetOffset());
-        if (offset < readStartOffset) {
-            continue;
+    try {
+        const auto batch = NKafka::ReadKafkaRecordBatch(dataChunk.GetData());
+        if (batch.Records.empty()) {
+            return TCutOutcome{.Records = {data.ReadResult}};
         }
 
-        const auto& record = batch.Records[i];
-        const ui64 seqNo = NKafka::GetRecordSeqNo(batch, i, record);
+        const auto codec = ToDataChunkCodec(batch.CompressionType());
 
-        TReadResult item(itemTemplate);
-        item.SetOffset(offset);
-        item.SetSeqNo(seqNo);
+        TVector<TReadResult> result;
+        result.reserve(batch.Records.size());
 
-        itemChunk.SetSeqNo(seqNo);
-        if (record.Value) {
-            itemChunk.SetData(CompressPayload(TStringBuf(record.Value->data(), record.Value->size()), codec));
-        } else {
-            itemChunk.ClearData();
-        }
-        TString serializedChunk;
-        Y_ENSURE(itemChunk.SerializeToString(&serializedChunk),
-            "failed to serialize data chunk"
-            << " offset=" << offset
-            << " seq_no=" << seqNo
-            << " codec=" << static_cast<int>(codec));
-        item.SetData(std::move(serializedChunk));
+        TReadResult itemTemplate(data.ReadResult);
+        itemTemplate.ClearData();
+        itemTemplate.SetLogicalMessageCount(1);
+        itemTemplate.SetIsBatch(false);
+        itemTemplate.ClearUncompressedSize();
 
-        if (record.Key) {
-            item.SetPartitionKey(TString(record.Key->data(), record.Key->size()));
+        NKikimrPQClient::TDataChunk itemChunk(dataChunk);
+        itemChunk.ClearData();
+        itemChunk.SetCodec(codec);
+
+        const ui64 baseOffset = data.ReadResult.GetOffset();
+        for (size_t i = 0; i < batch.Records.size(); ++i) {
+            ui64 offset = 0;
+            if (TString error = TryRecordOffset(baseOffset, batch.Records[i].OffsetDelta, data.ReadResult.GetOffset(), offset); !error.empty()) {
+                return TCutOutcome{.Error = std::move(error)};
+            }
+            if (offset < readStartOffset) {
+                continue;
+            }
+
+            const auto& record = batch.Records[i];
+            const ui64 seqNo = NKafka::GetRecordSeqNo(batch, i, record);
+
+            TReadResult item(itemTemplate);
+            item.SetOffset(offset);
+            item.SetSeqNo(seqNo);
+
+            itemChunk.SetSeqNo(seqNo);
+            if (record.Value) {
+                itemChunk.SetData(CompressPayload(TStringBuf(record.Value->data(), record.Value->size()), codec));
+            } else {
+                itemChunk.ClearData();
+            }
+            TString serializedChunk;
+            if (!itemChunk.SerializeToString(&serializedChunk)) {
+                return TCutOutcome{.Error = TStringBuilder()
+                    << "failed to serialize data chunk"
+                    << " offset=" << offset
+                    << " seq_no=" << seqNo
+                    << " codec=" << static_cast<int>(codec)};
+            }
+            item.SetData(std::move(serializedChunk));
+
+            if (record.Key) {
+                item.SetPartitionKey(TString(record.Key->data(), record.Key->size()));
+            }
+            const i64 timestamp = batch.BaseTimestamp + record.TimestampDelta;
+            if (timestamp > 0) {
+                item.SetCreateTimestampMS(timestamp);
+            }
+            result.push_back(std::move(item));
         }
-        const i64 timestamp = batch.BaseTimestamp + record.TimestampDelta;
-        if (timestamp > 0) {
-            item.SetCreateTimestampMS(timestamp);
-        }
-        result.push_back(std::move(item));
+
+        return TCutOutcome{.Records = std::move(result)};
+    } catch (const std::exception& e) {
+        return TCutOutcome{.Error = TString(e.what())};
     }
-
-    return result;
 }
 
-THashMap<TString, ui64> TKafkaBatchCutter::GetKeys(const TBatchCutterData& data, const ui64 readStartOffset) const {
-    THashMap<TString, ui64> result;
-
+TKeysOutcome TKafkaBatchCutter::GetKeys(const TBatchCutterData& data, const ui64 readStartOffset) const {
     const auto& dataChunk = data.DataChunk;
     if (dataChunk.GetChunkType() != NKikimrPQClient::TDataChunk::REGULAR) {
-        return result;
+        return {};
     }
 
-    Y_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec(),
-        "unexpected data chunk codec for kafka batch cutter"
-        << " has_codec=" << dataChunk.HasCodec()
-        << " codec=" << (dataChunk.HasCodec() ? static_cast<int>(dataChunk.GetCodec()) : -1)
-        << " expected_codec=" << static_cast<int>(KafkaBatchCodec())
-        << " offset=" << data.ReadResult.GetOffset());
-
-    const auto batch = NKafka::ReadKafkaRecordBatch(dataChunk.GetData());
-    const ui64 baseOffset = data.ReadResult.GetOffset();
-    for (const auto& record : batch.Records) {
-        const ui64 offset = RecordOffset(baseOffset, record.OffsetDelta, data.ReadResult.GetOffset());
-        if (offset < readStartOffset) {
-            continue;
-        }
-
-        if (!record.Key) {
-            continue;
-        }
-
-        TString key;
-        key.assign(record.Key->data(), record.Key->size());
-        result[key] = offset;
+    if (TString error = UnexpectedCodecError(data); !error.empty()) {
+        return TKeysOutcome{.Error = std::move(error)};
     }
 
-    return result;
+    try {
+        const auto batch = NKafka::ReadKafkaRecordBatch(dataChunk.GetData());
+        const ui64 baseOffset = data.ReadResult.GetOffset();
+        THashMap<TString, ui64> result;
+        for (const auto& record : batch.Records) {
+            ui64 offset = 0;
+            if (TString error = TryRecordOffset(baseOffset, record.OffsetDelta, data.ReadResult.GetOffset(), offset); !error.empty()) {
+                return TKeysOutcome{.Error = std::move(error)};
+            }
+            if (offset < readStartOffset) {
+                continue;
+            }
+
+            if (!record.Key) {
+                continue;
+            }
+
+            TString key;
+            key.assign(record.Key->data(), record.Key->size());
+            result[key] = offset;
+        }
+
+        return TKeysOutcome{.Keys = std::move(result)};
+    } catch (const std::exception& e) {
+        return TKeysOutcome{.Error = TString(e.what())};
+    }
 }
 
 } // namespace NKikimr::NPQ::NBatching

--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
@@ -82,6 +82,16 @@ TVector<TReadResult> TKafkaBatchCutter::Cut(const TBatchCutterData& data, const 
     TVector<TReadResult> result;
     result.reserve(batch.Records.size());
 
+    TReadResult itemTemplate(data.ReadResult);
+    itemTemplate.ClearData();
+    itemTemplate.SetLogicalMessageCount(1);
+    itemTemplate.SetIsBatch(false);
+    itemTemplate.ClearUncompressedSize();
+
+    NKikimrPQClient::TDataChunk itemChunk(dataChunk);
+    itemChunk.ClearData();
+    itemChunk.SetCodec(codec);
+
     const ui64 baseOffset = data.ReadResult.GetOffset();
     for (size_t i = 0; i < batch.Records.size(); ++i) {
         const auto offset = baseOffset + batch.Records[i].OffsetDelta;
@@ -91,16 +101,12 @@ TVector<TReadResult> TKafkaBatchCutter::Cut(const TBatchCutterData& data, const 
 
         const auto& record = batch.Records[i];
         const ui64 seqNo = NKafka::GetRecordSeqNo(batch, i, record);
-        TReadResult item = data.ReadResult;
+
+        TReadResult item(itemTemplate);
         item.SetOffset(offset);
         item.SetSeqNo(seqNo);
-        item.SetLogicalMessageCount(1);
-        item.SetIsBatch(false);
-        item.ClearUncompressedSize();
 
-        NKikimrPQClient::TDataChunk itemChunk = dataChunk;
         itemChunk.SetSeqNo(seqNo);
-        itemChunk.SetCodec(codec);
         if (record.Value) {
             itemChunk.SetData(CompressPayload(TStringBuf(record.Value->data(), record.Value->size()), codec));
         } else {

--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.h
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.h
@@ -24,18 +24,36 @@ struct TBatchCutterData {
     TBatchCutterData(TReadResult&&, NKikimrPQClient::TDataChunk&&) = delete;
 };
 
+struct TCutOutcome {
+    TVector<TReadResult> Records;
+    TString Error;
+
+    bool Ok() const {
+        return Error.empty();
+    }
+};
+
+struct TKeysOutcome {
+    THashMap<TString, ui64> Keys;
+    TString Error;
+
+    bool Ok() const {
+        return Error.empty();
+    }
+};
+
 class IBatchCutter {
 public:
     virtual ~IBatchCutter() = default;
 
-    virtual TVector<TReadResult> Cut(const TBatchCutterData& data, ui64 readStartOffset) const = 0;
-    virtual THashMap<TString, ui64> GetKeys(const TBatchCutterData& data, ui64 readStartOffset) const = 0;
+    virtual TCutOutcome Cut(const TBatchCutterData& data, ui64 readStartOffset) const = 0;
+    virtual TKeysOutcome GetKeys(const TBatchCutterData& data, ui64 readStartOffset) const = 0;
 };
 
 class TKafkaBatchCutter : public IBatchCutter {
 public:
-    TVector<TReadResult> Cut(const TBatchCutterData& data, ui64 readStartOffset) const override final;
-    THashMap<TString, ui64> GetKeys(const TBatchCutterData& data, ui64 readStartOffset) const override final;
+    TCutOutcome Cut(const TBatchCutterData& data, ui64 readStartOffset) const override final;
+    TKeysOutcome GetKeys(const TBatchCutterData& data, ui64 readStartOffset) const override final;
 };
 
 } // namespace NKikimr::NPQ::NBatching

--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.h
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.h
@@ -7,6 +7,8 @@
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 
+#include <expected>
+
 namespace NKikimr::NPQ::NBatching {
 
 using TReadResult = NKikimrClient::TCmdReadResult::TResult;
@@ -24,36 +26,18 @@ struct TBatchCutterData {
     TBatchCutterData(TReadResult&&, NKikimrPQClient::TDataChunk&&) = delete;
 };
 
-struct TCutOutcome {
-    TVector<TReadResult> Records;
-    TString Error;
-
-    bool Ok() const {
-        return Error.empty();
-    }
-};
-
-struct TKeysOutcome {
-    THashMap<TString, ui64> Keys;
-    TString Error;
-
-    bool Ok() const {
-        return Error.empty();
-    }
-};
-
 class IBatchCutter {
 public:
     virtual ~IBatchCutter() = default;
 
-    virtual TCutOutcome Cut(const TBatchCutterData& data, ui64 readStartOffset) const = 0;
-    virtual TKeysOutcome GetKeys(const TBatchCutterData& data, ui64 readStartOffset) const = 0;
+    virtual std::expected<TVector<TReadResult>, TString> Cut(const TBatchCutterData& data, ui64 readStartOffset) const = 0;
+    virtual std::expected<THashMap<TString, ui64>, TString> GetKeys(const TBatchCutterData& data, ui64 readStartOffset) const = 0;
 };
 
 class TKafkaBatchCutter : public IBatchCutter {
 public:
-    TCutOutcome Cut(const TBatchCutterData& data, ui64 readStartOffset) const override final;
-    TKeysOutcome GetKeys(const TBatchCutterData& data, ui64 readStartOffset) const override final;
+    std::expected<TVector<TReadResult>, TString> Cut(const TBatchCutterData& data, ui64 readStartOffset) const override final;
+    std::expected<THashMap<TString, ui64>, TString> GetKeys(const TBatchCutterData& data, ui64 readStartOffset) const override final;
 };
 
 } // namespace NKikimr::NPQ::NBatching

--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.h
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/protos/grpc_pq_old.pb.h>
+#include <ydb/core/protos/msgbus_pq.pb.h>
 
 #include <util/generic/hash.h>
 #include <util/generic/string.h>
+#include <util/generic/vector.h>
 
 namespace NKikimr::NPQ::NBatching {
 
@@ -33,9 +34,6 @@ public:
 
 class TKafkaBatchCutter : public IBatchCutter {
 public:
-    TKafkaBatchCutter() = default;
-    ~TKafkaBatchCutter() = default;
-
     TVector<TReadResult> Cut(const TBatchCutterData& data, ui64 readStartOffset) const override final;
     THashMap<TString, ui64> GetKeys(const TBatchCutterData& data, ui64 readStartOffset) const override final;
 };

--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.h
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.h
@@ -14,7 +14,13 @@ struct TBatchCutterData {
     NKikimrPQClient::TDataChunk DataChunk;
     const TReadResult& ReadResult;
 
-    TBatchCutterData(const TReadResult& readResult, NKikimrPQClient::TDataChunk&& dataChunk) : DataChunk(dataChunk), ReadResult(readResult) {}
+    TBatchCutterData(const TReadResult& readResult, NKikimrPQClient::TDataChunk&& dataChunk)
+        : ReadResult(readResult)
+    {
+        DataChunk.Swap(&dataChunk);
+    }
+
+    TBatchCutterData(TReadResult&&, NKikimrPQClient::TDataChunk&&) = delete;
 };
 
 class IBatchCutter {

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
@@ -33,14 +33,35 @@ NActors::TActorId TBatchProcessor::GetOrCreateConsumerProcessor(const TString& u
     return it->second;
 }
 
+void TBatchProcessor::SendToConsumerProcessor(
+    const NActors::TActorId& actorId,
+    NActors::IEventBase* ev,
+    const NActors::TActorContext& ctx)
+{
+    const auto self = ctx.SelfID;
+    ctx.Send(new NActors::IEventHandle(
+        actorId,
+        ctx.SelfID,
+        ev,
+        NActors::IEventHandle::FlagForwardOnNondelivery,
+        0,
+        &self));
+}
+
 void TBatchProcessor::Handle(TEvProcessBatch::TPtr& ev, const NActors::TActorContext& ctx) {
+    if (ev->Sender == ctx.SelfID) {
+        ConsumerProcessors.erase(ev->Get()->Context.User);
+    }
     const auto actorId = GetOrCreateConsumerProcessor(ev->Get()->Context.User);
-    ctx.Send(actorId, new TEvProcessBatch(std::move(ev->Get()->Context)));
+    SendToConsumerProcessor(actorId, new TEvProcessBatch(std::move(ev->Get()->Context)), ctx);
 }
 
 void TBatchProcessor::Handle(TEvProcessBatchKeys::TPtr& ev, const NActors::TActorContext& ctx) {
+    if (ev->Sender == ctx.SelfID) {
+        ConsumerProcessors.erase(TString{COMPACTIFICATION_WORKER});
+    }
     const auto actorId = GetOrCreateConsumerProcessor(TString{COMPACTIFICATION_WORKER});
-    ctx.Send(actorId, new TEvProcessBatchKeys(std::move(ev->Get()->Context)));
+    SendToConsumerProcessor(actorId, new TEvProcessBatchKeys(std::move(ev->Get()->Context)), ctx);
 }
 
 void TBatchProcessor::HandleConsumerRemoved(TEvPQ::TEvConsumerRemoved::TPtr& ev, const NActors::TActorContext&) {

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
@@ -37,35 +37,14 @@ NActors::TActorId TBatchProcessor::GetOrCreateConsumerProcessor(const TString& u
     return it->second;
 }
 
-void TBatchProcessor::SendToConsumerProcessor(
-    const NActors::TActorId& actorId,
-    NActors::IEventBase* ev,
-    const NActors::TActorContext& ctx)
-{
-    const auto self = ctx.SelfID;
-    ctx.Send(new NActors::IEventHandle(
-        actorId,
-        ctx.SelfID,
-        ev,
-        NActors::IEventHandle::FlagForwardOnNondelivery,
-        0,
-        &self));
-}
-
 void TBatchProcessor::Handle(TEvProcessBatch::TPtr& ev, const NActors::TActorContext& ctx) {
-    if (ev->Sender == ctx.SelfID) {
-        ConsumerProcessors.erase(ev->Get()->Context.User);
-    }
     const auto actorId = GetOrCreateConsumerProcessor(ev->Get()->Context.User);
-    SendToConsumerProcessor(actorId, new TEvProcessBatch(std::move(ev->Get()->Context)), ctx);
+    ctx.Send(actorId, new TEvProcessBatch(std::move(ev->Get()->Context)));
 }
 
 void TBatchProcessor::Handle(TEvProcessBatchKeys::TPtr& ev, const NActors::TActorContext& ctx) {
-    if (ev->Sender == ctx.SelfID) {
-        ConsumerProcessors.erase(TString{COMPACTIFICATION_WORKER});
-    }
     const auto actorId = GetOrCreateConsumerProcessor(TString{COMPACTIFICATION_WORKER});
-    SendToConsumerProcessor(actorId, new TEvProcessBatchKeys(std::move(ev->Get()->Context)), ctx);
+    ctx.Send(actorId, new TEvProcessBatchKeys(std::move(ev->Get()->Context)));
 }
 
 void TBatchProcessor::HandleConsumerRemoved(TEvPQ::TEvConsumerRemoved::TPtr& ev, const NActors::TActorContext&) {

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
@@ -21,6 +21,10 @@ void TBatchProcessor::Bootstrap(const NActors::TActorContext&) {
     Become(&TThis::StateWork);
 }
 
+TString TBatchProcessor::BuildLogPrefix() const {
+    return TStringBuilder() << "[BatchProcessor][" << SelfId() << "] ";
+}
+
 NActors::TActorId TBatchProcessor::GetOrCreateConsumerProcessor(const TString& user) {
     auto [it, inserted] = ConsumerProcessors.emplace(user, NActors::TActorId{});
     if (inserted) {

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
@@ -22,7 +22,9 @@ void TBatchProcessor::Bootstrap(const NActors::TActorContext&) {
 }
 
 TString TBatchProcessor::BuildLogPrefix() const {
-    return TStringBuilder() << "[BatchProcessor][" << SelfId() << "] ";
+    // TBaseTabletActor::LogBuilder logs tablet id, not SelfId. TActorId already
+    // prints itself in [node:local:hint] form.
+    return TStringBuilder() << "[BatchProcessor]" << SelfId() << " ";
 }
 
 NActors::TActorId TBatchProcessor::GetOrCreateConsumerProcessor(const TString& user) {

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.h
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.h
@@ -14,14 +14,9 @@ namespace NKikimr::NPQ::NBatching {
 struct TReadProcessingContext {
     TString User;
     ui32 PartitionId = 0;
-    ui64 Destination = 0;
     ui64 Offset = 0;
     ui32 Count = std::numeric_limits<ui32>::max();
     ui64 LastOffset = 0;
-    ui16 PartNo = 0;
-    ui64 Size = 0;
-    bool IsInternal = false;
-    NActors::TActorId ReplyTo;
     NActors::TActorId ResponseActor;
     THolder<NActors::IEventBase> Event;
 };

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.h
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.h
@@ -85,10 +85,6 @@ private:
     STFUNC(StateWork);
 
     NActors::TActorId GetOrCreateConsumerProcessor(const TString& user);
-    void SendToConsumerProcessor(
-        const NActors::TActorId& actorId,
-        NActors::IEventBase* ev,
-        const NActors::TActorContext& ctx);
 
 private:
     THashMap<TString, NActors::TActorId> ConsumerProcessors;

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.h
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.h
@@ -83,6 +83,10 @@ private:
     STFUNC(StateWork);
 
     NActors::TActorId GetOrCreateConsumerProcessor(const TString& user);
+    void SendToConsumerProcessor(
+        const NActors::TActorId& actorId,
+        NActors::IEventBase* ev,
+        const NActors::TActorContext& ctx);
 
 private:
     THashMap<TString, NActors::TActorId> ConsumerProcessors;

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.h
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.h
@@ -74,6 +74,8 @@ public:
 
     void Bootstrap(const NActors::TActorContext& ctx);
 
+    TString BuildLogPrefix() const override;
+
     void Handle(TEvProcessBatch::TPtr& ev, const NActors::TActorContext& ctx);
     void Handle(TEvProcessBatchKeys::TPtr& ev, const NActors::TActorContext& ctx);
     void HandleConsumerRemoved(TEvPQ::TEvConsumerRemoved::TPtr& ev, const NActors::TActorContext& ctx);

--- a/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
@@ -5,6 +5,7 @@
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/persqueue/counter_time_keeper/counter_time_keeper.h>
 
+#include <exception>
 #include <utility>
 
 #define YDB_LOG_THIS_FILE_COMPONENT Service
@@ -23,6 +24,46 @@ namespace {
             }
         }
         return key;
+    }
+
+    TVector<TReadResult> CutOrKeepOriginal(
+        const IBatchCutter& cutter,
+        const TBatchCutterData& data,
+        ui64 readStartOffset,
+        const TString& logPrefix,
+        const TString& user,
+        ui32 partitionId)
+    {
+        try {
+            return cutter.Cut(data, readStartOffset);
+        } catch (const std::exception& e) {
+            YDB_LOG_ERROR_COMP(PERSQUEUE, "Failed to cut kafka batch, keeping original result",
+                {"logPrefix", logPrefix},
+                {"user", user},
+                {"partitionId", partitionId},
+                {"offset", data.ReadResult.GetOffset()},
+                {"error", TString(e.what())});
+            return {data.ReadResult};
+        }
+    }
+
+    THashMap<TString, ui64> GetKeysOrEmpty(
+        const IBatchCutter& cutter,
+        const TBatchCutterData& data,
+        ui64 readStartOffset,
+        const TString& logPrefix,
+        ui32 partitionId)
+    {
+        try {
+            return cutter.GetKeys(data, readStartOffset);
+        } catch (const std::exception& e) {
+            YDB_LOG_ERROR_COMP(PERSQUEUE, "Failed to get keys from kafka batch",
+                {"logPrefix", logPrefix},
+                {"partitionId", partitionId},
+                {"offset", data.ReadResult.GetOffset()},
+                {"error", TString(e.what())});
+            return {};
+        }
     }
 }
 
@@ -68,54 +109,75 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatch::TPtr& ev, const NActors::T
     for (const auto& result : *results) {
         originalResults.push_back(result);
     }
-    results->Clear();
 
-    ui32 resultsCount = 0;
-    auto addResult = [&](TReadResult& result) {
-        if (result.GetOffset() < context.Offset) {
-            return false;
-        }
-        if (context.LastOffset != 0 && result.GetOffset() >= context.LastOffset) {
-            return false;
-        }
-        if (resultsCount >= context.Count && context.Count > 0) {
-            return true;
-        }
+    TVector<TReadResult> expanded;
+    expanded.reserve(originalResults.size());
 
-        resultsCount += result.GetLogicalMessageCount();
-        readResult->AddResult()->Swap(&result);
-        return resultsCount >= context.Count && context.Count > 0;
-    };
+    try {
+        ui32 resultsCount = 0;
+        auto addResult = [&](TReadResult& result) {
+            if (result.GetOffset() < context.Offset) {
+                return false;
+            }
+            if (context.LastOffset != 0 && result.GetOffset() >= context.LastOffset) {
+                return false;
+            }
+            if (resultsCount >= context.Count && context.Count > 0) {
+                return true;
+            }
 
-    for (auto& originalResult : originalResults) {
-        auto dataChunk = NKikimr::GetDeserializedData(originalResult.GetData());
+            resultsCount += result.GetLogicalMessageCount();
+            expanded.emplace_back();
+            expanded.back().Swap(&result);
+            return resultsCount >= context.Count && context.Count > 0;
+        };
 
-        if (!originalResult.GetIsBatch()) {
-            if (addResult(originalResult)) {
+        for (auto& originalResult : originalResults) {
+            auto dataChunk = NKikimr::GetDeserializedData(originalResult.GetData());
+
+            if (!originalResult.GetIsBatch()) {
+                if (addResult(originalResult)) {
+                    break;
+                }
+                continue;
+            }
+
+            auto it = BatchCutters.find(dataChunk.GetCodec());
+            if (it == BatchCutters.end()) {
+                if (addResult(originalResult)) {
+                    break;
+                }
+                continue;
+            }
+
+            TBatchCutterData data(originalResult, std::move(dataChunk));
+            auto cutResults = CutOrKeepOriginal(
+                *it->second,
+                data,
+                context.Offset,
+                GetLogPrefix(),
+                User,
+                context.PartitionId);
+            for (auto& cutResult : cutResults) {
+                if (addResult(cutResult)) {
+                    break;
+                }
+            }
+            if (resultsCount >= context.Count) {
                 break;
             }
-            continue;
         }
 
-        auto it = BatchCutters.find(dataChunk.GetCodec());
-        if (it == BatchCutters.end()) {
-            if (addResult(originalResult)) {
-                break;
-            }
-            continue;
+        results->Clear();
+        for (auto& result : expanded) {
+            readResult->AddResult()->Swap(&result);
         }
-
-        TBatchCutterData data(originalResult, std::move(dataChunk));
-
-        auto cutResults = it->second->Cut(data, context.Offset);
-        for (auto& cutResult : cutResults) {
-            if (addResult(cutResult)) {
-                break;
-            }
-        }
-        if (resultsCount >= context.Count) {
-            break;
-        }
+    } catch (const std::exception& e) {
+        YDB_LOG_ERROR("Failed to process read batch, returning original results",
+            {"logPrefix", GetLogPrefix()},
+            {"user", User},
+            {"partitionId", context.PartitionId},
+            {"error", TString(e.what())});
     }
 
     ctx.Send(context.ResponseActor, new TEvProcessBatchResult(std::move(context)));
@@ -128,30 +190,42 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatchKeys::TPtr& ev, const NActor
 
     THashMap<ui64, TString> offsetToKey;
 
-    for (const auto& result : context.Results) {
-        if (result.GetData().empty()) {
-            continue;
-        }
+    try {
+        for (const auto& result : context.Results) {
+            if (result.GetData().empty()) {
+                continue;
+            }
 
-        auto dataChunk = NKikimr::GetDeserializedData(result.GetData());
-        if (dataChunk.GetChunkType() != NKikimrPQClient::TDataChunk::REGULAR) {
-            continue;
-        }
+            auto dataChunk = NKikimr::GetDeserializedData(result.GetData());
+            if (dataChunk.GetChunkType() != NKikimrPQClient::TDataChunk::REGULAR) {
+                continue;
+            }
 
-        if (!result.GetIsBatch()) {
-            auto key = GetCompactionKey(dataChunk);
-            offsetToKey[result.GetOffset()] = std::move(key);
-            continue;
-        }
+            if (!result.GetIsBatch()) {
+                auto key = GetCompactionKey(dataChunk);
+                offsetToKey[result.GetOffset()] = std::move(key);
+                continue;
+            }
 
-        auto it = BatchCutters.find(dataChunk.GetCodec());
-        if (it != BatchCutters.end()) {
-            TBatchCutterData data(result, std::move(dataChunk));
-            auto batchKeys = it->second->GetKeys(data, result.GetOffset());
-            for (auto& [key, offset] : batchKeys) {
-                offsetToKey[offset] = std::move(key);
+            auto it = BatchCutters.find(dataChunk.GetCodec());
+            if (it != BatchCutters.end()) {
+                TBatchCutterData data(result, std::move(dataChunk));
+                auto batchKeys = GetKeysOrEmpty(
+                    *it->second,
+                    data,
+                    result.GetOffset(),
+                    GetLogPrefix(),
+                    context.PartitionId);
+                for (auto& [key, offset] : batchKeys) {
+                    offsetToKey[offset] = std::move(key);
+                }
             }
         }
+    } catch (const std::exception& e) {
+        YDB_LOG_ERROR("Failed to process batch keys, returning collected keys",
+            {"logPrefix", GetLogPrefix()},
+            {"partitionId", context.PartitionId},
+            {"error", TString(e.what())});
     }
 
     ctx.Send(context.ResponseActor, new TEvProcessBatchKeysResult(std::move(offsetToKey)));

--- a/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
@@ -8,6 +8,8 @@
 #include <exception>
 #include <utility>
 
+#include <util/generic/strbuf.h>
+
 #define YDB_LOG_THIS_FILE_COMPONENT Service
 
 namespace NKikimr::NPQ::NBatching {
@@ -26,25 +28,52 @@ namespace {
         return key;
     }
 
+    void LogKafkaBatchUserError(
+        TStringBuf message,
+        const TString& logPrefix,
+        ui32 partition,
+        ui64 offset,
+        const TString& error,
+        TStringBuf user = {})
+    {
+        if (!user.empty()) {
+            YDB_LOG_ERROR_COMP(PERSQUEUE, message,
+                {"logPrefix", logPrefix},
+                {"errorType", "user"},
+                {"user", user},
+                {"partition", partition},
+                {"offset", offset},
+                {"error", error});
+        } else {
+            YDB_LOG_ERROR_COMP(PERSQUEUE, message,
+                {"logPrefix", logPrefix},
+                {"errorType", "user"},
+                {"partition", partition},
+                {"offset", offset},
+                {"error", error});
+        }
+    }
+
     TVector<TReadResult> CutOrKeepOriginal(
         const IBatchCutter& cutter,
         const TBatchCutterData& data,
         ui64 readStartOffset,
         const TString& logPrefix,
         const TString& user,
-        ui32 partitionId)
+        ui32 partition)
     {
-        try {
-            return cutter.Cut(data, readStartOffset);
-        } catch (const std::exception& e) {
-            YDB_LOG_ERROR_COMP(PERSQUEUE, "Failed to cut kafka batch, keeping original result",
-                {"logPrefix", logPrefix},
-                {"user", user},
-                {"partitionId", partitionId},
-                {"offset", data.ReadResult.GetOffset()},
-                {"error", TString(e.what())});
+        auto outcome = cutter.Cut(data, readStartOffset);
+        if (!outcome.Ok()) {
+            LogKafkaBatchUserError(
+                "Failed to cut kafka batch, keeping original result",
+                logPrefix,
+                partition,
+                data.ReadResult.GetOffset(),
+                outcome.Error,
+                user);
             return {data.ReadResult};
         }
+        return std::move(outcome.Records);
     }
 
     THashMap<TString, ui64> GetKeysOrEmpty(
@@ -52,18 +81,19 @@ namespace {
         const TBatchCutterData& data,
         ui64 readStartOffset,
         const TString& logPrefix,
-        ui32 partitionId)
+        ui32 partition)
     {
-        try {
-            return cutter.GetKeys(data, readStartOffset);
-        } catch (const std::exception& e) {
-            YDB_LOG_ERROR_COMP(PERSQUEUE, "Failed to get keys from kafka batch",
-                {"logPrefix", logPrefix},
-                {"partitionId", partitionId},
-                {"offset", data.ReadResult.GetOffset()},
-                {"error", TString(e.what())});
+        auto outcome = cutter.GetKeys(data, readStartOffset);
+        if (!outcome.Ok()) {
+            LogKafkaBatchUserError(
+                "Failed to get keys from kafka batch",
+                logPrefix,
+                partition,
+                data.ReadResult.GetOffset(),
+                outcome.Error);
             return {};
         }
+        return std::move(outcome.Keys);
     }
 }
 
@@ -115,9 +145,12 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatch::TPtr& ev, const NActors::T
     TVector<TReadResult> expanded;
     expanded.reserve(originalResults.size());
 
+    ui64 batchOffset = context.Offset;
     try {
         ui32 resultsCount = 0;
-        auto addResult = [&](TReadResult& result) {
+        // Copy, do not Swap: if expansion throws later, originalResults must still
+        // hold the unmodified messages for the user-error fallback.
+        auto addResult = [&](const TReadResult& result) {
             if (result.GetOffset() < context.Offset) {
                 return false;
             }
@@ -126,12 +159,12 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatch::TPtr& ev, const NActors::T
             }
 
             resultsCount += result.GetLogicalMessageCount();
-            expanded.emplace_back();
-            expanded.back().Swap(&result);
+            expanded.push_back(result);
             return resultsCount >= context.Count && context.Count > 0;
         };
 
-        for (auto& originalResult : originalResults) {
+        for (const auto& originalResult : originalResults) {
+            batchOffset = originalResult.GetOffset();
             auto dataChunk = NKikimr::GetDeserializedData(originalResult.GetData());
 
             if (!originalResult.GetIsBatch()) {
@@ -171,11 +204,13 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatch::TPtr& ev, const NActors::T
             readResult->AddResult()->Swap(&result);
         }
     } catch (const std::exception& e) {
-        YDB_LOG_ERROR("Failed to process read batch, returning original results",
-            {"logPrefix", GetLogPrefix()},
-            {"user", User},
-            {"partitionId", context.PartitionId},
-            {"error", TString(e.what())});
+        LogKafkaBatchUserError(
+            "Failed to process read batch, returning original results",
+            GetLogPrefix(),
+            context.PartitionId,
+            batchOffset,
+            TString(e.what()),
+            User);
         results->Clear();
         for (auto& result : originalResults) {
             readResult->AddResult()->Swap(&result);
@@ -191,9 +226,11 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatchKeys::TPtr& ev, const NActor
     HasCurrentCPUUsagePartitionId = true;
 
     THashMap<ui64, TString> offsetToKey;
+    ui64 batchOffset = 0;
 
     try {
         for (const auto& result : context.Results) {
+            batchOffset = result.GetOffset();
             if (result.GetData().empty()) {
                 continue;
             }
@@ -224,10 +261,12 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatchKeys::TPtr& ev, const NActor
             }
         }
     } catch (const std::exception& e) {
-        YDB_LOG_ERROR("Failed to process batch keys, returning collected keys",
-            {"logPrefix", GetLogPrefix()},
-            {"partitionId", context.PartitionId},
-            {"error", TString(e.what())});
+        LogKafkaBatchUserError(
+            "Failed to process batch keys, returning collected keys",
+            GetLogPrefix(),
+            context.PartitionId,
+            batchOffset,
+            TString(e.what()));
     }
 
     ctx.Send(context.ResponseActor, new TEvProcessBatchKeysResult(std::move(offsetToKey)));

--- a/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
@@ -106,9 +106,11 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatch::TPtr& ev, const NActors::T
 
     TVector<TReadResult> originalResults;
     originalResults.reserve(results->size());
-    for (const auto& result : *results) {
-        originalResults.push_back(result);
+    for (int i = 0; i < results->size(); ++i) {
+        originalResults.emplace_back();
+        originalResults.back().Swap(results->Mutable(i));
     }
+    results->Clear();
 
     TVector<TReadResult> expanded;
     expanded.reserve(originalResults.size());
@@ -168,7 +170,6 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatch::TPtr& ev, const NActors::T
             }
         }
 
-        results->Clear();
         for (auto& result : expanded) {
             readResult->AddResult()->Swap(&result);
         }
@@ -178,6 +179,10 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatch::TPtr& ev, const NActors::T
             {"user", User},
             {"partitionId", context.PartitionId},
             {"error", TString(e.what())});
+        results->Clear();
+        for (auto& result : originalResults) {
+            readResult->AddResult()->Swap(&result);
+        }
     }
 
     ctx.Send(context.ResponseActor, new TEvProcessBatchResult(std::move(context)));

--- a/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
@@ -124,9 +124,6 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatch::TPtr& ev, const NActors::T
             if (context.LastOffset != 0 && result.GetOffset() >= context.LastOffset) {
                 return false;
             }
-            if (resultsCount >= context.Count && context.Count > 0) {
-                return true;
-            }
 
             resultsCount += result.GetLogicalMessageCount();
             expanded.emplace_back();
@@ -238,9 +235,7 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatchKeys::TPtr& ev, const NActor
 
 void TConsumerBatchProcessor::FlushCPUUsageMetrics(const NActors::TActorContext& ctx, bool scheduleNext) {
     for (auto& [partitionId, cpuUsage] : CPUUsageMetricByPartition) {
-        if (cpuUsage) {
-            ctx.Send(TabletActorId, new TEvPQ::TEvConsumerBatchProcessorMetrics(partitionId, User, cpuUsage));
-        }
+        ctx.Send(TabletActorId, new TEvPQ::TEvConsumerBatchProcessorMetrics(partitionId, User, cpuUsage));
     }
     CPUUsageMetricByPartition.clear();
 

--- a/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
@@ -63,17 +63,17 @@ namespace {
         ui32 partition)
     {
         auto outcome = cutter.Cut(data, readStartOffset);
-        if (!outcome.Ok()) {
+        if (!outcome) {
             LogKafkaBatchUserError(
                 "Failed to cut kafka batch, keeping original result",
                 logPrefix,
                 partition,
                 data.ReadResult.GetOffset(),
-                outcome.Error,
+                outcome.error(),
                 user);
             return {data.ReadResult};
         }
-        return std::move(outcome.Records);
+        return *std::move(outcome);
     }
 
     THashMap<TString, ui64> GetKeysOrEmpty(
@@ -84,16 +84,16 @@ namespace {
         ui32 partition)
     {
         auto outcome = cutter.GetKeys(data, readStartOffset);
-        if (!outcome.Ok()) {
+        if (!outcome) {
             LogKafkaBatchUserError(
                 "Failed to get keys from kafka batch",
                 logPrefix,
                 partition,
                 data.ReadResult.GetOffset(),
-                outcome.Error);
+                outcome.error());
             return {};
         }
-        return std::move(outcome.Keys);
+        return *std::move(outcome);
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
@@ -5,7 +5,6 @@
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/persqueue/counter_time_keeper/counter_time_keeper.h>
 
-#include <exception>
 #include <utility>
 
 #include <util/generic/strbuf.h>
@@ -36,22 +35,13 @@ namespace {
         const TString& error,
         TStringBuf user = {})
     {
-        if (!user.empty()) {
-            YDB_LOG_ERROR_COMP(PERSQUEUE, message,
-                {"logPrefix", logPrefix},
-                {"errorType", "user"},
-                {"user", user},
-                {"partition", partition},
-                {"offset", offset},
-                {"error", error});
-        } else {
-            YDB_LOG_ERROR_COMP(PERSQUEUE, message,
-                {"logPrefix", logPrefix},
-                {"errorType", "user"},
-                {"partition", partition},
-                {"offset", offset},
-                {"error", error});
-        }
+        YDB_LOG_ERROR_COMP(PERSQUEUE, message,
+            {"logPrefix", logPrefix},
+            {"errorType", "user"},
+            {"user", user},
+            {"partition", partition},
+            {"offset", offset},
+            {"error", error});
     }
 
     TVector<TReadResult> CutOrKeepOriginal(
@@ -142,78 +132,53 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatch::TPtr& ev, const NActors::T
     }
     results->Clear();
 
-    TVector<TReadResult> expanded;
-    expanded.reserve(originalResults.size());
+    ui32 resultsCount = 0;
+    auto addResult = [&](TReadResult& result) {
+        if (result.GetOffset() < context.Offset) {
+            return false;
+        }
+        if (context.LastOffset != 0 && result.GetOffset() >= context.LastOffset) {
+            return false;
+        }
 
-    ui64 batchOffset = context.Offset;
-    try {
-        ui32 resultsCount = 0;
-        // Copy, do not Swap: if expansion throws later, originalResults must still
-        // hold the unmodified messages for the user-error fallback.
-        auto addResult = [&](const TReadResult& result) {
-            if (result.GetOffset() < context.Offset) {
-                return false;
+        resultsCount += result.GetLogicalMessageCount();
+        readResult->AddResult()->Swap(&result);
+        return resultsCount >= context.Count && context.Count > 0;
+    };
+
+    for (auto& originalResult : originalResults) {
+        auto dataChunk = NKikimr::GetDeserializedData(originalResult.GetData());
+
+        if (!originalResult.GetIsBatch()) {
+            if (addResult(originalResult)) {
+                break;
             }
-            if (context.LastOffset != 0 && result.GetOffset() >= context.LastOffset) {
-                return false;
+            continue;
+        }
+
+        auto it = BatchCutters.find(dataChunk.GetCodec());
+        if (it == BatchCutters.end()) {
+            if (addResult(originalResult)) {
+                break;
             }
+            continue;
+        }
 
-            resultsCount += result.GetLogicalMessageCount();
-            expanded.push_back(result);
-            return resultsCount >= context.Count && context.Count > 0;
-        };
-
-        for (const auto& originalResult : originalResults) {
-            batchOffset = originalResult.GetOffset();
-            auto dataChunk = NKikimr::GetDeserializedData(originalResult.GetData());
-
-            if (!originalResult.GetIsBatch()) {
-                if (addResult(originalResult)) {
-                    break;
-                }
-                continue;
-            }
-
-            auto it = BatchCutters.find(dataChunk.GetCodec());
-            if (it == BatchCutters.end()) {
-                if (addResult(originalResult)) {
-                    break;
-                }
-                continue;
-            }
-
-            TBatchCutterData data(originalResult, std::move(dataChunk));
-            auto cutResults = CutOrKeepOriginal(
-                *it->second,
-                data,
-                context.Offset,
-                GetLogPrefix(),
-                User,
-                context.PartitionId);
-            for (auto& cutResult : cutResults) {
-                if (addResult(cutResult)) {
-                    break;
-                }
-            }
-            if (resultsCount >= context.Count) {
+        TBatchCutterData data(originalResult, std::move(dataChunk));
+        auto cutResults = CutOrKeepOriginal(
+            *it->second,
+            data,
+            context.Offset,
+            GetLogPrefix(),
+            User,
+            context.PartitionId);
+        for (auto& cutResult : cutResults) {
+            if (addResult(cutResult)) {
                 break;
             }
         }
-
-        for (auto& result : expanded) {
-            readResult->AddResult()->Swap(&result);
-        }
-    } catch (const std::exception& e) {
-        LogKafkaBatchUserError(
-            "Failed to process read batch, returning original results",
-            GetLogPrefix(),
-            context.PartitionId,
-            batchOffset,
-            TString(e.what()),
-            User);
-        results->Clear();
-        for (auto& result : originalResults) {
-            readResult->AddResult()->Swap(&result);
+        if (resultsCount >= context.Count) {
+            break;
         }
     }
 
@@ -226,47 +191,36 @@ void TConsumerBatchProcessor::Handle(TEvProcessBatchKeys::TPtr& ev, const NActor
     HasCurrentCPUUsagePartitionId = true;
 
     THashMap<ui64, TString> offsetToKey;
-    ui64 batchOffset = 0;
 
-    try {
-        for (const auto& result : context.Results) {
-            batchOffset = result.GetOffset();
-            if (result.GetData().empty()) {
-                continue;
-            }
+    for (const auto& result : context.Results) {
+        if (result.GetData().empty()) {
+            continue;
+        }
 
-            auto dataChunk = NKikimr::GetDeserializedData(result.GetData());
-            if (dataChunk.GetChunkType() != NKikimrPQClient::TDataChunk::REGULAR) {
-                continue;
-            }
+        auto dataChunk = NKikimr::GetDeserializedData(result.GetData());
+        if (dataChunk.GetChunkType() != NKikimrPQClient::TDataChunk::REGULAR) {
+            continue;
+        }
 
-            if (!result.GetIsBatch()) {
-                auto key = GetCompactionKey(dataChunk);
-                offsetToKey[result.GetOffset()] = std::move(key);
-                continue;
-            }
+        if (!result.GetIsBatch()) {
+            auto key = GetCompactionKey(dataChunk);
+            offsetToKey[result.GetOffset()] = std::move(key);
+            continue;
+        }
 
-            auto it = BatchCutters.find(dataChunk.GetCodec());
-            if (it != BatchCutters.end()) {
-                TBatchCutterData data(result, std::move(dataChunk));
-                auto batchKeys = GetKeysOrEmpty(
-                    *it->second,
-                    data,
-                    result.GetOffset(),
-                    GetLogPrefix(),
-                    context.PartitionId);
-                for (auto& [key, offset] : batchKeys) {
-                    offsetToKey[offset] = std::move(key);
-                }
+        auto it = BatchCutters.find(dataChunk.GetCodec());
+        if (it != BatchCutters.end()) {
+            TBatchCutterData data(result, std::move(dataChunk));
+            auto batchKeys = GetKeysOrEmpty(
+                *it->second,
+                data,
+                result.GetOffset(),
+                GetLogPrefix(),
+                context.PartitionId);
+            for (auto& [key, offset] : batchKeys) {
+                offsetToKey[offset] = std::move(key);
             }
         }
-    } catch (const std::exception& e) {
-        LogKafkaBatchUserError(
-            "Failed to process batch keys, returning collected keys",
-            GetLogPrefix(),
-            context.PartitionId,
-            batchOffset,
-            TString(e.what()));
     }
 
     ctx.Send(context.ResponseActor, new TEvProcessBatchKeysResult(std::move(offsetToKey)));

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
@@ -10,6 +10,7 @@
 #include <library/cpp/streams/zstd/zstd.h>
 
 #include <util/generic/string.h>
+#include <util/generic/ylimits.h>
 #include <util/stream/mem.h>
 #include <util/stream/zlib.h>
 
@@ -131,6 +132,24 @@ TString MakeKafkaBatchPayloadWithNullValue() {
     batch.BaseSequence = 10;
     batch.Records.push_back(MakeKafkaRecordWithoutValue(5, 0, "k0"));
     batch.Records.push_back(MakeKafkaRecord(7, 1, "k1", "value1"));
+    batch.BatchLength = batch.Size(2)
+        - sizeof(NKafka::TKafkaRecordBatch::BaseOffsetMeta::Type)
+        - sizeof(NKafka::TKafkaRecordBatch::BatchLengthMeta::Type);
+    return NKafka::WriteKafkaRecordBatch(batch);
+}
+
+TString MakeKafkaBatchPayloadWithOffsetDeltas(i64 delta0, i64 delta1) {
+    NKafka::TKafkaRecordBatch batch;
+    batch.BaseOffset = 100;
+    batch.Magic = 2;
+    batch.LastOffsetDelta = delta1;
+    batch.BaseTimestamp = 1000;
+    batch.MaxTimestamp = 1007;
+    batch.ProducerId = 42;
+    batch.ProducerEpoch = 3;
+    batch.BaseSequence = 10;
+    batch.Records.push_back(MakeKafkaRecord(5, delta0, "k0", "value0"));
+    batch.Records.push_back(MakeKafkaRecord(7, delta1, "k1", "value1"));
     batch.BatchLength = batch.Size(2)
         - sizeof(NKafka::TKafkaRecordBatch::BaseOffsetMeta::Type)
         - sizeof(NKafka::TKafkaRecordBatch::BatchLengthMeta::Type);
@@ -399,8 +418,38 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
             yexception);
     }
 
+    Y_UNIT_TEST(CutFailsOnNegativeOffsetDelta) {
+        const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayloadWithOffsetDeltas(-1, 1));
+        UNIT_ASSERT_EXCEPTION(
+            TKafkaBatchCutter().Cut(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
+            yexception);
+    }
+
+    Y_UNIT_TEST(CutFailsOnOffsetOverflow) {
+        auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
+        readResult.SetOffset(Max<ui64>());
+        UNIT_ASSERT_EXCEPTION(
+            TKafkaBatchCutter().Cut(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
+            yexception);
+    }
+
     Y_UNIT_TEST(GetKeysFailsOnCorruptKafkaPayload) {
         const auto readResult = MakeKafkaBatchReadResult("not-a-kafka-batch");
+        UNIT_ASSERT_EXCEPTION(
+            TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
+            yexception);
+    }
+
+    Y_UNIT_TEST(GetKeysFailsOnNegativeOffsetDelta) {
+        const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayloadWithOffsetDeltas(-1, 1));
+        UNIT_ASSERT_EXCEPTION(
+            TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
+            yexception);
+    }
+
+    Y_UNIT_TEST(GetKeysFailsOnOffsetOverflow) {
+        auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
+        readResult.SetOffset(Max<ui64>());
         UNIT_ASSERT_EXCEPTION(
             TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
             yexception);

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
@@ -265,6 +265,21 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         AssertKafkaBatchCut(TKafkaBatchCutter().Cut(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10));
     }
 
+    Y_UNIT_TEST(CutRecordsDoNotKeepOriginalBatchPayload) {
+        const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
+        const auto originalData = readResult.GetData();
+        const auto cut = TKafkaBatchCutter().Cut(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
+
+        UNIT_ASSERT_VALUES_EQUAL(readResult.GetData(), originalData);
+        UNIT_ASSERT_VALUES_EQUAL(cut.size(), 2u);
+        for (const auto& item : cut) {
+            UNIT_ASSERT(item.GetData().size() < originalData.size());
+            UNIT_ASSERT(item.GetData() != originalData);
+            UNIT_ASSERT(!item.GetIsBatch());
+        }
+    }
+
     Y_UNIT_TEST(CutSkipsRecordsBeforeReadStartOffset) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
         const auto cut = TKafkaBatchCutter().Cut(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 11);

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
@@ -227,30 +227,30 @@ TString DecompressPayload(TStringBuf data, NPersQueueCommon::ECodec codec) {
 }
 
 void AssertKafkaBatchCut(
-    const TCutOutcome& cut,
+    const std::expected<TVector<TReadResult>, TString>& cut,
     NPersQueueCommon::ECodec expectedCodec = NPersQueueCommon::RAW)
 {
-    UNIT_ASSERT_C(cut.Ok(), cut.Error);
-    UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 2u);
+    UNIT_ASSERT_C(cut.has_value(), cut.error());
+    UNIT_ASSERT_VALUES_EQUAL(cut->size(), 2u);
 
-    UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetOffset(), 10u);
-    UNIT_ASSERT_VALUES_EQUAL(cut.Records[1].GetOffset(), 11u);
-    UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetSeqNo(), 10u);
-    UNIT_ASSERT_VALUES_EQUAL(cut.Records[1].GetSeqNo(), 11u);
-    UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetLogicalMessageCount(), 1u);
-    UNIT_ASSERT_VALUES_EQUAL(cut.Records[1].GetLogicalMessageCount(), 1u);
-    UNIT_ASSERT(!cut.Records[0].HasUncompressedSize());
-    UNIT_ASSERT(!cut.Records[1].HasUncompressedSize());
+    UNIT_ASSERT_VALUES_EQUAL((*cut)[0].GetOffset(), 10u);
+    UNIT_ASSERT_VALUES_EQUAL((*cut)[1].GetOffset(), 11u);
+    UNIT_ASSERT_VALUES_EQUAL((*cut)[0].GetSeqNo(), 10u);
+    UNIT_ASSERT_VALUES_EQUAL((*cut)[1].GetSeqNo(), 11u);
+    UNIT_ASSERT_VALUES_EQUAL((*cut)[0].GetLogicalMessageCount(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL((*cut)[1].GetLogicalMessageCount(), 1u);
+    UNIT_ASSERT(!(*cut)[0].HasUncompressedSize());
+    UNIT_ASSERT(!(*cut)[1].HasUncompressedSize());
 
-    UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetPartitionKey(), "k0");
-    UNIT_ASSERT_VALUES_EQUAL(cut.Records[1].GetPartitionKey(), "k1");
-    UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetWriteTimestampMS(), 777);
-    UNIT_ASSERT_VALUES_EQUAL(cut.Records[1].GetWriteTimestampMS(), 777);
-    UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetCreateTimestampMS(), 1005);
-    UNIT_ASSERT_VALUES_EQUAL(cut.Records[1].GetCreateTimestampMS(), 1007);
+    UNIT_ASSERT_VALUES_EQUAL((*cut)[0].GetPartitionKey(), "k0");
+    UNIT_ASSERT_VALUES_EQUAL((*cut)[1].GetPartitionKey(), "k1");
+    UNIT_ASSERT_VALUES_EQUAL((*cut)[0].GetWriteTimestampMS(), 777);
+    UNIT_ASSERT_VALUES_EQUAL((*cut)[1].GetWriteTimestampMS(), 777);
+    UNIT_ASSERT_VALUES_EQUAL((*cut)[0].GetCreateTimestampMS(), 1005);
+    UNIT_ASSERT_VALUES_EQUAL((*cut)[1].GetCreateTimestampMS(), 1007);
 
-    const auto chunk0 = NKikimr::GetDeserializedData(cut.Records[0].GetData());
-    const auto chunk1 = NKikimr::GetDeserializedData(cut.Records[1].GetData());
+    const auto chunk0 = NKikimr::GetDeserializedData((*cut)[0].GetData());
+    const auto chunk1 = NKikimr::GetDeserializedData((*cut)[1].GetData());
     UNIT_ASSERT_VALUES_EQUAL(chunk0.GetCodec(), expectedCodec);
     UNIT_ASSERT_VALUES_EQUAL(chunk1.GetCodec(), expectedCodec);
     UNIT_ASSERT_VALUES_EQUAL(chunk0.GetSeqNo(), 10u);
@@ -259,14 +259,14 @@ void AssertKafkaBatchCut(
     UNIT_ASSERT_VALUES_EQUAL(DecompressPayload(chunk1.GetData(), expectedCodec), "value1");
 }
 
-void AssertCutFailed(const TCutOutcome& cut) {
-    UNIT_ASSERT_C(!cut.Ok(), "expected a cut error");
-    UNIT_ASSERT(cut.Records.empty());
+void AssertCutFailed(const std::expected<TVector<TReadResult>, TString>& cut) {
+    UNIT_ASSERT_C(!cut.has_value(), "expected a cut error");
+    UNIT_ASSERT(!cut.error().empty());
 }
 
-void AssertKeysFailed(const TKeysOutcome& keys) {
-    UNIT_ASSERT_C(!keys.Ok(), "expected a keys error");
-    UNIT_ASSERT(keys.Keys.empty());
+void AssertKeysFailed(const std::expected<THashMap<TString, ui64>, TString>& keys) {
+    UNIT_ASSERT_C(!keys.has_value(), "expected a keys error");
+    UNIT_ASSERT(!keys.error().empty());
 }
 
 } // namespace
@@ -313,9 +313,9 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
             TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
 
         UNIT_ASSERT_VALUES_EQUAL(readResult.GetData(), originalData);
-        UNIT_ASSERT_C(cut.Ok(), cut.Error);
-        UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 2u);
-        for (const auto& item : cut.Records) {
+        UNIT_ASSERT_C(cut.has_value(), cut.error());
+        UNIT_ASSERT_VALUES_EQUAL(cut->size(), 2u);
+        for (const auto& item : *cut) {
             UNIT_ASSERT(item.GetData().size() < originalData.size());
             UNIT_ASSERT(item.GetData() != originalData);
             UNIT_ASSERT(!item.GetIsBatch());
@@ -325,38 +325,38 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
     Y_UNIT_TEST(CutSkipsRecordsBeforeReadStartOffset) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
         const auto cut = TKafkaBatchCutter().Cut(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 11);
-        UNIT_ASSERT_C(cut.Ok(), cut.Error);
-        UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 1u);
-        UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetOffset(), 11u);
+        UNIT_ASSERT_C(cut.has_value(), cut.error());
+        UNIT_ASSERT_VALUES_EQUAL(cut->size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL((*cut)[0].GetOffset(), 11u);
     }
 
     Y_UNIT_TEST(GetKeysReturnsKafkaRecordKeysWithLogicalOffsets) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
         const auto keys = TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
 
-        UNIT_ASSERT_C(keys.Ok(), keys.Error);
-        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.size(), 2u);
-        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.at("k0"), 10u);
-        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.at("k1"), 11u);
+        UNIT_ASSERT_C(keys.has_value(), keys.error());
+        UNIT_ASSERT_VALUES_EQUAL(keys->size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(keys->at("k0"), 10u);
+        UNIT_ASSERT_VALUES_EQUAL(keys->at("k1"), 11u);
     }
 
     Y_UNIT_TEST(GetKeysSkipsRecordsBeforeReadStartOffset) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
         const auto keys = TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 11);
 
-        UNIT_ASSERT_C(keys.Ok(), keys.Error);
-        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.size(), 1u);
-        UNIT_ASSERT(!keys.Keys.contains("k0"));
-        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.at("k1"), 11u);
+        UNIT_ASSERT_C(keys.has_value(), keys.error());
+        UNIT_ASSERT_VALUES_EQUAL(keys->size(), 1u);
+        UNIT_ASSERT(!keys->contains("k0"));
+        UNIT_ASSERT_VALUES_EQUAL(keys->at("k1"), 11u);
     }
 
     Y_UNIT_TEST(GetKeysSkipsRecordsWithoutKey) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayloadWithNullKey());
         const auto keys = TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
 
-        UNIT_ASSERT_C(keys.Ok(), keys.Error);
-        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.size(), 1u);
-        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.at("k1"), 11u);
+        UNIT_ASSERT_C(keys.has_value(), keys.error());
+        UNIT_ASSERT_VALUES_EQUAL(keys->size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(keys->at("k1"), 11u);
     }
 
     Y_UNIT_TEST(NonRegularChunkIsNotCut) {
@@ -370,9 +370,9 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         readResult.SetData(SerializeDataChunk(std::move(chunk)));
 
         const auto cut = TKafkaBatchCutter().Cut(TBatchCutterData(readResult, std::move(dataChunk)), 10);
-        UNIT_ASSERT_C(cut.Ok(), cut.Error);
-        UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 1u);
-        UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetData(), readResult.GetData());
+        UNIT_ASSERT_C(cut.has_value(), cut.error());
+        UNIT_ASSERT_VALUES_EQUAL(cut->size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL((*cut)[0].GetData(), readResult.GetData());
     }
 
     Y_UNIT_TEST(CutZstdCompressedKafkaBatchInDataChunk) {
@@ -387,22 +387,22 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         const auto readResult = MakeKafkaBatchReadResult(MakeEmptyKafkaBatchPayload());
         const auto cut = TKafkaBatchCutter().Cut(
             TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
-        UNIT_ASSERT_C(cut.Ok(), cut.Error);
-        UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 1u);
-        UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetData(), readResult.GetData());
-        UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetOffset(), readResult.GetOffset());
+        UNIT_ASSERT_C(cut.has_value(), cut.error());
+        UNIT_ASSERT_VALUES_EQUAL(cut->size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL((*cut)[0].GetData(), readResult.GetData());
+        UNIT_ASSERT_VALUES_EQUAL((*cut)[0].GetOffset(), readResult.GetOffset());
     }
 
     Y_UNIT_TEST(CutClearsDataForNullRecordValue) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayloadWithNullValue());
         const auto cut = TKafkaBatchCutter().Cut(
             TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
-        UNIT_ASSERT_C(cut.Ok(), cut.Error);
-        UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 2u);
-        UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetPartitionKey(), "k0");
-        const auto chunk0 = NKikimr::GetDeserializedData(cut.Records[0].GetData());
+        UNIT_ASSERT_C(cut.has_value(), cut.error());
+        UNIT_ASSERT_VALUES_EQUAL(cut->size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL((*cut)[0].GetPartitionKey(), "k0");
+        const auto chunk0 = NKikimr::GetDeserializedData((*cut)[0].GetData());
         UNIT_ASSERT(!chunk0.HasData() || chunk0.GetData().empty());
-        const auto chunk1 = NKikimr::GetDeserializedData(cut.Records[1].GetData());
+        const auto chunk1 = NKikimr::GetDeserializedData((*cut)[1].GetData());
         UNIT_ASSERT_VALUES_EQUAL(chunk1.GetData(), "value1");
     }
 
@@ -410,10 +410,10 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayloadWithTimestamps(0, 0, -1));
         const auto cut = TKafkaBatchCutter().Cut(
             TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
-        UNIT_ASSERT_C(cut.Ok(), cut.Error);
-        UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 2u);
-        UNIT_ASSERT(!cut.Records[0].HasCreateTimestampMS());
-        UNIT_ASSERT(!cut.Records[1].HasCreateTimestampMS());
+        UNIT_ASSERT_C(cut.has_value(), cut.error());
+        UNIT_ASSERT_VALUES_EQUAL(cut->size(), 2u);
+        UNIT_ASSERT(!(*cut)[0].HasCreateTimestampMS());
+        UNIT_ASSERT(!(*cut)[1].HasCreateTimestampMS());
     }
 
     Y_UNIT_TEST(CutFailsOnMissingDataChunkCodec) {
@@ -477,8 +477,8 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         readResult.SetData(SerializeDataChunk(chunk));
 
         const auto keys = TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, std::move(chunk)), 10);
-        UNIT_ASSERT_C(keys.Ok(), keys.Error);
-        UNIT_ASSERT(keys.Keys.empty());
+        UNIT_ASSERT_C(keys.has_value(), keys.error());
+        UNIT_ASSERT(keys->empty());
     }
 
     Y_UNIT_TEST(GetKeysFailsOnNonRawDataChunkCodec) {
@@ -502,8 +502,8 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         const auto readResult = MakeKafkaBatchReadResult(MakeEmptyKafkaBatchPayload());
         const auto keys = TKafkaBatchCutter().GetKeys(
             TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
-        UNIT_ASSERT_C(keys.Ok(), keys.Error);
-        UNIT_ASSERT(keys.Keys.empty());
+        UNIT_ASSERT_C(keys.has_value(), keys.error());
+        UNIT_ASSERT(keys->empty());
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
@@ -365,6 +365,20 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
             yexception);
     }
 
+    Y_UNIT_TEST(CutFailsOnCorruptKafkaPayload) {
+        const auto readResult = MakeKafkaBatchReadResult("not-a-kafka-batch");
+        UNIT_ASSERT_EXCEPTION(
+            TKafkaBatchCutter().Cut(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
+            yexception);
+    }
+
+    Y_UNIT_TEST(GetKeysFailsOnCorruptKafkaPayload) {
+        const auto readResult = MakeKafkaBatchReadResult("not-a-kafka-batch");
+        UNIT_ASSERT_EXCEPTION(
+            TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
+            yexception);
+    }
+
     Y_UNIT_TEST(GetKeysIgnoresNonRegularChunk) {
         NKikimrPQClient::TDataChunk chunk;
         chunk.SetChunkType(NKikimrPQClient::TDataChunk::GROW);

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
@@ -242,6 +242,18 @@ void AssertKafkaBatchCut(
 } // namespace
 
 Y_UNIT_TEST_SUITE(TBatchCutterTest) {
+    Y_UNIT_TEST(BatchCutterDataMovesChunkAndKeepsReadResultReference) {
+        const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
+        auto chunk = NKikimr::GetDeserializedData(readResult.GetData());
+        const TString payload = chunk.GetData();
+        UNIT_ASSERT(!payload.empty());
+
+        TBatchCutterData data(readResult, std::move(chunk));
+        UNIT_ASSERT_VALUES_EQUAL(data.DataChunk.GetData(), payload);
+        UNIT_ASSERT(chunk.GetData().empty());
+        UNIT_ASSERT_EQUAL(&data.ReadResult, &readResult);
+    }
+
     Y_UNIT_TEST(CutUncompressedKafkaBatchInDataChunk) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
         AssertKafkaBatchCut(TKafkaBatchCutter().Cut(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10));

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
@@ -89,6 +89,72 @@ TString MakeKafkaBatchPayloadWithNullKey() {
     return NKafka::WriteKafkaRecordBatch(batch);
 }
 
+NKafka::TKafkaRecord MakeKafkaRecordWithoutValue(
+    i64 timestampDelta,
+    i64 offsetDelta,
+    TStringBuf key)
+{
+    NKafka::TKafkaRecord record;
+    record.TimestampDelta = timestampDelta;
+    record.OffsetDelta = offsetDelta;
+    record.SetKey(TString{key});
+    record.Length = record.Size(2)
+        - NKafka::NPrivate::SizeOfVarint<NKafka::TKafkaRecord::LengthMeta::Type>(0);
+    return record;
+}
+
+TString MakeEmptyKafkaBatchPayload() {
+    NKafka::TKafkaRecordBatch batch;
+    batch.BaseOffset = 100;
+    batch.Magic = 2;
+    batch.LastOffsetDelta = 0;
+    batch.BaseTimestamp = 1000;
+    batch.MaxTimestamp = 1000;
+    batch.ProducerId = 42;
+    batch.ProducerEpoch = 3;
+    batch.BaseSequence = 10;
+    batch.BatchLength = batch.Size(2)
+        - sizeof(NKafka::TKafkaRecordBatch::BaseOffsetMeta::Type)
+        - sizeof(NKafka::TKafkaRecordBatch::BatchLengthMeta::Type);
+    return NKafka::WriteKafkaRecordBatch(batch);
+}
+
+TString MakeKafkaBatchPayloadWithNullValue() {
+    NKafka::TKafkaRecordBatch batch;
+    batch.BaseOffset = 100;
+    batch.Magic = 2;
+    batch.LastOffsetDelta = 1;
+    batch.BaseTimestamp = 1000;
+    batch.MaxTimestamp = 1007;
+    batch.ProducerId = 42;
+    batch.ProducerEpoch = 3;
+    batch.BaseSequence = 10;
+    batch.Records.push_back(MakeKafkaRecordWithoutValue(5, 0, "k0"));
+    batch.Records.push_back(MakeKafkaRecord(7, 1, "k1", "value1"));
+    batch.BatchLength = batch.Size(2)
+        - sizeof(NKafka::TKafkaRecordBatch::BaseOffsetMeta::Type)
+        - sizeof(NKafka::TKafkaRecordBatch::BatchLengthMeta::Type);
+    return NKafka::WriteKafkaRecordBatch(batch);
+}
+
+TString MakeKafkaBatchPayloadWithTimestamps(i64 baseTimestamp, i64 delta0, i64 delta1) {
+    NKafka::TKafkaRecordBatch batch;
+    batch.BaseOffset = 100;
+    batch.Magic = 2;
+    batch.LastOffsetDelta = 1;
+    batch.BaseTimestamp = baseTimestamp;
+    batch.MaxTimestamp = baseTimestamp + (delta0 > delta1 ? delta0 : delta1);
+    batch.ProducerId = 42;
+    batch.ProducerEpoch = 3;
+    batch.BaseSequence = 10;
+    batch.Records.push_back(MakeKafkaRecord(delta0, 0, "k0", "value0"));
+    batch.Records.push_back(MakeKafkaRecord(delta1, 1, "k1", "value1"));
+    batch.BatchLength = batch.Size(2)
+        - sizeof(NKafka::TKafkaRecordBatch::BaseOffsetMeta::Type)
+        - sizeof(NKafka::TKafkaRecordBatch::BatchLengthMeta::Type);
+    return NKafka::WriteKafkaRecordBatch(batch);
+}
+
 TString SerializeDataChunk(NKikimrPQClient::TDataChunk chunk) {
     TString serialized;
     Y_ENSURE(chunk.SerializeToString(&serialized));
@@ -245,6 +311,99 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         const auto cut = TKafkaBatchCutter().Cut(TBatchCutterData(readResult, std::move(dataChunk)), 10);
         UNIT_ASSERT_VALUES_EQUAL(cut.size(), 1u);
         UNIT_ASSERT_VALUES_EQUAL(cut[0].GetData(), readResult.GetData());
+    }
+
+    Y_UNIT_TEST(CutZstdCompressedKafkaBatchInDataChunk) {
+        const auto readResult = MakeKafkaBatchReadResult(
+            MakeKafkaBatchPayload(NKafka::ECompressionType::ZSTD));
+        AssertKafkaBatchCut(
+            TKafkaBatchCutter().Cut(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
+            NPersQueueCommon::ZSTD);
+    }
+
+    Y_UNIT_TEST(CutEmptyKafkaBatchReturnsOriginalResult) {
+        const auto readResult = MakeKafkaBatchReadResult(MakeEmptyKafkaBatchPayload());
+        const auto cut = TKafkaBatchCutter().Cut(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
+        UNIT_ASSERT_VALUES_EQUAL(cut.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(cut[0].GetData(), readResult.GetData());
+        UNIT_ASSERT_VALUES_EQUAL(cut[0].GetOffset(), readResult.GetOffset());
+    }
+
+    Y_UNIT_TEST(CutClearsDataForNullRecordValue) {
+        const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayloadWithNullValue());
+        const auto cut = TKafkaBatchCutter().Cut(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
+        UNIT_ASSERT_VALUES_EQUAL(cut.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(cut[0].GetPartitionKey(), "k0");
+        const auto chunk0 = NKikimr::GetDeserializedData(cut[0].GetData());
+        UNIT_ASSERT(!chunk0.HasData() || chunk0.GetData().empty());
+        const auto chunk1 = NKikimr::GetDeserializedData(cut[1].GetData());
+        UNIT_ASSERT_VALUES_EQUAL(chunk1.GetData(), "value1");
+    }
+
+    Y_UNIT_TEST(CutSkipsNonPositiveCreateTimestamp) {
+        const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayloadWithTimestamps(0, 0, -1));
+        const auto cut = TKafkaBatchCutter().Cut(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
+        UNIT_ASSERT_VALUES_EQUAL(cut.size(), 2u);
+        UNIT_ASSERT(!cut[0].HasCreateTimestampMS());
+        UNIT_ASSERT(!cut[1].HasCreateTimestampMS());
+    }
+
+    Y_UNIT_TEST(CutFailsOnMissingDataChunkCodec) {
+        NKikimrPQClient::TDataChunk chunk;
+        chunk.SetChunkType(NKikimrPQClient::TDataChunk::REGULAR);
+        chunk.SetData(MakeKafkaBatchPayload());
+
+        TReadResult readResult;
+        readResult.SetOffset(10);
+        readResult.SetData(SerializeDataChunk(chunk));
+
+        UNIT_ASSERT_EXCEPTION(
+            TKafkaBatchCutter().Cut(TBatchCutterData(readResult, std::move(chunk)), 10),
+            yexception);
+    }
+
+    Y_UNIT_TEST(GetKeysIgnoresNonRegularChunk) {
+        NKikimrPQClient::TDataChunk chunk;
+        chunk.SetChunkType(NKikimrPQClient::TDataChunk::GROW);
+        chunk.SetCodec(KafkaBatchCodec());
+        chunk.SetData(MakeKafkaBatchPayload());
+
+        TReadResult readResult;
+        readResult.SetOffset(10);
+        readResult.SetData(SerializeDataChunk(chunk));
+
+        const auto keys = TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, std::move(chunk)), 10);
+        UNIT_ASSERT(keys.empty());
+    }
+
+    Y_UNIT_TEST(GetKeysFailsOnNonRawDataChunkCodec) {
+        const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload(), NPersQueueCommon::GZIP);
+        UNIT_ASSERT_EXCEPTION(
+            TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
+            yexception);
+    }
+
+    Y_UNIT_TEST(GetKeysFailsOnMissingDataChunkCodec) {
+        NKikimrPQClient::TDataChunk chunk;
+        chunk.SetChunkType(NKikimrPQClient::TDataChunk::REGULAR);
+        chunk.SetData(MakeKafkaBatchPayload());
+
+        TReadResult readResult;
+        readResult.SetOffset(10);
+
+        UNIT_ASSERT_EXCEPTION(
+            TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, std::move(chunk)), 10),
+            yexception);
+    }
+
+    Y_UNIT_TEST(GetKeysOnEmptyKafkaBatchIsEmpty) {
+        const auto readResult = MakeKafkaBatchReadResult(MakeEmptyKafkaBatchPayload());
+        const auto keys = TKafkaBatchCutter().GetKeys(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
+        UNIT_ASSERT(keys.empty());
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
@@ -227,35 +227,46 @@ TString DecompressPayload(TStringBuf data, NPersQueueCommon::ECodec codec) {
 }
 
 void AssertKafkaBatchCut(
-    const TVector<TReadResult>& cut,
+    const TCutOutcome& cut,
     NPersQueueCommon::ECodec expectedCodec = NPersQueueCommon::RAW)
 {
-    UNIT_ASSERT_VALUES_EQUAL(cut.size(), 2u);
+    UNIT_ASSERT_C(cut.Ok(), cut.Error);
+    UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 2u);
 
-    UNIT_ASSERT_VALUES_EQUAL(cut[0].GetOffset(), 10u);
-    UNIT_ASSERT_VALUES_EQUAL(cut[1].GetOffset(), 11u);
-    UNIT_ASSERT_VALUES_EQUAL(cut[0].GetSeqNo(), 10u);
-    UNIT_ASSERT_VALUES_EQUAL(cut[1].GetSeqNo(), 11u);
-    UNIT_ASSERT_VALUES_EQUAL(cut[0].GetLogicalMessageCount(), 1u);
-    UNIT_ASSERT_VALUES_EQUAL(cut[1].GetLogicalMessageCount(), 1u);
-    UNIT_ASSERT(!cut[0].HasUncompressedSize());
-    UNIT_ASSERT(!cut[1].HasUncompressedSize());
+    UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetOffset(), 10u);
+    UNIT_ASSERT_VALUES_EQUAL(cut.Records[1].GetOffset(), 11u);
+    UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetSeqNo(), 10u);
+    UNIT_ASSERT_VALUES_EQUAL(cut.Records[1].GetSeqNo(), 11u);
+    UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetLogicalMessageCount(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(cut.Records[1].GetLogicalMessageCount(), 1u);
+    UNIT_ASSERT(!cut.Records[0].HasUncompressedSize());
+    UNIT_ASSERT(!cut.Records[1].HasUncompressedSize());
 
-    UNIT_ASSERT_VALUES_EQUAL(cut[0].GetPartitionKey(), "k0");
-    UNIT_ASSERT_VALUES_EQUAL(cut[1].GetPartitionKey(), "k1");
-    UNIT_ASSERT_VALUES_EQUAL(cut[0].GetWriteTimestampMS(), 777);
-    UNIT_ASSERT_VALUES_EQUAL(cut[1].GetWriteTimestampMS(), 777);
-    UNIT_ASSERT_VALUES_EQUAL(cut[0].GetCreateTimestampMS(), 1005);
-    UNIT_ASSERT_VALUES_EQUAL(cut[1].GetCreateTimestampMS(), 1007);
+    UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetPartitionKey(), "k0");
+    UNIT_ASSERT_VALUES_EQUAL(cut.Records[1].GetPartitionKey(), "k1");
+    UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetWriteTimestampMS(), 777);
+    UNIT_ASSERT_VALUES_EQUAL(cut.Records[1].GetWriteTimestampMS(), 777);
+    UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetCreateTimestampMS(), 1005);
+    UNIT_ASSERT_VALUES_EQUAL(cut.Records[1].GetCreateTimestampMS(), 1007);
 
-    const auto chunk0 = NKikimr::GetDeserializedData(cut[0].GetData());
-    const auto chunk1 = NKikimr::GetDeserializedData(cut[1].GetData());
+    const auto chunk0 = NKikimr::GetDeserializedData(cut.Records[0].GetData());
+    const auto chunk1 = NKikimr::GetDeserializedData(cut.Records[1].GetData());
     UNIT_ASSERT_VALUES_EQUAL(chunk0.GetCodec(), expectedCodec);
     UNIT_ASSERT_VALUES_EQUAL(chunk1.GetCodec(), expectedCodec);
     UNIT_ASSERT_VALUES_EQUAL(chunk0.GetSeqNo(), 10u);
     UNIT_ASSERT_VALUES_EQUAL(chunk1.GetSeqNo(), 11u);
     UNIT_ASSERT_VALUES_EQUAL(DecompressPayload(chunk0.GetData(), expectedCodec), "value0");
     UNIT_ASSERT_VALUES_EQUAL(DecompressPayload(chunk1.GetData(), expectedCodec), "value1");
+}
+
+void AssertCutFailed(const TCutOutcome& cut) {
+    UNIT_ASSERT_C(!cut.Ok(), "expected a cut error");
+    UNIT_ASSERT(cut.Records.empty());
+}
+
+void AssertKeysFailed(const TKeysOutcome& keys) {
+    UNIT_ASSERT_C(!keys.Ok(), "expected a keys error");
+    UNIT_ASSERT(keys.Keys.empty());
 }
 
 } // namespace
@@ -286,9 +297,8 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
 
     Y_UNIT_TEST(CutFailsOnNonRawDataChunkCodec) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload(), NPersQueueCommon::GZIP);
-        UNIT_ASSERT_EXCEPTION(
-            TKafkaBatchCutter().Cut(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
-            yexception);
+        AssertCutFailed(TKafkaBatchCutter().Cut(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10));
     }
 
     Y_UNIT_TEST(CutIgnoresOuterUncompressedSize) {
@@ -303,8 +313,9 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
             TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
 
         UNIT_ASSERT_VALUES_EQUAL(readResult.GetData(), originalData);
-        UNIT_ASSERT_VALUES_EQUAL(cut.size(), 2u);
-        for (const auto& item : cut) {
+        UNIT_ASSERT_C(cut.Ok(), cut.Error);
+        UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 2u);
+        for (const auto& item : cut.Records) {
             UNIT_ASSERT(item.GetData().size() < originalData.size());
             UNIT_ASSERT(item.GetData() != originalData);
             UNIT_ASSERT(!item.GetIsBatch());
@@ -314,34 +325,38 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
     Y_UNIT_TEST(CutSkipsRecordsBeforeReadStartOffset) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
         const auto cut = TKafkaBatchCutter().Cut(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 11);
-        UNIT_ASSERT_VALUES_EQUAL(cut.size(), 1u);
-        UNIT_ASSERT_VALUES_EQUAL(cut[0].GetOffset(), 11u);
+        UNIT_ASSERT_C(cut.Ok(), cut.Error);
+        UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetOffset(), 11u);
     }
 
     Y_UNIT_TEST(GetKeysReturnsKafkaRecordKeysWithLogicalOffsets) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
         const auto keys = TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
 
-        UNIT_ASSERT_VALUES_EQUAL(keys.size(), 2u);
-        UNIT_ASSERT_VALUES_EQUAL(keys.at("k0"), 10u);
-        UNIT_ASSERT_VALUES_EQUAL(keys.at("k1"), 11u);
+        UNIT_ASSERT_C(keys.Ok(), keys.Error);
+        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.at("k0"), 10u);
+        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.at("k1"), 11u);
     }
 
     Y_UNIT_TEST(GetKeysSkipsRecordsBeforeReadStartOffset) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
         const auto keys = TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 11);
 
-        UNIT_ASSERT_VALUES_EQUAL(keys.size(), 1u);
-        UNIT_ASSERT(!keys.contains("k0"));
-        UNIT_ASSERT_VALUES_EQUAL(keys.at("k1"), 11u);
+        UNIT_ASSERT_C(keys.Ok(), keys.Error);
+        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.size(), 1u);
+        UNIT_ASSERT(!keys.Keys.contains("k0"));
+        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.at("k1"), 11u);
     }
 
     Y_UNIT_TEST(GetKeysSkipsRecordsWithoutKey) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayloadWithNullKey());
         const auto keys = TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
 
-        UNIT_ASSERT_VALUES_EQUAL(keys.size(), 1u);
-        UNIT_ASSERT_VALUES_EQUAL(keys.at("k1"), 11u);
+        UNIT_ASSERT_C(keys.Ok(), keys.Error);
+        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(keys.Keys.at("k1"), 11u);
     }
 
     Y_UNIT_TEST(NonRegularChunkIsNotCut) {
@@ -355,8 +370,9 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         readResult.SetData(SerializeDataChunk(std::move(chunk)));
 
         const auto cut = TKafkaBatchCutter().Cut(TBatchCutterData(readResult, std::move(dataChunk)), 10);
-        UNIT_ASSERT_VALUES_EQUAL(cut.size(), 1u);
-        UNIT_ASSERT_VALUES_EQUAL(cut[0].GetData(), readResult.GetData());
+        UNIT_ASSERT_C(cut.Ok(), cut.Error);
+        UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetData(), readResult.GetData());
     }
 
     Y_UNIT_TEST(CutZstdCompressedKafkaBatchInDataChunk) {
@@ -371,20 +387,22 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         const auto readResult = MakeKafkaBatchReadResult(MakeEmptyKafkaBatchPayload());
         const auto cut = TKafkaBatchCutter().Cut(
             TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
-        UNIT_ASSERT_VALUES_EQUAL(cut.size(), 1u);
-        UNIT_ASSERT_VALUES_EQUAL(cut[0].GetData(), readResult.GetData());
-        UNIT_ASSERT_VALUES_EQUAL(cut[0].GetOffset(), readResult.GetOffset());
+        UNIT_ASSERT_C(cut.Ok(), cut.Error);
+        UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetData(), readResult.GetData());
+        UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetOffset(), readResult.GetOffset());
     }
 
     Y_UNIT_TEST(CutClearsDataForNullRecordValue) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayloadWithNullValue());
         const auto cut = TKafkaBatchCutter().Cut(
             TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
-        UNIT_ASSERT_VALUES_EQUAL(cut.size(), 2u);
-        UNIT_ASSERT_VALUES_EQUAL(cut[0].GetPartitionKey(), "k0");
-        const auto chunk0 = NKikimr::GetDeserializedData(cut[0].GetData());
+        UNIT_ASSERT_C(cut.Ok(), cut.Error);
+        UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(cut.Records[0].GetPartitionKey(), "k0");
+        const auto chunk0 = NKikimr::GetDeserializedData(cut.Records[0].GetData());
         UNIT_ASSERT(!chunk0.HasData() || chunk0.GetData().empty());
-        const auto chunk1 = NKikimr::GetDeserializedData(cut[1].GetData());
+        const auto chunk1 = NKikimr::GetDeserializedData(cut.Records[1].GetData());
         UNIT_ASSERT_VALUES_EQUAL(chunk1.GetData(), "value1");
     }
 
@@ -392,9 +410,10 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayloadWithTimestamps(0, 0, -1));
         const auto cut = TKafkaBatchCutter().Cut(
             TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
-        UNIT_ASSERT_VALUES_EQUAL(cut.size(), 2u);
-        UNIT_ASSERT(!cut[0].HasCreateTimestampMS());
-        UNIT_ASSERT(!cut[1].HasCreateTimestampMS());
+        UNIT_ASSERT_C(cut.Ok(), cut.Error);
+        UNIT_ASSERT_VALUES_EQUAL(cut.Records.size(), 2u);
+        UNIT_ASSERT(!cut.Records[0].HasCreateTimestampMS());
+        UNIT_ASSERT(!cut.Records[1].HasCreateTimestampMS());
     }
 
     Y_UNIT_TEST(CutFailsOnMissingDataChunkCodec) {
@@ -406,53 +425,45 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         readResult.SetOffset(10);
         readResult.SetData(SerializeDataChunk(chunk));
 
-        UNIT_ASSERT_EXCEPTION(
-            TKafkaBatchCutter().Cut(TBatchCutterData(readResult, std::move(chunk)), 10),
-            yexception);
+        AssertCutFailed(TKafkaBatchCutter().Cut(TBatchCutterData(readResult, std::move(chunk)), 10));
     }
 
     Y_UNIT_TEST(CutFailsOnCorruptKafkaPayload) {
         const auto readResult = MakeKafkaBatchReadResult("not-a-kafka-batch");
-        UNIT_ASSERT_EXCEPTION(
-            TKafkaBatchCutter().Cut(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
-            yexception);
+        AssertCutFailed(TKafkaBatchCutter().Cut(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10));
     }
 
     Y_UNIT_TEST(CutFailsOnNegativeOffsetDelta) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayloadWithOffsetDeltas(-1, 1));
-        UNIT_ASSERT_EXCEPTION(
-            TKafkaBatchCutter().Cut(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
-            yexception);
+        AssertCutFailed(TKafkaBatchCutter().Cut(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10));
     }
 
     Y_UNIT_TEST(CutFailsOnOffsetOverflow) {
         auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
         readResult.SetOffset(Max<ui64>());
-        UNIT_ASSERT_EXCEPTION(
-            TKafkaBatchCutter().Cut(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
-            yexception);
+        AssertCutFailed(TKafkaBatchCutter().Cut(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10));
     }
 
     Y_UNIT_TEST(GetKeysFailsOnCorruptKafkaPayload) {
         const auto readResult = MakeKafkaBatchReadResult("not-a-kafka-batch");
-        UNIT_ASSERT_EXCEPTION(
-            TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
-            yexception);
+        AssertKeysFailed(TKafkaBatchCutter().GetKeys(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10));
     }
 
     Y_UNIT_TEST(GetKeysFailsOnNegativeOffsetDelta) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayloadWithOffsetDeltas(-1, 1));
-        UNIT_ASSERT_EXCEPTION(
-            TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
-            yexception);
+        AssertKeysFailed(TKafkaBatchCutter().GetKeys(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10));
     }
 
     Y_UNIT_TEST(GetKeysFailsOnOffsetOverflow) {
         auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload());
         readResult.SetOffset(Max<ui64>());
-        UNIT_ASSERT_EXCEPTION(
-            TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
-            yexception);
+        AssertKeysFailed(TKafkaBatchCutter().GetKeys(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10));
     }
 
     Y_UNIT_TEST(GetKeysIgnoresNonRegularChunk) {
@@ -466,14 +477,14 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         readResult.SetData(SerializeDataChunk(chunk));
 
         const auto keys = TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, std::move(chunk)), 10);
-        UNIT_ASSERT(keys.empty());
+        UNIT_ASSERT_C(keys.Ok(), keys.Error);
+        UNIT_ASSERT(keys.Keys.empty());
     }
 
     Y_UNIT_TEST(GetKeysFailsOnNonRawDataChunkCodec) {
         const auto readResult = MakeKafkaBatchReadResult(MakeKafkaBatchPayload(), NPersQueueCommon::GZIP);
-        UNIT_ASSERT_EXCEPTION(
-            TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10),
-            yexception);
+        AssertKeysFailed(TKafkaBatchCutter().GetKeys(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10));
     }
 
     Y_UNIT_TEST(GetKeysFailsOnMissingDataChunkCodec) {
@@ -484,16 +495,15 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         TReadResult readResult;
         readResult.SetOffset(10);
 
-        UNIT_ASSERT_EXCEPTION(
-            TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, std::move(chunk)), 10),
-            yexception);
+        AssertKeysFailed(TKafkaBatchCutter().GetKeys(TBatchCutterData(readResult, std::move(chunk)), 10));
     }
 
     Y_UNIT_TEST(GetKeysOnEmptyKafkaBatchIsEmpty) {
         const auto readResult = MakeKafkaBatchReadResult(MakeEmptyKafkaBatchPayload());
         const auto keys = TKafkaBatchCutter().GetKeys(
             TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())), 10);
-        UNIT_ASSERT(keys.empty());
+        UNIT_ASSERT_C(keys.Ok(), keys.Error);
+        UNIT_ASSERT(keys.Keys.empty());
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
@@ -1,0 +1,624 @@
+#include <ydb/core/persqueue/pqtablet/batching/batch_processor.h>
+#include <ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.h>
+#include <ydb/core/persqueue/public/codecs/kafka.h>
+#include <ydb/core/persqueue/public/constants.h>
+#include <ydb/core/persqueue/public/write_meta/write_meta.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/public/sdk/cpp/src/library/kafka/kafka_messages_int.h>
+#include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/string.h>
+#include <util/stream/str.h>
+
+#include <limits>
+
+namespace NKikimr::NPQ::NBatching {
+namespace {
+
+using TReadResult = NKikimrClient::TCmdReadResult::TResult;
+using NActors::IEventBase;
+using NActors::IEventHandle;
+using NActors::TActorId;
+using NActors::TEvents;
+using NActors::TTestBasicRuntime;
+
+NKafka::TKafkaRecord MakeKafkaRecord(
+    i64 timestampDelta,
+    i64 offsetDelta,
+    TStringBuf key,
+    TStringBuf value)
+{
+    NKafka::TKafkaRecord record;
+    record.TimestampDelta = timestampDelta;
+    record.OffsetDelta = offsetDelta;
+    record.SetKey(TString{key});
+    record.SetValue(TString{value});
+    record.Length = record.Size(2)
+        - NKafka::NPrivate::SizeOfVarint<NKafka::TKafkaRecord::LengthMeta::Type>(0);
+    return record;
+}
+
+TString MakeKafkaBatchPayload(
+    NKafka::ECompressionType compression = NKafka::ECompressionType::NONE,
+    size_t recordCount = 2,
+    size_t valueSize = 8)
+{
+    NKafka::TKafkaRecordBatch batch;
+    batch.BaseOffset = 100;
+    batch.Magic = 2;
+    batch.Attributes = static_cast<NKafka::TKafkaRecordBatch::AttributesMeta::Type>(compression);
+    batch.LastOffsetDelta = recordCount ? recordCount - 1 : 0;
+    batch.BaseTimestamp = 1000;
+    batch.MaxTimestamp = 1000 + recordCount;
+    batch.ProducerId = 42;
+    batch.ProducerEpoch = 3;
+    batch.BaseSequence = 10;
+    const TString value(valueSize, 'v');
+    for (size_t i = 0; i < recordCount; ++i) {
+        batch.Records.push_back(MakeKafkaRecord(
+            static_cast<i64>(i),
+            static_cast<i64>(i),
+            TStringBuilder() << "k" << i,
+            value));
+    }
+    batch.BatchLength = batch.Size(2)
+        - sizeof(NKafka::TKafkaRecordBatch::BaseOffsetMeta::Type)
+        - sizeof(NKafka::TKafkaRecordBatch::BatchLengthMeta::Type);
+    return NKafka::WriteKafkaRecordBatch(batch);
+}
+
+TString SerializeDataChunk(NKikimrPQClient::TDataChunk chunk) {
+    TString serialized;
+    Y_ENSURE(chunk.SerializeToString(&serialized));
+    return serialized;
+}
+
+TReadResult MakeKafkaBatchReadResult(TString payload, ui64 offset = 10) {
+    NKikimrPQClient::TDataChunk chunk;
+    chunk.SetChunkType(NKikimrPQClient::TDataChunk::REGULAR);
+    chunk.SetCodec(KafkaBatchCodec());
+    chunk.SetData(std::move(payload));
+    chunk.SetSeqNo(100);
+
+    TReadResult readResult;
+    readResult.SetOffset(offset);
+    readResult.SetSeqNo(100);
+    readResult.SetLogicalMessageCount(2);
+    readResult.SetIsBatch(true);
+    readResult.SetData(SerializeDataChunk(std::move(chunk)));
+    return readResult;
+}
+
+TReadResult MakePlainReadResult(
+    ui64 offset,
+    TStringBuf payload,
+    bool isBatch = false,
+    NKikimrPQClient::TDataChunk::EChunkType chunkType = NKikimrPQClient::TDataChunk::REGULAR,
+    TVector<std::pair<TString, TString>> meta = {})
+{
+    NKikimrPQClient::TDataChunk chunk;
+    chunk.SetChunkType(chunkType);
+    chunk.SetCodec(NPersQueueCommon::RAW);
+    if (!payload.empty()) {
+        chunk.SetData(TString{payload});
+    }
+    for (const auto& [key, value] : meta) {
+        auto* item = chunk.AddMessageMeta();
+        item->set_key(key);
+        item->set_value(value);
+    }
+
+    TReadResult readResult;
+    readResult.SetOffset(offset);
+    readResult.SetSeqNo(offset);
+    readResult.SetLogicalMessageCount(1);
+    readResult.SetIsBatch(isBatch);
+    readResult.SetData(SerializeDataChunk(std::move(chunk)));
+    return readResult;
+}
+
+THolder<TEvPQ::TEvProxyResponse> MakeProxyResponse(TVector<TReadResult> results) {
+    auto event = MakeHolder<TEvPQ::TEvProxyResponse>(1, false);
+    auto* cmdRead = event->Response->MutablePartitionResponse()->MutableCmdReadResult();
+    for (auto& result : results) {
+        cmdRead->AddResult()->Swap(&result);
+    }
+    return event;
+}
+
+TReadProcessingContext MakeReadContext(
+    TActorId responseActor,
+    TVector<TReadResult> results,
+    const TString& user = "user",
+    ui32 partitionId = 7,
+    ui64 offset = 0,
+    ui32 count = std::numeric_limits<ui32>::max(),
+    ui64 lastOffset = 0)
+{
+    TReadProcessingContext context;
+    context.User = user;
+    context.PartitionId = partitionId;
+    context.Destination = 11;
+    context.Offset = offset;
+    context.Count = count;
+    context.LastOffset = lastOffset;
+    context.ResponseActor = responseActor;
+    context.Event.Reset(MakeProxyResponse(std::move(results)).Release());
+    return context;
+}
+
+const NKikimrClient::TCmdReadResult& GetCmdReadResult(const TReadProcessingContext& context) {
+    auto* proxy = dynamic_cast<TEvPQ::TEvProxyResponse*>(context.Event.Get());
+    UNIT_ASSERT(proxy);
+    UNIT_ASSERT(proxy->Response);
+    UNIT_ASSERT(proxy->Response->HasPartitionResponse());
+    UNIT_ASSERT(proxy->Response->GetPartitionResponse().HasCmdReadResult());
+    return proxy->Response->GetPartitionResponse().GetCmdReadResult();
+}
+
+struct TEnv {
+    TTestBasicRuntime Runtime;
+    TActorId Tablet;
+    TActorId Edge;
+
+    TEnv()
+        : Runtime(1, false)
+    {
+        TAppPrepare app;
+        Runtime.Initialize(app.Unwrap());
+        Tablet = Runtime.AllocateEdgeActor();
+        Edge = Runtime.AllocateEdgeActor();
+    }
+
+    TActorId RegisterBatchProcessor() {
+        return Runtime.Register(CreateBatchProcessor(42, Tablet));
+    }
+
+    TActorId RegisterConsumer(const TString& user = "user") {
+        return Runtime.Register(CreateConsumerBatchProcessor(42, Tablet, user));
+    }
+
+    void Send(const TActorId& recipient, IEventBase* ev) {
+        Runtime.Send(new IEventHandle(recipient, Edge, ev), 0, true);
+    }
+
+    void DispatchQuiet() {
+        try {
+            Runtime.DispatchEvents(NActors::TDispatchOptions(), TDuration::MilliSeconds(50));
+        } catch (const NActors::TEmptyEventQueueException&) {
+        }
+    }
+
+    template <typename TEvent>
+    typename TEvent::TPtr Grab() {
+        auto ev = Runtime.GrabEdgeEvent<TEvent>(Edge, TDuration::Seconds(10));
+        UNIT_ASSERT(ev);
+        return ev;
+    }
+};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TConsumerBatchProcessorTest) {
+    Y_UNIT_TEST(ProcessNonBatchMessages) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(env.Edge, {
+            MakePlainReadResult(10, "a"),
+            MakePlainReadResult(11, "b"),
+        })));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(1).GetOffset(), 11u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Context.User, "user");
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Context.PartitionId, 7u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Context.Destination, 11u);
+    }
+
+    Y_UNIT_TEST(ProcessKafkaBatchCutsRecords) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakeKafkaBatchReadResult(MakeKafkaBatchPayload())},
+            "user",
+            7,
+            10)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(1).GetOffset(), 11u);
+        UNIT_ASSERT(!results.Get(0).GetIsBatch());
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetLogicalMessageCount(), 1u);
+    }
+
+    Y_UNIT_TEST(SkipOffsetsOutsideWindow) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {
+                MakePlainReadResult(9, "before"),
+                MakePlainReadResult(10, "ok"),
+                MakePlainReadResult(12, "after"),
+            },
+            "user",
+            7,
+            10,
+            std::numeric_limits<ui32>::max(),
+            12)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
+    }
+
+    Y_UNIT_TEST(StopAtCountOnNonBatchMessages) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {
+                MakePlainReadResult(10, "first"),
+                MakePlainReadResult(11, "second"),
+            },
+            "user",
+            7,
+            10,
+            1)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
+    }
+
+    Y_UNIT_TEST(StopAtCountIncludingMidBatch) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {
+                MakePlainReadResult(10, "first"),
+                MakeKafkaBatchReadResult(MakeKafkaBatchPayload()),
+                MakePlainReadResult(20, "tail"),
+            },
+            "user",
+            7,
+            10,
+            2)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(1).GetOffset(), 10u);
+    }
+
+    Y_UNIT_TEST(ZeroCountAddsAllNonBatchMessages) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {
+                MakePlainReadResult(10, "a"),
+                MakePlainReadResult(11, "b"),
+            },
+            "user",
+            7,
+            0,
+            0)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        UNIT_ASSERT_VALUES_EQUAL(GetCmdReadResult(ev->Get()->Context).GetResult().size(), 2);
+    }
+
+    Y_UNIT_TEST(ZeroCountStopsAfterFirstKafkaBatch) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {
+                MakeKafkaBatchReadResult(MakeKafkaBatchPayload()),
+                MakePlainReadResult(20, "tail"),
+            },
+            "user",
+            7,
+            10,
+            0)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(1).GetOffset(), 11u);
+    }
+
+    Y_UNIT_TEST(ContinuesAfterKafkaBatchWhenCountNotReached) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {
+                MakeKafkaBatchReadResult(MakeKafkaBatchPayload()),
+                MakePlainReadResult(20, "tail"),
+            },
+            "user",
+            7,
+            10,
+            4)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(2).GetOffset(), 20u);
+    }
+
+    Y_UNIT_TEST(LastOffsetSkipsRecordsInsideKafkaBatch) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakeKafkaBatchReadResult(MakeKafkaBatchPayload())},
+            "user",
+            7,
+            10,
+            std::numeric_limits<ui32>::max(),
+            11)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
+    }
+
+    Y_UNIT_TEST(UnknownBatchCodecIsKeptAsOriginal) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        auto unknown = MakePlainReadResult(15, "gzip-batch", true);
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {unknown, MakePlainReadResult(16, "next")},
+            "user",
+            7,
+            15,
+            1)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 15u);
+        UNIT_ASSERT(results.Get(0).GetIsBatch());
+    }
+
+    Y_UNIT_TEST(SkipKafkaRecordsBeforeReadStartOffset) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakeKafkaBatchReadResult(MakeKafkaBatchPayload())},
+            "user",
+            7,
+            11)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 11u);
+    }
+
+    Y_UNIT_TEST(ProcessBatchKeysCollectsPlainAndKafkaKeys) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        TReadResult emptyData;
+        emptyData.SetOffset(1);
+
+        TBatchKeysProcessingContext keys;
+        keys.PartitionId = 3;
+        keys.ResponseActor = env.Edge;
+        keys.Results = {
+            emptyData,
+            MakePlainReadResult(2, "grow", false, NKikimrPQClient::TDataChunk::GROW, {{TString{MESSAGE_ATTRIBUTE_KEY}, "g"}}),
+            MakePlainReadResult(3, "plain", false, NKikimrPQClient::TDataChunk::REGULAR, {
+                {"other", "skip"},
+                {TString{MESSAGE_ATTRIBUTE_KEY}, "plain-key"},
+            }),
+            MakePlainReadResult(4, "no-key", false),
+            MakePlainReadResult(5, "unknown-batch", true),
+            MakeKafkaBatchReadResult(MakeKafkaBatchPayload()),
+        };
+
+        env.Send(actor, new TEvProcessBatchKeys(std::move(keys)));
+
+        const auto ev = env.Grab<TEvProcessBatchKeysResult>();
+        const auto& offsetToKey = ev->Get()->OffsetToKey;
+        UNIT_ASSERT(!offsetToKey.contains(1u));
+        UNIT_ASSERT(!offsetToKey.contains(2u));
+        UNIT_ASSERT_VALUES_EQUAL(offsetToKey.at(3u), "plain-key");
+        UNIT_ASSERT_VALUES_EQUAL(offsetToKey.at(4u), "");
+        UNIT_ASSERT(!offsetToKey.contains(5u));
+        UNIT_ASSERT_VALUES_EQUAL(offsetToKey.at(10u), "k0");
+        UNIT_ASSERT_VALUES_EQUAL(offsetToKey.at(11u), "k1");
+    }
+
+    Y_UNIT_TEST(UnexpectedEventDoesNotBreakProcessor) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvents::TEvPing());
+        env.DispatchQuiet();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(env.Edge, {MakePlainReadResult(1, "ok")})));
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        UNIT_ASSERT_VALUES_EQUAL(GetCmdReadResult(ev->Get()->Context).GetResult().size(), 1);
+    }
+
+    Y_UNIT_TEST(WakeupFlushesCpuMetrics) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer("metrics-user");
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakeKafkaBatchReadResult(MakeKafkaBatchPayload(NKafka::ECompressionType::GZIP, 32, 4096))},
+            "metrics-user",
+            9,
+            10)));
+        env.Grab<TEvProcessBatchResult>();
+
+        env.Send(actor, new TEvents::TEvWakeup());
+        auto metrics = env.Runtime.GrabEdgeEvent<TEvPQ::TEvConsumerBatchProcessorMetrics>(env.Tablet, TDuration::Seconds(10));
+        UNIT_ASSERT(metrics);
+        UNIT_ASSERT_VALUES_EQUAL(metrics->Get()->GetPartitionId(), 9u);
+        UNIT_ASSERT_VALUES_EQUAL(metrics->Get()->User, "metrics-user");
+        UNIT_ASSERT(metrics->Get()->CPUUsage > 0);
+    }
+
+    Y_UNIT_TEST(PoisonFlushesMetricsAndStops) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakeKafkaBatchReadResult(MakeKafkaBatchPayload(NKafka::ECompressionType::ZSTD, 16, 2048))},
+            "user",
+            4,
+            10)));
+        env.Grab<TEvProcessBatchResult>();
+
+        env.Send(actor, new TEvents::TEvPoisonPill());
+        env.DispatchQuiet();
+        UNIT_ASSERT(!env.Runtime.FindActor(actor));
+    }
+}
+
+Y_UNIT_TEST_SUITE(TBatchProcessorTest) {
+    Y_UNIT_TEST(RoutesProcessBatchToPerUserProcessor) {
+        TEnv env;
+        const auto actor = env.RegisterBatchProcessor();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakePlainReadResult(10, "a")},
+            "alice")));
+        const auto first = env.Grab<TEvProcessBatchResult>();
+        UNIT_ASSERT_VALUES_EQUAL(first->Get()->Context.User, "alice");
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakePlainReadResult(11, "b")},
+            "alice")));
+        UNIT_ASSERT_VALUES_EQUAL(env.Grab<TEvProcessBatchResult>()->Get()->Context.User, "alice");
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakePlainReadResult(12, "c")},
+            "bob")));
+        UNIT_ASSERT_VALUES_EQUAL(env.Grab<TEvProcessBatchResult>()->Get()->Context.User, "bob");
+    }
+
+    Y_UNIT_TEST(RoutesProcessBatchKeysToCompactificationWorker) {
+        TEnv env;
+        const auto actor = env.RegisterBatchProcessor();
+
+        TBatchKeysProcessingContext keys;
+        keys.PartitionId = 1;
+        keys.ResponseActor = env.Edge;
+        keys.Results = {MakePlainReadResult(8, "x", false, NKikimrPQClient::TDataChunk::REGULAR, {
+            {TString{MESSAGE_ATTRIBUTE_KEY}, "ck"},
+        })};
+
+        env.Send(actor, new TEvProcessBatchKeys(std::move(keys)));
+        const auto ev = env.Grab<TEvProcessBatchKeysResult>();
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->OffsetToKey.at(8u), "ck");
+    }
+
+    Y_UNIT_TEST(ConsumerRemovedPoisonsOnlyThatUser) {
+        TEnv env;
+        const auto actor = env.RegisterBatchProcessor();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakePlainReadResult(1, "a")},
+            "alice")));
+        env.Grab<TEvProcessBatchResult>();
+
+        TBatchKeysProcessingContext keys;
+        keys.PartitionId = 1;
+        keys.ResponseActor = env.Edge;
+        keys.Results = {MakePlainReadResult(2, "b", false, NKikimrPQClient::TDataChunk::REGULAR, {
+            {TString{MESSAGE_ATTRIBUTE_KEY}, "k"},
+        })};
+        env.Send(actor, new TEvProcessBatchKeys(std::move(keys)));
+        env.Grab<TEvProcessBatchKeysResult>();
+
+        env.Send(actor, new TEvPQ::TEvConsumerRemoved("nobody"));
+        env.DispatchQuiet();
+
+        env.Send(actor, new TEvPQ::TEvConsumerRemoved("alice"));
+        env.DispatchQuiet();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakePlainReadResult(3, "again")},
+            "alice")));
+        UNIT_ASSERT_VALUES_EQUAL(env.Grab<TEvProcessBatchResult>()->Get()->Context.User, "alice");
+
+        TBatchKeysProcessingContext keysAgain;
+        keysAgain.ResponseActor = env.Edge;
+        keysAgain.Results = {MakePlainReadResult(4, "still", false, NKikimrPQClient::TDataChunk::REGULAR, {
+            {TString{MESSAGE_ATTRIBUTE_KEY}, "k2"},
+        })};
+        env.Send(actor, new TEvProcessBatchKeys(std::move(keysAgain)));
+        UNIT_ASSERT_VALUES_EQUAL(env.Grab<TEvProcessBatchKeysResult>()->Get()->OffsetToKey.at(4u), "k2");
+    }
+
+    Y_UNIT_TEST(UnexpectedEventIsIgnored) {
+        TEnv env;
+        const auto actor = env.RegisterBatchProcessor();
+
+        env.Send(actor, new TEvents::TEvPing());
+        env.DispatchQuiet();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(env.Edge, {MakePlainReadResult(1, "ok")}, "user")));
+        UNIT_ASSERT_VALUES_EQUAL(GetCmdReadResult(env.Grab<TEvProcessBatchResult>()->Get()->Context).GetResult().size(), 1);
+    }
+
+    Y_UNIT_TEST(PoisonPillsChildProcessors) {
+        TEnv env;
+        const auto actor = env.RegisterBatchProcessor();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakePlainReadResult(1, "a")},
+            "alice")));
+        env.Grab<TEvProcessBatchResult>();
+
+        env.Send(actor, new TEvents::TEvPoisonPill());
+        env.DispatchQuiet();
+        UNIT_ASSERT(!env.Runtime.FindActor(actor));
+    }
+}
+
+} // namespace NKikimr::NPQ::NBatching

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
@@ -71,6 +71,24 @@ TString MakeKafkaBatchPayload(
     return NKafka::WriteKafkaRecordBatch(batch);
 }
 
+TString MakeKafkaBatchPayloadWithOffsetDeltas(i64 delta0, i64 delta1) {
+    NKafka::TKafkaRecordBatch batch;
+    batch.BaseOffset = 100;
+    batch.Magic = 2;
+    batch.LastOffsetDelta = delta1;
+    batch.BaseTimestamp = 1000;
+    batch.MaxTimestamp = 1007;
+    batch.ProducerId = 42;
+    batch.ProducerEpoch = 3;
+    batch.BaseSequence = 10;
+    batch.Records.push_back(MakeKafkaRecord(5, delta0, "k0", "value0"));
+    batch.Records.push_back(MakeKafkaRecord(7, delta1, "k1", "value1"));
+    batch.BatchLength = batch.Size(2)
+        - sizeof(NKafka::TKafkaRecordBatch::BaseOffsetMeta::Type)
+        - sizeof(NKafka::TKafkaRecordBatch::BatchLengthMeta::Type);
+    return NKafka::WriteKafkaRecordBatch(batch);
+}
+
 TString SerializeDataChunk(NKikimrPQClient::TDataChunk chunk) {
     TString serialized;
     Y_ENSURE(chunk.SerializeToString(&serialized));
@@ -461,6 +479,49 @@ Y_UNIT_TEST_SUITE(TConsumerBatchProcessorTest) {
 
         env.Send(actor, new TEvProcessBatch(MakeReadContext(env.Edge, {MakePlainReadResult(11, "ok")})));
         UNIT_ASSERT_VALUES_EQUAL(GetCmdReadResult(env.Grab<TEvProcessBatchResult>()->Get()->Context).GetResult().size(), 1);
+    }
+
+    Y_UNIT_TEST(NegativeOffsetDeltaKeepsOriginalAndDoesNotPoisonTablet) {
+        TEnv env(true);
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakeKafkaBatchReadResult(MakeKafkaBatchPayloadWithOffsetDeltas(-1, 1), 10)},
+            "user",
+            7,
+            10)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+        UNIT_ASSERT(results.Get(0).GetIsBatch());
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
+        UNIT_ASSERT(env.Runtime.FindActor(actor));
+    }
+
+    Y_UNIT_TEST(ProcessBatchKeepsPlainPrefixWhenLaterBatchIsCorrupt) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {
+                MakePlainReadResult(10, "keep-me"),
+                MakeCorruptKafkaBatchReadResult(20),
+            },
+            "user",
+            7,
+            10)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
+        const auto chunk0 = NKikimr::GetDeserializedData(results.Get(0).GetData());
+        UNIT_ASSERT_VALUES_EQUAL(chunk0.GetData(), "keep-me");
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(1).GetOffset(), 20u);
+        UNIT_ASSERT(results.Get(1).GetIsBatch());
     }
 
     Y_UNIT_TEST(UnsupportedSnappyKafkaBatchKeepsOriginalAndReplies) {

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
@@ -156,7 +156,6 @@ TReadProcessingContext MakeReadContext(
     TReadProcessingContext context;
     context.User = user;
     context.PartitionId = partitionId;
-    context.Destination = 11;
     context.Offset = offset;
     context.Count = count;
     context.LastOffset = lastOffset;
@@ -235,7 +234,6 @@ Y_UNIT_TEST_SUITE(TConsumerBatchProcessorTest) {
         UNIT_ASSERT_VALUES_EQUAL(results.Get(1).GetOffset(), 11u);
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Context.User, "user");
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Context.PartitionId, 7u);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Context.Destination, 11u);
     }
 
     Y_UNIT_TEST(ProcessKafkaBatchCutsRecords) {

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
@@ -1,11 +1,14 @@
 #include <ydb/core/persqueue/pqtablet/batching/batch_processor.h>
 #include <ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.h>
+#include <ydb/core/persqueue/pqtablet/readproxy/readproxy.h>
+#include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/public/codecs/kafka.h>
 #include <ydb/core/persqueue/public/constants.h>
 #include <ydb/core/persqueue/public/write_meta/write_meta.h>
 #include <ydb/core/testlib/basics/appdata.h>
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/library/actors/core/events.h>
+#include <ydb/public/lib/base/msgbus_status.h>
 #include <ydb/public/sdk/cpp/src/library/kafka/kafka_messages_int.h>
 #include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
 
@@ -787,6 +790,59 @@ Y_UNIT_TEST_SUITE(TBatchProcessorTest) {
         env.Send(actor, new TEvents::TEvPoisonPill());
         env.DispatchQuiet();
         UNIT_ASSERT(!env.Runtime.FindActor(actor));
+    }
+
+    Y_UNIT_TEST(ProcessBatchBouncedFromDeadChildStillReplies) {
+        TEnv env;
+        const auto actor = env.RegisterBatchProcessor();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakePlainReadResult(1, "warmup")},
+            "alice")));
+        env.Grab<TEvProcessBatchResult>();
+
+        env.Send(actor, new TEvPQ::TEvConsumerRemoved("alice"));
+        env.DispatchQuiet();
+
+        auto context = MakeReadContext(
+            env.Edge,
+            {MakePlainReadResult(2, "bounced")},
+            "alice");
+        env.Runtime.Send(new IEventHandle(actor, actor, new TEvProcessBatch(std::move(context))), 0, true);
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        UNIT_ASSERT_VALUES_EQUAL(GetCmdReadResult(ev->Get()->Context).GetResult().Get(0).GetOffset(), 2u);
+    }
+
+    Y_UNIT_TEST(ReadProxyRepliesWhenBatchProcessorDied) {
+        TEnv env;
+        const auto batchProcessor = env.RegisterBatchProcessor();
+        env.Send(batchProcessor, new TEvents::TEvPoisonPill());
+        env.DispatchQuiet();
+        UNIT_ASSERT(!env.Runtime.FindActor(batchProcessor));
+
+        NKikimrClient::TPersQueueRequest request;
+        auto* cmdRead = request.MutablePartitionRequest()->MutableCmdRead();
+        cmdRead->SetClientId("alice");
+        cmdRead->SetOffset(10);
+        cmdRead->SetPartNo(0);
+        cmdRead->SetCanReadBatches(false);
+
+        const auto proxy = env.Runtime.Register(CreateReadProxy(
+            env.Edge, 42, env.Tablet, 1, TDirectReadKey{}, request, batchProcessor));
+
+        auto response = MakeHolder<TEvPersQueue::TEvResponse>();
+        response->Record.SetStatus(NMsgBusProxy::MSTATUS_OK);
+        response->Record.SetErrorCode(NPersQueue::NErrorCode::OK);
+        response->Record.MutablePartitionResponse()->MutableCmdReadResult()->AddResult()->CopyFrom(
+            MakeKafkaBatchReadResult(MakeKafkaBatchPayload()));
+
+        env.Send(proxy, response.Release());
+        const auto ev = env.Runtime.GrabEdgeEvent<TEvPersQueue::TEvResponse>(env.Edge, TDuration::Seconds(10));
+        UNIT_ASSERT(ev);
+        UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NMsgBusProxy::MSTATUS_ERROR);
+        UNIT_ASSERT_EQUAL(ev->Get()->Record.GetErrorCode(), NPersQueue::NErrorCode::READ_NOT_DONE);
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
@@ -1,14 +1,11 @@
 #include <ydb/core/persqueue/pqtablet/batching/batch_processor.h>
 #include <ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.h>
-#include <ydb/core/persqueue/pqtablet/readproxy/readproxy.h>
-#include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/public/codecs/kafka.h>
 #include <ydb/core/persqueue/public/constants.h>
 #include <ydb/core/persqueue/public/write_meta/write_meta.h>
 #include <ydb/core/testlib/basics/appdata.h>
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/library/actors/core/events.h>
-#include <ydb/public/lib/base/msgbus_status.h>
 #include <ydb/public/sdk/cpp/src/library/kafka/kafka_messages_int.h>
 #include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
 
@@ -790,59 +787,6 @@ Y_UNIT_TEST_SUITE(TBatchProcessorTest) {
         env.Send(actor, new TEvents::TEvPoisonPill());
         env.DispatchQuiet();
         UNIT_ASSERT(!env.Runtime.FindActor(actor));
-    }
-
-    Y_UNIT_TEST(ProcessBatchBouncedFromDeadChildStillReplies) {
-        TEnv env;
-        const auto actor = env.RegisterBatchProcessor();
-
-        env.Send(actor, new TEvProcessBatch(MakeReadContext(
-            env.Edge,
-            {MakePlainReadResult(1, "warmup")},
-            "alice")));
-        env.Grab<TEvProcessBatchResult>();
-
-        env.Send(actor, new TEvPQ::TEvConsumerRemoved("alice"));
-        env.DispatchQuiet();
-
-        auto context = MakeReadContext(
-            env.Edge,
-            {MakePlainReadResult(2, "bounced")},
-            "alice");
-        env.Runtime.Send(new IEventHandle(actor, actor, new TEvProcessBatch(std::move(context))), 0, true);
-
-        const auto ev = env.Grab<TEvProcessBatchResult>();
-        UNIT_ASSERT_VALUES_EQUAL(GetCmdReadResult(ev->Get()->Context).GetResult().Get(0).GetOffset(), 2u);
-    }
-
-    Y_UNIT_TEST(ReadProxyRepliesWhenBatchProcessorDied) {
-        TEnv env;
-        const auto batchProcessor = env.RegisterBatchProcessor();
-        env.Send(batchProcessor, new TEvents::TEvPoisonPill());
-        env.DispatchQuiet();
-        UNIT_ASSERT(!env.Runtime.FindActor(batchProcessor));
-
-        NKikimrClient::TPersQueueRequest request;
-        auto* cmdRead = request.MutablePartitionRequest()->MutableCmdRead();
-        cmdRead->SetClientId("alice");
-        cmdRead->SetOffset(10);
-        cmdRead->SetPartNo(0);
-        cmdRead->SetCanReadBatches(false);
-
-        const auto proxy = env.Runtime.Register(CreateReadProxy(
-            env.Edge, 42, env.Tablet, 1, TDirectReadKey{}, request, batchProcessor));
-
-        auto response = MakeHolder<TEvPersQueue::TEvResponse>();
-        response->Record.SetStatus(NMsgBusProxy::MSTATUS_OK);
-        response->Record.SetErrorCode(NPersQueue::NErrorCode::OK);
-        response->Record.MutablePartitionResponse()->MutableCmdReadResult()->AddResult()->CopyFrom(
-            MakeKafkaBatchReadResult(MakeKafkaBatchPayload()));
-
-        env.Send(proxy, response.Release());
-        const auto ev = env.Runtime.GrabEdgeEvent<TEvPersQueue::TEvResponse>(env.Edge, TDuration::Seconds(10));
-        UNIT_ASSERT(ev);
-        UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NMsgBusProxy::MSTATUS_ERROR);
-        UNIT_ASSERT_EQUAL(ev->Get()->Record.GetErrorCode(), NPersQueue::NErrorCode::READ_NOT_DONE);
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
@@ -93,6 +93,20 @@ TReadResult MakeKafkaBatchReadResult(TString payload, ui64 offset = 10) {
     return readResult;
 }
 
+TReadResult MakeCorruptKafkaBatchReadResult(ui64 offset = 10, TString payload = "not-a-kafka-batch") {
+    return MakeKafkaBatchReadResult(std::move(payload), offset);
+}
+
+TString MakeSnappyKafkaBatchPayload() {
+    auto payload = MakeKafkaBatchPayload();
+    // Kafka v2 attributes are int16 BE after baseOffset(8)+batchLength(4)+leaderEpoch(4)+magic(1)+crc(4).
+    constexpr size_t attributesOffset = 21;
+    UNIT_ASSERT(payload.size() > attributesOffset + 1);
+    payload[attributesOffset] = 0;
+    payload[attributesOffset + 1] = static_cast<char>(NKafka::ECompressionType::SNAPPY);
+    return payload;
+}
+
 TReadResult MakePlainReadResult(
     ui64 offset,
     TStringBuf payload,
@@ -165,10 +179,11 @@ struct TEnv {
     TActorId Tablet;
     TActorId Edge;
 
-    TEnv()
+    explicit TEnv(bool restartOnUnhandledExceptions = false)
         : Runtime(1, false)
     {
         TAppPrepare app;
+        app.FeatureFlags.SetEnableTabletRestartOnUnhandledExceptions(restartOnUnhandledExceptions);
         Runtime.Initialize(app.Unwrap());
         Tablet = Runtime.AllocateEdgeActor();
         Edge = Runtime.AllocateEdgeActor();
@@ -426,6 +441,160 @@ Y_UNIT_TEST_SUITE(TConsumerBatchProcessorTest) {
         const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
         UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 11u);
+    }
+
+    Y_UNIT_TEST(CorruptKafkaBatchKeepsOriginalAndReplies) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakeCorruptKafkaBatchReadResult(10)},
+            "user",
+            7,
+            10)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
+        UNIT_ASSERT(results.Get(0).GetIsBatch());
+        UNIT_ASSERT(env.Runtime.FindActor(actor));
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(env.Edge, {MakePlainReadResult(11, "ok")})));
+        UNIT_ASSERT_VALUES_EQUAL(GetCmdReadResult(env.Grab<TEvProcessBatchResult>()->Get()->Context).GetResult().size(), 1);
+    }
+
+    Y_UNIT_TEST(UnsupportedSnappyKafkaBatchKeepsOriginalAndReplies) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakeCorruptKafkaBatchReadResult(10, MakeSnappyKafkaBatchPayload())},
+            "user",
+            7,
+            10)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+        UNIT_ASSERT(results.Get(0).GetIsBatch());
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
+    }
+
+    Y_UNIT_TEST(TruncatedKafkaBatchKeepsOriginalAndReplies) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        const auto truncated = MakeKafkaBatchPayload().substr(0, 8);
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakeCorruptKafkaBatchReadResult(12, truncated)},
+            "user",
+            7,
+            12)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+        UNIT_ASSERT(results.Get(0).GetIsBatch());
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 12u);
+    }
+
+    Y_UNIT_TEST(CorruptKafkaBatchDoesNotPoisonTablet) {
+        TEnv env(true);
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakeCorruptKafkaBatchReadResult()},
+            "user",
+            7,
+            10)));
+
+        UNIT_ASSERT(env.Grab<TEvProcessBatchResult>());
+        UNIT_ASSERT(env.Runtime.FindActor(actor));
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(env.Edge, {MakePlainReadResult(11, "ok")})));
+        UNIT_ASSERT_VALUES_EQUAL(GetCmdReadResult(env.Grab<TEvProcessBatchResult>()->Get()->Context).GetResult().size(), 1);
+    }
+
+    Y_UNIT_TEST(CorruptKafkaBatchInTheMiddleKeepsCutPrefixAndOriginal) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {
+                MakeKafkaBatchReadResult(MakeKafkaBatchPayload(), 10),
+                MakeCorruptKafkaBatchReadResult(20),
+                MakePlainReadResult(30, "tail"),
+            },
+            "user",
+            7,
+            10)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
+        UNIT_ASSERT(!results.Get(0).GetIsBatch());
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(1).GetOffset(), 11u);
+        UNIT_ASSERT(!results.Get(1).GetIsBatch());
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(2).GetOffset(), 20u);
+        UNIT_ASSERT(results.Get(2).GetIsBatch());
+        UNIT_ASSERT_VALUES_EQUAL(results.Get(3).GetOffset(), 30u);
+        UNIT_ASSERT(!results.Get(3).GetIsBatch());
+    }
+
+    Y_UNIT_TEST(CorruptKafkaBatchKeysStillReplies) {
+        TEnv env;
+        const auto actor = env.RegisterConsumer();
+
+        TBatchKeysProcessingContext keys;
+        keys.PartitionId = 3;
+        keys.ResponseActor = env.Edge;
+        keys.Results = {
+            MakePlainReadResult(3, "plain", false, NKikimrPQClient::TDataChunk::REGULAR, {
+                {TString{MESSAGE_ATTRIBUTE_KEY}, "plain-key"},
+            }),
+            MakeCorruptKafkaBatchReadResult(10),
+            MakeKafkaBatchReadResult(MakeKafkaBatchPayload(), 20),
+        };
+
+        env.Send(actor, new TEvProcessBatchKeys(std::move(keys)));
+
+        const auto ev = env.Grab<TEvProcessBatchKeysResult>();
+        const auto& offsetToKey = ev->Get()->OffsetToKey;
+        UNIT_ASSERT_VALUES_EQUAL(offsetToKey.at(3u), "plain-key");
+        UNIT_ASSERT(!offsetToKey.contains(10u));
+        UNIT_ASSERT_VALUES_EQUAL(offsetToKey.at(20u), "k0");
+        UNIT_ASSERT_VALUES_EQUAL(offsetToKey.at(21u), "k1");
+        UNIT_ASSERT(env.Runtime.FindActor(actor));
+    }
+
+    Y_UNIT_TEST(CorruptKafkaBatchThroughBatchProcessorReplies) {
+        TEnv env(true);
+        const auto actor = env.RegisterBatchProcessor();
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakeCorruptKafkaBatchReadResult()},
+            "alice",
+            7,
+            10)));
+
+        const auto ev = env.Grab<TEvProcessBatchResult>();
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Context.User, "alice");
+        UNIT_ASSERT(GetCmdReadResult(ev->Get()->Context).GetResult().Get(0).GetIsBatch());
+        UNIT_ASSERT(env.Runtime.FindActor(actor));
+
+        env.Send(actor, new TEvProcessBatch(MakeReadContext(
+            env.Edge,
+            {MakePlainReadResult(11, "ok")},
+            "alice")));
+        UNIT_ASSERT_VALUES_EQUAL(GetCmdReadResult(env.Grab<TEvProcessBatchResult>()->Get()->Context).GetResult().size(), 1);
     }
 
     Y_UNIT_TEST(ProcessBatchKeysCollectsPlainAndKafkaKeys) {

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_processor_ut.cpp
@@ -6,9 +6,11 @@
 #include <ydb/core/testlib/basics/appdata.h>
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/library/actors/core/events.h>
+#include <ydb/library/services/services.pb.h>
 #include <ydb/public/sdk/cpp/src/library/kafka/kafka_messages_int.h>
 #include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
 
+#include <library/cpp/logger/stream.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/generic/string.h>
@@ -24,6 +26,7 @@ using NActors::IEventBase;
 using NActors::IEventHandle;
 using NActors::TActorId;
 using NActors::TEvents;
+using NActors::TTestActorRuntimeBase;
 using NActors::TTestBasicRuntime;
 
 NKafka::TKafkaRecord MakeKafkaRecord(
@@ -115,16 +118,6 @@ TReadResult MakeCorruptKafkaBatchReadResult(ui64 offset = 10, TString payload = 
     return MakeKafkaBatchReadResult(std::move(payload), offset);
 }
 
-TString MakeSnappyKafkaBatchPayload() {
-    auto payload = MakeKafkaBatchPayload();
-    // Kafka v2 attributes are int16 BE after baseOffset(8)+batchLength(4)+leaderEpoch(4)+magic(1)+crc(4).
-    constexpr size_t attributesOffset = 21;
-    UNIT_ASSERT(payload.size() > attributesOffset + 1);
-    payload[attributesOffset] = 0;
-    payload[attributesOffset + 1] = static_cast<char>(NKafka::ECompressionType::SNAPPY);
-    return payload;
-}
-
 TReadResult MakePlainReadResult(
     ui64 offset,
     TStringBuf payload,
@@ -192,18 +185,38 @@ const NKikimrClient::TCmdReadResult& GetCmdReadResult(const TReadProcessingConte
 }
 
 struct TEnv {
+    TStringStream Log;
     TTestBasicRuntime Runtime;
     TActorId Tablet;
     TActorId Edge;
+    bool TabletGotPoison = false;
 
     explicit TEnv(bool restartOnUnhandledExceptions = false)
         : Runtime(1, false)
     {
+        Runtime.SetLogBackend(new TStreamLogBackend(&Log));
         TAppPrepare app;
         app.FeatureFlags.SetEnableTabletRestartOnUnhandledExceptions(restartOnUnhandledExceptions);
         Runtime.Initialize(app.Unwrap());
+        Runtime.SetLogPriority(NKikimrServices::PERSQUEUE, NActors::NLog::PRI_ERROR);
         Tablet = Runtime.AllocateEdgeActor();
         Edge = Runtime.AllocateEdgeActor();
+        Runtime.SetObserverFunc([this](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetRecipientRewrite() == Tablet && ev->GetTypeRewrite() == TEvents::TEvPoison::EventType) {
+                TabletGotPoison = true;
+            }
+            return TTestActorRuntimeBase::EEventAction::PROCESS;
+        });
+    }
+
+    void AssertTabletDidNotRestart() {
+        UNIT_ASSERT_C(!TabletGotPoison, "tablet received TEvPoison and would restart");
+    }
+
+    void AssertUserErrorLogged(TStringBuf message) {
+        const TString log = Log.Str();
+        UNIT_ASSERT_STRING_CONTAINS(log, "errorType=user");
+        UNIT_ASSERT_STRING_CONTAINS(log, TString{message});
     }
 
     TActorId RegisterBatchProcessor() {
@@ -460,7 +473,7 @@ Y_UNIT_TEST_SUITE(TConsumerBatchProcessorTest) {
     }
 
     Y_UNIT_TEST(CorruptKafkaBatchKeepsOriginalAndReplies) {
-        TEnv env;
+        TEnv env(true);
         const auto actor = env.RegisterConsumer();
 
         env.Send(actor, new TEvProcessBatch(MakeReadContext(
@@ -476,9 +489,13 @@ Y_UNIT_TEST_SUITE(TConsumerBatchProcessorTest) {
         UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
         UNIT_ASSERT(results.Get(0).GetIsBatch());
         UNIT_ASSERT(env.Runtime.FindActor(actor));
+        env.AssertTabletDidNotRestart();
+        env.AssertUserErrorLogged("Failed to cut kafka batch, keeping original result");
 
         env.Send(actor, new TEvProcessBatch(MakeReadContext(env.Edge, {MakePlainReadResult(11, "ok")})));
         UNIT_ASSERT_VALUES_EQUAL(GetCmdReadResult(env.Grab<TEvProcessBatchResult>()->Get()->Context).GetResult().size(), 1);
+        UNIT_ASSERT(env.Runtime.FindActor(actor));
+        env.AssertTabletDidNotRestart();
     }
 
     Y_UNIT_TEST(NegativeOffsetDeltaKeepsOriginalAndDoesNotPoisonTablet) {
@@ -498,85 +515,8 @@ Y_UNIT_TEST_SUITE(TConsumerBatchProcessorTest) {
         UNIT_ASSERT(results.Get(0).GetIsBatch());
         UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
         UNIT_ASSERT(env.Runtime.FindActor(actor));
-    }
-
-    Y_UNIT_TEST(ProcessBatchKeepsPlainPrefixWhenLaterBatchIsCorrupt) {
-        TEnv env;
-        const auto actor = env.RegisterConsumer();
-
-        env.Send(actor, new TEvProcessBatch(MakeReadContext(
-            env.Edge,
-            {
-                MakePlainReadResult(10, "keep-me"),
-                MakeCorruptKafkaBatchReadResult(20),
-            },
-            "user",
-            7,
-            10)));
-
-        const auto ev = env.Grab<TEvProcessBatchResult>();
-        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
-        UNIT_ASSERT_VALUES_EQUAL(results.size(), 2);
-        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
-        const auto chunk0 = NKikimr::GetDeserializedData(results.Get(0).GetData());
-        UNIT_ASSERT_VALUES_EQUAL(chunk0.GetData(), "keep-me");
-        UNIT_ASSERT_VALUES_EQUAL(results.Get(1).GetOffset(), 20u);
-        UNIT_ASSERT(results.Get(1).GetIsBatch());
-    }
-
-    Y_UNIT_TEST(UnsupportedSnappyKafkaBatchKeepsOriginalAndReplies) {
-        TEnv env;
-        const auto actor = env.RegisterConsumer();
-
-        env.Send(actor, new TEvProcessBatch(MakeReadContext(
-            env.Edge,
-            {MakeCorruptKafkaBatchReadResult(10, MakeSnappyKafkaBatchPayload())},
-            "user",
-            7,
-            10)));
-
-        const auto ev = env.Grab<TEvProcessBatchResult>();
-        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
-        UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
-        UNIT_ASSERT(results.Get(0).GetIsBatch());
-        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 10u);
-    }
-
-    Y_UNIT_TEST(TruncatedKafkaBatchKeepsOriginalAndReplies) {
-        TEnv env;
-        const auto actor = env.RegisterConsumer();
-
-        const auto truncated = MakeKafkaBatchPayload().substr(0, 8);
-        env.Send(actor, new TEvProcessBatch(MakeReadContext(
-            env.Edge,
-            {MakeCorruptKafkaBatchReadResult(12, truncated)},
-            "user",
-            7,
-            12)));
-
-        const auto ev = env.Grab<TEvProcessBatchResult>();
-        const auto& results = GetCmdReadResult(ev->Get()->Context).GetResult();
-        UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
-        UNIT_ASSERT(results.Get(0).GetIsBatch());
-        UNIT_ASSERT_VALUES_EQUAL(results.Get(0).GetOffset(), 12u);
-    }
-
-    Y_UNIT_TEST(CorruptKafkaBatchDoesNotPoisonTablet) {
-        TEnv env(true);
-        const auto actor = env.RegisterConsumer();
-
-        env.Send(actor, new TEvProcessBatch(MakeReadContext(
-            env.Edge,
-            {MakeCorruptKafkaBatchReadResult()},
-            "user",
-            7,
-            10)));
-
-        UNIT_ASSERT(env.Grab<TEvProcessBatchResult>());
-        UNIT_ASSERT(env.Runtime.FindActor(actor));
-
-        env.Send(actor, new TEvProcessBatch(MakeReadContext(env.Edge, {MakePlainReadResult(11, "ok")})));
-        UNIT_ASSERT_VALUES_EQUAL(GetCmdReadResult(env.Grab<TEvProcessBatchResult>()->Get()->Context).GetResult().size(), 1);
+        env.AssertTabletDidNotRestart();
+        env.AssertUserErrorLogged("Failed to cut kafka batch, keeping original result");
     }
 
     Y_UNIT_TEST(CorruptKafkaBatchInTheMiddleKeepsCutPrefixAndOriginal) {
@@ -631,11 +571,20 @@ Y_UNIT_TEST_SUITE(TConsumerBatchProcessorTest) {
         UNIT_ASSERT_VALUES_EQUAL(offsetToKey.at(20u), "k0");
         UNIT_ASSERT_VALUES_EQUAL(offsetToKey.at(21u), "k1");
         UNIT_ASSERT(env.Runtime.FindActor(actor));
+        env.AssertTabletDidNotRestart();
+        env.AssertUserErrorLogged("Failed to get keys from kafka batch");
     }
 
     Y_UNIT_TEST(CorruptKafkaBatchThroughBatchProcessorReplies) {
         TEnv env(true);
         const auto actor = env.RegisterBatchProcessor();
+        TActorId consumer;
+        env.Runtime.SetRegistrationObserverFunc([&](TTestActorRuntimeBase& runtime, const TActorId& parent, const TActorId& child) {
+            TTestActorRuntimeBase::DefaultRegistrationObserver(runtime, parent, child);
+            if (parent == actor) {
+                consumer = child;
+            }
+        });
 
         env.Send(actor, new TEvProcessBatch(MakeReadContext(
             env.Edge,
@@ -648,12 +597,19 @@ Y_UNIT_TEST_SUITE(TConsumerBatchProcessorTest) {
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Context.User, "alice");
         UNIT_ASSERT(GetCmdReadResult(ev->Get()->Context).GetResult().Get(0).GetIsBatch());
         UNIT_ASSERT(env.Runtime.FindActor(actor));
+        UNIT_ASSERT(consumer);
+        UNIT_ASSERT(env.Runtime.FindActor(consumer));
+        env.AssertTabletDidNotRestart();
+        env.AssertUserErrorLogged("Failed to cut kafka batch, keeping original result");
 
         env.Send(actor, new TEvProcessBatch(MakeReadContext(
             env.Edge,
             {MakePlainReadResult(11, "ok")},
             "alice")));
         UNIT_ASSERT_VALUES_EQUAL(GetCmdReadResult(env.Grab<TEvProcessBatchResult>()->Get()->Context).GetResult().size(), 1);
+        UNIT_ASSERT(env.Runtime.FindActor(actor));
+        UNIT_ASSERT(env.Runtime.FindActor(consumer));
+        env.AssertTabletDidNotRestart();
     }
 
     Y_UNIT_TEST(ProcessBatchKeysCollectsPlainAndKafkaKeys) {

--- a/ydb/core/persqueue/pqtablet/batching/ut/ya.make
+++ b/ydb/core/persqueue/pqtablet/batching/ut/ya.make
@@ -1,13 +1,23 @@
 UNITTEST_FOR(ydb/core/persqueue/pqtablet/batching)
 
+SIZE(MEDIUM)
+
+YQL_LAST_ABI_VERSION()
+
 SRCS(
     batch_cutter_ut.cpp
+    batch_processor_ut.cpp
 )
 
 PEERDIR(
     library/cpp/streams/zstd
+    library/cpp/testing/unittest
+    ydb/core/base
+    ydb/core/persqueue/events
     ydb/core/persqueue/public/write_meta
     ydb/core/protos
+    ydb/core/testlib/basics
+    ydb/core/testlib/default
     ydb/public/sdk/cpp/src/library/kafka
 )
 

--- a/ydb/core/persqueue/pqtablet/batching/ut/ya.make
+++ b/ydb/core/persqueue/pqtablet/batching/ut/ya.make
@@ -10,6 +10,7 @@ SRCS(
 )
 
 PEERDIR(
+    library/cpp/logger
     library/cpp/streams/zstd
     library/cpp/testing/unittest
     ydb/core/base

--- a/ydb/core/persqueue/pqtablet/batching/ut/ya.make
+++ b/ydb/core/persqueue/pqtablet/batching/ut/ya.make
@@ -14,6 +14,7 @@ PEERDIR(
     library/cpp/testing/unittest
     ydb/core/base
     ydb/core/persqueue/events
+    ydb/core/persqueue/pqtablet/readproxy
     ydb/core/persqueue/public/write_meta
     ydb/core/protos
     ydb/core/testlib/basics

--- a/ydb/core/persqueue/pqtablet/batching/ut/ya.make
+++ b/ydb/core/persqueue/pqtablet/batching/ut/ya.make
@@ -14,7 +14,6 @@ PEERDIR(
     library/cpp/testing/unittest
     ydb/core/base
     ydb/core/persqueue/events
-    ydb/core/persqueue/pqtablet/readproxy
     ydb/core/persqueue/public/write_meta
     ydb/core/protos
     ydb/core/testlib/basics

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -115,14 +115,9 @@ private:
             ctx.Send(BatchProcessorActor, new NBatching::TEvProcessBatch(NBatching::TReadProcessingContext{
                 .User = cmdRead.GetClientId(),
                 .PartitionId = static_cast<ui32>(Request.GetPartitionRequest().GetPartition()),
-                .Destination = 0,
                 .Offset = InitialReadOffset,
                 .Count = cmdRead.HasCount() ? static_cast<ui32>(cmdRead.GetCount()) : std::numeric_limits<ui32>::max(),
                 .LastOffset = cmdRead.GetLastOffset() > 0 ? static_cast<ui64>(cmdRead.GetLastOffset()) : 0,
-                .PartNo = 0,
-                .Size = static_cast<ui64>(proxyEvent->Response->ByteSize()),
-                .IsInternal = false,
-                .ReplyTo = TActorId{},
                 .ResponseActor = SelfId(),
                 .Event = std::move(proxyEvent)}));
             return;

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -112,22 +112,19 @@ private:
             proxyEvent->Response->CopyFrom(responseRecord);
 
             const auto& cmdRead = Request.GetPartitionRequest().GetCmdRead();
-            ctx.Send(
-                BatchProcessorActor,
-                new NBatching::TEvProcessBatch(NBatching::TReadProcessingContext{
-                    .User = cmdRead.GetClientId(),
-                    .PartitionId = static_cast<ui32>(Request.GetPartitionRequest().GetPartition()),
-                    .Destination = 0,
-                    .Offset = InitialReadOffset,
-                    .Count = cmdRead.HasCount() ? static_cast<ui32>(cmdRead.GetCount()) : std::numeric_limits<ui32>::max(),
-                    .LastOffset = cmdRead.GetLastOffset() > 0 ? static_cast<ui64>(cmdRead.GetLastOffset()) : 0,
-                    .PartNo = 0,
-                    .Size = static_cast<ui64>(proxyEvent->Response->ByteSize()),
-                    .IsInternal = false,
-                    .ReplyTo = TActorId{},
-                    .ResponseActor = SelfId(),
-                    .Event = std::move(proxyEvent)}),
-                IEventHandle::FlagTrackDelivery);
+            ctx.Send(BatchProcessorActor, new NBatching::TEvProcessBatch(NBatching::TReadProcessingContext{
+                .User = cmdRead.GetClientId(),
+                .PartitionId = static_cast<ui32>(Request.GetPartitionRequest().GetPartition()),
+                .Destination = 0,
+                .Offset = InitialReadOffset,
+                .Count = cmdRead.HasCount() ? static_cast<ui32>(cmdRead.GetCount()) : std::numeric_limits<ui32>::max(),
+                .LastOffset = cmdRead.GetLastOffset() > 0 ? static_cast<ui64>(cmdRead.GetLastOffset()) : 0,
+                .PartNo = 0,
+                .Size = static_cast<ui64>(proxyEvent->Response->ByteSize()),
+                .IsInternal = false,
+                .ReplyTo = TActorId{},
+                .ResponseActor = SelfId(),
+                .Event = std::move(proxyEvent)}));
             return;
         }
 
@@ -381,23 +378,10 @@ private:
         PassAway();
     }
 
-    void Handle(TEvents::TEvUndelivered::TPtr&, const TActorContext& ctx)
-    {
-        YDB_LOG_ERROR("Batch processor is unavailable",
-            {"logPrefix", NPQ_LOG_PREFIX});
-        AFL_ENSURE(Response);
-        Response->Record.SetStatus(NMsgBusProxy::MSTATUS_ERROR);
-        Response->Record.SetErrorCode(NPersQueue::NErrorCode::READ_NOT_DONE);
-        Response->Record.SetErrorReason("batch processor is unavailable");
-        ctx.Send(Sender, Response.Release());
-        PassAway();
-    }
-
     STFUNC(StateFunc) {
         switch (ev->GetTypeRewrite()) {
             HFunc(TEvPersQueue::TEvResponse, Handle);
             HFunc(NBatching::TEvProcessBatchResult, Handle);
-            HFunc(TEvents::TEvUndelivered, Handle);
         default:
             break;
         };

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -112,19 +112,22 @@ private:
             proxyEvent->Response->CopyFrom(responseRecord);
 
             const auto& cmdRead = Request.GetPartitionRequest().GetCmdRead();
-            ctx.Send(BatchProcessorActor, new NBatching::TEvProcessBatch(NBatching::TReadProcessingContext{
-                .User = cmdRead.GetClientId(),
-                .PartitionId = static_cast<ui32>(Request.GetPartitionRequest().GetPartition()),
-                .Destination = 0,
-                .Offset = InitialReadOffset,
-                .Count = cmdRead.HasCount() ? static_cast<ui32>(cmdRead.GetCount()) : std::numeric_limits<ui32>::max(),
-                .LastOffset = cmdRead.GetLastOffset() > 0 ? static_cast<ui64>(cmdRead.GetLastOffset()) : 0,
-                .PartNo = 0,
-                .Size = static_cast<ui64>(proxyEvent->Response->ByteSize()),
-                .IsInternal = false,
-                .ReplyTo = TActorId{},
-                .ResponseActor = SelfId(),
-                .Event = std::move(proxyEvent)}));
+            ctx.Send(
+                BatchProcessorActor,
+                new NBatching::TEvProcessBatch(NBatching::TReadProcessingContext{
+                    .User = cmdRead.GetClientId(),
+                    .PartitionId = static_cast<ui32>(Request.GetPartitionRequest().GetPartition()),
+                    .Destination = 0,
+                    .Offset = InitialReadOffset,
+                    .Count = cmdRead.HasCount() ? static_cast<ui32>(cmdRead.GetCount()) : std::numeric_limits<ui32>::max(),
+                    .LastOffset = cmdRead.GetLastOffset() > 0 ? static_cast<ui64>(cmdRead.GetLastOffset()) : 0,
+                    .PartNo = 0,
+                    .Size = static_cast<ui64>(proxyEvent->Response->ByteSize()),
+                    .IsInternal = false,
+                    .ReplyTo = TActorId{},
+                    .ResponseActor = SelfId(),
+                    .Event = std::move(proxyEvent)}),
+                IEventHandle::FlagTrackDelivery);
             return;
         }
 
@@ -378,10 +381,23 @@ private:
         PassAway();
     }
 
+    void Handle(TEvents::TEvUndelivered::TPtr&, const TActorContext& ctx)
+    {
+        YDB_LOG_ERROR("Batch processor is unavailable",
+            {"logPrefix", NPQ_LOG_PREFIX});
+        AFL_ENSURE(Response);
+        Response->Record.SetStatus(NMsgBusProxy::MSTATUS_ERROR);
+        Response->Record.SetErrorCode(NPersQueue::NErrorCode::READ_NOT_DONE);
+        Response->Record.SetErrorReason("batch processor is unavailable");
+        ctx.Send(Sender, Response.Release());
+        PassAway();
+    }
+
     STFUNC(StateFunc) {
         switch (ev->GetTypeRewrite()) {
             HFunc(TEvPersQueue::TEvResponse, Handle);
             HFunc(NBatching::TEvProcessBatchResult, Handle);
+            HFunc(TEvents::TEvUndelivered, Handle);
         default:
             break;
         };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

A corrupt Kafka record batch no longer crashes the topic tablet; the original batch is returned to the reader.

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Catch cutter / `GetKeys` exceptions in `TConsumerBatchProcessor` and reply with the original result (or collected keys) instead of poisoning the tablet.
- Treat a negative Kafka `offsetDelta` as corrupt client data instead of wrapping `ui64`.
- Stop copying the full Kafka payload for every cut record; `TBatchCutterData` takes ownership of `TDataChunk`.
- Identify `TBatchProcessor` in logs by actor type and `SelfId`.
- Drop unused `TReadProcessingContext` fields and unreachable branches.
- Add actor and cutter unit tests for the production event paths.
