### PR TITLE
ydb workload sqs: size HTTP connection pool as 4 × workers

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/sqs_workload/sqs_workload_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/sqs_workload/sqs_workload_scenario.cpp
@@ -59,6 +59,7 @@ namespace NYdb::NConsoleClient {
             Aws::String(Endpoint.c_str(), Endpoint.size());
         sqsClientConfiguration.scheme = Aws::Http::Scheme::HTTP;
         sqsClientConfiguration.httpRequestTimeoutMs = RequestTimeoutMs;
+        sqsClientConfiguration.maxConnections = WorkersCount * 4;
         sqsClientConfiguration.executor =
             Aws::MakeShared<Aws::Utils::Threading::PooledThreadExecutor>(
                 "pooled-thread-executor", WorkersCount);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

`ydb workload sqs run write|read` now opens `4 * workers` HTTP connections instead of the AWS SDK default of 25, so `--workers` can actually raise concurrency.

### Description for reviewers <!-- (optional) description for those who read this PR -->

AWS C++ SDK `ClientConfiguration::maxConnections` defaults to 25. The SQS workload never set it, so `--workers 500` still ran over 25 TCP connections and throughput stayed around that cap.

Set `maxConnections = WorkersCount * 4` in `InitSqsClient`. The writer/reader keep up to `2 * workers` requests in flight; `* 4` leaves room for retries and curl handle reuse. No new CLI flag.
