### PR TITLE
Fix configs dispatcher trace memory leak

### DIFF
--- a/ydb/core/cms/console/configs_dispatcher.cpp
+++ b/ydb/core/cms/console/configs_dispatcher.cpp
@@ -1108,6 +1108,9 @@ try {
             break;
     }
 
+    // Trace only this replay. Reusing the tracer accumulates update history
+    // (including source file names) for the lifetime of the dispatcher.
+    RecordedInitialConfiguratorDeps->ConfigUpdateTracer = MakeDefaultConfigUpdateTracer();
     auto deps = RecordedInitialConfiguratorDeps->GetDeps();
     NConfig::TInitialConfigurator initCfg(deps);
 

--- a/ydb/core/cms/console/configs_dispatcher_ut.cpp
+++ b/ydb/core/cms/console/configs_dispatcher_ut.cpp
@@ -1563,6 +1563,84 @@ Y_UNIT_TEST_SUITE(TConfigsDispatcherObservabilityTests) {
         cfg.CreateConfigsDispatcher = false;
         return cfg;
     }
+
+    Y_UNIT_TEST(TestStartupReplayDoesNotAccumulateConfigTrace) {
+        auto recorded = std::make_shared<NConfig::TRecordedInitialConfiguratorDeps>();
+        recorded->ErrorCollector = NConfig::MakeDefaultErrorCollector();
+        auto files = std::make_unique<NConfig::TProtoConfigFileProviderMock>();
+        NConfig::AddProtoConfigOptions(*files);
+        files->SavedFiles["config.yaml"] = R"(
+metadata:
+  kind: MainConfig
+  version: 0
+  cluster: test_cluster
+config:
+  default_disk_type: NVME
+  self_management_config:
+    enabled: true
+  actor_system_config:
+    use_auto_config: true
+    node_type: COMPUTE
+    cpu_count: 10
+  host_configs:
+  - nvme:
+    - disk1
+  hosts:
+  - host: localhost
+    port: 19001
+  log_config:
+    default_level: 5
+allowed_labels: {}
+selector_config: []
+)";
+        files->SavedFiles["kikimr.token"] = "StaffApiUserToken: \"test-token\"";
+        recorded->ProtoConfigFileProvider = std::move(files);
+        recorded->ConfigUpdateTracer = NConfig::MakeDefaultConfigUpdateTracer();
+        recorded->MemLogInit = NConfig::MakeNoopMemLogInitializer();
+        recorded->NodeBrokerClient = NConfig::MakeNoopNodeBrokerClient();
+        recorded->DynConfigClient = NConfig::MakeNoopDynConfigClient();
+        recorded->ConfigClient = NConfig::MakeNoopConfigClient();
+        auto env = std::make_unique<NConfig::TEnvMock>();
+        env->SavedHostName = "localhost";
+        env->SavedFQDNHostName = "localhost";
+        recorded->Env = std::move(env);
+        recorded->Logger = NConfig::MakeNoopInitLogger();
+
+        NConfig::TConfigsDispatcherInitInfo initInfo;
+        initInfo.RecordedInitialConfiguratorDeps = recorded;
+        initInfo.Args = {"server", "--yaml-config", "config.yaml", "--node", "static",
+            "--mon-port", "8765", "--grpc-port", "2135", "--ic-port", "19001",
+            "--auth-token-file", "kikimr.token", "--mbus", "--mbus-port", "2134",
+            "--mbus-worker-count=4", "--mbus-max-in-flight", "10000",
+            "--mbus-max-in-flight-by-size", "5000000000", "--mbus-max-message-size", "140000000"};
+
+        TTenantTestRuntime runtime(ConfigWithoutDispatcher());
+        auto dispatcherId = runtime.Register(CreateConfigsDispatcher(initInfo));
+        runtime.EnableScheduleForActor(dispatcherId, true);
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvConsole::EvConfigSubscriptionNotification);
+            runtime.DispatchEvents(options);
+        }
+        QueryState(runtime, dispatcherId);
+
+        const auto initialTrace = recorded->ConfigUpdateTracer->Dump();
+        // This update is recorded near the end of startup parsing.
+        UNIT_ASSERT(initialTrace.contains(NKikimrConsole::TConfigItem::MessageBusConfigItem));
+
+        for (ui32 i = 0; i < 10; ++i) {
+            // Even an unchanged notification replays the startup configuration.
+            runtime.Send(new IEventHandle(dispatcherId, runtime.Sender,
+                new TEvConsole::TEvConfigSubscriptionNotification()));
+            QueryState(runtime, dispatcherId);
+
+            const auto trace = recorded->ConfigUpdateTracer->Dump();
+            UNIT_ASSERT_VALUES_EQUAL(trace.size(), initialTrace.size());
+            for (const auto& [kind, info] : initialTrace) {
+                UNIT_ASSERT_VALUES_EQUAL(trace.at(kind).Updates.size(), info.Updates.size());
+            }
+        }
+    }
     
     Y_UNIT_TEST(TestGetStateRequestResponse) {
         TTenantTestRuntime runtime(DefaultConsoleTestConfig());


### PR DESCRIPTION
### Changelog entry

Fix unbounded memory growth in the configs dispatcher when processing configuration updates.

### Description for reviewers

Every console notification replays startup configuration parsing to calculate the candidate startup config. The recorded dependencies reused one `TDefaultConfigUpdateTracer` for the lifetime of the dispatcher. Each replay appended to its per-kind update vectors, retaining source-file strings allocated by `TrimSourceFileName`. YAML startup configuration follows this path through `ApplyMainYamlConfig`, including when the YAML itself has not changed. Replays also copied the accumulated history into temporary debug data.

Replace the tracer before each replay so retained history is bounded to one run. The reported dispatcher heap stacks through `TrimSourceFileName`, `ApplyMainYamlConfig`, and `UpdateCandidateStartupConfig` match this retention path.

The regression test uses recorded YAML startup inputs with `--node static`, auth-token, and message-bus options, then sends ten unchanged notifications and checks that every trace vector keeps its original length. Without the fix it fails on the first repeated notification (`2 != 1`).

Validation: all 28 dispatcher tests passed:

```bash
./ya make --build relwithdebinfo -tA ydb/core/cms/console/ut_configs_dispatcher -F '*TConfigsDispatcher*' --no-bazel-remote-store 2>&1 | tail -25
```

Remote cache lookups were disabled after repeated cache server errors and delays.
