### PR TITLE
DQ-122: use relative TTL for JobStop filters

### DIFF
--- a/ydb/library/yql/providers/dq/api/protos/service.proto
+++ b/ydb/library/yql/providers/dq/api/protos/service.proto
@@ -223,11 +223,10 @@ message JobStopRequest {
     repeated TAttribute Attribute = 4;
     bool Force = 5;
     bool NegativeRevision = 6;
-    // Lifetime of a non-forced stop filter in milliseconds, e.g. 30000 for
-    // 30 seconds. Ignored when Force = true. Values above 600000 are clamped
-    // to 600000. Zero keeps the legacy TTL: 600000 milliseconds since the
-    // filter's last match. Negative values are rejected.
-    int64 TtlMs = 7;
+    // Lifetime of a non-forced stop filter in seconds, e.g. 30. Ignored when
+    // Force = true. Values above 600 are clamped to 600. Zero keeps the legacy
+    // TTL: 600 seconds since the filter's last match. Negative values are rejected.
+    int64 TtlSeconds = 7;
 }
 
 message JobStopResponse {

--- a/ydb/library/yql/providers/dq/api/protos/service.proto
+++ b/ydb/library/yql/providers/dq/api/protos/service.proto
@@ -227,7 +227,7 @@ message JobStopRequest {
     // 30 seconds. Ignored when Force = true. Values above 600000 are clamped
     // to 600000. Zero keeps the legacy TTL: 600000 milliseconds since the
     // filter's last match. Negative values are rejected.
-    int64 DeadlineMs = 7;
+    int64 TtlMs = 7;
 }
 
 message JobStopResponse {

--- a/ydb/library/yql/providers/dq/api/protos/service.proto
+++ b/ydb/library/yql/providers/dq/api/protos/service.proto
@@ -223,12 +223,11 @@ message JobStopRequest {
     repeated TAttribute Attribute = 4;
     bool Force = 5;
     bool NegativeRevision = 6;
-    // Absolute ISO-8601 deadline for a non-forced stop filter,
-    // e.g. "2026-09-02T14:30:00Z". Ignored when Force = true.
-    // Malformed values are rejected; values beyond 10 minutes from server
-    // processing time are clamped. A past deadline is already expired.
-    // Empty keeps the legacy TTL: 600 seconds since the filter's last match.
-    string Deadline = 7;
+    // Lifetime of a non-forced stop filter in milliseconds, e.g. 30000 for
+    // 30 seconds. Ignored when Force = true. Values above 600000 are clamped
+    // to 600000. Zero keeps the legacy TTL: 600000 milliseconds since the
+    // filter's last match. Negative values are rejected.
+    int64 DeadlineMs = 7;
 }
 
 message JobStopResponse {


### PR DESCRIPTION
## Summary

- replace the absolute string deadline with a relative TtlSeconds value
- document the 30-second example, 10-minute clamp, zero-value compatibility, and negative-value validation
- avoid requiring clients and servers to have synchronized clocks

## Testing

Not run (protobuf-only change).