### PR TITLE
[YQ-5680] Fix cloud_id attribute path in FQ streaming IAM tests

### DIFF
--- a/ydb/tests/fq/streaming/generic/test_iam_generic.py
+++ b/ydb/tests/fq/streaming/generic/test_iam_generic.py
@@ -26,15 +26,6 @@ class TestIamAuthGeneric(StreamingTestBase):
             CREATE SECRET `{secret_name}` WITH (value="{USER_TOKEN}");
         """)
 
-    def set_cloud_id(self, kikimr: Kikimr, cloud_id: str = "test-cloud-id") -> None:
-        """Set cloud_id user attribute on the database root path (/Root).
-
-        DescribeResourceId reads GetAttributes() of the database root, so we must
-        use ESchemeOpAlterUserAttributes rather than ALTER TABLE which only supports
-        table-level settings.
-        """
-        kikimr.cluster.client.add_attr("/", "Root", {"cloud_id": cloud_id}, token="root@builtin")
-
     def create_iam_source(
         self,
         kikimr: Kikimr,

--- a/ydb/tests/fq/streaming/test_iam.py
+++ b/ydb/tests/fq/streaming/test_iam.py
@@ -24,15 +24,6 @@ class TestIamAuth(StreamingTestBase):
             CREATE SECRET `{secret_name}` WITH (value="{USER_TOKEN}");
         """)
 
-    def set_cloud_id(self, kikimr: Kikimr, cloud_id: str = "test-cloud-id") -> None:
-        """Set cloud_id user attribute on the database root path (/Root).
-
-        DescribeResourceId reads GetAttributes() of the database root, so we must
-        use ESchemeOpAlterUserAttributes rather than ALTER TABLE which only supports
-        table-level settings.
-        """
-        kikimr.cluster.client.add_attr("/", "Root", {"cloud_id": cloud_id}, token="root@builtin")
-
     def create_iam_source(
         self,
         kikimr: Kikimr,

--- a/ydb/tests/fq/streaming_common/common.py
+++ b/ydb/tests/fq/streaming_common/common.py
@@ -504,6 +504,22 @@ class StreamingTestBase(TestYdsBase):
     def get_endpoint(self, kikimr: Kikimr, local_topics: bool) -> Endpoint:
         return kikimr.endpoint if local_topics else kikimr.external_endpoint
 
+    def set_cloud_id(self, kikimr: Kikimr, cloud_id: str = "test-cloud-id") -> None:
+        """Set the cloud_id user attribute on the root of the database under test.
+
+        DescribeResourceId describes the database path itself and looks for the
+        cloud_id attribute there, so we must use ESchemeOpAlterUserAttributes
+        rather than ALTER TABLE which only supports table-level settings.
+
+        The database is the tenant created by the kikimr fixture (/Root/my_tenant),
+        not /Root, so the attribute has to be set on the tenant path: an attribute
+        on /Root is never read by DescribeResourceId and leaves resource_id empty,
+        which silently degrades the IAM token to no-auth.
+        """
+        database = kikimr.get_database_name().rstrip("/")
+        working_dir, _, name = database.rpartition("/")
+        kikimr.cluster.client.add_attr(working_dir or "/", name, {"cloud_id": cloud_id}, token="root@builtin")
+
     def get_ydb_client(self, kikimr: Kikimr, local_topics: bool) -> YdbClient:
         return kikimr.ydb_client if local_topics else kikimr.external_ydb_client
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Not for changelog (test infrastructure only).

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes #52273: all 6 `TestIamAuthGeneric` parametrizations fail with

```
Call FillCredentials for table `/Root/my_tenant/iam_source_*`.`iam_table_*`:
(yexception) ydb/library/yql/providers/generic/provider/yql_generic_describe_table.cpp:127: empty IAM token
```

instead of the expected `Reject bad SA` / `Access denied`.

**Root cause.** #51285 (YQ-5473) moved the fq streaming suite onto a tenant database (`tenant_database="/Root/my_tenant"` in `ydb/tests/fq/streaming/conftest.py`), but `set_cloud_id` kept writing the `cloud_id` user attribute to `/Root` via a hardcoded `add_attr("/", "Root", ...)`.

`DescribeResourceId` calls `DescribeTable(state->Database, {})` and looks for `cloud_id` among **that path's** attributes, returning an empty description when it is absent (`ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.cpp:260-275`). The attribute on `/Root` is therefore never read. From there:

1. `resource_id` resolves to empty;
2. `NYql::ComposeStructuredTokenJsonForIamAuth` sets `iam_auth` only when **both** `service_account_id` and `resource_id` are non-empty, and otherwise silently falls back to `SetNoAuth()`;
3. `TDefaultStructuredTokenCredentialsFactory::Create` maps `no_auth` to `CreateInsecureCredentialsProviderFactory()`, whose `GetAuthInfoAsync()` returns an empty string;
4. `yql_generic_describe_table.cpp:127` throws `empty IAM token`.

The query fails before the IAM gRPC emulator is reached, so the negative-path assertions can never observe the rejection they are written to check — the failure is identical for every service-account parametrization, which matches the observed all-variant pattern.

**This is deterministic, not a propagation race.** The attribute is written to a path that is not consulted at all, so the `time.sleep(1)` after `set_cloud_id` is irrelevant to the failure. The `p-3 / f-2` history in the mute issue is runs before vs. after #51285 merged (2026-09-04), not timing noise.

**Fix.** Derive the path from the database under test, using the same tenant-aware accessor #51285 introduced for `wait_completed_checkpoints`:

```python
database = kikimr.get_database_name().rstrip("/")
working_dir, _, name = database.rpartition("/")
kikimr.cluster.client.add_attr(working_dir or "/", name, {"cloud_id": cloud_id}, token="root@builtin")
```

This yields `add_attr("/Root", "my_tenant", ...)` for the tenant and remains correct for a plain `/Root` database.

`ydb/tests/fq/streaming/test_iam.py` carried a byte-identical copy of `set_cloud_id` with the same defect (not currently muted, but on the same tenant conftest). Rather than patch one copy and leave the other to regress separately, the helper is hoisted into `StreamingTestBase` and both duplicates are removed — one definition, three call sites.

**Testing.** Not run locally: these tests need a full `ydbd` build plus the IAM emulator and the generic connector. The causal chain above was established by reading the harness and server code; CI is the actual verification. Reviewers may want to confirm that `test_iam.py::TestIamAuth::test_read_topic_iam_auth` was passing before this change — if it was, it is worth understanding why it tolerated the empty-token path.

**Follow-up, out of scope here.** The silent `SetNoAuth()` fallback in `ComposeStructuredTokenJsonForIamAuth` turns a misconfigured `resource_id` into a confusing downstream `empty IAM token` rather than a clear diagnostic. That robustness gap is worth addressing separately.
