### PR TITLE
streamlookup input transform/kikimr lookup: use CA stats level

### DIFF
--- a/ydb/core/kqp/federated_query/actors/lookup_actor/kikimr_lookup_actor.cpp
+++ b/ydb/core/kqp/federated_query/actors/lookup_actor/kikimr_lookup_actor.cpp
@@ -187,7 +187,8 @@ namespace {
             const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv,
             const NKikimr::NMiniKQL::THolderFactory& holderFactory,
             const size_t maxKeysInRequest,
-            bool isMultiMatches = false)
+            bool isMultiMatches,
+            TCollectStatsLevel statsLevel)
             : ParentId(std::move(parentId))
             , Alloc(alloc)
             , KeyTypeHelper(keyTypeHelper)
@@ -202,6 +203,17 @@ namespace {
             , SelectBody(MakeSelect())
             , SelectWithKeys(MakeSelectWithKeys())
         {
+            switch(statsLevel) {
+#define TRANSLATE(DQ, PROTO) \
+                case TCollectStatsLevel::DQ: \
+                    StatsMode = Ydb::Query::STATS_MODE_##PROTO; \
+                    break
+                TRANSLATE(None, NONE);
+                TRANSLATE(Basic, BASIC);
+                TRANSLATE(Full, FULL);
+                TRANSLATE(Profile, PROFILE);
+#undef TRANSLATE
+            }
             if (auto token = LookupSource.GetToken(); !token.empty()) {
                 Token.emplace(token);
             }
@@ -961,11 +973,10 @@ namespace {
                 tx_control.mutable_begin_tx()->mutable_snapshot_read_only();
                 tx_control.set_commit_tx(true);
             }
+
             YDB_LOG_DEBUG("QueryStatsMode",
                     COMMON_LOG,
-                    {"mode", (request.set_stats_mode(Ydb::Query::STATS_MODE_BASIC), "BASIC")}); // intentional side effects, order important
-            YDB_LOG_TRACE("QueryStatsMode",
-                    {"mode", (request.set_stats_mode(Ydb::Query::STATS_MODE_FULL), "FULL")}); // intentional side effects, order important
+                    {"mode", (request.set_stats_mode(StatsMode), Ydb::Query::StatsMode_Name(StatsMode))}); // intentional side effects, there are no point to collect stats unless we enabled debug logs
             YDB_LOG_TRACE("Query",
                     COMMON_LOG,
                     {"query", request.DebugString()});
@@ -986,6 +997,7 @@ namespace {
         const size_t MaxKeysInRequest;
         const bool IsMultiMatches;
         TMaybe<TString> Token;
+        Ydb::Query::StatsMode StatsMode;
         static inline constexpr std::string_view KeyTupleListName = "$keyTupleList"sv;
         NYql::NUdf::ITypeInfoHelper::TPtr TypeInfoHelper = new NKikimr::NMiniKQL::TTypeInfoHelper();
         const TString SelectBody;
@@ -1021,7 +1033,8 @@ namespace {
         const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv,
         const NKikimr::NMiniKQL::THolderFactory& holderFactory,
         const size_t maxKeysInRequest,
-        const bool isMultiMatches
+        const bool isMultiMatches,
+        TCollectStatsLevel statsLevel
     )
     {
         auto guard = Guard(*alloc);
@@ -1036,7 +1049,9 @@ namespace {
             typeEnv,
             holderFactory,
             maxKeysInRequest,
-            isMultiMatches);
+            isMultiMatches,
+            statsLevel
+        );
         return {actor, actor};
     }
 

--- a/ydb/core/kqp/federated_query/actors/lookup_actor/kikimr_lookup_actor.h
+++ b/ydb/core/kqp/federated_query/actors/lookup_actor/kikimr_lookup_actor.h
@@ -17,7 +17,8 @@ namespace NYql::NDq {
         const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv,
         const NKikimr::NMiniKQL::THolderFactory& holderFactory,
         const size_t maxKeysInRequest,
-        const bool isMultiMatches
+        const bool isMultiMatches,
+        TCollectStatsLevel statsLevel
     );
 
 } // namespace NYql::NDq

--- a/ydb/core/kqp/federated_query/actors/lookup_actor/kikimr_lookup_factories.cpp
+++ b/ydb/core/kqp/federated_query/actors/lookup_actor/kikimr_lookup_factories.cpp
@@ -19,7 +19,8 @@ namespace NYql::NDq {
                 args.TypeEnv,
                 args.HolderFactory,
                 args.MaxKeysInRequest,
-                args.IsMultiMatches
+                args.IsMultiMatches,
+                args.StatsLevel
             );
         };
 

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -299,6 +299,7 @@ public:
         const THashMap<TString, TString>& SecureParams;
         size_t MaxKeysInRequest;
         const bool IsMultiMatches;
