### PR TITLE
ydb-bench: collect and visualize per-attempt YDB metrics

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -223,6 +223,20 @@ geometry on a fresh cluster; that cluster's configuration is stored in
 The profile page separates the final **Result** from the **Discovery** process.
 Result presents the selected load, throughput, latency, errors, and CPU metrics;
 Discovery keeps the attempt history, synchronized search charts, and commands.
+Each attempt links to a separate page with YDB executor-pool counters, grouped by
+node and measurement repetition. Verification has its own metrics page.
+The collector samples the local monitoring endpoints every two seconds during
+measurements and saves `ydb-metrics.jsonl` with the profile artifacts.
+Thread-count gauges are displayed as threads (the original counters use threads
+multiplied by 100); elapsed and CPU microseconds can be displayed as raw counters
+or per-second deltas. Counter resets and failed samples break the rate series.
+Each counter has its own chart with lines for all pools of the selected
+node, including both microsecond counters. Hover values use
+two decimal places and share a time cursor across charts.
+Collection is best-effort, limited to 32 MiB per profile, 64 nodes and 32 pools
+per node. The attempt view retains at most 300 samples / 2 MiB and reports
+truncation; the full saved file can be downloaded. Historical runs without the
+artifact show an empty metrics page.
 
 During a local YDB run, the CLI reports cluster startup, workload initialization,
 warmup, measurement, cleanup, evaluation, and dynamic-node scaling milestones.

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -28,6 +28,7 @@ from ydb.tools.ydb_bench.lib.common import (
     atomic_write_text,
 )
 from ydb.tools.ydb_bench.lib.linux_telemetry import LinuxCpuMonitor
+from ydb.tools.ydb_bench.lib.ydb_telemetry import YdbCountersMonitor
 from ydb.tools.ydb_bench.lib.load_control import evaluate_load, search_load
 from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
     GENERIC_TOTAL_RESULT,
@@ -330,6 +331,13 @@ class LocalYdbCluster:
     def static_pids(self):
         return tuple(process.pid for process in self.static_processes if process.poll() is None)
 
+    def monitoring_nodes(self):
+        return [
+            (role, index, node["mon_port"])
+            for role, nodes in (("static", self.static_nodes), ("dynamic", self.dynamic_nodes))
+            for index, node in enumerate(nodes, 1)
+        ]
+
     @property
     def dynamic_pids(self):
         return tuple(process.pid for process in self.dynamic_processes if process.poll() is None)
@@ -541,6 +549,14 @@ class LocalYdbCluster:
             if result.interrupted:
                 self._write_attempts("client-discovery", result, attempts)
                 raise BenchmarkInterrupted("YDB client endpoint discovery was interrupted")
+            if (
+                result.exit_code
+                and not result.timed_out
+                and "Status: UNAVAILABLE" in (line.strip() for line in result.stderr.splitlines())
+                and time.monotonic() < deadline
+            ):
+                time.sleep(1)
+                continue
             if result.timed_out or result.exit_code:
                 self._write_attempts("client-discovery", result, attempts)
                 details = result.stderr.strip() or result.stdout.strip() or "no diagnostics"
@@ -916,6 +932,7 @@ class WorkloadLifecycle:
         cancel_event,
         progress,
         command_timeout_seconds=None,
+        metrics_path=None,
     ):
         self.cluster = cluster
         self.workload_cli = workload_cli
@@ -933,6 +950,7 @@ class WorkloadLifecycle:
         ):
             raise BenchmarkError("workload command timeout must be a positive finite number")
         self.command_timeout_seconds = command_timeout_seconds
+        self.metrics_path = metrics_path
         self.definition = workload_definition(workload["type"])
         self._profile_opened = False
         self._profile_closed = False
@@ -1250,8 +1268,14 @@ class WorkloadLifecycle:
                 "cli": _role_capacity(self.affinities["ydb_cli"], self.topology),
             },
         )
+        ydb_monitor = YdbCountersMonitor(
+            self.metrics_path,
+            self.cluster.monitoring_nodes,
+            {**state.fields, "phase": phases["measure"], "repetition": repetition},
+        )
         monitor.start()
         try:
+            ydb_monitor.start()
             plan = build_run_plan(
                 self.workload_cli,
                 state.table_path,
@@ -1288,7 +1312,10 @@ class WorkloadLifecycle:
                 on_process_started=lambda process: cli_pids.append(process.pid),
             )
         finally:
