### PR TITLE
Fix udf_store cpu_spec include to use wavm_llvm16 ADDINCL path.

### DIFF
--- a/ydb/services/udf_store/cpu_spec.cpp
+++ b/ydb/services/udf_store/cpu_spec.cpp
@@ -1,7 +1,7 @@
 #include "cpu_spec.h"
 #include "metadata_subscription/storage_paths.h"
 
-#include <contrib/restricted/wavm/Include/WAVM/LLVMJIT/LLVMJIT.h>
+#include <WAVM/LLVMJIT/LLVMJIT.h>
 
 namespace NKikimr::NUdfStore {
 


### PR DESCRIPTION
The absolute include into contrib/restricted/wavm broke DistBuild sandboxing because nested WAVM headers were not found; wasm already peers wavm_llvm16.