### PR TITLE
[SQS] Add database_id label to HTTP proxy metrics

### DIFF
--- a/ydb/core/http_proxy/sqs.cpp
+++ b/ydb/core/http_proxy/sqs.cpp
@@ -98,6 +98,7 @@ namespace NKikimr::NHttpProxy {
             }
 
             void SendGrpcRequestNoDriver(const TActorContext& ctx) {
+                ReportInputCounters(ctx);
                 YDB_LOG_INFO_CTX(ctx, "Sending grpc request to database: iam token",
                     {"logPrefix", LogPrefix()},
                     {"discoveryEndpoint", HttpContext.DiscoveryEndpoint},
@@ -143,13 +144,14 @@ namespace NKikimr::NHttpProxy {
                 Y_UNUSED(ev);
             }
 
-            void TryUpdateDbInfo(const TDatabase& db) {
+            void TryUpdateDbInfo(const TDatabase& db, const TActorContext& ctx) {
                 if (db.Path) {
                     HttpContext.DatabasePath = db.Path;
                     HttpContext.DatabaseId = db.Id;
                     HttpContext.CloudId = db.CloudId;
                     HttpContext.FolderId = db.FolderId;
                 }
+                ReportInputCounters(ctx);
             }
 
             void HandleSecurityTokenAuth(TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev, const TActorContext& ctx) {
@@ -186,18 +188,24 @@ namespace NKikimr::NHttpProxy {
                         return;
                     }
                 }
-                TryUpdateDbInfo(ev->Get()->Database);
+                TryUpdateDbInfo(ev->Get()->Database, ctx);
 
                 SendGrpcRequestNoDriver(ctx);
             }
 
             void HandleErrorWithIssue(TEvServerlessProxy::TEvErrorWithIssue::TPtr& ev, const TActorContext& ctx) {
-                TryUpdateDbInfo(ev->Get()->Database);
+                TryUpdateDbInfo(ev->Get()->Database, ctx);
                 ReplyWithYdbError(ctx, ev->Get()->Status, ev->Get()->Response, ev->Get()->IssueCode);
             }
 
             TVector<std::pair<TString, TString>> AddCommonLabels(TVector<std::pair<TString, TString>>&& labels) const {
-                return NSqsTopic::GetMetricsLabels(HttpContext.DatabasePath, TopicPath, ConsumerName, Method, std::move(labels));
+                return NSqsTopic::GetMetricsLabels(
+                    HttpContext.DatabasePath,
+                    TopicPath,
+                    ConsumerName,
+                    Method,
+                    std::move(labels),
+                    HttpContext.DatabaseId);
             }
 
             void ReplyWithYdbError(const TActorContext& ctx, NYdb::EStatus status, const TString& errorText, size_t issueCode = ISSUE_CODE_GENERIC) {
@@ -265,6 +273,7 @@ namespace NKikimr::NHttpProxy {
             void ReplyToHttpContext(THttpResponseData&& data, size_t messageSize, TStringBuf errorText = "") {
                 const TActorContext& ctx = TlsActivationContext->AsActorContext();
 
+                ReportInputCounters(ctx);
                 ReportLatencyCounters(ctx);
                 ReportResponseSizeCounters(TStringBuilder() << data.HttpCode, messageSize, ctx);
                 LogHttpRequestResponse(ctx, data.HttpCode, errorText);
@@ -430,7 +439,6 @@ namespace NKikimr::NHttpProxy {
                     {"databasePath", HttpContext.DatabasePath},
                     {"request", MaybeGetQueueUrl<TProtoRequest>(Request)});
 
-                ReportInputCounters(ctx);
                 if (!HttpContext.SecurityToken.empty()) {
                     ctx.Send(MakeTicketParserID(), new TEvTicketParser::TEvAuthorizeTicket({
                         .Ticket = HttpContext.SecurityToken,

--- a/ydb/services/sqs_topic/ut/utils_ut.cpp
+++ b/ydb/services/sqs_topic/ut/utils_ut.cpp
@@ -95,10 +95,16 @@ namespace {
 
     class TMetricsLabelsTestActor : public NActors::TActorBootstrapped<TMetricsLabelsTestActor> {
     public:
-        TMetricsLabelsTestActor(NActors::TActorId edge, TString consumer, bool firstClassCitizen)
+        TMetricsLabelsTestActor(
+            NActors::TActorId edge,
+            TString consumer,
+            bool firstClassCitizen,
+            TString databaseId = {}
+        )
             : Edge_(edge)
             , Consumer_(std::move(consumer))
             , FirstClassCitizen_(firstClassCitizen)
+            , DatabaseId_(std::move(databaseId))
         {
         }
 
@@ -106,12 +112,23 @@ namespace {
             NKikimr::AppData(ctx)->PQConfig.SetTopicsAreFirstClassCitizen(FirstClassCitizen_);
 
             auto* ev = new TEvMetricsLabelsResult;
-            ev->Labels = GetRequestMessageCountMetricsLabels(
-                "/Root/db",
-                "/Root/db/topic",
-                Consumer_,
-                "SendMessage"
-            );
+            if (DatabaseId_) {
+                ev->Labels = GetMetricsLabels(
+                    "/Root/db",
+                    "/Root/db/topic",
+                    Consumer_,
+                    "SendMessage",
+                    {{"name", "api.sqs.request.count"}},
+                    DatabaseId_
+                );
+            } else {
+                ev->Labels = GetRequestMessageCountMetricsLabels(
+                    "/Root/db",
+                    "/Root/db/topic",
+                    Consumer_,
+                    "SendMessage"
+                );
+            }
             ctx.Send(Edge_, ev);
             Die(ctx);
         }
@@ -120,6 +137,7 @@ namespace {
         NActors::TActorId Edge_;
         TString Consumer_;
         bool FirstClassCitizen_;
+        TString DatabaseId_;
     };
 
     TVector<std::pair<TString, TString>> CollectRequestMessageCountMetricsLabels(
@@ -135,6 +153,32 @@ namespace {
         );
         auto ev = runtime.GrabEdgeEvent<TEvMetricsLabelsResult>(edge);
         return ev->Get()->Labels;
+    }
+
+    TVector<std::pair<TString, TString>> CollectMetricsLabelsWithDatabaseId(
+        NKikimr::TTestActorRuntime& runtime,
+        const TString& databaseId
+    ) {
+        const auto edge = runtime.AllocateEdgeActor();
+        runtime.Register(
+            new TMetricsLabelsTestActor(edge, "ydb_sqs_consumer", true, databaseId),
+            0,
+            runtime.GetAppData().SystemPoolId
+        );
+        auto ev = runtime.GrabEdgeEvent<TEvMetricsLabelsResult>(edge);
+        return ev->Get()->Labels;
+    }
+
+    bool HasLabel(
+        const TVector<std::pair<TString, TString>>& labels,
+        const TString& key
+    ) {
+        for (const auto& [labelKey, _] : labels) {
+            if (labelKey == key) {
+                return true;
+            }
+        }
+        return false;
     }
 
 } // namespace
@@ -154,6 +198,18 @@ Y_UNIT_TEST_SUITE(SqsTopicMetricsLabels) {
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "name"), "api.sqs.request.message_count");
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "method"), "SendMessage");
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "topic"), "topic");
+        UNIT_ASSERT(HasLabel(labels, "database_id"));
+    }
+
+    Y_UNIT_TEST(IncludesDatabaseIdLabel) {
+        NKikimr::TTestActorRuntime runtime(1, false);
+        InitRuntime(runtime);
+
+        const auto labels = CollectMetricsLabelsWithDatabaseId(runtime, "database4");
+
+        UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "database_id"), "database4");
+        UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "database"), "/Root/db");
+        UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "name"), "api.sqs.request.count");
     }
 
     Y_UNIT_TEST(ConvertOldConsumerNameForSharedConsumerInFederation) {

--- a/ydb/services/sqs_topic/utils.cpp
+++ b/ydb/services/sqs_topic/utils.cpp
@@ -82,7 +82,8 @@ namespace NKikimr::NSqsTopic {
         const TString& topicPath,
         const TString& consumerName,
         const TString& method,
-        TVector<std::pair<TString, TString>>&& labels
+        TVector<std::pair<TString, TString>>&& labels,
+        const TString& databaseId
     ) {
         TString fullDatabasePath = databasePath + "/";
         TString adjustedTopicPath;
@@ -94,6 +95,7 @@ namespace NKikimr::NSqsTopic {
 
         TVector<std::pair<TString, TString>> common{
             {"database", databasePath},
+            {"database_id", databaseId},
             {"method", method},
             {"topic", adjustedTopicPath},
             {"consumer", ConvertOldConsumerName(consumerName)},

--- a/ydb/services/sqs_topic/utils.h
+++ b/ydb/services/sqs_topic/utils.h
@@ -39,7 +39,8 @@ namespace NKikimr::NSqsTopic {
         const TString& topicPath,
         const TString& consumer,
         const TString& method,
-        TVector<std::pair<TString, TString>>&& labels
+        TVector<std::pair<TString, TString>>&& labels,
+        const TString& databaseId = {}
     );
 
     TVector<std::pair<TString, TString>> GetRequestMessageCountMetricsLabels(


### PR DESCRIPTION
Tracker: [LOGBROKER-10649](https://st.yandex-team.ru/LOGBROKER-10649)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

SQS HTTP proxy counters now include the `database_id` label, matching Kinesis metrics so serverless monitoring can attribute traffic per database.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Unified Agent maps `database.serverless` from `{database_id}`. Kinesis (`api.http.data_streams.*`) already emitted this label; SQS (`api.sqs.*`) did not, because `AddCommonLabels` never passed `HttpContext.DatabaseId` into `GetMetricsLabels`.

- Write `database_id` from `GetMetricsLabels`, same as Kinesis counters.
- Pass `HttpContext.DatabaseId` from the SQS HTTP proxy.
- Report `api.sqs.request.count` after database info is known (as in datastreams), so the label is populated instead of empty.
- Cover the label in `SqsTopicMetricsLabels` unit tests.