-            cpu = monitor.stop()
+            try:
+                cpu = monitor.stop()
+            finally:
+                ydb_monitor.stop()
         self.cluster.ensure_running("YDB process exited during workload measurement")
         commands.append(
             _command_record(
@@ -1525,6 +1552,7 @@ def run_local_ydb(
             cancel_event,
             publish_progress,
             command_timeout_seconds=(configuration.timeout_seconds if configuration.timeout_explicit else None),
+            metrics_path=output_directory / "ydb-metrics.jsonl",
         )
 
     cluster = create_cluster(output_directory / "cluster", profile["geometry"])
@@ -1793,6 +1821,7 @@ def run_local_ydb(
                         purpose="verification",
                     )
                     atomic_write_json(directory / "commands.json", commands)
+                    verification.setdefault("commands", []).extend(commands)
                     verification["completed_repetitions"] = repetition
                     verification_rows.append(metrics)
                     _write_csv(
@@ -1896,7 +1925,7 @@ def run_local_ydb(
             publish_progress(
                 "verification-completed",
                 result=compact_result_progress(),
-                verification=verification,
+                verification={key: value for key, value in verification.items() if key != "commands"},
             )
 
         close_lifecycle()
@@ -1922,6 +1951,8 @@ def run_local_ydb(
                 "repetitions.csv",
                 "cluster/cluster.yaml",
             ]
+            if (output_directory / "ydb-metrics.jsonl").is_file():
+                artifacts.append("ydb-metrics.jsonl")
             if verification["status"] == "completed":
                 artifacts += ["verification-summary.csv", "verification-repetitions.csv"]
                 if verification.get("cluster") == "fresh":

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -33,6 +33,7 @@ from ydb.tools.ydb_bench.lib.import_results import MAX_TOTAL_SIZE, export_archiv
 from ydb.tools.ydb_bench.lib.local_ydb import run_local_ydb
 from ydb.tools.ydb_bench.lib.local_ydb_workloads import web_workload_catalog
 from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES, discover_topology, plan_affinity, topology_record
+from ydb.tools.ydb_bench.lib.ydb_telemetry import read_metrics
 
 _CSP = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
 _STREAM_CHUNK_SIZE = 1024 * 1024
@@ -166,6 +167,7 @@ _CSS = (
 .local-stage{min-width:13rem;padding:.65rem;border:1px solid #d0d5dd;border-radius:7px;background:#fff}
 .local-stage.current{border-color:#84adff;background:#eff6ff}.local-stage .stage-arrow{color:var(--muted);margin-top:.35rem}
 .local-charts{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.9rem}
+.local-charts>.chart-legend{grid-column:1/-1}
 .local-charts .chart-panel{margin:0;padding:.8rem;border:1px solid #d0d5dd;border-radius:7px}
 .local-charts .chart-panel h3{margin-top:0}
 .local-attempts-scroll{max-width:100%;overflow-x:auto}
@@ -991,7 +993,7 @@ function addProfile(){
     "  return '<div class=chart-surface>'+svg+'</svg><div class=chart-tooltip hidden></div></div>'\n"
     '}\n'
     """
-function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,synchronize=false){
+function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,synchronize=false,formatValue=metricLabel){
   const seriesFor=metric=>Array.isArray(seriesRows)?seriesRows:(seriesRows[metric]||[]);
   const panels=[...container.querySelectorAll('.chart-panel')].map(panel=>({
     panel,
@@ -1033,7 +1035,7 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
       active.tooltip.innerHTML='<strong>'+esc(xName)+' = '+esc(metricLabel(selected))+'</strong>'+
         values.map(item=>'<div class=tooltip-row><i class="tooltip-dot chart-bg-'+item.colorClass+
           '"></i><span class="chart-color-'+item.colorClass+'">'+esc(item.label)+
-          '</span><span class=tooltip-value>'+esc(metricLabel(item.value))+'</span></div>').join('');
+          '</span><span class=tooltip-value>'+esc(formatValue(item.value))+'</span></div>').join('');
       active.tooltip.hidden=false;
       const surfaceBounds=active.surface.getBoundingClientRect(),tooltipWidth=active.tooltip.offsetWidth;
       const rawLeft=event.clientX-surfaceBounds.left+12;
@@ -2178,7 +2180,9 @@ function renderLocalYdbProfile(container,data){
       '<table class=local-attempts><thead><tr><th>#</th><th>Stage</th><th>Dynamic</th><th>Candidate</th>'+
       workloadHeaders+'<th>Static CPU</th><th>Dynamic CPU</th><th>CLI CPU</th>'+
       '<th>Verdict</th><th>Decision</th><th>Duration</th><th>Commands</th></tr></thead><tbody>'+
-      attempts.map(item=>'<tr><td>'+esc(item.attempt)+'</td><td>'+esc(item.search_stage)+'</td><td>'+
+      attempts.map(item=>'<tr><td><a href="'+esc(localAttemptHref(
+        container.dataset.localYdbRunId,container.dataset.localYdbProfile,item.attempt
+      ))+'">'+esc(item.attempt)+'</a></td><td>'+esc(item.search_stage)+'</td><td>'+
         esc(item.dynamic_nodes)+'</td><td>'+esc(metricLabel(item.load))+'</td>'+
         displayedMetrics.map(metric=>'<td>'+esc(metricLabel(
           localAttemptMetric(item,metric.name,resultSchema)??'—'
@@ -2190,6 +2194,12 @@ function renderLocalYdbProfile(container,data){
         localCommandDetails(item,openCommandAttempts.has(String(item.attempt)))+'</td></tr>'
       ).join('')+'</tbody></table></div>';
   }else html+='<div class=empty>No completed search attempts yet. The timeline will appear after the first measurement.</div>';
+  if(data.progress?.attempt)html+='<p><a href="'+esc(localAttemptHref(
+    container.dataset.localYdbRunId,container.dataset.localYdbProfile,data.progress.attempt
+  ))+'">Current attempt metrics</a></p>';
+  if(data.verification?.configured_repetitions)html+='<p><a href="'+esc(localAttemptHref(
+    container.dataset.localYdbRunId,container.dataset.localYdbProfile,'verification'
+  ))+'">Verification metrics</a></p>';
   container.innerHTML=localYdbViewTabs(container,data,selectedView)+
     '<section class=local-profile-view data-local-ydb-panel=result'+
     (selectedView==='result'?'':' hidden')+'>'+localResultPanel(data)+'</section>'+
@@ -2241,6 +2251,110 @@ async function mountLocalYdbProfile(container,runId,profile,runState,requestedVi
     }catch(error){container.innerHTML=displayError(error)}finally{loading=false}
   };
   await refresh();if(!terminal&&['running','queued','recovery_required'].includes(runState)&&!refreshTimer)refreshTimer=setInterval(refresh,1000)
+}
+function localAttemptHref(runId,profile,attempt){
+  return '#attempt/'+enc(runId)+'/'+enc(profile)+'/'+enc(attempt)
+}
+function localCounterCharts(samples,repetition,nodeKey,raw){
+  const selected=samples.filter(item=>String(item.context?.repetition)===String(repetition));
+  const start=selected.find(item=>Number.isFinite(item.timestamp_unix))?.timestamp_unix;
+  const xValues=[];
+  const names=['Current','Default','Max','PossibleMax','PotentialMax'];
+  const pools=[...new Set(selected.flatMap(sample=>sample.nodes.filter(
+    node=>node.role+' '+node.index===nodeKey
+  ).flatMap(node=>Object.keys(node.pools||{}))))].sort();
+  const poolRows=new Map(pools.map(name=>[name,new Map]));
+  for(const sample of selected){
+    if(!Number.isFinite(sample.timestamp_unix)||!Number.isFinite(start))continue;
+    const x=Number((sample.timestamp_unix-start).toFixed(3));
+    const node=sample.nodes.find(item=>item.role+' '+item.index===nodeKey);
+    for(const poolName of pools){
+      const threadRow={};
+      for(const name of names){
+        const value=node?.pools?.[poolName]?.[name+'ThreadCountPercent'];
+        threadRow[name]=Number.isFinite(value)?value/100:null
+      }
+      const counters=(raw?node?.pools:node?.rates)?.[poolName]||{};
+      for(const name of ['ElapsedMicrosec','CpuMicrosec'])threadRow[name]=counters[name]??null;
+      poolRows.get(poolName).set(String(x),threadRow)
+    }
+    xValues.push(x)
+  }
+  const threadSeries=pools.map((name,index)=>({label:name,rows:poolRows.get(name),colorIndex:index}));
+  return {xValues,series:Object.fromEntries(
+    [...names,'ElapsedMicrosec','CpuMicrosec'].map(name=>[name,threadSeries])
+  )}
+}
+async function renderLocalYdbAttempt(runId,profile,attempt){
+  clearRefresh();
+  const discovery='#run/'+enc(runId)+'/profile/'+enc('local-ydb/'+profile+'/view/discovery');
+  app.innerHTML=shell('runs','<div class=breadcrumbs><a href="'+esc(discovery)+'">'+
+    esc(runId+' / '+profile)+' / Discovery</a></div><h1 class=page-title>'+
+    (attempt==='verification'?'Verification':'Attempt '+esc(attempt))+
+    '</h1><div id=attempt-summary></div><section class=card><div class=toolbar>'+
+    '<label>Repetition <select id=counter-repetition></select></label>'+
+    '<label>Node <select id=counter-node></select></label>'+
+    '<label><input type=checkbox id=counter-raw> Raw microsecond counters</label>'+
+    '<button id=counter-refresh>Refresh</button></div><div id=counter-notice></div>'+
+    '<div id=counter-charts class=local-charts></div></section>');
+  const target=document.querySelector('#counter-charts'),summary=document.querySelector('#attempt-summary');
+  const repetition=document.querySelector('#counter-repetition'),node=document.querySelector('#counter-node');
+  const raw=document.querySelector('#counter-raw');
+  let samples=[],loading=false;
+  const options=(select,values)=>{
+    if(JSON.stringify([...select.options].map(option=>option.value))===JSON.stringify(values.map(String)))return;
+    const previous=select.value;
+    select.innerHTML=values.map(value=>'<option value="'+esc(value)+'">'+esc(value)+'</option>').join('');
+    if(values.map(String).includes(previous))select.value=previous
+  };
+  const draw=()=>{
+    options(repetition,[...new Set(samples.map(item=>item.context?.repetition).filter(Number.isFinite))].sort((a,b)=>a-b));
+    const selected=samples.filter(item=>String(item.context?.repetition)===repetition.value);
+    options(node,[...new Set(selected.flatMap(item=>item.nodes.map(value=>value.role+' '+value.index)))].sort());
+    if(!selected.length){target.innerHTML='<div class=empty>No YDB counter samples for this attempt.</div>';return}
+    const {xValues,series}=localCounterCharts(samples,repetition.value,node.value,raw.checked);
+    const unit=raw.checked?'µs':'µs/s';
+    target.innerHTML='<div class=chart-legend>'+series.Current.map((item,index)=>
+      '<span><i class="legend-swatch chart-bg-'+index%chartColors.length+'"></i>'+esc(item.label)+'</span>'
+    ).join('')+'</div>'+['Current','Default','Max','PossibleMax','PotentialMax'].map(name=>
+      localChart(name+' threads',name,'Time (s)',xValues,series[name])
+    ).join('')+
+      localChart('ElapsedMicrosec ('+unit+')','ElapsedMicrosec','Time (s)',xValues,series.ElapsedMicrosec)+
+      localChart('CpuMicrosec ('+unit+')','CpuMicrosec','Time (s)',xValues,series.CpuMicrosec);
+    bindChartTooltips(target,'Time (s)',xValues,series,Object.keys(series),chartColors,true,value=>value.toFixed(2))
+  };
+  for(const select of [repetition,node,raw])select.onchange=draw;
+  const refresh=async()=>{
+    if(loading||!target.isConnected)return;loading=true;
+    try{
+      const [data,metrics]=await Promise.all([
+        api('/api/runs/'+enc(runId)+'/local-ydb-profile?profile='+enc(profile)),
+        api('/api/runs/'+enc(runId)+'/local-ydb-metrics?profile='+enc(profile)+'&attempt='+enc(attempt))
+      ]);
+      if(!target.isConnected)return;
+      const item=attempt==='verification'?data.verification:(data.attempts||[]).find(value=>String(value.attempt)===attempt);
+      const context=item||data.progress||{};
+      const load=context.load??data.result?.selected_load;
+      const dynamic=context.dynamic_nodes??data.result?.dynamic_nodes;
+      const commandsOpen=Boolean(summary.querySelector('.local-command-history')?.open);
+      summary.innerHTML='<section class=card><div class=toolbar><span>Candidate: <strong>'+esc(load??'—')+
+        '</strong> '+esc(data.parameters?.load?.parameter||'')+'</span><span>Dynamic nodes: <strong>'+
+        esc(dynamic??'—')+'</strong></span></div>'+localCommandDetails(context,commandsOpen)+
+        (metrics.artifact?'<p><a href="'+esc(metrics.artifact)+'">Download raw YDB metrics (JSONL)</a></p>':'')+'</section>';
+      samples=metrics.samples||[];
+      const errors=[...new Set(samples.flatMap(sample=>[
+        sample.error,...sample.nodes.map(value=>value.error?value.role+' '+value.index+': '+value.error:null)
+      ]).filter(Boolean))];
+      document.querySelector('#counter-notice').innerHTML=[
+        metrics.truncated?'Showing a limited sample history.':null,
+        metrics.invalid_records?'Some invalid metric records were skipped.':null,...errors.slice(0,8)
+      ].filter(Boolean).map(message=>'<div class=notice>'+esc(message)+'</div>').join('');
+      draw();
+      if(!['running','preparing'].includes(data.state))clearRefresh()
+    }catch(error){if(target.isConnected)target.innerHTML=displayError(error)}finally{loading=false}
+  };
+  document.querySelector('#counter-refresh').onclick=refresh;
+  refreshTimer=setInterval(refresh,2000);await refresh()
 }
     """
     """
@@ -2410,7 +2524,8 @@ function parseLocalYdbProfileSelection(groups,selected){
     '}\n'
     "async function compose(){const pieces=routeParts(),current=pieces.join('/');if(current==='runs')return renderRuns();if(current==='new')return renderN"
     "ew('builder');if(current==='new/yaml')return renderNew('yaml');if(current==='topology')return renderTopology();if(curren"
-    "t==='comparisons')return renderComparisons();if(pieces[0]==='run'){if(pieces[2]"
+    "t==='comparisons')return renderComparisons();if(pieces[0]==='attempt'&&pieces.length===4)"
+    "return renderLocalYdbAttempt(pieces[1],pieces[2],pieces[3]);if(pieces[0]==='run'){if(pieces[2]"
     "==='profile')return renderRun(pieces[1],pieces.slice(3).join('/'));return renderRun(pieces.slice(1).join('/'))}setRoute("
     "'runs')}\n"
     "addEventListener('hashchange',compose);compose();\n"
@@ -3587,6 +3702,37 @@ class RunService:
     def chart_data(self, run_ids, benchmark_filter=None):
         return chart_data(self.output, run_ids, benchmark_filter)
 
+    def local_ydb_metrics(self, run_id, profile, attempt):
+        if attempt != "verification" and not re.fullmatch(r"[1-9][0-9]{0,8}", str(attempt)):
+            raise BenchmarkError("attempt must be a positive integer or verification")
+        self.local_ydb_profile(run_id, profile)
+        root = _run_directory(self.output, run_id)
+        manifest = load_manifest(root / "run.json")
+        record = next(
+            (
+                item
+                for item in manifest.get("runs", [])
+                if item.get("benchmark") == "local-ydb" and item.get("profile") == profile
+            ),
+            None,
+        )
+        if record is None:
+            return {"samples": [], "truncated": False}
+        relative = record.get("manifest") or str(Path(record.get("directory", "")) / "run.json")
+        unresolved = (root / relative).parent / "ydb-metrics.jsonl"
+        candidate = unresolved.resolve()
+        if root not in candidate.parents or unresolved.is_symlink():
+            raise BenchmarkError("local-ydb metrics escape the run directory")
+        try:
+            value = read_metrics(candidate, attempt)
+            if candidate.is_file():
+                value["artifact"] = "/api/runs/{}/artifact/{}".format(
+                    quote(run_id, safe=""), quote(str(candidate.relative_to(root)), safe="/")
+                )
+            return value
+        except OSError as error:
+            raise BenchmarkError("cannot read local-ydb metrics: {}".format(error)) from error
+
     def local_ydb_profile(self, run_id, profile):
         root = _run_directory(self.output, run_id)
         manifest = load_manifest(root / "run.json")
@@ -4484,6 +4630,16 @@ def _handler(service):
                     return self._json(400, {"error": "activity cursor must be a non-negative integer"})
                 try:
                     value = service.local_ydb_activity(run_id, profile, after)
+                except BenchmarkError as error:
+                    return self._json(400, {"error": str(error)})
+                return self._json(200, value)
+            if path.startswith("/api/runs/") and path.endswith("/local-ydb-metrics"):
+                run_id = unquote(path[len("/api/runs/") : -len("/local-ydb-metrics")])
+                query = parse_qs(parsed.query)
+                try:
+                    value = service.local_ydb_metrics(
+                        run_id, query.get("profile", [""])[-1], query.get("attempt", [""])[-1]
+                    )
                 except BenchmarkError as error:
                     return self._json(400, {"error": str(error)})
                 return self._json(200, value)

--- a/ydb/tools/ydb_bench/lib/ya.make
+++ b/ydb/tools/ydb_bench/lib/ya.make
@@ -11,6 +11,7 @@ PY_SRCS(
     local_ydb.py
     local_ydb_workloads.py
     linux_telemetry.py
+    ydb_telemetry.py
     runner.py
     results.py
     system_info.py

--- a/ydb/tools/ydb_bench/lib/ydb_telemetry.py
+++ b/ydb/tools/ydb_bench/lib/ydb_telemetry.py
@@ -1,0 +1,262 @@
+"""Bounded, best-effort executor-pool telemetry from local YDB monitoring ports."""
+
+import json
+import logging
+import math
+import threading
+import time
+from pathlib import Path
+from collections import deque
+from urllib.request import HTTPRedirectHandler, ProxyHandler, build_opener
+
+COUNTERS = (
+    "CurrentThreadCountPercent",
+    "DefaultThreadCountPercent",
+    "MaxThreadCountPercent",
+    "PossibleMaxThreadCountPercent",
+    "PotentialMaxThreadCountPercent",
+    "ElapsedMicrosec",
+    "CpuMicrosec",
+)
+MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+MAX_FILE_BYTES = 32 * 1024 * 1024
+MAX_VIEW_BYTES = 2 * 1024 * 1024
+
+
+class _NoRedirect(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def parse_counters(payload):
+    pools = {}
+    if not isinstance(payload, dict) or not isinstance(payload.get("sensors"), list):
+        raise ValueError("monitoring response has no sensors list")
+    for sensor in payload["sensors"]:
+        if not isinstance(sensor, dict):
+            continue
+        labels = sensor.get("labels")
+        if not isinstance(labels, dict):
+            continue
+        pool, name, value = labels.get("execpool"), labels.get("sensor"), sensor.get("value")
+        if not isinstance(pool, str) or not pool or len(pool) > 128 or name not in COUNTERS:
+            continue
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+            continue
+        try:
+            if not math.isfinite(value):
+                continue
+        except OverflowError:
+            continue
+        if pool not in pools and len(pools) >= 32:
+            raise ValueError("too many executor pools")
+        values = pools.setdefault(pool, {})
+        if name in values:
+            raise ValueError("ambiguous executor-pool counter labels")
+        values[name] = value
+    return pools
+
+
+class YdbCountersMonitor:
+    def __init__(self, path, nodes, context, interval=2.0):
+        self.path = Path(path) if path is not None else None
+        self.nodes = nodes
+        self.context = dict(context)
+        self.interval = interval
+        self._stop = threading.Event()
+        self._thread = None
+        self._previous = {}
+        self._write_lock = threading.Lock()
+        self.error = None
+        self._opener = build_opener(ProxyHandler({}), _NoRedirect())
+
+    def start(self):
+        if self.path is not None:
+            self._thread = threading.Thread(target=self._run, name="ydb-bench-ydb-counters", daemon=True)
+            try:
+                self._thread.start()
+            except RuntimeError as error:
+                self._thread = None
+                self.error = str(error)[:300]
+                logging.warning("YDB counters collection could not start: %s", self.error)
+        return self
+
+    def stop(self):
+        with self._write_lock:
+            self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+
+    def _fetch(self, port):
+        if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65535:
+            raise ValueError("invalid local monitoring port")
+        url = "http://127.0.0.1:{}/counters/counters=utils/json".format(port)
+        deadline = time.monotonic() + 2.0
+        with self._opener.open(url, timeout=1.0) as response:
+            payload = bytearray()
+            while len(payload) <= MAX_RESPONSE_BYTES:
+                if self._stop.is_set() or time.monotonic() >= deadline:
+                    raise ValueError("monitoring request cancelled or timed out")
+                chunk = response.read1(min(65536, MAX_RESPONSE_BYTES + 1 - len(payload)))
+                if not chunk:
+                    break
+                payload.extend(chunk)
+        if len(payload) > MAX_RESPONSE_BYTES:
+            raise ValueError("monitoring response is too large")
+        return parse_counters(json.loads(payload))
+
+    def _sample(self):
+        record = {"timestamp_unix": time.time(), "context": self.context, "nodes": []}
+        nodes = self.nodes()
+        if not isinstance(nodes, (tuple, list)):
+            raise ValueError("monitoring node list is unavailable")
+        if len(nodes) > 64:
+            record["error"] = "Only the first 64 nodes are sampled"
+        for role, index, port in nodes[:64]:
+            if self._stop.is_set():
+                break
+            node = {"role": role, "index": index, "port": port}
+            key = (role, index, port)
+            try:
+                pools = self._fetch(port)
+                now = time.monotonic()
+                node.update(timestamp_unix=time.time(), pools=pools, rates={})
+                if not pools:
+                    node["error"] = "Requested executor-pool counters are unavailable"
+                previous = self._previous.get(key)
+                if previous and now > previous[0]:
+                    for pool, counters in pools.items():
+                        rates = {}
+                        for name in ("ElapsedMicrosec", "CpuMicrosec"):
+                            old = previous[1].get(pool, {}).get(name)
+                            current = counters.get(name)
+                            if old is not None and current is not None and current >= old:
+                                rate = (current - old) / (now - previous[0])
+                                if math.isfinite(rate):
+                                    rates[name] = rate
+                        node["rates"][pool] = rates
+                self._previous[key] = (now, pools)
+            except (OSError, ValueError, TypeError) as error:
+                node["error"] = str(error)[:300]
+                self._previous.pop(key, None)
+            record["nodes"].append(node)
+        return record
+
+    def _run(self):
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            size = self.path.stat().st_size if self.path.exists() else 0
+            if size >= MAX_FILE_BYTES:
+                return
+            if size:
+                with self.path.open("rb") as previous:
+                    previous.seek(max(0, size - 1024))
+                    if b'"truncated":true' in previous.read():
+                        return
+            with self.path.open("ab") as stream:
+                while not self._stop.is_set():
+                    record = self._sample()
+                    payload = (json.dumps(record, allow_nan=False, separators=(",", ":")) + "\n").encode()
+                    with self._write_lock:
+                        if self._stop.is_set():
+                            break
+                        if size + len(payload) > MAX_FILE_BYTES - 1024:
+                            stream.write(b'{"error":"YDB metrics storage limit reached","truncated":true,"nodes":[]}\n')
+                            break
+                        stream.write(payload)
+                        stream.flush()
+                    size += len(payload)
+                    if self._stop.wait(self.interval):
+                        break
+        except Exception as error:
+            self.error = str(error)[:300]
+            logging.warning("YDB counters collection stopped: %s", self.error)
+
+
+def read_metrics(path, attempt):
+    """Read one attempt, including early attempts; bound both scanning and response size."""
+    path = Path(path)
+    if not path.is_file():
+        return {"samples": [], "truncated": False}
+    records = deque()
+    retained_bytes = 0
+    invalid = 0
+    truncated = False
+    with path.open("rb") as stream:
+        scanned = 0
+        while scanned < MAX_FILE_BYTES:
+            line = stream.readline(min(MAX_VIEW_BYTES + 1, MAX_FILE_BYTES - scanned))
+            if not line:
+                break
+            scanned += len(line)
+            if not line.endswith(b"\n"):
+                truncated = truncated or len(line) > MAX_VIEW_BYTES or scanned >= MAX_FILE_BYTES
+                break
+            try:
+                record = json.loads(line)
+                if not isinstance(record, dict) or not isinstance(record.get("nodes"), list):
+                    raise ValueError("invalid metrics record")
+                truncated = truncated or bool(record.get("truncated"))
+                context = record.get("context", {})
+                if not isinstance(context, dict):
+                    raise ValueError("invalid metrics context")
+                selected = "verification" if context.get("verification") is True else str(context.get("attempt"))
+                if selected != str(attempt):
+                    continue
+                record = _project_record(record)
+                encoded_size = len(json.dumps(record).encode())
+                records.append((record, encoded_size))
+                retained_bytes += encoded_size
+                while len(records) > 300 or retained_bytes > MAX_VIEW_BYTES:
+                    retained_bytes -= records.popleft()[1]
+                    truncated = True
+            except (ValueError, UnicodeError, TypeError, RecursionError):
+                invalid += 1
+        truncated = truncated or bool(stream.read(1))
+    return {
+        "samples": [record for record, _ in records],
+        "truncated": truncated,
+        "invalid_records": invalid,
+    }
+
+
+def _number(value):
+    if isinstance(value, bool) or not isinstance(value, (float, int)) or value < 0:
+        return None
+    try:
+        return value if math.isfinite(value) else None
+    except OverflowError:
+        return None
+
+
+def _project_record(record):
+    context = record["context"]
+    result = {
+        "timestamp_unix": _number(record.get("timestamp_unix")),
+        "context": {key: _number(context.get(key)) for key in ("attempt", "repetition", "load", "dynamic_nodes")},
+        "nodes": [],
+    }
+    result["context"]["verification"] = context.get("verification") is True
+    if record.get("error"):
+        result["error"] = str(record["error"])[:300]
+    for node in record["nodes"][:64]:
+        if not isinstance(node, dict) or node.get("role") not in ("static", "dynamic"):
+            continue
+        projected = {
+            "role": node["role"],
+            "index": _number(node.get("index")),
+            "timestamp_unix": _number(node.get("timestamp_unix")),
+        }
+        if node.get("error"):
+            projected["error"] = str(node["error"])[:300]
+        for field in ("pools", "rates"):
+            pools = node.get(field, {})
+            projected[field] = {}
+            if not isinstance(pools, dict):
+                continue
+            for pool, counters in list(pools.items())[:32]:
+                if not isinstance(pool, str) or len(pool) > 128 or not isinstance(counters, dict):
+                    continue
+                projected[field][pool] = {name: _number(counters[name]) for name in COUNTERS if name in counters}
+        result["nodes"].append(projected)
+    return result

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -2910,7 +2910,9 @@ class YdbBenchTest(unittest.TestCase):
         render_start = web._JS.index("function renderLocalYdbProfile")
         render_finish = web._JS.index("async function mountLocalYdbProfile", render_start)
         script = (
-            """
+            "const enc=encodeURIComponent;\n"
+            + web._JS[web._JS.index("function localAttemptHref(") : web._JS.index("function localCounterCharts(")]
+            + """
             const esc=value=>String(value??'');
             const metricLabel=value=>String(value??'—');
             const elapsedLabel=value=>String(value??0);
@@ -4537,12 +4539,13 @@ class YdbBenchTest(unittest.TestCase):
 
         partial = command_result("grpc://benchmark-host:20000\n")
         complete = command_result("grpc://benchmark-host:20000\ngrpc://benchmark-host:20001 [zone-a]\n")
-        with mock.patch.object(local_ydb, "run_command", side_effect=(partial, complete)) as run, mock.patch.object(
-            local_ydb.time, "sleep"
-        ):
+        unavailable = command_result("", exit_code=1, stderr="Status: UNAVAILABLE\nDatabase nodes resolve failed")
+        with mock.patch.object(
+            local_ydb, "run_command", side_effect=(unavailable, partial, complete)
+        ) as run, mock.patch.object(local_ydb.time, "sleep"):
             cluster._wait_client_endpoints(30)
 
-        self.assertEqual(run.call_count, 2)
+        self.assertEqual(run.call_count, 3)
         command = run.call_args_list[0].args[0]
         self.assertEqual(
             command,
@@ -4558,7 +4561,12 @@ class YdbBenchTest(unittest.TestCase):
         )
         self.assertEqual(run.call_args_list[0].kwargs["cpu_affinity"], (0, 1))
         attempts = json.loads((cluster_directory / "client-discovery-attempts.json").read_text(encoding="utf-8"))
-        self.assertEqual([item["stdout"] for item in attempts], [partial.stdout, complete.stdout])
+        self.assertEqual([item["stdout"] for item in attempts], [unavailable.stdout, partial.stdout, complete.stdout])
+        with mock.patch.object(local_ydb, "run_command", return_value=unavailable) as run, mock.patch.object(
+            local_ydb.time, "monotonic", side_effect=(0, 0, 31)
+        ), self.assertRaisesRegex(BenchmarkError, "discovery exited with code 1: Status: UNAVAILABLE"):
+            cluster._wait_client_endpoints(30)
+        run.assert_called_once()
 
     def test_local_ydb_client_readiness_does_not_hide_cli_failures(self):
         cluster_directory = self.root / "client-ready-failure"

--- a/ydb/tools/ydb_bench/tests/test_ydb_telemetry.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_telemetry.py
@@ -1,0 +1,205 @@
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from ydb.tools.ydb_bench.lib import web, ydb_telemetry
+from ydb.tools.ydb_bench.lib.common import BenchmarkError
+from ydb.tools.ydb_bench.lib.results import SCHEMA_VERSION
+
+
+class YdbTelemetryTest(unittest.TestCase):
+    def test_parse_exact_executor_counters(self):
+        sensors = [
+            {"labels": {"execpool": "User", "sensor": "CurrentThreadCountPercent"}, "value": 250},
+            {"labels": {"execpool": "User", "sensor": "CpuMicrosec"}, "value": 12000000},
+            {"labels": {"sensor": "CpuMicrosec"}, "value": 1},
+            {"labels": {"execpool": "User", "sensor": "Other"}, "value": 7},
+        ]
+        self.assertEqual(
+            ydb_telemetry.parse_counters({"sensors": sensors}),
+            {
+                "User": {"CurrentThreadCountPercent": 250, "CpuMicrosec": 12000000},
+            },
+        )
+        with self.assertRaisesRegex(ValueError, "ambiguous"):
+            ydb_telemetry.parse_counters({"sensors": sensors + sensors[:1]})
+        with self.assertRaises(ValueError):
+            ydb_telemetry.parse_counters({})
+
+    def test_invalid_numbers_are_ignored(self):
+        for value in (True, -1, float("inf"), float("nan"), "12", 10**500):
+            with self.subTest(value=str(value)[:30]):
+                self.assertEqual(
+                    ydb_telemetry.parse_counters(
+                        {
+                            "sensors": [
+                                {
+                                    "labels": {"execpool": "User", "sensor": "CpuMicrosec"},
+                                    "value": value,
+                                }
+                            ]
+                        }
+                    ),
+                    {},
+                )
+
+    def test_rates_reset_after_errors_and_counter_restart(self):
+        monitor = ydb_telemetry.YdbCountersMonitor(None, lambda: [("dynamic", 1, 31000)], {"attempt": 1})
+        values = [{"User": {"CpuMicrosec": value}} for value in (100, 500, 10, 30, 60)]
+        values.insert(3, OSError("offline"))
+        with mock.patch.object(monitor, "_fetch", side_effect=values), mock.patch.object(
+            ydb_telemetry.time, "monotonic", side_effect=(1, 3, 5, 9, 11)
+        ):
+            nodes = [monitor._sample()["nodes"][0] for _ in values]
+        self.assertEqual(nodes[0]["rates"], {})
+        self.assertEqual(nodes[1]["rates"]["User"]["CpuMicrosec"], 200)
+        self.assertNotIn("CpuMicrosec", nodes[2]["rates"]["User"])
+        self.assertEqual(nodes[3]["error"], "offline")
+        self.assertEqual(nodes[4]["rates"], {})
+        self.assertEqual(nodes[5]["rates"]["User"]["CpuMicrosec"], 15)
+
+    @staticmethod
+    def sample(attempt=1, repetition=1):
+        return {
+            "timestamp_unix": 100,
+            "context": {"attempt": attempt, "repetition": repetition},
+            "nodes": [
+                {
+                    "role": "dynamic",
+                    "index": 1,
+                    "timestamp_unix": 100,
+                    "pools": {"User": {"CurrentThreadCountPercent": 250, "CpuMicrosec": 100}},
+                    "rates": {},
+                }
+            ],
+        }
+
+    def test_reader_selects_early_attempt_and_verification(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "metrics.jsonl"
+            samples = [self.sample(1)] + [self.sample(2)] * 400
+            verification = self.sample()
+            verification["context"]["verification"] = True
+            samples.append(verification)
+            path.write_text("".join(json.dumps(value) + "\n" for value in samples) + '{"partial":')
+            self.assertEqual(len(ydb_telemetry.read_metrics(path, "1")["samples"]), 1)
+            self.assertEqual(len(ydb_telemetry.read_metrics(path, "verification")["samples"]), 1)
+            limited = ydb_telemetry.read_metrics(path, "2")
+            self.assertEqual(len(limited["samples"]), 300)
+            self.assertTrue(limited["truncated"])
+
+    def test_reader_sanitizes_imported_values_and_reports_errors(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "metrics.jsonl"
+            sample = self.sample()
+            sample["nodes"][0]["pools"]["User"]["CpuMicrosec"] = float("nan")
+            sample["nodes"].append("bad node")
+            path.write_text("invalid json\n" + json.dumps(sample) + "\n")
+            value = ydb_telemetry.read_metrics(path, 1)
+            self.assertEqual(value["invalid_records"], 1)
+            self.assertIsNone(value["samples"][0]["nodes"][0]["pools"]["User"]["CpuMicrosec"])
+            json.dumps(value, allow_nan=False)
+
+    def test_collection_errors_are_best_effort(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "metrics.jsonl"
+            monitor = ydb_telemetry.YdbCountersMonitor(path, lambda: None, {})
+            monitor._run()
+            self.assertIn("node list", monitor.error)
+
+    def test_storage_limit_is_not_repeated_for_later_attempts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "metrics.jsonl"
+            with mock.patch.object(ydb_telemetry, "MAX_FILE_BYTES", 1200):
+                for _ in range(3):
+                    monitor = ydb_telemetry.YdbCountersMonitor(path, lambda: [], {})
+                    with mock.patch.object(monitor, "_sample", return_value=self.sample()):
+                        monitor._run()
+            self.assertEqual(len(path.read_text().splitlines()), 1)
+            self.assertTrue(ydb_telemetry.read_metrics(path, 1)["truncated"])
+
+    def test_service_scopes_metrics_and_rejects_symlink(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            run = root / "run-1"
+            profile = run / "local-ydb" / "profile"
+            profile.mkdir(parents=True)
+            (run / "run.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": SCHEMA_VERSION,
+                        "state": "passed",
+                        "runs": [
+                            {
+                                "benchmark": "local-ydb",
+                                "profile": "profile",
+                                "manifest": "local-ydb/profile/run.json",
+                            }
+                        ],
+                    }
+                )
+            )
+            (profile / "run.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": SCHEMA_VERSION,
+                        "benchmark": "local-ydb",
+                        "state": "passed",
+                    }
+                )
+            )
+            path = profile / "ydb-metrics.jsonl"
+            path.write_text(json.dumps(self.sample()) + "\n")
+            service = web.RunService(root)
+            try:
+                value = service.local_ydb_metrics("run-1", "profile", "1")
+                self.assertEqual(len(value["samples"]), 1)
+                self.assertIn("/artifact/", value["artifact"])
+                for attempt in ("0", "../1", "", "-2"):
+                    with self.assertRaises(BenchmarkError):
+                        service.local_ydb_metrics("run-1", "profile", attempt)
+                with self.assertRaises(BenchmarkError):
+                    service.local_ydb_metrics("run-1", "other", "1")
+                path.unlink()
+                path.symlink_to(root / "outside")
+                with self.assertRaisesRegex(BenchmarkError, "escape"):
+                    service.local_ydb_metrics("run-1", "profile", "1")
+            finally:
+                service.shutdown()
+
+    @unittest.skipUnless(shutil.which("node"), "node is required for chart behavior checks")
+    def test_attempt_charts_keep_repetitions_separate_and_convert_thread_units(self):
+        script = web._JS[
+            web._JS.index("function localCounterCharts(") : web._JS.index("async function renderLocalYdbAttempt(")
+        ]
+        first = self.sample()
+        first["nodes"][0]["pools"]["User"]["CurrentThreadCountPercent"] = 253
+        first["nodes"][0]["pools"]["System"] = {
+            "CurrentThreadCountPercent": 175,
+            "CpuMicrosec": 500,
+            "ElapsedMicrosec": 600,
+        }
+        first["nodes"][0]["rates"] = {"System": {"CpuMicrosec": 25, "ElapsedMicrosec": 30}}
+        second = self.sample(repetition=2)
+        second["nodes"][0]["pools"]["User"]["CurrentThreadCountPercent"] = 900
+        script += "const samples=" + json.dumps([first, second]) + ";"
+        script += """
+        const result=localCounterCharts(samples,1,'dynamic 1',true);
+        const row=result.series.Current.find(item=>item.label==='User').rows.get('0');
+        if(row.Current!==2.53||result.xValues.length!==1)throw Error('wrong samples');
+        for(const name of ['Current','Default','Max','PossibleMax','PotentialMax','ElapsedMicrosec','CpuMicrosec']){
+          if(result.series[name].length!==2)throw Error('missing pool');
+        }
+        if(result.series.Current[0].rows.get('0').Current!==1.75)throw Error('wrong System threads');
+        if(result.series.CpuMicrosec[1].rows.get('0').CpuMicrosec!==100)throw Error('wrong raw counter');
+        if(result.series.CpuMicrosec[0].rows.get('0').CpuMicrosec!==500)throw Error('wrong System counter');
+        const rate=localCounterCharts(samples,1,'dynamic 1',false);
+        if(rate.series.CpuMicrosec[1].rows.get('0').CpuMicrosec!==null)throw Error('raw treated as rate');
+        if(rate.series.CpuMicrosec[0].rows.get('0').CpuMicrosec!==25)throw Error('wrong System rate');
+        if(rate.series.ElapsedMicrosec[0].rows.get('0').ElapsedMicrosec!==30)throw Error('wrong elapsed rate');
+        """
+        subprocess.run([shutil.which("node"), "-e", script], check=True, capture_output=True, text=True)

--- a/ydb/tools/ydb_bench/tests/ya.make
+++ b/ydb/tools/ydb_bench/tests/ya.make
@@ -2,6 +2,7 @@ PY3TEST()
 
 TEST_SRCS(
     test_ydb_bench.py
+    test_ydb_telemetry.py
 )
 
 PEERDIR(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Collect YDB executor-pool metrics and display them on dedicated benchmark attempt pages.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Persist bounded, best-effort monitoring samples per profile, separated by attempt and repetition. Charts compare all pools of a selected node, show cumulative counters as per-second deltas by default, and share a time cursor with two-decimal tooltips. Verification has its own page; raw samples remain downloadable.

Also retry transient discovery UNAVAILABLE responses within the existing startup timeout: a database can report RUNNING before its dynamic endpoints are discoverable, previously causing the benchmark to fail before measurement.