### PR TITLE
[HashJoin] added correct slots number (like in the paper)

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
@@ -191,7 +191,9 @@ class TNeumannHashTable {
 
 
     ui64 RequiredMemoryForBuild(int nItems) const {
-        return sizeof(TDirectory)*EstimateLogSize(nItems)+ static_cast<size_t>(BufferSlotSize_) * nItems;
+        const ui32 directoryHashBits = EstimateLogSize(nItems);
+        return sizeof(TDirectory) * ((ui64{1} << directoryHashBits) + 1)
+            + static_cast<ui64>(BufferSlotSize_) * nItems;
     }
 
     void Build(const ui8 *const tuples, const ui8 *const overflow, int nItems,

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
@@ -9,6 +9,8 @@
 
 #include <util/generic/buffer.h>
 
+#include <bit>
+
 #include "tuple.h"
 #include "join_defs.h"
 namespace NKikimr {
@@ -177,7 +179,11 @@ class TNeumannHashTable {
     TNeumannHashTable &operator=(TNeumannHashTable &&) = default;
 
     static ui32 EstimateLogSize(int nItems) {
-        int estimated = 32 - std::countl_zero<ui32>(nItems);
+        if (nItems <= 0) {
+            return 1;
+        }
+        const ui64 want = (static_cast<ui64>(nItems) * 9 + 7) / 8;
+        const int estimated = std::bit_width(want - 1);
         return std::max(1, std::min(24, estimated));
     }
 

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
@@ -178,7 +178,7 @@ class TNeumannHashTable {
 
     static ui32 EstimateLogSize(int nItems) {
         int estimated = 32 - std::countl_zero<ui32>(nItems);
-        return std::max(1, std::min(24, estimated > 2 ? estimated - 2 : estimated));
+        return std::max(1, std::min(24, estimated));
     }
 
 

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/hash_table_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/hash_table_ut.cpp
@@ -485,6 +485,26 @@ using TPageTableAVX2Pref = TPageHashTableImpl<NSimd::TSimdAVX2Traits, true>;
 
 // -----------------------------------------------------------------
 
+Y_UNIT_TEST_SUITE(NeumannHashTableTest) {
+    Y_UNIT_TEST(RequiredMemoryForBuild) {
+        TColumnDesc key;
+        key.Role = EColumnRole::Key;
+        key.DataSize = sizeof(ui32);
+
+        auto layout = TTupleLayout::Create({key});
+        TNeumannTable table(layout.Get());
+
+        constexpr int nItems = 1024;
+        constexpr ui64 directoryEntries = 2049;
+        const ui64 expected = directoryEntries * sizeof(ui64)
+            + static_cast<ui64>(layout->TotalRowSize) * nItems;
+
+        UNIT_ASSERT_VALUES_EQUAL(table.RequiredMemoryForBuild(nItems), expected);
+    }
+}
+
+// -----------------------------------------------------------------
+
 template <typename... Args> struct TTablesCase {
     template <size_t Batch> using TBenchmark = TBenchmark<Batch, Args...>;
 };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
should be `2^log2(1.125 n)` like in https://db.in.tum.de/~birler/papers/hashtable.pdf
...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