+        TCollectStatsLevel StatsLevel;
     };
 
     struct TSinkArguments {

--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -50,6 +50,7 @@ public:
         , InputIndex(args.InputIndex)
         , InputFlow(args.InputFlow)
         , ComputeActorId(args.ComputeActorId)
+        , StatsLevel(args.StatsLevel)
         , TaskCounters(taskCounters)
         , Factory(factory)
         , Settings(std::move(settings))
@@ -186,6 +187,7 @@ private: //IDqComputeActorAsyncInput
                 .SecureParams = SecureParams,
                 .MaxKeysInRequest = 1000, // TODO configure me
                 .IsMultiMatches = IsMultiMatches,
+                .StatsLevel = StatsLevel,
             };
             auto [lookupSource, lookupSourceActor] = Factory->CreateDqLookupSource(Settings.GetRightSource().GetProviderName(), std::move(lookupSourceArgs));
             MaxKeysInRequest = lookupSource->GetMaxSupportedKeysInRequest();
@@ -254,6 +256,7 @@ protected:
     ui64 InputIndex; // NYql::NDq::IDqComputeActorAsyncInput
     NUdf::TUnboxedValue InputFlow;
     const NActors::TActorId ComputeActorId;
+    TCollectStatsLevel StatsLevel;
     ::NMonitoring::TDynamicCounterPtr TaskCounters;
     IDqAsyncIoFactory::TPtr Factory;
     NDqProto::TDqInputTransformLookupSettings Settings;

--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -1216,8 +1216,8 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
         lookupPayloadColumns,
         inputColumns
     );
-    auto taskCounters = args.TaskCounters;
-    if (taskCounters) {
+    auto taskCounters = args.StatsLevel != TCollectStatsLevel::None ? args.TaskCounters : nullptr;
+    if (taskCounters && args.StatsLevel != TCollectStatsLevel::Basic) {
         taskCounters = taskCounters->GetSubgroup("task_id", ToString(args.TaskId))->GetSubgroup("input", ToString(args.InputIndex));
     }
     if (settings.GetIsMultiget()) {

--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -32,12 +32,7 @@ class TInputTransformStreamLookupCommonBase
     friend TDerived;
 public:
     TInputTransformStreamLookupCommonBase(
-        std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
-        const NMiniKQL::THolderFactory& holderFactory,
-        const NMiniKQL::TTypeEnvironment& typeEnv,
-        ui64 inputIndex,
-        NUdf::TUnboxedValue inputFlow,
-        NActors::TActorId computeActorId,
+        IDqAsyncIoFactory::TInputTransformArguments&& args,
         ::NMonitoring::TDynamicCounterPtr taskCounters,
         IDqAsyncIoFactory* factory,
         NDqProto::TDqInputTransformLookupSettings&& settings,
@@ -47,20 +42,18 @@ public:
         const NMiniKQL::TStructType* lookupKeyType,
         const NMiniKQL::TStructType* lookupPayloadType,
         const NMiniKQL::TMultiType* outputRowType,
-        TOutputRowColumnOrder&& outputRowColumnOrder,
-        TDqComputeActorWatermarks* watermarksTracker,
-        const THashMap<TString, TString>& secureParams)
+        TOutputRowColumnOrder&& outputRowColumnOrder)
         : TActor(&TInputTransformStreamLookupDerivedBase::StateFunc)
-        , Alloc(alloc)
-        , HolderFactory(holderFactory)
-        , TypeEnv(typeEnv)
-        , InputIndex(inputIndex)
-        , InputFlow(std::move(inputFlow))
-        , ComputeActorId(std::move(computeActorId))
+        , Alloc(std::move(args.Alloc))
+        , HolderFactory(args.HolderFactory)
+        , TypeEnv(args.TypeEnv)
+        , InputIndex(args.InputIndex)
+        , InputFlow(args.InputFlow)
+        , ComputeActorId(args.ComputeActorId)
         , TaskCounters(taskCounters)
         , Factory(factory)
         , Settings(std::move(settings))
-        , SecureParams(secureParams)
+        , SecureParams(args.SecureParams)
         , FullscanRowLimit(Settings.HasFullscanLimit() ? Settings.GetFullscanLimit() : Settings.GetCacheLimit())
         , LookupInputIndexes(std::move(lookupInputIndexes))
         , OtherInputIndexes(std::move(otherInputIndexes))
@@ -70,7 +63,7 @@ public:
         , LookupPayloadType(lookupPayloadType)
         , OutputRowType(outputRowType)
         , OutputRowColumnOrder(std::move(outputRowColumnOrder))
-        , WatermarksTracker(watermarksTracker)
+        , WatermarksTracker(args.WatermarksTracker)
         , InputFlowFetchStatus(NUdf::EFetchStatus::Yield)
         , LruCache(std::make_unique<NKikimr::NMiniKQL::TUnboxedKeyValueLruCacheWithTtl>(std::max(Settings.GetCacheLimit(), ui64(1)), lookupKeyType))
         , DisableLruCache(Settings.GetCacheLimit() < 1)
@@ -1223,12 +1216,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
     if (settings.GetIsMultiget()) {
         auto actor = isWide ?
             (TInputTransformStreamMultiLookupBase*)new TInputTransformStreamMultiLookupWide(
-                args.Alloc,
-                args.HolderFactory,
-                args.TypeEnv,
-                args.InputIndex,
-                args.TransformInput,
-                args.ComputeActorId,
+                std::move(args),
                 taskCounters,
                 factory,
                 std::move(settings),
@@ -1238,17 +1226,10 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
                 lookupKeyType,
                 lookupPayloadType,
                 outputRowType,
-                std::move(outputColumnsOrder),
-                args.WatermarksTracker,
-                args.SecureParams
+                std::move(outputColumnsOrder)
             ) :
             (TInputTransformStreamMultiLookupBase*)new TInputTransformStreamMultiLookupNarrow(
-                args.Alloc,
-                args.HolderFactory,
-                args.TypeEnv,
-                args.InputIndex,
-                args.TransformInput,
-                args.ComputeActorId,
+                std::move(args),
                 taskCounters,
                 factory,
                 std::move(settings),
@@ -1258,20 +1239,13 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
                 lookupKeyType,
                 lookupPayloadType,
                 outputRowType,
-                std::move(outputColumnsOrder),
-                args.WatermarksTracker,
-                args.SecureParams
+                std::move(outputColumnsOrder)
             );
         return {actor, actor};
     }
     auto actor = isWide ?
         (TInputTransformStreamLookupBase*)new TInputTransformStreamLookupWide(
-            args.Alloc,
-            args.HolderFactory,
-            args.TypeEnv,
-            args.InputIndex,
-            args.TransformInput,
-            args.ComputeActorId,
+            std::move(args),
             taskCounters,
             factory,
             std::move(settings),
@@ -1281,17 +1255,10 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
             lookupKeyType,
             lookupPayloadType,
             outputRowType,
-            std::move(outputColumnsOrder),
-            args.WatermarksTracker,
-            args.SecureParams
+            std::move(outputColumnsOrder)
         ) :
         (TInputTransformStreamLookupBase*)new TInputTransformStreamLookupNarrow(
-            args.Alloc,
-            args.HolderFactory,
-            args.TypeEnv,
-            args.InputIndex,
-            args.TransformInput,
-            args.ComputeActorId,
+            std::move(args),
             taskCounters,
             factory,
             std::move(settings),
@@ -1301,9 +1268,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
             lookupKeyType,
             lookupPayloadType,
             outputRowType,
-            std::move(outputColumnsOrder),
-            args.WatermarksTracker,
-            args.SecureParams
+            std::move(outputColumnsOrder)
         );
     return {actor, actor};
 }

