### PR TITLE
Deduce node domain from tenant name in node init

### DIFF
--- a/ydb/core/config/init/init.cpp
+++ b/ydb/core/config/init/init.cpp
@@ -883,11 +883,18 @@ TString DeduceNodeDomain(const NConfig::TCommonAppOptions& cf, const NKikimrConf
     }
 
     if (appConfig.GetTenantPoolConfig().SlotsSize() == 1) {
-        auto &slot = appConfig.GetTenantPoolConfig().GetSlots(0);
+        const auto &slot = appConfig.GetTenantPoolConfig().GetSlots(0);
         if (slot.GetDomainName()) {
             return slot.GetDomainName();
         }
 
+        if (slot.GetTenantName()) {
+            return ToString(ExtractDomain(slot.GetTenantName()));
+        }
+    }
+
+    if (cf.TenantName.GetOrElse("")) {
+        return ToString(ExtractDomain(*cf.TenantName));
     }
 
     return "";


### PR DESCRIPTION
- `DeduceNodeDomain()` now falls back to the domain extracted from the single tenant pool slot's TenantName when neither an explicit node domain, a single-domain DomainsConfig, nor a slot DomainName is available.
- As a last resort, the domain is extracted from the `--tenant `command line option, so nodes started with only a tenant name resolve their domain correctly instead of getting an empty one.
