### PR TITLE
ydb-bench: expose shared threads and united pool settings

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -86,6 +86,9 @@ local-ydb:
       max-dynamic-nodes: 8
       disk-size-gb: 64
       storage-groups: 1
+    actor-system:
+      use-shared-threads: false
+      use-united-pool: false
     client:
       threads: 64
     load:
@@ -124,6 +127,14 @@ ties prefer fewer dynamic nodes.
 Each static node gets its own `NONE`-profile SectorMap with the virtual size
 specified by `disk-size-gb`, so benchmark results are not limited by a host
 block device.
+
+`actor-system.use-shared-threads` and `actor-system.use-united-pool` are
+independent boolean switches (both default to `false`). They set YDBD's
+`use_shared_threads` and `use_united_pool` in `actor_system_config` for all
+static and dynamic nodes, including scaled and verification clusters, while
+keeping automatic pool sizing enabled. They do not affect the YDB CLI.
+The Builder exposes both switches; saved profile parameters and comparisons
+retain their values.
 
 An explicitly configured profile `timeout` caps every YDB CLI setup, warmup,
 measurement, and cleanup command. Workload-specific safety limits still apply

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -120,6 +120,14 @@ def _profile_schema(benchmark):
             "required": ["workload", "load"],
             "properties": {
                 "workload": workload_config_schema(),
+                "actor-system": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "use-shared-threads": {"type": "boolean", "default": False},
+                        "use-united-pool": {"type": "boolean", "default": False},
+                    },
+                },
                 "geometry": {
                     "type": "object",
                     "additionalProperties": False,
@@ -534,12 +542,24 @@ def _local_role_affinity(value, location, default_mode, default_cpus=None):
 
 def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_frequency):
     location = "{}.{}".format(benchmark.name, profile_name)
-    value = _mapping(value, location, ("workload", "geometry", "client", "load", "measurement", "affinity", "timeout"))
+    value = _mapping(
+        value,
+        location,
+        ("workload", "geometry", "actor-system", "client", "load", "measurement", "affinity", "timeout"),
+    )
     if perf_enabled:
         _config_error(location, "does not support --perf; CPU utilization is collected per process role")
 
     workload = normalize_workload(value.get("workload"), location + ".workload")
     workload_metadata = workload_definition(workload["type"])
+
+    actor_system = _mapping(
+        value.get("actor-system"), location + ".actor-system", ("use-shared-threads", "use-united-pool")
+    )
+    actor_system_config = {
+        name.replace("-", "_"): _boolean(actor_system.get(name, False), location + ".actor-system." + name)
+        for name in ("use-shared-threads", "use-united-pool")
+    }
 
     geometry = _mapping(
         value.get("geometry"),
@@ -842,6 +862,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
             "local_ydb": {
                 "workload": workload,
                 "geometry": geometry_config,
+                "actor_system": actor_system_config,
                 "client": {"threads": client_threads},
                 "load": load_config,
                 "measurement": measurement_config,

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -230,7 +230,7 @@ def _sector_map_path(index, disk_size_gb):
     return "SectorMap:map_{}:{}:NONE".format(index, disk_size_gb)
 
 
-def _cluster_config(static_nodes, disk_size_gb, hostname=None):
+def _cluster_config(static_nodes, disk_size_gb, hostname=None, actor_system=None):
     # Nameservice and NodeBroker identify a node by its real host name.  Using
     # localhost here prevents a dynamic node from registering as a compute
     # unit of the tenant even when all processes run on the same machine.
@@ -270,6 +270,12 @@ def _cluster_config(static_nodes, disk_size_gb, hostname=None):
             "host_configs": host_configs,
             "hosts": hosts,
             "domains_config": {"domain": [{"domain_id": 1, "name": "Root"}]},
+            "actor_system_config": {
+                # An explicit actor-system config must retain automatic pool sizing.
+                "use_auto_config": True,
+                "use_shared_threads": (actor_system or {}).get("use_shared_threads", False),
+                "use_united_pool": (actor_system or {}).get("use_united_pool", False),
+            },
         },
     }
 
@@ -286,6 +292,7 @@ class LocalYdbCluster:
         timeout,
         cancel_event=None,
         progress=None,
+        actor_system=None,
     ):
         self.ydbd = Path(ydbd)
         self.ydb_cli = Path(ydb_cli)
@@ -296,6 +303,7 @@ class LocalYdbCluster:
         self.timeout = timeout
         self.cancel_event = cancel_event
         self.progress = progress