--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -48,7 +48,7 @@ public:
         , HolderFactory(args.HolderFactory)
         , TypeEnv(args.TypeEnv)
         , InputIndex(args.InputIndex)
-        , InputFlow(args.InputFlow)
+        , InputFlow(args.TransformInput)
         , ComputeActorId(args.ComputeActorId)
         , StatsLevel(args.StatsLevel)
         , TaskCounters(taskCounters)

--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -1212,9 +1212,19 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
         lookupPayloadColumns,
         inputColumns
     );
-    auto taskCounters = args.StatsLevel != TCollectStatsLevel::None ? args.TaskCounters : nullptr;
-    if (taskCounters && args.StatsLevel != TCollectStatsLevel::Basic) {
-        taskCounters = taskCounters->GetSubgroup("task_id", ToString(args.TaskId))->GetSubgroup("input", ToString(args.InputIndex));
+    auto taskCounters = args.TaskCounters;
+    switch(args.StatsLevel) {
+        case TCollectStatsLevel::None:
+        case TCollectStatsLevel::Basic:
+            taskCounters = nullptr;
+            break;
+        case TCollectStatsLevel::Profile:
+            if (taskCounters) {
+                taskCounters = taskCounters->GetSubgroup("task_id", ToString(args.TaskId))->GetSubgroup("input", ToString(args.InputIndex));
+            }
+            break;
+        case TCollectStatsLevel::Full:
+            break;
     }
     if (settings.GetIsMultiget()) {
         auto actor = isWide ?


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

Known problem: in kqp minimum possible CA StatsLevel is BASIC, there are no way to turn collecting off
Probably, we should shift levels by one? NONE, BASIC -> no collection, FULL -> same as BASIC, PROFILE->PROFILE ?
YQ-5685