### PR TITLE
dq streamlookup join/kikimr lookup: inherit StatsMode from outer query

### DIFF
--- a/ydb/core/kqp/federated_query/actors/lookup_actor/kikimr_lookup_actor.cpp
+++ b/ydb/core/kqp/federated_query/actors/lookup_actor/kikimr_lookup_actor.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/formats/arrow/arrow_helpers.h>
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/core/grpc_services/local_rpc/local_rpc.h>
+#include <ydb/core/kqp/provider/yql_kikimr_provider.h>
 #include <ydb/core/protos/kqp_lookup_source.pb.h>
 #include <ydb/core/util/backoff.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
@@ -961,11 +962,21 @@ namespace {
                 tx_control.mutable_begin_tx()->mutable_snapshot_read_only();
                 tx_control.set_commit_tx(true);
             }
+            auto statsMode = Ydb::Query::STATS_MODE_NONE;
+            switch((NYql::EKikimrStatsMode)LookupSource.GetStatsMode()) {
+#define TRANSLATE(X, Y) \
+                case NYql::EKikimrStatsMode::X: \
+                    statsMode = Ydb::Query::STATS_MODE_##Y; \
+                    break
+                TRANSLATE(None, NONE);
+                TRANSLATE(Basic, BASIC);
+                TRANSLATE(Full, FULL);
+                TRANSLATE(Profile, PROFILE);
+#undef TRANSLATE
+            }
             YDB_LOG_DEBUG("QueryStatsMode",
                     COMMON_LOG,
-                    {"mode", (request.set_stats_mode(Ydb::Query::STATS_MODE_BASIC), "BASIC")}); // intentional side effects, order important
-            YDB_LOG_TRACE("QueryStatsMode",
-                    {"mode", (request.set_stats_mode(Ydb::Query::STATS_MODE_FULL), "FULL")}); // intentional side effects, order important
+                    {"mode", (request.set_stats_mode(statsMode), Ydb::Query::StatsMode_Name(statsMode))}); // intentional side effects, there are no point to collect stats unless we enabled debug logs
             YDB_LOG_TRACE("Query",
                     COMMON_LOG,
                     {"query", request.DebugString()});

--- a/ydb/core/kqp/federated_query/actors/lookup_actor/ya.make
+++ b/ydb/core/kqp/federated_query/actors/lookup_actor/ya.make
@@ -8,6 +8,7 @@ SRCS(
 PEERDIR(
     ydb/core/protos
     ydb/core/base
+    ydb/core/kqp/provider
     ydb/core/control/lib
     ydb/library/aclib/protos
     ydb/library/yql/dq/actors/compute

--- a/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
@@ -590,6 +590,7 @@ private:
         source.SetPath(path);
         source.SetToken(SessionCtx->GetUserToken() ? SessionCtx->GetUserToken()->SerializeAsString() : "");
         source.SetDatabase(SessionCtx->GetDatabase());
+        source.SetStatsMode((int)SessionCtx->Query().StatsMode);
 
         // preserve source description for read actor
         protoSettings.PackFrom(source);

--- a/ydb/core/protos/kqp_lookup_source.proto
+++ b/ydb/core/protos/kqp_lookup_source.proto
@@ -10,4 +10,5 @@ message TDqSourceKikimrLookupSource {
     string Path = 1;
     string Token = 2 [(Ydb.sensitive) = true];
     string Database = 3;
+    int32 StatsMode = 4;
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

Inherit StatsMode from parent query settings (still, ignore without at least debug logs, as stats are reported as debug logs only)
Alternative/Conflicts with #52481
YQ-5685