### PR TITLE
Reply to Kafka EndTxn retries instead of dropping them mid-commit.

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_transaction_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_transaction_actor.cpp
@@ -121,7 +121,17 @@ namespace NKafka {
 
         bool txnAborted = !ev->Get()->Request->Committed;
         if (CommitStarted) {
-            return; // we just ignore second and subsequent requests
+            if (txnAborted) {
+                SendFailResponse<TEndTxnResponseData>(ev, EKafkaErrors::COORDINATOR_NOT_AVAILABLE,
+                    "Commit already in progress");
+                return;
+            }
+            YDB_LOG_DEBUG("EndTxn commit already in progress; attaching retry",
+                {LogPrefix()},
+                {"correlationId", ev->Get()->CorrelationId},
+                {"pending", PendingEndTxnRequests.size()});
+            PendingEndTxnRequests.push_back(std::move(ev));
+            return;
         } else if (txnAborted) {
             SendOkResponse<TEndTxnResponseData>(ev);
             Die(ctx);
@@ -130,7 +140,7 @@ namespace NKafka {
             Die(ctx);
         } else {
             CommitStarted = true;
-            EndTxnRequestPtr = std::move(ev);
+            PendingEndTxnRequests.push_back(std::move(ev));
             StartKqpSession(ctx);
         }
     }
@@ -274,10 +284,19 @@ namespace NKafka {
         TBase::Die(ctx);
     }
 
-    void TTransactionActor::FailEndTxnRetryable(const TActorContext& ctx, const TString& errorMessage) {
-        if (EndTxnRequestPtr) {
-            SendFailResponse<TEndTxnResponseData>(EndTxnRequestPtr, EKafkaErrors::COORDINATOR_NOT_AVAILABLE, errorMessage);
+    void TTransactionActor::ReplyPendingEndTxn(EKafkaErrors errorCode, const TString& errorMessage) {
+        for (auto& request : PendingEndTxnRequests) {
+            if (errorCode == EKafkaErrors::NONE_ERROR) {
+                SendOkResponse<TEndTxnResponseData>(request);
+            } else {
+                SendFailResponse<TEndTxnResponseData>(request, errorCode, errorMessage);
+            }
         }
+        PendingEndTxnRequests.clear();
+    }
+
+    void TTransactionActor::FailEndTxnRetryable(const TActorContext& ctx, const TString& errorMessage) {
+        ReplyPendingEndTxn(EKafkaErrors::COORDINATOR_NOT_AVAILABLE, errorMessage);
         ++KqpCookie;
         if (Kqp) {
             Kqp->CloseKqpSession(ctx);
@@ -286,7 +305,6 @@ namespace NKafka {
         KqpSessionId = "";
         LastSentToKqpRequest = EKafkaTxnKqpRequests::NO_REQUEST;
         CommitStarted = false;
-        EndTxnRequestPtr.Destroy();
     }
 
     bool TTransactionActor::TxnExpired() {
@@ -412,7 +430,7 @@ namespace NKafka {
         if (auto error = GetErrorInProducerState(producerState)) {
             YDB_LOG_WARN(error,
                 {LogPrefix()});
-            SendFailResponse<TEndTxnResponseData>(EndTxnRequestPtr, EKafkaErrors::PRODUCER_FENCED, error->data());
+            ReplyPendingEndTxn(EKafkaErrors::PRODUCER_FENCED, error->data());
             Die(ctx);
             return;
         }
@@ -423,7 +441,7 @@ namespace NKafka {
             if (auto error = GetErrorInConsumersStates(consumerGenerationsByName)) {
                 YDB_LOG_WARN(error,
                     {LogPrefix()});
-                SendFailResponse<TEndTxnResponseData>(EndTxnRequestPtr, EKafkaErrors::PRODUCER_FENCED, error->data());
+                ReplyPendingEndTxn(EKafkaErrors::PRODUCER_FENCED, error->data());
                 Die(ctx);
                 return;
             }
@@ -453,7 +471,7 @@ namespace NKafka {
     void TTransactionActor::HandleCommitResponse(const TActorContext& ctx) {
         YDB_LOG_DEBUG("Successfully committed transaction. Sending ok and dying",
             {LogPrefix()});
-        SendOkResponse<TEndTxnResponseData>(EndTxnRequestPtr);
+        ReplyPendingEndTxn(EKafkaErrors::NONE_ERROR);
         Die(ctx);
     }
 

--- a/ydb/core/kafka_proxy/actors/kafka_transaction_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_transaction_actor.h
@@ -8,6 +8,7 @@
 #include <ydb/core/kafka_proxy/kafka_producer_instance_id.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/core/kafka_proxy/kqp_helper.h>
+#include <util/generic/vector.h>
 
 namespace NKafka {
     /*
@@ -77,9 +78,7 @@ namespace NKafka {
                     YDB_LOG_CRIT_COMP(NKikimrServices::KAFKA_PROXY, "Critical error happened",
                         {LogPrefix()},
                         {"reason", y.what()});
-                    if (EndTxnRequestPtr) {
-                        SendFailResponse<TEndTxnResponseData>(EndTxnRequestPtr, EKafkaErrors::UNKNOWN_SERVER_ERROR, y.what());
-                    }
+                    ReplyPendingEndTxn(EKafkaErrors::UNKNOWN_SERVER_ERROR, y.what());
                     Die(ActorContext());
                 }
             }
@@ -120,6 +119,7 @@ namespace NKafka {
             void HandleSelectResponse(const NKqp::TEvKqp::TEvQueryResponse& response, const TActorContext& ctx);
             void HandleAddKafkaOperationsResponse(const TString& kqpTransactionId, const TActorContext& ctx);
             void HandleCommitResponse(const TActorContext& ctx);
+            void ReplyPendingEndTxn(EKafkaErrors errorCode, const TString& errorMessage = {});
             // Kafka Java treats BROKER_NOT_AVAILABLE / INVALID_TXN_STATE as fatal on EndTxn.
             // COORDINATOR_NOT_AVAILABLE is retryable; keep the actor so a retry still sees partitions/offsets.
             void FailEndTxnRetryable(const TActorContext& ctx, const TString& errorMessage);
@@ -139,9 +139,9 @@ namespace NKafka {
             // helper fields
             const TString DatabasePath;
             const TString ResourceDatabasePath;
-            // This field need to preserve request details between several requests to KQP
-            // In case something goes off road, we can always send error back to client
-            TAutoPtr<TEventHandle<TEvKafka::TEvEndTxnRequest>> EndTxnRequestPtr;
+            // EndTxn is idempotent: Kafka clients retry with a new correlation id while KQP is still
+            // committing. Dropping those retries left the producer hanging until request timeout.
+            TVector<TAutoPtr<TEventHandle<TEvKafka::TEvEndTxnRequest>>> PendingEndTxnRequests;
             bool CommitStarted = false;
             ui64 TxnTimeoutMs;
             TInstant CreatedAt;

--- a/ydb/core/kafka_proxy/ut/ut_transaction_actor.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_transaction_actor.cpp
@@ -30,6 +30,28 @@ namespace {
                 ReturnSuccessOnCreateSession = success;
             }
 
+            void SetHoldCommit(bool hold) {
+                HoldCommit = hold;
+            }
+
+            bool HasHeldCommit() const {
+                return HeldCommitSender.Defined();
+            }
+
+            void ReleaseHeldCommit(TTestActorRuntime& runtime) {
+                Y_ABORT_UNLESS(HeldCommitSender.Defined());
+                auto response = MakeStatusResponse(ReturnSuccessOnCommit ? Ydb::StatusIds::SUCCESS : Ydb::StatusIds::ABORTED);
+                runtime.Send(new IEventHandle(
+                    *HeldCommitSender,
+                    SelfId(),
+                    response.Release(),
+                    0,
+                    HeldCommitCookie
+                ), 0, true);
+                HeldCommitSender.Clear();
+                HoldCommit = false;
+            }
+
         private:
             STFUNC(StateFunc) {
                 switch (ev->GetTypeRewrite()) {
@@ -49,6 +71,12 @@ namespace {
 
             void Handle(NKqp::TEvKqp::TEvQueryRequest::TPtr& ev, const TActorContext& ctx) {
                 Cout << "Handling query request" << Endl;
+                if (HoldCommit && ev->Get()->Record.GetRequest().GetTxControl().commit_tx() && !HeldCommitSender.Defined()) {
+                    Cout << "Holding commit request from dummy kqp" << Endl;
+                    HeldCommitSender = ev->Sender;
+                    HeldCommitCookie = ev->Cookie;
+                    return;
+                }
                 THolder<NKqp::TEvKqp::TEvQueryResponse> response;
                 if (ev->Get()->Record.GetRequest().GetTxControl().commit_tx()) {
                     Cout << "Sending response on commit from dummy kqp" << Endl;
@@ -165,6 +193,9 @@ namespace {
             TMaybe<std::unordered_map<TString, i32>> ConsumerGenerationsToReturn = Nothing();
             bool ReturnSuccessOnCommit = true;
             bool ReturnSuccessOnCreateSession = true;
+            bool HoldCommit = false;
+            TMaybe<TActorId> HeldCommitSender;
+            ui64 HeldCommitCookie = 0;
         };
 
     class TTransactionActorFixture : public NUnitTest::TBaseFixture {
@@ -277,7 +308,7 @@ namespace {
                 return Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
             }
 
-            THolder<NKafka::TEvKafka::TEvResponse> SendEndTxnRequest(bool commit = false, ui64 correlationId = 0) {
+            void SendEndTxnRequestAsync(bool commit = false, ui64 correlationId = 0) {
                 auto message = std::make_shared<NKafka::TEndTxnRequestData>();
                 message->TransactionalId = TransactionalId;
                 message->ProducerId = ProducerId;
@@ -286,7 +317,10 @@ namespace {
                 auto event = MakeHolder<NKafka::TEvKafka::TEvEndTxnRequest>(correlationId, NKafka::TMessagePtr<NKafka::TEndTxnRequestData>({}, message), Ctx->Edge, Database, Database);
 
                 Ctx->Runtime->SingleSys()->Send(new IEventHandle(ActorId, Ctx->Edge, event.Release()));
+            }
 
+            THolder<NKafka::TEvKafka::TEvResponse> SendEndTxnRequest(bool commit = false, ui64 correlationId = 0) {
+                SendEndTxnRequestAsync(commit, correlationId);
                 return Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
             }
 
@@ -611,6 +645,49 @@ namespace {
             UNIT_ASSERT_VALUES_EQUAL(txnActorDiedEvent->TransactionalId, TransactionalId);
             UNIT_ASSERT_VALUES_EQUAL(txnActorDiedEvent->ProducerState.Id, ProducerId);
             UNIT_ASSERT_VALUES_EQUAL(txnActorDiedEvent->ProducerState.Epoch, ProducerEpoch);
+        }
+
+        Y_UNIT_TEST(OnDuplicateEndTxnCommitWhileInFlight_shouldReplyToBoth) {
+            Ctx->Runtime->SetScheduledLimit(50'000);
+            ui32 endTxnSeen = 0;
+            auto observer = [&endTxnSeen](TAutoPtr<IEventHandle>& input) {
+                if (input->CastAsLocal<NKafka::TEvKafka::TEvEndTxnRequest>()) {
+                    ++endTxnSeen;
+                }
+                return TTestActorRuntimeBase::EEventAction::PROCESS;
+            };
+            Ctx->Runtime->SetObserverFunc(observer);
+            DummyKqpActor->SetHoldCommit(true);
+            SendAddPartitionsToTxnRequest({{"topic1", {0}}});
+
+            SendEndTxnRequestAsync(true, 1);
+            TDispatchOptions waitHeld;
+            waitHeld.CustomFinalCondition = [this]() {
+                return DummyKqpActor->HasHeldCommit();
+            };
+            UNIT_ASSERT(Ctx->Runtime->DispatchEvents(waitHeld, TDuration::Seconds(5)));
+            UNIT_ASSERT(DummyKqpActor->HasHeldCommit());
+
+            SendEndTxnRequestAsync(true, 2);
+            TDispatchOptions waitSecond;
+            waitSecond.CustomFinalCondition = [&endTxnSeen]() {
+                return endTxnSeen >= 2;
+            };
+            UNIT_ASSERT(Ctx->Runtime->DispatchEvents(waitSecond, TDuration::Seconds(5)));
+
+            DummyKqpActor->ReleaseHeldCommit(*Ctx->Runtime);
+            auto first = Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
+            auto second = Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
+
+            UNIT_ASSERT(first != nullptr);
+            UNIT_ASSERT(second != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(first->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+            UNIT_ASSERT_VALUES_EQUAL(second->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+            UNIT_ASSERT_EQUAL(first->Response->ApiKey(), NKafka::EApiKey::END_TXN);
+            UNIT_ASSERT_EQUAL(second->Response->ApiKey(), NKafka::EApiKey::END_TXN);
+            UNIT_ASSERT(first->CorrelationId != second->CorrelationId);
+            UNIT_ASSERT(first->CorrelationId == 1 || second->CorrelationId == 1);
+            UNIT_ASSERT(first->CorrelationId == 2 || second->CorrelationId == 2);
         }
 
         Y_UNIT_TEST(OnEndTxnWithCommitAndAbortFromTxn_shouldReturnCOORDINATOR_NOT_AVAILABLE) {

--- a/ydb/tests/stress/kafka/workload/__init__.py
+++ b/ydb/tests/stress/kafka/workload/__init__.py
@@ -280,6 +280,7 @@ class Workload(unittest.TestCase):
             )
             source_count = self.count_messages(messages_info_test)
             print(f"Source topic has {source_count} readable messages")
+            self.dump_topic_end_offsets(self.test_topic_path)
             print(f"Waiting up to {self.duration} sec for readable target topic messages")
             messages_info_targets = self.read_messages_from_topics(
                 [
@@ -707,6 +708,10 @@ class Workload(unittest.TestCase):
             if total_counts[i] < expected_count
         ]
         if missing:
+            for i, (topic, _) in enumerate(topics):
+                per_partition = {pid: len(msgs) for pid, msgs in messages_info[i].items()}
+                print(f"Read from {topic}: count={total_counts[i]} per_partition={per_partition}")
+                self.dump_topic_end_offsets(topic)
             raise AssertionError(
                 f"Target topics did not expose {expected_count} readable messages each: "
                 + "; ".join(missing)
@@ -751,6 +756,20 @@ class Workload(unittest.TestCase):
         if end == -1:
             raise AssertionError(f"Cannot parse payload index: {payload[:64]!r}")
         return int(payload[len(marker):end])
+
+    def dump_topic_end_offsets(self, topic):
+        try:
+            description = self.driver.topic_client.describe_topic(topic, include_stats=True)
+            parts = []
+            total = 0
+            for partition in description.partitions:
+                end = partition.partition_stats.partition_end if partition.partition_stats else None
+                parts.append(f"{partition.partition_id}:{end}")
+                if end is not None:
+                    total += end
+            print(f"Topic {topic} end offsets total={total} partitions=[{', '.join(parts)}]")
+        except Exception as error:
+            print(f"Failed to describe {topic}: {error}")
 
     def count_messages(self, messages_info):
         return sum(len(messages) for messages in messages_info.values())


### PR DESCRIPTION
Clients retry EndTxn with a new correlation id while KQP is still committing; ignoring those requests left EOS produces invisible until timeout.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