+        self.actor_system = dict(actor_system or {})
         self.static_processes = []
         self.dynamic_processes = []
         self.port_candidates = _mnc_port_candidates()
@@ -583,7 +591,9 @@ class LocalYdbCluster:
         for index, node in enumerate(self.static_nodes, 1):
             node_directory = self.directory / "static-{:02d}".format(index)
             node_directory.mkdir()
-        cluster_config = _cluster_config(self.static_nodes, self.geometry["disk_size_gb"], self.hostname)
+        cluster_config = _cluster_config(
+            self.static_nodes, self.geometry["disk_size_gb"], self.hostname, self.actor_system
+        )
         atomic_write_text(self.config_path, yaml.safe_dump(cluster_config, sort_keys=False))
         self._progress("starting-static-nodes", static_nodes=len(self.static_nodes))
         for index, (node, mask) in enumerate(zip(self.static_nodes, self.static_masks), 1):
@@ -1498,6 +1508,7 @@ def run_local_ydb(
             configuration.timeout_seconds,
             cancel_event,
             publish_progress,
+            actor_system=profile.get("actor_system"),
         )
 
     def create_lifecycle(target_cluster):

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -248,6 +248,7 @@ _JS = (
     "function yamlScalar(value){return typeof value==='string'?JSON.stringify(value):String(value)}\n"
     "const localYdbGeometryKeys={static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes',max_dynamic_nodes:'max-dynamic-"
     "nodes',disk_size_gb:'disk-size-gb',storage_groups:'storage-groups'};\n"
+    "const localYdbActorSystemKeys={use_shared_threads:'use-shared-threads',use_united_pool:'use-united-pool'};\n"
     "const localYdbSearchKeys={resolution_percent:'resolution-percent'};\n"
     "const localYdbObjectiveKeys={target_role:'target-role',plateau_gain_percent:'plateau-gain-percent',plateau_points:'p"
     "lateau-points',cpu_saturation_percent:'cpu-saturation-percent'};\n"
@@ -341,6 +342,7 @@ function localYdbLoadForWorkload(load,parameters,definition=null,workload=null){
     "option.operation_defaults,operation)?option.operation_defaults[operation]:option.default]));return {type,operation,opt"
     "ions}}\n"
     "function defaultLocalYdb(){const definition=localYdbWorkloadDefinition('kv');return {workload:defaultLocalYdbWorkload('kv'),"
+    "actor_system:{use_shared_threads:false,use_united_pool:false},"
     "geometry:{preset:'single',static_nodes:1,dynamic_nodes:1,max_dynamic_nodes:1,disk_size_gb:64,storage_groups:1},client"
     ":{threads:localYdbDefaultClientThreads(definition)},load:{parameter:'rate',allow_errors:false,values:[1000]},measurement:{warmup:localYdbDefaultWarmupSeconds(definition),duration:30,rep"
     "etitions:3,verification_repetitions:3},affinity:{ydb_cli:{mode:'pack-numa-pack-chiplet-spread-core',cpus:'one-chiplet'},static_nodes:{mode:'none'"
@@ -349,7 +351,10 @@ function localYdbLoadForWorkload(load,parameters,definition=null,workload=null){
     "load:','      type: '+workload.type,'      operation: '+workload.operation,'      options:');for(const [key,value] of "
     "Object.entries(workload.options))lines.push('        '+key+': '+yamlScalar(value));lines.push('    geometry:','      preset: '+conf"
     "ig.geometry.preset);for(const [key,yamlKey] of Object.entries(localYdbGeometryKeys))lines.push('      '+yamlKey+': '+c"
-    "onfig.geometry[key]);lines.push('    client:','      threads: '+config.client.threads,'    load:','      parameter: '"
+    "onfig.geometry[key]);lines.push('    actor-system:');"
+    "for(const [key,yamlKey] of Object.entries(localYdbActorSystemKeys))"
+    "lines.push('      '+yamlKey+': '+Boolean(config.actor_system?.[key]));"
+    "lines.push('    client:','      threads: '+config.client.threads,'    load:','      parameter: '"
     "+config.load.parameter,'      allow-errors: '+Boolean(config.load.allow_errors));if(config.load.values)lines.push('      values: '+yamlArray(config.load.values));else{lines."
     "push('      search:','        start: '+config.load.search.start,'        maximum: '+config.load.search.maximum);if("
     "config.load.objective.type==='latency-slo')lines.push('        multiplier: '+config.load.search.multiplier);for("
@@ -489,6 +494,8 @@ function localYdbProfileEditor(profile){
   const options=definition.options.map(option=>localYdbOptionField(option,workload.options[option.name])).join('');
   const geometryFields=Object.entries(localYdbGeometryKeys)
     .map(([key,label])=>localField('local-geometry-'+key,label,geometry[key],'','type=number min=1')).join('');
+  const actorSystemFields=Object.keys(localYdbActorSystemKeys)
+    .map(key=>localCheck('local-actor-system-'+key,key,Boolean(config.actor_system?.[key]),'')).join('');
   const loadCommon=
     localSelect('local-load-mode','Objective',loadMode,objectiveChoices)+
     localSelect('local-load-parameter','Parameter',load.parameter,definition.load_parameters)+
@@ -552,6 +559,7 @@ function localYdbProfileEditor(profile){
       'local-workload-operation','Operation',workload.operation,definition.operations
     )+options+'</div><h3>Cluster geometry</h3><div class=form-grid>'+
     localSelect('local-geometry-preset','Preset',geometry.preset,['single','storage','custom'])+geometryFields+
+    '</div><h3>Actor system (static and dynamic nodes)</h3><div class=form-grid>'+actorSystemFields+
     '</div><h3>Client and load</h3><div class=form-grid>'+
     localField('local-client-threads','YDB CLI threads',config.client.threads,clientThreadsHelp,'type=number min=1')+
     loadCommon+loadFields+'</div>'+slo+'<h3>Measurement</h3><div class=form-grid>'+
@@ -699,6 +707,9 @@ function bindLocalYdbEditor(profile){
       config.geometry.dynamic_nodes=1;config.geometry.max_dynamic_nodes=1
     }
     config.client.threads=localInteger('local-client-threads');
+    config.actor_system=Object.fromEntries(Object.keys(localYdbActorSystemKeys).map(key=>[
+      key,Boolean(document.querySelector('#local-actor-system-'+key)?.checked)
+    ]));
     const loadMode=document.querySelector('#local-load-mode').value;
     const parameter=document.querySelector('#local-load-parameter').value;
     const allow_errors=Boolean(document.querySelector('#local-load-allow-errors')?.checked);
@@ -1229,6 +1240,8 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     "    'Objective':objective.type??'points','Warmup seconds':warmup,\n"
     "    'Duration seconds':measurement.duration??'—','Repetitions':measurement.repetitions??'—',\n"
     "    'Verification repetitions':measurement.verification_repetitions??0,\n"
+    "    'use_shared_threads':parameters.actor_system?.use_shared_threads??false,\n"
+    "    'use_united_pool':parameters.actor_system?.use_united_pool??false,\n"
     "    'Geometry preset':geometry.preset??'—','Static nodes':geometry.static_nodes??'—',\n"
     "    'Initial dynamic nodes':geometry.dynamic_nodes??'—','Maximum dynamic nodes':geometry.max_dynamic_nodes??'—',\n"
     "    'Storage groups':geometry.storage_groups??'—','Disk size GiB':geometry.disk_size_gb??'—','YDB CLI threads':client.threads??'—',\n"
@@ -3958,6 +3971,7 @@ class RunService:
                 ),
             )
             client = project(value.get("client"), ("threads",))
+            actor_system = project(value.get("actor_system"), ("use_shared_threads", "use_united_pool"))
             load = project(value.get("load"), ("parameter", "allow_errors", "values", "search", "objective"))
             measurement = project(
                 value.get("measurement"),
@@ -3969,6 +3983,7 @@ class RunService:
                 for name, item in (
                     ("workload", workload),
                     ("geometry", geometry),
+                    ("actor_system", actor_system),
                     ("client", client),
                     ("load", load),
                     ("measurement", measurement),

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -1103,6 +1103,7 @@ class YdbBenchTest(unittest.TestCase):
             local-ydb:
               geometry-best:
                 workload: {type: kv, operation: upsert}
+                actor-system: {use-shared-threads: true, use-united-pool: true}
                 geometry: {preset: storage, static-nodes: 1, dynamic-nodes: 1, max-dynamic-nodes: 2}
                 load: {parameter: threads, values: [1]}
                 measurement: {warmup: 0, duration: 1, repetitions: 1, verification-repetitions: 2}
@@ -1136,6 +1137,9 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(manifest["verification"]["cluster"], "fresh")
         self.assertEqual(manifest["verification"]["dynamic_nodes"], 1)
         self.assertEqual(self.last_local_ydb_cluster_constructor.call_count, 2)
+        for call in self.last_local_ydb_cluster_constructor.call_args_list:
+            self.assertEqual(call.kwargs["actor_system"], {"use_shared_threads": True, "use_united_pool": True})
+        self.assertEqual(manifest["parameters"]["actor_system"], {"use_shared_threads": True, "use_united_pool": True})
         verification_cluster = self.last_local_ydb_cluster_constructor.call_args_list[1]
         self.assertEqual(verification_cluster.args[3], self.root / "geometry-best" / "verification-cluster")
         self.assertEqual(verification_cluster.args[4]["dynamic_nodes"], 1)
@@ -2169,6 +2173,80 @@ class YdbBenchTest(unittest.TestCase):
                     )
                 )
 
+    def test_local_ydb_actor_system_flags_default_and_validate(self):
+        profile = {"workload": {"type": "kv", "operation": "upsert"}, "load": {"parameter": "threads", "values": [1]}}
+
+        def load():
+            return load_config(self._config(yaml.safe_dump({"local-ydb": {"flags": profile}}))).runs[0]
+
+        self.assertEqual(
+            load().parameters["local_ydb"]["actor_system"],
+            {
+                "use_shared_threads": False,
+                "use_united_pool": False,
+            },
+        )
+        for shared in (False, True):
+            for united in (False, True):
+                with self.subTest(shared=shared, united=united):
+                    profile["actor-system"] = {"use-shared-threads": shared, "use-united-pool": united}
+                    flags = load().parameters["local_ydb"]["actor_system"]
+                    self.assertEqual(flags, {"use_shared_threads": shared, "use_united_pool": united})
+                    cluster = local_ydb._cluster_config([{"ic_port": 19001}], 64, "host", flags)
+                    self.assertEqual(cluster["config"]["actor_system_config"], {"use_auto_config": True, **flags})
+        for key in ("use-shared-threads", "use-united-pool"):
+            for value in (0, 1, "true", "false", None, [], {}):
+                with self.subTest(key=key, value=value):
+                    profile["actor-system"] = {key: value}
+                    with self.assertRaisesRegex(BenchmarkError, "actor-system.*must be a boolean"):
+                        load()
+        profile["actor-system"] = {"unknown": True}
+        with self.assertRaisesRegex(BenchmarkError, "unknown fields"):
+            load()
+
+    @unittest.skipUnless(shutil.which("node"), "node is required for browser logic checks")
+    def test_local_ydb_actor_system_builder_round_trip_and_comparison(self):
+        loaded = load_config(self._config("""
+            local-ydb:
+              flags:
+                workload: {type: stock, operation: put-rand-order}
+                load: {parameter: threads, values: [1]}
+                actor-system: {use-shared-threads: true, use-united-pool: false}
+        """))
+        model = web.editor_model(loaded, self.root / "results")
+        script = "const editor={model:" + json.dumps(model) + "};\n"
+        script += web._JS[web._JS.index("function yamlArray") : web._JS.index("async function syncEditor")]
+        script += web._JS[
+            web._JS.index("function localComparisonConfig") : web._JS.index("function localComparisonSemantic")
+        ]
+        script += """
+            const profile=editor.model.profiles[0], yaml=[];
+            serializeLocalYdb(yaml,profile);
+            const old={parameters:{}},current={parameters:profile.local_ydb};
+            process.stdout.write(JSON.stringify({
+              yaml:'local-ydb:\\n  flags:\\n'+yaml.join('\\n'),
+              defaults:defaultLocalYdb().actor_system,
+              old:localComparisonConfig(old),current:localComparisonConfig(current)
+            }));
+        """
+        result = json.loads(
+            subprocess.run(
+                [shutil.which("node"), "-e", script],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            ).stdout
+        )
+        flags = loaded.runs[0].parameters["local_ydb"]["actor_system"]
+        self.assertEqual(
+            load_config(self._config(result["yaml"])).runs[0].parameters["local_ydb"]["actor_system"], flags
+        )
+        self.assertEqual(result["defaults"], {"use_shared_threads": False, "use_united_pool": False})
+        self.assertFalse(result["old"]["use_shared_threads"])
+        self.assertTrue(result["current"]["use_shared_threads"])
+        self.assertFalse(result["current"]["use_united_pool"])
+
     def test_local_ydb_profile_is_editable_by_web_builder(self):
         loaded = load_config(self._config("""
             local-ydb:
@@ -2915,6 +2993,7 @@ class YdbBenchTest(unittest.TestCase):
             const esc=value=>String(value??'');
             const localYdbGeometryKeys={static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes',max_dynamic_nodes:'max-dynamic-nodes',disk_size_gb:'disk-size-gb',storage_groups:'storage-groups'};
             const localYdbAffinityKeys={ydb_cli:'ydb-cli',static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes'};
+            const localYdbActorSystemKeys={use_shared_threads:'use-shared-threads',use_united_pool:'use-united-pool'};
             const definition={type:'fake',operations:['run'],load_parameters:['rate'],options:[],
               slo_metrics:{p90:'latency_ms'},reports_errors:false,minimum_duration_seconds:1,
               maximum_total_seconds:3600};
@@ -4311,6 +4390,41 @@ class YdbBenchTest(unittest.TestCase):
         config = yaml.safe_load((cluster_directory / "cluster.yaml").read_text(encoding="utf-8"))
         self.assertEqual(config["config"]["host_configs"][0]["ssd"], ["SectorMap:map_0:64:NONE"])
         self.assertEqual(start_process.call_args.kwargs["parent_death_wrapper"], self.root / "process_guard")
+
+    def test_local_ydb_actor_system_config_is_used_by_static_dynamic_and_scaled_nodes(self):
+        flags = {"use_shared_threads": True, "use_united_pool": True}
+        cluster = local_ydb.LocalYdbCluster(
+            self.root / "ydbd",
+            self.root / "ydb",
+            self.root / "process_guard",
+            self.root / "flags-cluster",
+            {"static_nodes": 1, "dynamic_nodes": 1, "disk_size_gb": 64},
+            {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+            30,
+            actor_system=flags,
+        )
+        nodes = [{"grpc_port": 2135 + i, "ic_port": 19001 + i, "mon_port": 8765 + i} for i in range(3)]
+        with mock.patch.object(cluster, "_node_ports", side_effect=nodes), mock.patch.object(
+            cluster, "_wait_for_port"
+        ), mock.patch.object(cluster, "_bootstrap_cluster"), mock.patch.object(
+            cluster, "_create_tenant"
+        ), mock.patch.object(
+            cluster, "_wait_database_ready"
+        ), mock.patch.object(
+            cluster, "_wait_tenant_ready"
+        ), mock.patch.object(
+            cluster, "_wait_client_endpoints"
+        ), mock.patch.object(
+            local_ydb, "start_managed_process", return_value=mock.Mock(pid=1)
+        ) as start_process:
+            cluster.start()
+            cluster.add_dynamic_nodes(1)
+        self.assertEqual(start_process.call_count, 3)
+        for call in start_process.call_args_list:
+            command = call.args[0]
+            self.assertEqual(command[command.index("--yaml-config") + 1], cluster.config_path)
+        config = yaml.safe_load(cluster.config_path.read_text(encoding="utf-8"))
+        self.assertEqual(config["config"]["actor_system_config"], {"use_auto_config": True, **flags})
 
     def test_local_ydb_scaling_waits_for_database_and_every_new_node(self):
         cluster_directory = self.root / "scaling-cluster"
@@ -6934,6 +7048,14 @@ class WebTest(unittest.TestCase):
     def test_local_ydb_comparison_returns_bounded_profile_results(self):
         self._local_ydb_result(self.root / "baseline", 1000, verified=True)
         self._local_ydb_result(self.root / "candidate", 1100, operation="mixed")
+        manifest_path = self.root / "candidate" / "local-ydb" / "capacity" / "run.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["parameters"]["actor_system"] = {
+            "use_shared_threads": True,
+            "use_united_pool": False,
+            "private": "not projected",
+        }
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
         service = RunService(self.root)
         try:
             comparison = service.local_ydb_comparison(["baseline", "candidate"])
@@ -6957,6 +7079,13 @@ class WebTest(unittest.TestCase):
             self.assertEqual(comparison["entries"][0]["verification"]["cluster"], "search")
             self.assertNotIn("samples", comparison["entries"][0]["verification"])
             self.assertEqual(comparison["entries"][1]["parameters"]["workload"]["operation"], "mixed")
+            self.assertEqual(
+                comparison["entries"][1]["parameters"]["actor_system"],
+                {
+                    "use_shared_threads": True,
+                    "use_united_pool": False,
+                },
+            )
             with self.assertRaisesRegex(BenchmarkError, "between 1 and 20"):
                 service.local_ydb_comparison([])
             with self.assertRaisesRegex(BenchmarkError, "between 1 and 20"):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Allow local YDB benchmarks to configure shared threads and the united pool through YAML and the web Builder.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add independent use-shared-threads and use-united-pool switches under actor-system, both disabled by default. Apply them to static and dynamic nodes, including scaled nodes and verification clusters, while keeping automatic pool sizing enabled. Preserve the settings in profile manifests and display them in run comparisons.