### PR TITLE
Fix destruction order in NPersQueue::TReadSession::Close

### DIFF
--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.cpp
@@ -391,83 +391,88 @@ bool TReadSession::Close(TDuration timeout) {
 
     std::vector<TCallbackContextPtr> cbContextsToCancel;
     std::shared_ptr<TCallbackContext<TCountersLogger>> dumpCountersContextToCancel;
-    TDeferredActions deferred;
+    TInstant closeDeadline;
+    bool result = false;
     {
-        std::lock_guard guard(Lock);
-        if (Closing || Aborting) {
-            return false;
-        }
 
-        if (!timeout) {
-            AbortImpl(EStatus::ABORTED, "Close with zero timeout", deferred);
-            return false;
-        }
+        TDeferredActions deferred;
+        {
+            std::lock_guard guard(Lock);
+            if (Closing || Aborting) {
+                return false;
+            }
 
-        Closing = true;
-        sessions.reserve(ClusterSessions.size());
-        for (auto& [cluster, sessionInfo] : ClusterSessions) {
-            if (sessionInfo.Session) {
-                sessions.emplace_back(sessionInfo.Session);
+            if (!timeout) {
+                AbortImpl(EStatus::ABORTED, "Close with zero timeout", deferred);
+                return false;
+            }
+
+            Closing = true;
+            sessions.reserve(ClusterSessions.size());
+            for (auto& [cluster, sessionInfo] : ClusterSessions) {
+                if (sessionInfo.Session) {
+                    sessions.emplace_back(sessionInfo.Session);
+                }
             }
         }
-    }
-    *count = sessions.size() + 1;
-    for (const auto& session : sessions) {
-        session->Close(callback);
-    }
-
-    callback(); // For the case when there are no subsessions yet.
-
-    auto timeoutCallback = [=](bool) mutable {
-        promise.TrySetValue(false);
-    };
-
-    auto timeoutContext = Connections->CreateContext();
-    if (!timeoutContext) {
-        std::lock_guard guard(Lock);
-        AbortImpl(EStatus::ABORTED, DRIVER_IS_STOPPING_DESCRIPTION, deferred);
-        return false;
-    }
-    const TInstant closeDeadline = TInstant::Now() + timeout;
-    Connections->ScheduleCallback(timeout,
-                                  std::move(timeoutCallback),
-                                  timeoutContext);
-
-    // Wait.
-    NThreading::TFuture<bool> resultFuture = promise.GetFuture();
-    const bool result = resultFuture.GetValueSync();
-    if (result) {
-        Cancel(timeoutContext);
-
-        NYdb::NIssue::TIssues issues;
-        issues.AddIssue("Session was gracefully closed");
-        EventsQueue->Close(TSessionClosedEvent(EStatus::SUCCESS, std::move(issues)), deferred);
-    } else {
-        ++*Settings.Counters_->Errors;
+        *count = sessions.size() + 1;
         for (const auto& session : sessions) {
-            session->Abort();
+            session->Close(callback);
         }
 
-        NYdb::NIssue::TIssues issues;
-        issues.AddIssue(TStringBuilder() << "Session was closed after waiting " << timeout);
-        EventsQueue->Close(TSessionClosedEvent(EStatus::TIMEOUT, std::move(issues)), deferred);
-    }
+        callback(); // For the case when there are no subsessions yet.
 
-    {
-        std::lock_guard guard(Lock);
-        Aborting = true; // Set abort flag for doing nothing on destructor.
-        cbContextsToCancel = CbContexts;
-        dumpCountersContextToCancel = DumpCountersContext;
-    }
+        auto timeoutCallback = [=](bool) mutable {
+            promise.TrySetValue(false);
+        };
 
-    for (const auto& session : sessions) {
-        if (!session->WaitAllDecompressionTasks(closeDeadline)) {
-            LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session close timeout");
+        auto timeoutContext = Connections->CreateContext();
+        if (!timeoutContext) {
+            std::lock_guard guard(Lock);
+            AbortImpl(EStatus::ABORTED, DRIVER_IS_STOPPING_DESCRIPTION, deferred);
+            return false;
         }
-    }
-    ClearAllEvents();
-    for (const auto& session : sessions) {
-        session->ClearAllPartitionStreamEvents();
+        closeDeadline = TInstant::Now() + timeout;
+        Connections->ScheduleCallback(timeout,
+                                    std::move(timeoutCallback),
+                                    timeoutContext);
+
+        // Wait.
+        NThreading::TFuture<bool> resultFuture = promise.GetFuture();
+        result = resultFuture.GetValueSync();
+        if (result) {
+            Cancel(timeoutContext);
+
+            NYdb::NIssue::TIssues issues;
+            issues.AddIssue("Session was gracefully closed");
+            EventsQueue->Close(TSessionClosedEvent(EStatus::SUCCESS, std::move(issues)), deferred);
+        } else {
+            ++*Settings.Counters_->Errors;
+            for (const auto& session : sessions) {
+                session->Abort();
+            }
+
+            NYdb::NIssue::TIssues issues;
+            issues.AddIssue(TStringBuilder() << "Session was closed after waiting " << timeout);
+            EventsQueue->Close(TSessionClosedEvent(EStatus::TIMEOUT, std::move(issues)), deferred);
+        }
+
+        {
+            std::lock_guard guard(Lock);
+            Aborting = true; // Set abort flag for doing nothing on destructor.
+            cbContextsToCancel = CbContexts;
+            dumpCountersContextToCancel = DumpCountersContext;
+        }
+
+        for (const auto& session : sessions) {
+            if (!session->WaitAllDecompressionTasks(closeDeadline)) {
+                LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session close timeout");
+            }
+        }
+        ClearAllEvents();
+        for (const auto& session : sessions) {
+            session->ClearAllPartitionStreamEvents();
+        }
     }
 
     for (const auto& ctx : cbContextsToCancel) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed crash in NPersQueue::TReadSession::Close.

### Description for reviewers <!-- (optional) description for those who read this PR -->

```
#0  0x0000000025b48912 in bool std::__y1::__cxx_atomic_compare_exchange_strong[abi:ne210000]<long>(std::__y1::__cxx_atomic_base_impl<long>*, long*, long, std::__y1::memory_order, std::__y1::memory_order) (__a=<optimized out>, 
    __expected=<optimized out>, __value=<optimized out>, __success=<optimized out>, __failure=<optimized out>) at /-S/contrib/libs/cxxsupp/libcxx/include/__atomic/support/c11.h:138
#1  std::__y1::__atomic_base<long, false>::compare_exchange_strong[abi:ne210000](long&, long, std::__y1::memory_order) (this=<optimized out>, __e=<optimized out>, __d=<optimized out>, __m=<optimized out>)
    at /-S/contrib/libs/cxxsupp/libcxx/include/__atomic/atomic.h:112
#2  0x0000000025b48912 in TSpinLock::Acquire (this=0x458)
#3  TSpinLock::lock (this=0x458) at /-S/util/system/spinlock.h:82
#4  std::__y1::lock_guard<TSpinLock>::lock_guard[abi:ne210000](TSpinLock&) (__m=..., this=<optimized out>) at /-S/contrib/libs/cxxsupp/libcxx/include/__mutex/lock_guard.h:33
#5  NYdb::V3::NTopic::TDataDecompressionInfo<true>::Cleanup (this=0x12da7d6e6718) at /-S/contrib/libs/ydb-cpp-sdk/src/client/topic/impl/read_session_impl.ipp:3075
#6  0x0000000025b17518 in NYdb::V3::NTopic::TDeferredActions<true>::DestroyDecompressionInfos (this=0x7fff62320410) at /-S/contrib/libs/ydb-cpp-sdk/src/client/topic/impl/read_session_impl.ipp:3906
#7  NYdb::V3::NTopic::TDeferredActions<true>::DoActions (this=0x7fff62320410) at /-S/contrib/libs/ydb-cpp-sdk/src/client/topic/impl/read_session_impl.ipp:3808
#8  NYdb::V3::NTopic::TDeferredActions<true>::~TDeferredActions (this=this@entry=0x7fff62320410) at /-S/contrib/libs/ydb-cpp-sdk/src/client/topic/impl/read_session_impl.h:149
#9  0x0000000025b1c7f3 in NYdb::V3::NPersQueue::TReadSession::Close (this=<optimized out>, timeout=...) at /-S/contrib/libs/ydb-cpp-sdk/src/client/persqueue_public/impl/read_session.cpp:481
```