### PR TITLE
Scheme operations with only-read transactions [add repeatable read for it]

### DIFF
--- a/ydb/core/kqp/common/kqp_tx.cpp
+++ b/ydb/core/kqp/common/kqp_tx.cpp
@@ -44,6 +44,33 @@ TKqpTransactionInfo TKqpTransactionContext::GetInfo() const {
     return txInfo;
 }
 
+bool HasRepeatableReads(NKqpProto::EIsolationLevel isolationLevel) {
+    switch (isolationLevel) {
+        case NKqpProto::ISOLATION_LEVEL_SERIALIZABLE:
+        case NKqpProto::ISOLATION_LEVEL_STRICT_SERIALIZABLE:
+        case NKqpProto::ISOLATION_LEVEL_SNAPSHOT_RO:
+        case NKqpProto::ISOLATION_LEVEL_SNAPSHOT_RW:
+            // These run on a single snapshot reused by every statement of the transaction.
+            return true;
+
+        case NKqpProto::ISOLATION_LEVEL_READ_COMMITTED_RW:
+            // Every statement is meant to see the latest committed data.
+            return false;
+
+        case NKqpProto::ISOLATION_LEVEL_ONLINE_RO:
+        case NKqpProto::ISOLATION_LEVEL_INCONSISTENT_ONLINE_RO:
+        case NKqpProto::ISOLATION_LEVEL_READ_STALE:
+            // No snapshot at all, and consistency between statements is not promised.
+            return false;
+
+        case NKqpProto::ISOLATION_LEVEL_UNDEFINED:
+            return false;
+
+        default:
+            return false;
+    }
+}
+
 bool NeedSnapshot(const TKqpTransactionContext& txCtx, const NYql::TKikimrConfiguration& config, bool rollbackTx,
     bool commitTx, const NKqpProto::TKqpPhyQuery& physicalQuery)
 {

--- a/ydb/core/kqp/common/kqp_tx.cpp
+++ b/ydb/core/kqp/common/kqp_tx.cpp
@@ -64,9 +64,8 @@ bool HasRepeatableReads(NKqpProto::EIsolationLevel isolationLevel) {
             return false;
 
         case NKqpProto::ISOLATION_LEVEL_UNDEFINED:
-            return false;
-
-        default:
+        case NKqpProto::EIsolationLevel_INT_MIN_SENTINEL_DO_NOT_USE_:
+        case NKqpProto::EIsolationLevel_INT_MAX_SENTINEL_DO_NOT_USE_:
             return false;
     }
 }

--- a/ydb/core/kqp/common/kqp_tx.cpp
+++ b/ydb/core/kqp/common/kqp_tx.cpp
@@ -44,7 +44,7 @@ TKqpTransactionInfo TKqpTransactionContext::GetInfo() const {
     return txInfo;
 }
 
-bool HasRepeatableReads(NKqpProto::EIsolationLevel isolationLevel) {
+bool GuaranteesRepeatableReads(NKqpProto::EIsolationLevel isolationLevel) {
     switch (isolationLevel) {
         case NKqpProto::ISOLATION_LEVEL_SERIALIZABLE:
         case NKqpProto::ISOLATION_LEVEL_STRICT_SERIALIZABLE:
@@ -64,10 +64,15 @@ bool HasRepeatableReads(NKqpProto::EIsolationLevel isolationLevel) {
             return false;
 
         case NKqpProto::ISOLATION_LEVEL_UNDEFINED:
+            // A query without transaction control: every statement is its own transaction.
+            return false;
+
         case NKqpProto::EIsolationLevel_INT_MIN_SENTINEL_DO_NOT_USE_:
         case NKqpProto::EIsolationLevel_INT_MAX_SENTINEL_DO_NOT_USE_:
-            return false;
+            break;
     }
+
+    Y_UNREACHABLE();
 }
 
 bool NeedSnapshot(const TKqpTransactionContext& txCtx, const NYql::TKikimrConfiguration& config, bool rollbackTx,

--- a/ydb/core/kqp/common/kqp_tx.h
+++ b/ydb/core/kqp/common/kqp_tx.h
@@ -191,6 +191,7 @@ public:
         HasTableRead = false;
         NeedUncommittedChangesFlush = false;
         QueryTextCollector.Clear();
+        TableSchemaVersions.clear();
     }
 
     TKqpTransactionInfo GetInfo() const;
@@ -335,6 +336,9 @@ public:
     IKqpTransactionManagerPtr TxManager = nullptr;
 
     TShardIdToTableInfoPtr ShardIdToTableInfo = std::make_shared<TShardIdToTableInfo>();
+
+    // Schema version of every table seen at compilation time of the queries in this tx.
+    THashMap<NYql::TKikimrPathId, ui64> TableSchemaVersions;
 
     NDataIntegrity::TQueryTextCollector QueryTextCollector;
 };

--- a/ydb/core/kqp/common/kqp_tx.h
+++ b/ydb/core/kqp/common/kqp_tx.h
@@ -191,7 +191,7 @@ public:
         HasTableRead = false;
         NeedUncommittedChangesFlush = false;
         QueryTextCollector.Clear();
-        TableSchemaVersions.clear();
+        SchemaObjects.clear();
     }
 
     TKqpTransactionInfo GetInfo() const;
@@ -337,8 +337,17 @@ public:
 
     TShardIdToTableInfoPtr ShardIdToTableInfo = std::make_shared<TShardIdToTableInfo>();
 
-    // Schema version of every table seen at compilation time of the queries in this tx.
-    THashMap<NYql::TKikimrPathId, ui64> TableSchemaVersions;
+    struct TSchemaIdentity {
+        NYql::TKikimrPathId PathId;
+        ui64 SchemaVersion = 0;
+
+        bool operator==(const TSchemaIdentity& other) const = default;
+    };
+
+    // Identity of every schema object, as the statements of this tx were compiled against it.
+    // Keyed by path rather than by path id: an object dropped and created anew under the same
+    // name is a different object, and the transaction must not read it as if nothing happened.
+    THashMap<TString, TSchemaIdentity> SchemaObjects;
 
     NDataIntegrity::TQueryTextCollector QueryTextCollector;
 };

--- a/ydb/core/kqp/common/kqp_tx.h
+++ b/ydb/core/kqp/common/kqp_tx.h
@@ -491,6 +491,9 @@ public:
 bool NeedSnapshot(const TKqpTransactionContext& txCtx, const NYql::TKikimrConfiguration& config, bool rollbackTx,
     bool commitTx, const NKqpProto::TKqpPhyQuery& physicalQuery);
 
+// Whether the mode promises that all reads of a transaction observe the same state.
+bool HasRepeatableReads(NKqpProto::EIsolationLevel isolationLevel);
+
 bool HasOlapTableReadInTx(const NKqpProto::TKqpPhyQuery& physicalQuery);
 bool HasOlapTableWriteInStage(const NKqpProto::TKqpPhyStage& stage);
 bool HasOlapTableWriteInTx(const NKqpProto::TKqpPhyQuery& physicalQuery);

--- a/ydb/core/kqp/common/kqp_tx.h
+++ b/ydb/core/kqp/common/kqp_tx.h
@@ -344,9 +344,11 @@ public:
         bool operator==(const TSchemaIdentity& other) const = default;
     };
 
-    // Identity of every schema object, as the statements of this tx were compiled against it.
-    // Keyed by path rather than by path id: an object dropped and created anew under the same
-    // name is a different object, and the transaction must not read it as if nothing happened.
+    // A statement is compiled against one schema version of each object it uses, and every
+    // later statement of the transaction has to see that same version. This is what the
+    // earlier statements were compiled against.
+    // Keyed by path, not by path id: an object dropped and created anew under the same name is
+    // a different object, and the transaction must not read it as if nothing had changed.
     THashMap<TString, TSchemaIdentity> SchemaObjects;
 
     NDataIntegrity::TQueryTextCollector QueryTextCollector;
@@ -501,7 +503,7 @@ bool NeedSnapshot(const TKqpTransactionContext& txCtx, const NYql::TKikimrConfig
     bool commitTx, const NKqpProto::TKqpPhyQuery& physicalQuery);
 
 // Whether the mode promises that all reads of a transaction observe the same state.
-bool HasRepeatableReads(NKqpProto::EIsolationLevel isolationLevel);
+bool GuaranteesRepeatableReads(NKqpProto::EIsolationLevel isolationLevel);
 
 bool HasOlapTableReadInTx(const NKqpProto::TKqpPhyQuery& physicalQuery);
 bool HasOlapTableWriteInStage(const NKqpProto::TKqpPhyStage& stage);

--- a/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
@@ -463,6 +463,7 @@ public:
                 ) {
                     const auto& viewMetadata = *res.Metadata;
                     auto* viewInfo = preparingQuery->MutablePhysicalQuery()->MutableViewInfos()->Add();
+                    viewInfo->SetTableName(viewMetadata.Name);
                     auto* pathId = viewInfo->MutableTableId();
                     pathId->SetOwnerId(viewMetadata.PathId.OwnerId());
                     pathId->SetTableId(viewMetadata.PathId.TableId());

--- a/ydb/core/kqp/session_actor/kqp_query_state.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_state.cpp
@@ -91,8 +91,8 @@ bool TKqpQueryState::EnsureTableVersions(const TEvTxProxySchemeCache::TEvNavigat
     return true;
 }
 
-void TKqpQueryState::FillViews(const google::protobuf::RepeatedPtrField< ::NKqpProto::TKqpTableInfo>& views) {
-    for (const auto& view : views) {
+void TKqpQueryState::FillTableInfos(const google::protobuf::RepeatedPtrField< ::NKqpProto::TKqpTableInfo>& infos) {
+    for (const auto& view : infos) {
         const auto& pathId = view.GetTableId();
         const auto schemaVersion = view.GetSchemaVersion();
         auto [it, isInserted] = TableVersions.emplace(TTableId(pathId.GetOwnerId(), pathId.GetTableId()), schemaVersion);
@@ -108,7 +108,11 @@ std::unique_ptr<TEvTxProxySchemeCache::TEvNavigateKeySet> TKqpQueryState::BuildN
     for (const auto& tx : PreparedQuery->GetPhysicalQuery().GetTransactions()) {
         FillTables(tx);
     }
-    FillViews(PreparedQuery->GetPhysicalQuery().GetViewInfos());
+    // The physical plan only names the tables it actually reads, so a query served entirely
+    // from an index leaves the table it logically reads out of the set. Take the logical
+    // tables too, otherwise a change to such a table never invalidates the compiled query.
+    FillTableInfos(PreparedQuery->GetPhysicalQuery().GetTableInfos());
+    FillTableInfos(PreparedQuery->GetPhysicalQuery().GetViewInfos());
 
     auto navigate = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
     navigate->DatabaseName = Database;

--- a/ydb/core/kqp/session_actor/kqp_query_state.h
+++ b/ydb/core/kqp/session_actor/kqp_query_state.h
@@ -419,7 +419,7 @@ public:
         }
     }
 
-    void FillViews(const google::protobuf::RepeatedPtrField< ::NKqpProto::TKqpTableInfo>& views);
+    void FillTableInfos(const google::protobuf::RepeatedPtrField< ::NKqpProto::TKqpTableInfo>& infos);
 
     bool NeedCheckTableVersions() const {
         return CompileStats.FromCache;

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1575,7 +1575,7 @@ public:
         // Only modes that promise repeatable reads are aborted: the rest are documented to
         // observe newer data between statements.
         if (QueryState->TxCtx->EffectiveIsolationLevel
-                && HasRepeatableReads(*QueryState->TxCtx->EffectiveIsolationLevel)) {
+                && GuaranteesRepeatableReads(*QueryState->TxCtx->EffectiveIsolationLevel)) {
             const NKqpProto::TKqpTableInfo* changed = nullptr;
 
             auto rememberOrCompare = [&](const auto& infos) {

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1572,21 +1572,26 @@ public:
             AFL_ENSURE(checkSchemeTx());
         }
 
-        for (const auto& tableInfo : phyQuery.GetTableInfos()) {
-            const ui64 schemaVersion = tableInfo.GetSchemaVersion();
-            if (!schemaVersion) {
-                continue;
-            }
+        // Only modes that promise repeatable reads are aborted: the rest are documented to
+        // observe newer data between statements.
+        if (QueryState->TxCtx->EffectiveIsolationLevel
+                && HasRepeatableReads(*QueryState->TxCtx->EffectiveIsolationLevel)) {
+            for (const auto& tableInfo : phyQuery.GetTableInfos()) {
+                const ui64 schemaVersion = tableInfo.GetSchemaVersion();
+                if (!schemaVersion) {
+                    continue;
+                }
 
-            const NYql::TKikimrPathId pathId(
-                tableInfo.GetTableId().GetOwnerId(), tableInfo.GetTableId().GetTableId());
-            const auto [it, inserted] = QueryState->TxCtx->TableSchemaVersions.emplace(pathId, schemaVersion);
-            if (!inserted && it->second != schemaVersion) {
-                ReplyQueryError(Ydb::StatusIds::ABORTED, TStringBuilder()
-                    << "Scheme changed for table '" << tableInfo.GetTableName()
-                    << "' during transaction execution, schema version "
-                    << it->second << " -> " << schemaVersion << ".");
-                return false;
+                const NYql::TKikimrPathId pathId(
+                    tableInfo.GetTableId().GetOwnerId(), tableInfo.GetTableId().GetTableId());
+                const auto [it, inserted] = QueryState->TxCtx->TableSchemaVersions.emplace(pathId, schemaVersion);
+                if (!inserted && it->second != schemaVersion) {
+                    ReplyQueryError(Ydb::StatusIds::ABORTED, TStringBuilder()
+                        << "Scheme changed for table '" << tableInfo.GetTableName()
+                        << "' during transaction execution, schema version "
+                        << it->second << " -> " << schemaVersion << ".");
+                    return false;
+                }
             }
         }
 

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1572,6 +1572,24 @@ public:
             AFL_ENSURE(checkSchemeTx());
         }
 
+        for (const auto& tableInfo : phyQuery.GetTableInfos()) {
+            const ui64 schemaVersion = tableInfo.GetSchemaVersion();
+            if (!schemaVersion) {
+                continue;
+            }
+
+            const NYql::TKikimrPathId pathId(
+                tableInfo.GetTableId().GetOwnerId(), tableInfo.GetTableId().GetTableId());
+            const auto [it, inserted] = QueryState->TxCtx->TableSchemaVersions.emplace(pathId, schemaVersion);
+            if (!inserted && it->second != schemaVersion) {
+                ReplyQueryError(Ydb::StatusIds::ABORTED, TStringBuilder()
+                    << "Scheme changed for table '" << tableInfo.GetTableName()
+                    << "' during transaction execution, schema version "
+                    << it->second << " -> " << schemaVersion << ".");
+                return false;
+            }
+        }
+
         const bool hasOlapWrite = ::NKikimr::NKqp::HasOlapTableWriteInTx(phyQuery);
         const bool hasOltpWrite = ::NKikimr::NKqp::HasOltpTableWriteInTx(phyQuery);
         const bool hasOlapRead = ::NKikimr::NKqp::HasOlapTableReadInTx(phyQuery);

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1576,22 +1576,38 @@ public:
         // observe newer data between statements.
         if (QueryState->TxCtx->EffectiveIsolationLevel
                 && HasRepeatableReads(*QueryState->TxCtx->EffectiveIsolationLevel)) {
-            for (const auto& tableInfo : phyQuery.GetTableInfos()) {
-                const ui64 schemaVersion = tableInfo.GetSchemaVersion();
-                if (!schemaVersion) {
-                    continue;
-                }
+            const NKqpProto::TKqpTableInfo* changed = nullptr;
 
-                const NYql::TKikimrPathId pathId(
-                    tableInfo.GetTableId().GetOwnerId(), tableInfo.GetTableId().GetTableId());
-                const auto [it, inserted] = QueryState->TxCtx->TableSchemaVersions.emplace(pathId, schemaVersion);
-                if (!inserted && it->second != schemaVersion) {
-                    ReplyQueryError(Ydb::StatusIds::ABORTED, TStringBuilder()
-                        << "Scheme changed for table '" << tableInfo.GetTableName()
-                        << "' during transaction execution, schema version "
-                        << it->second << " -> " << schemaVersion << ".");
-                    return false;
+            auto rememberOrCompare = [&](const auto& infos) {
+                for (const auto& info : infos) {
+                    if (!info.GetSchemaVersion()) {
+                        continue;
+                    }
+
+                    const TKqpTransactionContext::TSchemaIdentity identity{
+                        .PathId = NYql::TKikimrPathId(
+                            info.GetTableId().GetOwnerId(), info.GetTableId().GetTableId()),
+                        .SchemaVersion = info.GetSchemaVersion(),
+                    };
+
+                    const auto [it, inserted] =
+                        QueryState->TxCtx->SchemaObjects.emplace(info.GetTableName(), identity);
+                    if (!inserted && it->second != identity) {
+                        changed = &info;
+                        return false;
+                    }
                 }
+                return true;
+            };
+
+            // Views carry their own version and their own path, so a view redefined over an
+            // untouched table has to be caught here as well.
+            if (!rememberOrCompare(phyQuery.GetTableInfos()) || !rememberOrCompare(phyQuery.GetViewInfos())) {
+                std::vector<TIssue> issues{YqlIssue({}, TIssuesIds::KIKIMR_SCHEME_MISMATCH,
+                    TStringBuilder() << "Scheme changed for '" << changed->GetTableName()
+                        << "' during transaction execution.")};
+                ReplyQueryError(Ydb::StatusIds::ABORTED, "", MessageFromIssues(issues));
+                return false;
             }
         }
 

--- a/ydb/core/kqp/ut/effects/kqp_effects_ut.cpp
+++ b/ydb/core/kqp/ut/effects/kqp_effects_ut.cpp
@@ -662,15 +662,14 @@ Y_UNIT_TEST_SUITE(KqpEffects) {
         )").ExtractValueSync();
         UNIT_ASSERT_C(alterResult.IsSuccess(), alterResult.GetIssues().ToString());
 
+        // The statement is compiled against a schema version the transaction has not seen, so
+        // it is refused right away instead of being deferred and failing at commit.
         auto upsertResult2 = session1.ExecuteDataQuery(R"(
             UPSERT INTO `TestTable` (Key, Value1) VALUES
                 (1u, "First"),
                 (2u, "Second");
         )", TTxControl::Tx(*tx1)).ExtractValueSync();
-        UNIT_ASSERT_C(upsertResult2.IsSuccess(), upsertResult2.GetIssues().ToString());
-
-        auto commitResult = tx1->Commit().GetValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(commitResult.GetStatus(), EStatus::ABORTED, commitResult.GetIssues().ToString());
+        UNIT_ASSERT_VALUES_EQUAL_C(upsertResult2.GetStatus(), EStatus::ABORTED, upsertResult2.GetIssues().ToString());
     }
 
     Y_UNIT_TEST(AlterAfterUpsertBeforeUpsertSelectTransaction) {

--- a/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
@@ -1335,6 +1335,9 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         DropChangefeed,
         SetFamily,
         SetDefault,
+        ViewReadAddColumn,
+        ViewRecreate,
+        ViewDrop,
     };
 
     constexpr ESchemeOp AllSchemeOps[] = {
@@ -1349,6 +1352,9 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         ESchemeOp::DropChangefeed,
         ESchemeOp::SetFamily,
         ESchemeOp::SetDefault,
+        ESchemeOp::ViewReadAddColumn,
+        ESchemeOp::ViewRecreate,
+        ESchemeOp::ViewDrop,
     };
 
     struct TSchemeOpSpec {
@@ -1451,6 +1457,45 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             case ESchemeOp::SetDefault:
                 spec.Operation = R"(ALTER TABLE `/Root/SchemeOpsTable` ALTER COLUMN Value SET DEFAULT "def"u;)";
                 break;
+
+            case ESchemeOp::ViewReadAddColumn:
+                // The transaction reads the table through a view, and the table changes.
+                spec.Setup = R"(
+                    CREATE VIEW `/Root/SchemeOpsView` WITH (security_invoker = TRUE) AS
+                        SELECT * FROM `/Root/SchemeOpsTable`;
+                )";
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ADD COLUMN Extra Uint64;";
+                spec.Read = "SELECT * FROM `/Root/SchemeOpsView` ORDER BY Key;";
+                break;
+
+            case ESchemeOp::ViewRecreate:
+                // The table is untouched; the view is redefined to select fewer columns.
+                // The transaction reads through the new definition instead of aborting: view
+                // versions travel in ViewInfos, which the check does not look at. Fixed by the
+                // next commit.
+                spec.Setup = R"(
+                    CREATE VIEW `/Root/SchemeOpsView` WITH (security_invoker = TRUE) AS
+                        SELECT Key, Value FROM `/Root/SchemeOpsTable`;
+                )";
+                spec.Operation = R"(
+                    DROP VIEW `/Root/SchemeOpsView`;
+                    CREATE VIEW `/Root/SchemeOpsView` WITH (security_invoker = TRUE) AS
+                        SELECT Key FROM `/Root/SchemeOpsTable`;
+                )";
+                spec.Read = "SELECT * FROM `/Root/SchemeOpsView` ORDER BY Key;";
+                spec.RepeatableReadStatus = EStatus::SUCCESS;
+                break;
+
+            case ESchemeOp::ViewDrop:
+                spec.Setup = R"(
+                    CREATE VIEW `/Root/SchemeOpsView` WITH (security_invoker = TRUE) AS
+                        SELECT Key, Value FROM `/Root/SchemeOpsTable`;
+                )";
+                spec.Operation = "DROP VIEW `/Root/SchemeOpsView`;";
+                spec.Read = "SELECT * FROM `/Root/SchemeOpsView` ORDER BY Key;";
+                spec.RepeatableReadStatus = EStatus::SCHEME_ERROR;
+                spec.RelaxedStatus = EStatus::SCHEME_ERROR;
+                break;
         }
         return spec;
     }
@@ -1501,9 +1546,10 @@ Y_UNIT_TEST_SUITE(KqpTx) {
                 UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Scheme changed for table");
             }
 
-            // The transaction is released on failure, so the client cannot commit it anymore.
+            // A failed statement releases the transaction; a tolerated change leaves it usable.
             auto commitResult = tx->Commit().ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(commitResult.GetStatus(), EStatus::NOT_FOUND,
+            UNIT_ASSERT_VALUES_EQUAL_C(commitResult.GetStatus(),
+                spec.RepeatableReadStatus == EStatus::SUCCESS ? EStatus::SUCCESS : EStatus::NOT_FOUND,
                 commitResult.GetIssues().ToString());
         }
     };
@@ -1571,6 +1617,24 @@ Y_UNIT_TEST_SUITE(KqpTx) {
     Y_UNIT_TEST(SchemeChangeSetDefault) {
         TSchemeChangeInTxTester tester;
         tester.Operation = ESchemeOp::SetDefault;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeViewReadAddColumn) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = ESchemeOp::ViewReadAddColumn;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeViewRecreate) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = ESchemeOp::ViewRecreate;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeViewDrop) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = ESchemeOp::ViewDrop;
         tester.Execute();
     }
 

--- a/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
@@ -1764,7 +1764,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
     }
 
     // Same scenario over the query service, where every isolation mode is reachable.
-    // PromisesRepeatableReads mirrors HasRepeatableReads() in kqp_tx.cpp and picks which of
+    // PromisesRepeatableReads mirrors GuaranteesRepeatableReads() in kqp_tx.cpp and picks which of
     // the two statuses of the operation is expected.
     struct TSchemeChangeIsolationTester {
         ESchemeOp Operation = ESchemeOp::AddColumn;

--- a/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
@@ -1337,6 +1337,20 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         SetDefault,
     };
 
+    constexpr ESchemeOp AllSchemeOps[] = {
+        ESchemeOp::AddColumn,
+        ESchemeOp::DropReadColumn,
+        ESchemeOp::DropUnreadColumn,
+        ESchemeOp::TruncateTable,
+        ESchemeOp::AddIndex,
+        ESchemeOp::DropIndex,
+        ESchemeOp::DropIndexWithIndexRead,
+        ESchemeOp::AddChangefeed,
+        ESchemeOp::DropChangefeed,
+        ESchemeOp::SetFamily,
+        ESchemeOp::SetDefault,
+    };
+
     struct TSchemeOpSpec {
         TString Create = R"(
             CREATE TABLE `/Root/SchemeOpsTable` (
@@ -1626,151 +1640,73 @@ Y_UNIT_TEST_SUITE(KqpTx) {
     };
 
     Y_UNIT_TEST(SchemeChangeIsolationSerializableRW) {
-        TSchemeChangeIsolationTester tester;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::SerializableRW();
-        tester.Execute();
+        for (const auto op : AllSchemeOps) {
+            TSchemeChangeIsolationTester tester;
+            tester.Operation = op;
+            tester.TxSettings = NYdb::NQuery::TTxSettings::SerializableRW();
+            tester.Execute();
+        }
     }
 
     Y_UNIT_TEST(SchemeChangeIsolationSnapshotRO) {
-        TSchemeChangeIsolationTester tester;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::SnapshotRO();
-        tester.Execute();
+        for (const auto op : AllSchemeOps) {
+            TSchemeChangeIsolationTester tester;
+            tester.Operation = op;
+            tester.TxSettings = NYdb::NQuery::TTxSettings::SnapshotRO();
+            tester.Execute();
+        }
     }
 
     Y_UNIT_TEST(SchemeChangeIsolationSnapshotRW) {
-        TSchemeChangeIsolationTester tester;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::SnapshotRW();
-        tester.Execute();
+        for (const auto op : AllSchemeOps) {
+            TSchemeChangeIsolationTester tester;
+            tester.Operation = op;
+            tester.TxSettings = NYdb::NQuery::TTxSettings::SnapshotRW();
+            tester.Execute();
+        }
     }
 
     Y_UNIT_TEST(SchemeChangeIsolationStrictSerializableRW) {
-        TSchemeChangeIsolationTester tester;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::StrictSerializableRW();
-        tester.EnableStrictSerializable = true;
-        tester.Execute();
+        for (const auto op : AllSchemeOps) {
+            TSchemeChangeIsolationTester tester;
+            tester.Operation = op;
+            tester.TxSettings = NYdb::NQuery::TTxSettings::StrictSerializableRW();
+            tester.EnableStrictSerializable = true;
+            tester.Execute();
+        }
     }
 
-    // Read Committed is meant to see the latest committed data on every statement, and the
-    // Online and Stale modes promise no consistency between statements at all.
+    // Read Committed is meant to see the latest committed data on every statement, and
+    // the Online and Stale modes promise no consistency between statements at all.
     Y_UNIT_TEST(SchemeChangeIsolationReadCommittedRW) {
-        TSchemeChangeIsolationTester tester;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
-        tester.EnableReadCommitted = true;
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
+        for (const auto op : AllSchemeOps) {
+            TSchemeChangeIsolationTester tester;
+            tester.Operation = op;
+            tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
+            tester.EnableReadCommitted = true;
+            tester.PromisesRepeatableReads = false;
+            tester.Execute();
+        }
     }
 
     Y_UNIT_TEST(SchemeChangeIsolationStaleRO) {
-        TSchemeChangeIsolationTester tester;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::StaleRO();
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
+        for (const auto op : AllSchemeOps) {
+            TSchemeChangeIsolationTester tester;
+            tester.Operation = op;
+            tester.TxSettings = NYdb::NQuery::TTxSettings::StaleRO();
+            tester.PromisesRepeatableReads = false;
+            tester.Execute();
+        }
     }
 
     Y_UNIT_TEST(SchemeChangeIsolationOnlineRO) {
-        TSchemeChangeIsolationTester tester;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::OnlineRO();
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
-    }
-
-    Y_UNIT_TEST(SchemeChangeReadCommittedAddColumn) {
-        TSchemeChangeIsolationTester tester;
-        tester.Operation = ESchemeOp::AddColumn;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
-        tester.EnableReadCommitted = true;
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
-    }
-
-    Y_UNIT_TEST(SchemeChangeReadCommittedDropReadColumn) {
-        TSchemeChangeIsolationTester tester;
-        tester.Operation = ESchemeOp::DropReadColumn;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
-        tester.EnableReadCommitted = true;
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
-    }
-
-    Y_UNIT_TEST(SchemeChangeReadCommittedDropUnreadColumn) {
-        TSchemeChangeIsolationTester tester;
-        tester.Operation = ESchemeOp::DropUnreadColumn;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
-        tester.EnableReadCommitted = true;
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
-    }
-
-    Y_UNIT_TEST(SchemeChangeReadCommittedTruncateTable) {
-        TSchemeChangeIsolationTester tester;
-        tester.Operation = ESchemeOp::TruncateTable;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
-        tester.EnableReadCommitted = true;
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
-    }
-
-    Y_UNIT_TEST(SchemeChangeReadCommittedAddIndex) {
-        TSchemeChangeIsolationTester tester;
-        tester.Operation = ESchemeOp::AddIndex;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
-        tester.EnableReadCommitted = true;
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
-    }
-
-    Y_UNIT_TEST(SchemeChangeReadCommittedDropIndex) {
-        TSchemeChangeIsolationTester tester;
-        tester.Operation = ESchemeOp::DropIndex;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
-        tester.EnableReadCommitted = true;
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
-    }
-
-    Y_UNIT_TEST(SchemeChangeReadCommittedDropIndexWithIndexRead) {
-        TSchemeChangeIsolationTester tester;
-        tester.Operation = ESchemeOp::DropIndexWithIndexRead;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
-        tester.EnableReadCommitted = true;
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
-    }
-
-    Y_UNIT_TEST(SchemeChangeReadCommittedAddChangefeed) {
-        TSchemeChangeIsolationTester tester;
-        tester.Operation = ESchemeOp::AddChangefeed;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
-        tester.EnableReadCommitted = true;
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
-    }
-
-    Y_UNIT_TEST(SchemeChangeReadCommittedDropChangefeed) {
-        TSchemeChangeIsolationTester tester;
-        tester.Operation = ESchemeOp::DropChangefeed;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
-        tester.EnableReadCommitted = true;
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
-    }
-
-    Y_UNIT_TEST(SchemeChangeReadCommittedSetFamily) {
-        TSchemeChangeIsolationTester tester;
-        tester.Operation = ESchemeOp::SetFamily;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
-        tester.EnableReadCommitted = true;
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
-    }
-
-    Y_UNIT_TEST(SchemeChangeReadCommittedSetDefault) {
-        TSchemeChangeIsolationTester tester;
-        tester.Operation = ESchemeOp::SetDefault;
-        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
-        tester.EnableReadCommitted = true;
-        tester.PromisesRepeatableReads = false;
-        tester.Execute();
+        for (const auto op : AllSchemeOps) {
+            TSchemeChangeIsolationTester tester;
+            tester.Operation = op;
+            tester.TxSettings = NYdb::NQuery::TTxSettings::OnlineRO();
+            tester.PromisesRepeatableReads = false;
+            tester.Execute();
+        }
     }
 }
 

--- a/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
@@ -1340,6 +1340,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         SetFamily,
         SetDefault,
         DropCreateTable,
+        SamePathWrittenTwoWays,
         ViewReadAddColumn,
         ViewRecreate,
         TwoViewsRecreateOne,
@@ -1363,6 +1364,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         ESchemeOp::SetFamily,
         ESchemeOp::SetDefault,
         ESchemeOp::DropCreateTable,
+        ESchemeOp::SamePathWrittenTwoWays,
         ESchemeOp::ViewReadAddColumn,
         ESchemeOp::ViewRecreate,
         ESchemeOp::TwoViewsRecreateOne,
@@ -1387,6 +1389,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             case ESchemeOp::SetFamily: return "SetFamily";
             case ESchemeOp::SetDefault: return "SetDefault";
             case ESchemeOp::DropCreateTable: return "DropCreateTable";
+            case ESchemeOp::SamePathWrittenTwoWays: return "SamePathWrittenTwoWays";
             case ESchemeOp::ViewReadAddColumn: return "ViewReadAddColumn";
             case ESchemeOp::ViewRecreate: return "ViewRecreate";
             case ESchemeOp::TwoViewsRecreateOne: return "TwoViewsRecreateOne";
@@ -1409,6 +1412,9 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         TString Operation;
 
         TString Read = "SELECT Key, Value FROM `/Root/SchemeOpsTable` ORDER BY Key;";
+
+        // The statement issued after the scheme operation, when it differs from the first.
+        TString SecondRead;
 
         // Status of the second read, in a transaction that promises repeatable reads and in
         // one that does not. They differ only where the schema version check is what fails:
@@ -1552,6 +1558,14 @@ Y_UNIT_TEST_SUITE(KqpTx) {
                 )";
                 break;
 
+            case ESchemeOp::SamePathWrittenTwoWays:
+                // The same table named absolutely and then relatively to the database. It is
+                // one object, so the change between the two reads has to be noticed.
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ADD COLUMN Extra Uint64;";
+                spec.Read = "SELECT Key, Value FROM `/Root/SchemeOpsTable` ORDER BY Key;";
+                spec.SecondRead = "SELECT Key, Value FROM `SchemeOpsTable` ORDER BY Key;";
+                break;
+
             case ESchemeOp::ViewReadAddColumn:
                 // The transaction reads the table through a view, and the table changes.
                 spec.Setup = R"(
@@ -1657,7 +1671,8 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             UNIT_ASSERT_VALUES_EQUAL_C(schemeResult.GetStatus(), EStatus::SUCCESS,
                 schemeResult.GetIssues().ToString());
 
-            result = session.ExecuteDataQuery(Q_(spec.Read), TTxControl::Tx(*tx)).ExtractValueSync();
+            const TString& secondRead = spec.SecondRead ? spec.SecondRead : spec.Read;
+            result = session.ExecuteDataQuery(Q_(secondRead), TTxControl::Tx(*tx)).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), spec.RepeatableReadStatus,
                 result.GetIssues().ToString());
             if (spec.RepeatableReadStatus == EStatus::ABORTED) {
@@ -1768,6 +1783,12 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         tester.Execute();
     }
 
+    Y_UNIT_TEST(SchemeChangeSamePathWrittenTwoWays) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = ESchemeOp::SamePathWrittenTwoWays;
+        tester.Execute();
+    }
+
     Y_UNIT_TEST(SchemeChangeViewReadAddColumn) {
         TSchemeChangeInTxTester tester;
         tester.Operation = ESchemeOp::ViewReadAddColumn;
@@ -1855,7 +1876,8 @@ Y_UNIT_TEST_SUITE(KqpTx) {
                 ? spec.RepeatableReadStatus
                 : spec.RelaxedStatus;
 
-            result = session.ExecuteQuery(spec.Read, NYdb::NQuery::TTxControl::Tx(*tx)).ExtractValueSync();
+            const TString& secondRead = spec.SecondRead ? spec.SecondRead : spec.Read;
+            result = session.ExecuteQuery(secondRead, NYdb::NQuery::TTxControl::Tx(*tx)).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expectedStatus, op << ": " << result.GetIssues().ToString());
             if (expectedStatus == EStatus::ABORTED) {
                 UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Scheme changed for", op);

--- a/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
@@ -1636,6 +1636,13 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             if (expectedStatus == EStatus::ABORTED) {
                 UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Scheme changed for table");
             }
+
+            // A mode that keeps reading past the scheme change keeps a usable transaction,
+            // while a failed statement releases it.
+            auto commitResult = tx->Commit().ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(commitResult.GetStatus(),
+                expectedStatus == EStatus::SUCCESS ? EStatus::SUCCESS : EStatus::NOT_FOUND,
+                commitResult.GetIssues().ToString());
         }
     };
 

--- a/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
@@ -1322,6 +1322,40 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Strict Serializable mode is disabled");
     }
+
+    Y_UNIT_TEST(SchemeChangeBreaksRepeatableRead) {
+        auto kikimr = DefaultKikimrRunner();
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        auto schemeSession = db.CreateSession().GetValueSync().GetSession();
+
+        auto result = session.ExecuteDataQuery(Q_(R"(
+            SELECT * FROM `/Root/KeyValue` ORDER BY Key;
+        )"), TTxControl::BeginTx(TTxSettings::SerializableRW())).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+        auto tx = result.GetTransaction();
+        UNIT_ASSERT(tx);
+        const TString firstRead = FormatResultSetYson(result.GetResultSet(0));
+
+        auto alterResult = schemeSession.ExecuteSchemeQuery(R"(
+            ALTER TABLE `/Root/KeyValue` ADD COLUMN Value2 Uint64;
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(alterResult.GetStatus(), EStatus::SUCCESS, alterResult.GetIssues().ToString());
+
+        result = session.ExecuteDataQuery(Q_(R"(
+            SELECT * FROM `/Root/KeyValue` ORDER BY Key;
+        )"), TTxControl::Tx(*tx)).ExtractValueSync();
+
+        // Buggy behaviour, fixed by the next commit: the second read succeeds and
+        // observes the new schema, so the transaction is not repeatable.
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        const TString secondRead = FormatResultSetYson(result.GetResultSet(0));
+        UNIT_ASSERT_STRINGS_UNEQUAL(firstRead, secondRead);
+
+        auto commitResult = tx->Commit().ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(commitResult.GetStatus(), EStatus::SUCCESS, commitResult.GetIssues().ToString());
+    }
 }
 
 } // namespace NKqp

--- a/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
@@ -1331,6 +1331,9 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         AddIndex,
         DropIndex,
         DropIndexWithIndexRead,
+        AlterIndexWithIndexRead,
+        AlterTableWithIndexRead,
+        MoveTable,
         AddChangefeed,
         DropChangefeed,
         SetFamily,
@@ -1349,6 +1352,9 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         ESchemeOp::AddIndex,
         ESchemeOp::DropIndex,
         ESchemeOp::DropIndexWithIndexRead,
+        ESchemeOp::AlterIndexWithIndexRead,
+        ESchemeOp::AlterTableWithIndexRead,
+        ESchemeOp::MoveTable,
         ESchemeOp::AddChangefeed,
         ESchemeOp::DropChangefeed,
         ESchemeOp::SetFamily,
@@ -1358,6 +1364,29 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         ESchemeOp::ViewRecreate,
         ESchemeOp::ViewDrop,
     };
+
+    TStringBuf ToString(ESchemeOp op) {
+        switch (op) {
+            case ESchemeOp::AddColumn: return "AddColumn";
+            case ESchemeOp::DropReadColumn: return "DropReadColumn";
+            case ESchemeOp::DropUnreadColumn: return "DropUnreadColumn";
+            case ESchemeOp::TruncateTable: return "TruncateTable";
+            case ESchemeOp::AddIndex: return "AddIndex";
+            case ESchemeOp::DropIndex: return "DropIndex";
+            case ESchemeOp::DropIndexWithIndexRead: return "DropIndexWithIndexRead";
+            case ESchemeOp::AlterIndexWithIndexRead: return "AlterIndexWithIndexRead";
+            case ESchemeOp::AlterTableWithIndexRead: return "AlterTableWithIndexRead";
+            case ESchemeOp::MoveTable: return "MoveTable";
+            case ESchemeOp::AddChangefeed: return "AddChangefeed";
+            case ESchemeOp::DropChangefeed: return "DropChangefeed";
+            case ESchemeOp::SetFamily: return "SetFamily";
+            case ESchemeOp::SetDefault: return "SetDefault";
+            case ESchemeOp::DropCreateTable: return "DropCreateTable";
+            case ESchemeOp::ViewReadAddColumn: return "ViewReadAddColumn";
+            case ESchemeOp::ViewRecreate: return "ViewRecreate";
+            case ESchemeOp::ViewDrop: return "ViewDrop";
+        }
+    }
 
     struct TSchemeOpSpec {
         TString Create = R"(
@@ -1424,6 +1453,40 @@ Y_UNIT_TEST_SUITE(KqpTx) {
                 spec.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
                 spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP INDEX ValueIndex;";
                 spec.Read = R"(SELECT Key, Value FROM `/Root/SchemeOpsTable` VIEW ValueIndex WHERE Value = "One";)";
+                spec.RepeatableReadStatus = EStatus::SCHEME_ERROR;
+                spec.RelaxedStatus = EStatus::SCHEME_ERROR;
+                break;
+
+            case ESchemeOp::AlterIndexWithIndexRead:
+                // Only the index's partitioning changes, which is storage layout: the rows the
+                // index returns are the same, so the transaction has nothing to be saved from.
+                spec.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ALTER INDEX ValueIndex SET AUTO_PARTITIONING_MIN_PARTITIONS_COUNT 10;";
+                spec.Read = R"(SELECT Key, Value FROM `/Root/SchemeOpsTable` VIEW ValueIndex WHERE Value = "One";)";
+                spec.RepeatableReadStatus = EStatus::SUCCESS;
+                break;
+
+            case ESchemeOp::AlterTableWithIndexRead:
+                // The read goes through the index but asks for a column the index does not
+                // cover, so it has to reach the table that then gains a column. Reading only
+                // covered columns is served from the index alone and is a different case.
+                spec.Create = R"(
+                    CREATE TABLE `/Root/SchemeOpsTable` (
+                        Key Uint64,
+                        Value String,
+                        Payload String,
+                        PRIMARY KEY (Key)
+                    );
+                )";
+                spec.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ADD COLUMN Extra Uint64;";
+                spec.Read = R"(SELECT Key, Payload FROM `/Root/SchemeOpsTable` VIEW ValueIndex WHERE Value = "One";)";
+                break;
+
+            case ESchemeOp::MoveTable:
+                // Renaming allocates a new path id and drops the old path, so the statement
+                // cannot resolve the table at all and never reaches the schema version check.
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` RENAME TO `/Root/SchemeOpsTableMoved`;";
                 spec.RepeatableReadStatus = EStatus::SCHEME_ERROR;
                 spec.RelaxedStatus = EStatus::SCHEME_ERROR;
                 break;
@@ -1521,12 +1584,13 @@ Y_UNIT_TEST_SUITE(KqpTx) {
 
         void Execute() const {
             const auto spec = MakeSchemeOpSpec(Operation);
+            const TString op = TStringBuilder() << "operation " << ToString(Operation);
 
             TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
             auto db = kikimr.GetTableClient();
-            auto createSession = [&db]() {
+            auto createSession = [&]() {
                 auto result = db.CreateSession().GetValueSync();
-                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, op << ": " << result.GetIssues().ToString());
                 return result.GetSession();
             };
             auto schemeSession = createSession();
@@ -1539,7 +1603,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             auto result = session.ExecuteDataQuery(Q_(R"(
                 REPLACE INTO `/Root/SchemeOpsTable` (Key, Value) VALUES (1u, "One"), (2u, "Two");
             )"), TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, op << ": " << result.GetIssues().ToString());
 
             if (spec.Setup) {
                 schemeResult = schemeSession.ExecuteSchemeQuery(spec.Setup).ExtractValueSync();
@@ -1549,10 +1613,10 @@ Y_UNIT_TEST_SUITE(KqpTx) {
 
             result = session.ExecuteDataQuery(Q_(spec.Read),
                 TTxControl::BeginTx(TTxSettings::SerializableRW())).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, op << ": " << result.GetIssues().ToString());
 
             auto tx = result.GetTransaction();
-            UNIT_ASSERT(tx);
+            UNIT_ASSERT_C(tx, op);
 
             schemeResult = schemeSession.ExecuteSchemeQuery(spec.Operation).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(schemeResult.GetStatus(), EStatus::SUCCESS,
@@ -1562,7 +1626,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), spec.RepeatableReadStatus,
                 result.GetIssues().ToString());
             if (spec.RepeatableReadStatus == EStatus::ABORTED) {
-                UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Scheme changed for");
+                UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Scheme changed for", op);
             }
 
             // A failed statement releases the transaction; a tolerated change leaves it usable.
@@ -1612,6 +1676,24 @@ Y_UNIT_TEST_SUITE(KqpTx) {
     Y_UNIT_TEST(SchemeChangeDropIndexWithIndexRead) {
         TSchemeChangeInTxTester tester;
         tester.Operation = ESchemeOp::DropIndexWithIndexRead;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeAlterIndexWithIndexRead) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = ESchemeOp::AlterIndexWithIndexRead;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeAlterTableWithIndexRead) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = ESchemeOp::AlterTableWithIndexRead;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeMoveTable) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = ESchemeOp::MoveTable;
         tester.Execute();
     }
 
@@ -1675,6 +1757,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
 
         void Execute() const {
             const auto spec = MakeSchemeOpSpec(Operation);
+            const TString op = TStringBuilder() << "operation " << ToString(Operation);
 
             TKikimrSettings settings;
             settings.SetWithSampleTables(false);
@@ -1683,9 +1766,9 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             TKikimrRunner kikimr(settings);
 
             auto db = kikimr.GetQueryClient();
-            auto createSession = [&db]() {
+            auto createSession = [&]() {
                 auto result = db.GetSession().GetValueSync();
-                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, op << ": " << result.GetIssues().ToString());
                 return result.GetSession();
             };
             auto session = createSession();
@@ -1700,7 +1783,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
                 REPLACE INTO `/Root/SchemeOpsTable` (Key, Value) VALUES (1u, "One"), (2u, "Two");
             )", NYdb::NQuery::TTxControl::BeginTx(NYdb::NQuery::TTxSettings::SerializableRW()).CommitTx())
                 .ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, op << ": " << result.GetIssues().ToString());
 
             if (spec.Setup) {
                 schemeResult = schemeSession.ExecuteQuery(spec.Setup,
@@ -1711,10 +1794,10 @@ Y_UNIT_TEST_SUITE(KqpTx) {
 
             result = session.ExecuteQuery(spec.Read,
                 NYdb::NQuery::TTxControl::BeginTx(TxSettings)).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, op << ": " << result.GetIssues().ToString());
 
             auto tx = result.GetTransaction();
-            UNIT_ASSERT(tx);
+            UNIT_ASSERT_C(tx, op);
 
             schemeResult = schemeSession.ExecuteQuery(spec.Operation,
                 NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
@@ -1726,9 +1809,9 @@ Y_UNIT_TEST_SUITE(KqpTx) {
                 : spec.RelaxedStatus;
 
             result = session.ExecuteQuery(spec.Read, NYdb::NQuery::TTxControl::Tx(*tx)).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expectedStatus, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expectedStatus, op << ": " << result.GetIssues().ToString());
             if (expectedStatus == EStatus::ABORTED) {
-                UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Scheme changed for");
+                UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Scheme changed for", op);
             }
 
             // A mode that keeps reading past the scheme change keeps a usable transaction,

--- a/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
@@ -1342,6 +1342,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         DropCreateTable,
         ViewReadAddColumn,
         ViewRecreate,
+        TwoViewsRecreateOne,
         ViewDrop,
     };
 
@@ -1364,6 +1365,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         ESchemeOp::DropCreateTable,
         ESchemeOp::ViewReadAddColumn,
         ESchemeOp::ViewRecreate,
+        ESchemeOp::TwoViewsRecreateOne,
         ESchemeOp::ViewDrop,
     };
 
@@ -1387,6 +1389,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             case ESchemeOp::DropCreateTable: return "DropCreateTable";
             case ESchemeOp::ViewReadAddColumn: return "ViewReadAddColumn";
             case ESchemeOp::ViewRecreate: return "ViewRecreate";
+            case ESchemeOp::TwoViewsRecreateOne: return "TwoViewsRecreateOne";
             case ESchemeOp::ViewDrop: return "ViewDrop";
         }
     }
@@ -1575,6 +1578,26 @@ Y_UNIT_TEST_SUITE(KqpTx) {
                 spec.Read = "SELECT * FROM `/Root/SchemeOpsView` ORDER BY Key;";
                 break;
 
+            case ESchemeOp::TwoViewsRecreateOne:
+                // Two views in one query, one of them redefined. Guards the identity of each
+                // object: if they were not told apart, the very first read would already fail.
+                spec.Setup = R"(
+                    CREATE VIEW `/Root/SchemeOpsView1` WITH (security_invoker = TRUE) AS
+                        SELECT Key, Value FROM `/Root/SchemeOpsTable`;
+                    CREATE VIEW `/Root/SchemeOpsView2` WITH (security_invoker = TRUE) AS
+                        SELECT Key, Value FROM `/Root/SchemeOpsTable`;
+                )";
+                spec.Operation = R"(
+                    DROP VIEW `/Root/SchemeOpsView2`;
+                    CREATE VIEW `/Root/SchemeOpsView2` WITH (security_invoker = TRUE) AS
+                        SELECT Key, Value FROM `/Root/SchemeOpsTable` WHERE Key > 0;
+                )";
+                spec.Read = R"(
+                    SELECT v1.Key AS K FROM `/Root/SchemeOpsView1` AS v1
+                    JOIN `/Root/SchemeOpsView2` AS v2 ON v1.Key = v2.Key ORDER BY K;
+                )";
+                break;
+
             case ESchemeOp::ViewDrop:
                 spec.Setup = R"(
                     CREATE VIEW `/Root/SchemeOpsView` WITH (security_invoker = TRUE) AS
@@ -1754,6 +1777,12 @@ Y_UNIT_TEST_SUITE(KqpTx) {
     Y_UNIT_TEST(SchemeChangeViewRecreate) {
         TSchemeChangeInTxTester tester;
         tester.Operation = ESchemeOp::ViewRecreate;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeTwoViewsRecreateOne) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = ESchemeOp::TwoViewsRecreateOne;
         tester.Execute();
     }
 

--- a/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
@@ -1333,6 +1333,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         DropIndexWithIndexRead,
         AlterIndexWithIndexRead,
         AlterTableWithIndexRead,
+        AlterTableWithCoveredIndexRead,
         MoveTable,
         AddChangefeed,
         DropChangefeed,
@@ -1354,6 +1355,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         ESchemeOp::DropIndexWithIndexRead,
         ESchemeOp::AlterIndexWithIndexRead,
         ESchemeOp::AlterTableWithIndexRead,
+        ESchemeOp::AlterTableWithCoveredIndexRead,
         ESchemeOp::MoveTable,
         ESchemeOp::AddChangefeed,
         ESchemeOp::DropChangefeed,
@@ -1376,6 +1378,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             case ESchemeOp::DropIndexWithIndexRead: return "DropIndexWithIndexRead";
             case ESchemeOp::AlterIndexWithIndexRead: return "AlterIndexWithIndexRead";
             case ESchemeOp::AlterTableWithIndexRead: return "AlterTableWithIndexRead";
+            case ESchemeOp::AlterTableWithCoveredIndexRead: return "AlterTableWithCoveredIndexRead";
             case ESchemeOp::MoveTable: return "MoveTable";
             case ESchemeOp::AddChangefeed: return "AddChangefeed";
             case ESchemeOp::DropChangefeed: return "DropChangefeed";
@@ -1481,6 +1484,15 @@ Y_UNIT_TEST_SUITE(KqpTx) {
                 spec.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
                 spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ADD COLUMN Extra Uint64;";
                 spec.Read = R"(SELECT Key, Payload FROM `/Root/SchemeOpsTable` VIEW ValueIndex WHERE Value = "One";)";
+                break;
+
+            case ESchemeOp::AlterTableWithCoveredIndexRead:
+                // Every column read is covered by the index, so the plan never touches the
+                // table. The query still names the table, so its version is what the statement
+                // was compiled against and a change to it has to abort just the same.
+                spec.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ADD COLUMN Extra Uint64;";
+                spec.Read = R"(SELECT Key, Value FROM `/Root/SchemeOpsTable` VIEW ValueIndex WHERE Value = "One";)";
                 break;
 
             case ESchemeOp::MoveTable:
@@ -1688,6 +1700,12 @@ Y_UNIT_TEST_SUITE(KqpTx) {
     Y_UNIT_TEST(SchemeChangeAlterTableWithIndexRead) {
         TSchemeChangeInTxTester tester;
         tester.Operation = ESchemeOp::AlterTableWithIndexRead;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeAlterTableWithCoveredIndexRead) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = ESchemeOp::AlterTableWithCoveredIndexRead;
         tester.Execute();
     }
 

--- a/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
@@ -1323,36 +1323,167 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Strict Serializable mode is disabled");
     }
 
-    Y_UNIT_TEST(SchemeChangeAbortsTx) {
-        auto kikimr = DefaultKikimrRunner();
-        auto db = kikimr.GetTableClient();
-        auto session = db.CreateSession().GetValueSync().GetSession();
-        auto schemeSession = db.CreateSession().GetValueSync().GetSession();
+    // Runs `read`, then the scheme `Operation` from another session, then `read` again,
+    // all inside one SerializableRW transaction, and checks how the second read fails.
+    struct TSchemeChangeInTxTester {
+        TString Create = R"(
+            CREATE TABLE `/Root/SchemeOpsTable` (
+                Key Uint64,
+                Value String,
+                PRIMARY KEY (Key)
+            );
+        )";
 
-        auto result = session.ExecuteDataQuery(Q_(R"(
-            SELECT * FROM `/Root/KeyValue` ORDER BY Key;
-        )"), TTxControl::BeginTx(TTxSettings::SerializableRW())).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        // Applied after the table is filled, before the transaction starts.
+        TString Setup;
 
-        auto tx = result.GetTransaction();
-        UNIT_ASSERT(tx);
-        CompareYson(R"([[[1u];["One"]];[[2u];["Two"]]])", FormatResultSetYson(result.GetResultSet(0)));
+        TString Operation;
 
-        auto alterResult = schemeSession.ExecuteSchemeQuery(R"(
-            ALTER TABLE `/Root/KeyValue` ADD COLUMN Value2 Uint64;
-        )").ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(alterResult.GetStatus(), EStatus::SUCCESS, alterResult.GetIssues().ToString());
+        TString Read = "SELECT Key, Value FROM `/Root/SchemeOpsTable` ORDER BY Key;";
 
-        result = session.ExecuteDataQuery(Q_(R"(
-            SELECT * FROM `/Root/KeyValue` ORDER BY Key;
-        )"), TTxControl::Tx(*tx)).ExtractValueSync();
+        EStatus ExpectedStatus = EStatus::ABORTED;
+        TString ExpectedIssue = "Scheme changed for table";
 
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::ABORTED, result.GetIssues().ToString());
-        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Scheme changed for table");
+        void Execute() const {
+            TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+            auto db = kikimr.GetTableClient();
+            auto schemeSession = db.CreateSession().GetValueSync().GetSession();
+            auto session = db.CreateSession().GetValueSync().GetSession();
 
-        // The aborted transaction is released, so the client cannot commit it anymore.
-        auto commitResult = tx->Commit().ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(commitResult.GetStatus(), EStatus::NOT_FOUND, commitResult.GetIssues().ToString());
+            auto schemeResult = schemeSession.ExecuteSchemeQuery(Create).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(schemeResult.GetStatus(), EStatus::SUCCESS,
+                schemeResult.GetIssues().ToString());
+
+            auto result = session.ExecuteDataQuery(Q_(R"(
+                REPLACE INTO `/Root/SchemeOpsTable` (Key, Value) VALUES (1u, "One"), (2u, "Two");
+            )"), TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            if (Setup) {
+                schemeResult = schemeSession.ExecuteSchemeQuery(Setup).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(schemeResult.GetStatus(), EStatus::SUCCESS,
+                    schemeResult.GetIssues().ToString());
+            }
+
+            result = session.ExecuteDataQuery(Q_(Read),
+                TTxControl::BeginTx(TTxSettings::SerializableRW())).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            auto tx = result.GetTransaction();
+            UNIT_ASSERT(tx);
+
+            schemeResult = schemeSession.ExecuteSchemeQuery(Operation).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(schemeResult.GetStatus(), EStatus::SUCCESS,
+                schemeResult.GetIssues().ToString());
+
+            result = session.ExecuteDataQuery(Q_(Read), TTxControl::Tx(*tx)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), ExpectedStatus, result.GetIssues().ToString());
+            if (ExpectedIssue) {
+                UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), ExpectedIssue);
+            }
+
+            // The transaction is released on abort, so the client cannot commit it anymore.
+            auto commitResult = tx->Commit().ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(commitResult.GetStatus(), EStatus::NOT_FOUND,
+                commitResult.GetIssues().ToString());
+        }
+    };
+
+    Y_UNIT_TEST(SchemeChangeAddColumn) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ADD COLUMN Extra Uint64;";
+        tester.Read = "SELECT * FROM `/Root/SchemeOpsTable` ORDER BY Key;";
+        tester.Execute();
+    }
+
+    // The dropped column is the one being read, so the statement cannot even be
+    // recompiled against the new schema.
+    Y_UNIT_TEST(SchemeChangeDropReadColumn) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP COLUMN Value;";
+        tester.ExpectedStatus = EStatus::GENERIC_ERROR;
+        tester.ExpectedIssue = "";
+        tester.Execute();
+    }
+
+    // The dropped column is irrelevant to the read, yet the transaction still aborts:
+    // the schema version check is unconditional for now.
+    Y_UNIT_TEST(SchemeChangeDropUnreadColumn) {
+        TSchemeChangeInTxTester tester;
+        tester.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD COLUMN Spare Uint64;";
+        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP COLUMN Spare;";
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeTruncateTable) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = "TRUNCATE TABLE `/Root/SchemeOpsTable`;";
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeAddIndex) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeDropIndex) {
+        TSchemeChangeInTxTester tester;
+        tester.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
+        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP INDEX ValueIndex;";
+        tester.Execute();
+    }
+
+    // Same operation, but the transaction reads through the index being dropped, so it
+    // fails to resolve the index rather than to match the schema version.
+    Y_UNIT_TEST(SchemeChangeDropIndexWithIndexRead) {
+        TSchemeChangeInTxTester tester;
+        tester.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
+        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP INDEX ValueIndex;";
+        tester.Read = R"(SELECT Key, Value FROM `/Root/SchemeOpsTable` VIEW ValueIndex WHERE Value = "One";)";
+        tester.ExpectedStatus = EStatus::SCHEME_ERROR;
+        tester.ExpectedIssue = "";
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeAddChangefeed) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = R"(
+            ALTER TABLE `/Root/SchemeOpsTable` ADD CHANGEFEED Feed WITH (FORMAT = 'JSON', MODE = 'UPDATES');
+        )";
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeDropChangefeed) {
+        TSchemeChangeInTxTester tester;
+        tester.Setup = R"(
+            ALTER TABLE `/Root/SchemeOpsTable` ADD CHANGEFEED Feed WITH (FORMAT = 'JSON', MODE = 'UPDATES');
+        )";
+        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP CHANGEFEED Feed;";
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeSetFamily) {
+        TSchemeChangeInTxTester tester;
+        tester.Create = R"(
+            CREATE TABLE `/Root/SchemeOpsTable` (
+                Key Uint64,
+                Value String,
+                PRIMARY KEY (Key),
+                FAMILY Family1 (
+                    DATA = "test",
+                    COMPRESSION = "off"
+                )
+            );
+        )";
+        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ALTER COLUMN Value SET FAMILY Family1;";
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeSetDefault) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = R"(ALTER TABLE `/Root/SchemeOpsTable` ALTER COLUMN Value SET DEFAULT "def"u;)";
+        tester.Execute();
     }
 }
 

--- a/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
@@ -1323,9 +1323,21 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Strict Serializable mode is disabled");
     }
 
-    // Runs `read`, then the scheme `Operation` from another session, then `read` again,
-    // all inside one SerializableRW transaction, and checks how the second read fails.
-    struct TSchemeChangeInTxTester {
+    enum class ESchemeOp {
+        AddColumn,
+        DropReadColumn,
+        DropUnreadColumn,
+        TruncateTable,
+        AddIndex,
+        DropIndex,
+        DropIndexWithIndexRead,
+        AddChangefeed,
+        DropChangefeed,
+        SetFamily,
+        SetDefault,
+    };
+
+    struct TSchemeOpSpec {
         TString Create = R"(
             CREATE TABLE `/Root/SchemeOpsTable` (
                 Key Uint64,
@@ -1341,16 +1353,108 @@ Y_UNIT_TEST_SUITE(KqpTx) {
 
         TString Read = "SELECT Key, Value FROM `/Root/SchemeOpsTable` ORDER BY Key;";
 
-        EStatus ExpectedStatus = EStatus::ABORTED;
-        TString ExpectedIssue = "Scheme changed for table";
+        // Status of the second read, in a transaction that promises repeatable reads and in
+        // one that does not. They differ only where the schema version check is what fails:
+        // a statement that no longer compiles against the new schema fails either way.
+        EStatus RepeatableReadStatus = EStatus::ABORTED;
+        EStatus RelaxedStatus = EStatus::SUCCESS;
+    };
+
+    TSchemeOpSpec MakeSchemeOpSpec(ESchemeOp op) {
+        TSchemeOpSpec spec;
+        switch (op) {
+            case ESchemeOp::AddColumn:
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ADD COLUMN Extra Uint64;";
+                spec.Read = "SELECT * FROM `/Root/SchemeOpsTable` ORDER BY Key;";
+                break;
+
+            case ESchemeOp::DropReadColumn:
+                // The dropped column is the one being read, so the statement cannot be
+                // recompiled against the new schema.
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP COLUMN Value;";
+                spec.RepeatableReadStatus = EStatus::GENERIC_ERROR;
+                spec.RelaxedStatus = EStatus::GENERIC_ERROR;
+                break;
+
+            case ESchemeOp::DropUnreadColumn:
+                // The dropped column is irrelevant to the read, yet the transaction still
+                // aborts: the schema version check is unconditional for now.
+                spec.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD COLUMN Spare Uint64;";
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP COLUMN Spare;";
+                break;
+
+            case ESchemeOp::TruncateTable:
+                spec.Operation = "TRUNCATE TABLE `/Root/SchemeOpsTable`;";
+                break;
+
+            case ESchemeOp::AddIndex:
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
+                break;
+
+            case ESchemeOp::DropIndex:
+                spec.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP INDEX ValueIndex;";
+                break;
+
+            case ESchemeOp::DropIndexWithIndexRead:
+                // The transaction reads through the index being dropped, so it fails to
+                // resolve the index rather than to match the schema version.
+                spec.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP INDEX ValueIndex;";
+                spec.Read = R"(SELECT Key, Value FROM `/Root/SchemeOpsTable` VIEW ValueIndex WHERE Value = "One";)";
+                spec.RepeatableReadStatus = EStatus::SCHEME_ERROR;
+                spec.RelaxedStatus = EStatus::SCHEME_ERROR;
+                break;
+
+            case ESchemeOp::AddChangefeed:
+                spec.Operation = R"(
+                    ALTER TABLE `/Root/SchemeOpsTable` ADD CHANGEFEED Feed WITH (FORMAT = 'JSON', MODE = 'UPDATES');
+                )";
+                break;
+
+            case ESchemeOp::DropChangefeed:
+                spec.Setup = R"(
+                    ALTER TABLE `/Root/SchemeOpsTable` ADD CHANGEFEED Feed WITH (FORMAT = 'JSON', MODE = 'UPDATES');
+                )";
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP CHANGEFEED Feed;";
+                break;
+
+            case ESchemeOp::SetFamily:
+                spec.Create = R"(
+                    CREATE TABLE `/Root/SchemeOpsTable` (
+                        Key Uint64,
+                        Value String,
+                        PRIMARY KEY (Key),
+                        FAMILY Family1 (
+                            DATA = "test",
+                            COMPRESSION = "off"
+                        )
+                    );
+                )";
+                spec.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ALTER COLUMN Value SET FAMILY Family1;";
+                break;
+
+            case ESchemeOp::SetDefault:
+                spec.Operation = R"(ALTER TABLE `/Root/SchemeOpsTable` ALTER COLUMN Value SET DEFAULT "def"u;)";
+                break;
+        }
+        return spec;
+    }
+
+    // Runs the read, then the scheme operation from another session, then the read again, all
+    // inside one SerializableRW transaction of the table service.
+    struct TSchemeChangeInTxTester {
+        ESchemeOp Operation = ESchemeOp::AddColumn;
 
         void Execute() const {
+            const auto spec = MakeSchemeOpSpec(Operation);
+
             TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
             auto db = kikimr.GetTableClient();
             auto schemeSession = db.CreateSession().GetValueSync().GetSession();
             auto session = db.CreateSession().GetValueSync().GetSession();
 
-            auto schemeResult = schemeSession.ExecuteSchemeQuery(Create).ExtractValueSync();
+            auto schemeResult = schemeSession.ExecuteSchemeQuery(spec.Create).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(schemeResult.GetStatus(), EStatus::SUCCESS,
                 schemeResult.GetIssues().ToString());
 
@@ -1359,30 +1463,31 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             )"), TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
-            if (Setup) {
-                schemeResult = schemeSession.ExecuteSchemeQuery(Setup).ExtractValueSync();
+            if (spec.Setup) {
+                schemeResult = schemeSession.ExecuteSchemeQuery(spec.Setup).ExtractValueSync();
                 UNIT_ASSERT_VALUES_EQUAL_C(schemeResult.GetStatus(), EStatus::SUCCESS,
                     schemeResult.GetIssues().ToString());
             }
 
-            result = session.ExecuteDataQuery(Q_(Read),
+            result = session.ExecuteDataQuery(Q_(spec.Read),
                 TTxControl::BeginTx(TTxSettings::SerializableRW())).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
             auto tx = result.GetTransaction();
             UNIT_ASSERT(tx);
 
-            schemeResult = schemeSession.ExecuteSchemeQuery(Operation).ExtractValueSync();
+            schemeResult = schemeSession.ExecuteSchemeQuery(spec.Operation).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(schemeResult.GetStatus(), EStatus::SUCCESS,
                 schemeResult.GetIssues().ToString());
 
-            result = session.ExecuteDataQuery(Q_(Read), TTxControl::Tx(*tx)).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), ExpectedStatus, result.GetIssues().ToString());
-            if (ExpectedIssue) {
-                UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), ExpectedIssue);
+            result = session.ExecuteDataQuery(Q_(spec.Read), TTxControl::Tx(*tx)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), spec.RepeatableReadStatus,
+                result.GetIssues().ToString());
+            if (spec.RepeatableReadStatus == EStatus::ABORTED) {
+                UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Scheme changed for table");
             }
 
-            // The transaction is released on abort, so the client cannot commit it anymore.
+            // The transaction is released on failure, so the client cannot commit it anymore.
             auto commitResult = tx->Commit().ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(commitResult.GetStatus(), EStatus::NOT_FOUND,
                 commitResult.GetIssues().ToString());
@@ -1391,98 +1496,280 @@ Y_UNIT_TEST_SUITE(KqpTx) {
 
     Y_UNIT_TEST(SchemeChangeAddColumn) {
         TSchemeChangeInTxTester tester;
-        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ADD COLUMN Extra Uint64;";
-        tester.Read = "SELECT * FROM `/Root/SchemeOpsTable` ORDER BY Key;";
+        tester.Operation = ESchemeOp::AddColumn;
         tester.Execute();
     }
 
-    // The dropped column is the one being read, so the statement cannot even be
-    // recompiled against the new schema.
     Y_UNIT_TEST(SchemeChangeDropReadColumn) {
         TSchemeChangeInTxTester tester;
-        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP COLUMN Value;";
-        tester.ExpectedStatus = EStatus::GENERIC_ERROR;
-        tester.ExpectedIssue = "";
+        tester.Operation = ESchemeOp::DropReadColumn;
         tester.Execute();
     }
 
-    // The dropped column is irrelevant to the read, yet the transaction still aborts:
-    // the schema version check is unconditional for now.
     Y_UNIT_TEST(SchemeChangeDropUnreadColumn) {
         TSchemeChangeInTxTester tester;
-        tester.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD COLUMN Spare Uint64;";
-        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP COLUMN Spare;";
+        tester.Operation = ESchemeOp::DropUnreadColumn;
         tester.Execute();
     }
 
     Y_UNIT_TEST(SchemeChangeTruncateTable) {
         TSchemeChangeInTxTester tester;
-        tester.Operation = "TRUNCATE TABLE `/Root/SchemeOpsTable`;";
+        tester.Operation = ESchemeOp::TruncateTable;
         tester.Execute();
     }
 
     Y_UNIT_TEST(SchemeChangeAddIndex) {
         TSchemeChangeInTxTester tester;
-        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
+        tester.Operation = ESchemeOp::AddIndex;
         tester.Execute();
     }
 
     Y_UNIT_TEST(SchemeChangeDropIndex) {
         TSchemeChangeInTxTester tester;
-        tester.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
-        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP INDEX ValueIndex;";
+        tester.Operation = ESchemeOp::DropIndex;
         tester.Execute();
     }
 
-    // Same operation, but the transaction reads through the index being dropped, so it
-    // fails to resolve the index rather than to match the schema version.
     Y_UNIT_TEST(SchemeChangeDropIndexWithIndexRead) {
         TSchemeChangeInTxTester tester;
-        tester.Setup = "ALTER TABLE `/Root/SchemeOpsTable` ADD INDEX ValueIndex GLOBAL SYNC ON (`Value`);";
-        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP INDEX ValueIndex;";
-        tester.Read = R"(SELECT Key, Value FROM `/Root/SchemeOpsTable` VIEW ValueIndex WHERE Value = "One";)";
-        tester.ExpectedStatus = EStatus::SCHEME_ERROR;
-        tester.ExpectedIssue = "";
+        tester.Operation = ESchemeOp::DropIndexWithIndexRead;
         tester.Execute();
     }
 
     Y_UNIT_TEST(SchemeChangeAddChangefeed) {
         TSchemeChangeInTxTester tester;
-        tester.Operation = R"(
-            ALTER TABLE `/Root/SchemeOpsTable` ADD CHANGEFEED Feed WITH (FORMAT = 'JSON', MODE = 'UPDATES');
-        )";
+        tester.Operation = ESchemeOp::AddChangefeed;
         tester.Execute();
     }
 
     Y_UNIT_TEST(SchemeChangeDropChangefeed) {
         TSchemeChangeInTxTester tester;
-        tester.Setup = R"(
-            ALTER TABLE `/Root/SchemeOpsTable` ADD CHANGEFEED Feed WITH (FORMAT = 'JSON', MODE = 'UPDATES');
-        )";
-        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` DROP CHANGEFEED Feed;";
+        tester.Operation = ESchemeOp::DropChangefeed;
         tester.Execute();
     }
 
     Y_UNIT_TEST(SchemeChangeSetFamily) {
         TSchemeChangeInTxTester tester;
-        tester.Create = R"(
-            CREATE TABLE `/Root/SchemeOpsTable` (
-                Key Uint64,
-                Value String,
-                PRIMARY KEY (Key),
-                FAMILY Family1 (
-                    DATA = "test",
-                    COMPRESSION = "off"
-                )
-            );
-        )";
-        tester.Operation = "ALTER TABLE `/Root/SchemeOpsTable` ALTER COLUMN Value SET FAMILY Family1;";
+        tester.Operation = ESchemeOp::SetFamily;
         tester.Execute();
     }
 
     Y_UNIT_TEST(SchemeChangeSetDefault) {
         TSchemeChangeInTxTester tester;
-        tester.Operation = R"(ALTER TABLE `/Root/SchemeOpsTable` ALTER COLUMN Value SET DEFAULT "def"u;)";
+        tester.Operation = ESchemeOp::SetDefault;
+        tester.Execute();
+    }
+
+    // Same scenario over the query service, where every isolation mode is reachable.
+    // PromisesRepeatableReads mirrors HasRepeatableReads() in kqp_tx.cpp and picks which of
+    // the two statuses of the operation is expected.
+    struct TSchemeChangeIsolationTester {
+        ESchemeOp Operation = ESchemeOp::AddColumn;
+        NYdb::NQuery::TTxSettings TxSettings = NYdb::NQuery::TTxSettings::SerializableRW();
+        bool PromisesRepeatableReads = true;
+        bool EnableReadCommitted = false;
+        bool EnableStrictSerializable = false;
+
+        void Execute() const {
+            const auto spec = MakeSchemeOpSpec(Operation);
+
+            TKikimrSettings settings;
+            settings.SetWithSampleTables(false);
+            settings.SetEnableStrictSerializableIsolation(EnableStrictSerializable);
+            settings.AppConfig.MutableTableServiceConfig()->SetEnableReadCommittedIsolation(EnableReadCommitted);
+            TKikimrRunner kikimr(settings);
+
+            auto db = kikimr.GetQueryClient();
+            auto session = db.GetSession().GetValueSync().GetSession();
+            auto schemeSession = db.GetSession().GetValueSync().GetSession();
+
+            auto schemeResult = schemeSession.ExecuteQuery(spec.Create,
+                NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(schemeResult.GetStatus(), EStatus::SUCCESS,
+                schemeResult.GetIssues().ToString());
+
+            auto result = session.ExecuteQuery(R"(
+                REPLACE INTO `/Root/SchemeOpsTable` (Key, Value) VALUES (1u, "One"), (2u, "Two");
+            )", NYdb::NQuery::TTxControl::BeginTx(NYdb::NQuery::TTxSettings::SerializableRW()).CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            if (spec.Setup) {
+                schemeResult = schemeSession.ExecuteQuery(spec.Setup,
+                    NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(schemeResult.GetStatus(), EStatus::SUCCESS,
+                    schemeResult.GetIssues().ToString());
+            }
+
+            result = session.ExecuteQuery(spec.Read,
+                NYdb::NQuery::TTxControl::BeginTx(TxSettings)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            auto tx = result.GetTransaction();
+            UNIT_ASSERT(tx);
+
+            schemeResult = schemeSession.ExecuteQuery(spec.Operation,
+                NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(schemeResult.GetStatus(), EStatus::SUCCESS,
+                schemeResult.GetIssues().ToString());
+
+            const EStatus expectedStatus = PromisesRepeatableReads
+                ? spec.RepeatableReadStatus
+                : spec.RelaxedStatus;
+
+            result = session.ExecuteQuery(spec.Read, NYdb::NQuery::TTxControl::Tx(*tx)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expectedStatus, result.GetIssues().ToString());
+            if (expectedStatus == EStatus::ABORTED) {
+                UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Scheme changed for table");
+            }
+        }
+    };
+
+    Y_UNIT_TEST(SchemeChangeIsolationSerializableRW) {
+        TSchemeChangeIsolationTester tester;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::SerializableRW();
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeIsolationSnapshotRO) {
+        TSchemeChangeIsolationTester tester;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::SnapshotRO();
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeIsolationSnapshotRW) {
+        TSchemeChangeIsolationTester tester;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::SnapshotRW();
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeIsolationStrictSerializableRW) {
+        TSchemeChangeIsolationTester tester;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::StrictSerializableRW();
+        tester.EnableStrictSerializable = true;
+        tester.Execute();
+    }
+
+    // Read Committed is meant to see the latest committed data on every statement, and the
+    // Online and Stale modes promise no consistency between statements at all.
+    Y_UNIT_TEST(SchemeChangeIsolationReadCommittedRW) {
+        TSchemeChangeIsolationTester tester;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
+        tester.EnableReadCommitted = true;
+        tester.PromisesRepeatableReads = false;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeIsolationStaleRO) {
+        TSchemeChangeIsolationTester tester;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::StaleRO();
+        tester.PromisesRepeatableReads = false;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeIsolationOnlineRO) {
+        TSchemeChangeIsolationTester tester;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::OnlineRO();
+        tester.PromisesRepeatableReads = false;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeReadCommittedAddColumn) {
+        TSchemeChangeIsolationTester tester;
+        tester.Operation = ESchemeOp::AddColumn;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
+        tester.EnableReadCommitted = true;
+        tester.PromisesRepeatableReads = false;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeReadCommittedDropReadColumn) {
+        TSchemeChangeIsolationTester tester;
+        tester.Operation = ESchemeOp::DropReadColumn;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
+        tester.EnableReadCommitted = true;
+        tester.PromisesRepeatableReads = false;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeReadCommittedDropUnreadColumn) {
+        TSchemeChangeIsolationTester tester;
+        tester.Operation = ESchemeOp::DropUnreadColumn;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
+        tester.EnableReadCommitted = true;
+        tester.PromisesRepeatableReads = false;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeReadCommittedTruncateTable) {
+        TSchemeChangeIsolationTester tester;
+        tester.Operation = ESchemeOp::TruncateTable;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
+        tester.EnableReadCommitted = true;
+        tester.PromisesRepeatableReads = false;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeReadCommittedAddIndex) {
+        TSchemeChangeIsolationTester tester;
+        tester.Operation = ESchemeOp::AddIndex;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
+        tester.EnableReadCommitted = true;
+        tester.PromisesRepeatableReads = false;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeReadCommittedDropIndex) {
+        TSchemeChangeIsolationTester tester;
+        tester.Operation = ESchemeOp::DropIndex;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
+        tester.EnableReadCommitted = true;
+        tester.PromisesRepeatableReads = false;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeReadCommittedDropIndexWithIndexRead) {
+        TSchemeChangeIsolationTester tester;
+        tester.Operation = ESchemeOp::DropIndexWithIndexRead;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
+        tester.EnableReadCommitted = true;
+        tester.PromisesRepeatableReads = false;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeReadCommittedAddChangefeed) {
+        TSchemeChangeIsolationTester tester;
+        tester.Operation = ESchemeOp::AddChangefeed;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
+        tester.EnableReadCommitted = true;
+        tester.PromisesRepeatableReads = false;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeReadCommittedDropChangefeed) {
+        TSchemeChangeIsolationTester tester;
+        tester.Operation = ESchemeOp::DropChangefeed;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
+        tester.EnableReadCommitted = true;
+        tester.PromisesRepeatableReads = false;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeReadCommittedSetFamily) {
+        TSchemeChangeIsolationTester tester;
+        tester.Operation = ESchemeOp::SetFamily;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
+        tester.EnableReadCommitted = true;
+        tester.PromisesRepeatableReads = false;
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(SchemeChangeReadCommittedSetDefault) {
+        TSchemeChangeIsolationTester tester;
+        tester.Operation = ESchemeOp::SetDefault;
+        tester.TxSettings = NYdb::NQuery::TTxSettings::ReadCommittedRW();
+        tester.EnableReadCommitted = true;
+        tester.PromisesRepeatableReads = false;
         tester.Execute();
     }
 }

--- a/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
@@ -1335,6 +1335,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         DropChangefeed,
         SetFamily,
         SetDefault,
+        DropCreateTable,
         ViewReadAddColumn,
         ViewRecreate,
         ViewDrop,
@@ -1352,6 +1353,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         ESchemeOp::DropChangefeed,
         ESchemeOp::SetFamily,
         ESchemeOp::SetDefault,
+        ESchemeOp::DropCreateTable,
         ESchemeOp::ViewReadAddColumn,
         ESchemeOp::ViewRecreate,
         ESchemeOp::ViewDrop,
@@ -1458,6 +1460,20 @@ Y_UNIT_TEST_SUITE(KqpTx) {
                 spec.Operation = R"(ALTER TABLE `/Root/SchemeOpsTable` ALTER COLUMN Value SET DEFAULT "def"u;)";
                 break;
 
+            case ESchemeOp::DropCreateTable:
+                // The table is replaced by a brand new, empty one under the same path. The
+                // path id changes while the path does not, so only a check that compares
+                // both notices that the transaction is now reading a different object.
+                spec.Operation = R"(
+                    DROP TABLE `/Root/SchemeOpsTable`;
+                    CREATE TABLE `/Root/SchemeOpsTable` (
+                        Key Uint64,
+                        Value String,
+                        PRIMARY KEY (Key)
+                    );
+                )";
+                break;
+
             case ESchemeOp::ViewReadAddColumn:
                 // The transaction reads the table through a view, and the table changes.
                 spec.Setup = R"(
@@ -1470,9 +1486,8 @@ Y_UNIT_TEST_SUITE(KqpTx) {
 
             case ESchemeOp::ViewRecreate:
                 // The table is untouched; the view is redefined to select fewer columns.
-                // The transaction reads through the new definition instead of aborting: view
-                // versions travel in ViewInfos, which the check does not look at. Fixed by the
-                // next commit.
+                // Dropping and creating the view makes a new object under the same path, so
+                // the check has to notice the path id changing, not just the version.
                 spec.Setup = R"(
                     CREATE VIEW `/Root/SchemeOpsView` WITH (security_invoker = TRUE) AS
                         SELECT Key, Value FROM `/Root/SchemeOpsTable`;
@@ -1483,7 +1498,6 @@ Y_UNIT_TEST_SUITE(KqpTx) {
                         SELECT Key FROM `/Root/SchemeOpsTable`;
                 )";
                 spec.Read = "SELECT * FROM `/Root/SchemeOpsView` ORDER BY Key;";
-                spec.RepeatableReadStatus = EStatus::SUCCESS;
                 break;
 
             case ESchemeOp::ViewDrop:
@@ -1510,8 +1524,13 @@ Y_UNIT_TEST_SUITE(KqpTx) {
 
             TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
             auto db = kikimr.GetTableClient();
-            auto schemeSession = db.CreateSession().GetValueSync().GetSession();
-            auto session = db.CreateSession().GetValueSync().GetSession();
+            auto createSession = [&db]() {
+                auto result = db.CreateSession().GetValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+                return result.GetSession();
+            };
+            auto schemeSession = createSession();
+            auto session = createSession();
 
             auto schemeResult = schemeSession.ExecuteSchemeQuery(spec.Create).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(schemeResult.GetStatus(), EStatus::SUCCESS,
@@ -1543,7 +1562,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), spec.RepeatableReadStatus,
                 result.GetIssues().ToString());
             if (spec.RepeatableReadStatus == EStatus::ABORTED) {
-                UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Scheme changed for table");
+                UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Scheme changed for");
             }
 
             // A failed statement releases the transaction; a tolerated change leaves it usable.
@@ -1620,6 +1639,12 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         tester.Execute();
     }
 
+    Y_UNIT_TEST(SchemeChangeDropCreateTable) {
+        TSchemeChangeInTxTester tester;
+        tester.Operation = ESchemeOp::DropCreateTable;
+        tester.Execute();
+    }
+
     Y_UNIT_TEST(SchemeChangeViewReadAddColumn) {
         TSchemeChangeInTxTester tester;
         tester.Operation = ESchemeOp::ViewReadAddColumn;
@@ -1658,8 +1683,13 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             TKikimrRunner kikimr(settings);
 
             auto db = kikimr.GetQueryClient();
-            auto session = db.GetSession().GetValueSync().GetSession();
-            auto schemeSession = db.GetSession().GetValueSync().GetSession();
+            auto createSession = [&db]() {
+                auto result = db.GetSession().GetValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+                return result.GetSession();
+            };
+            auto session = createSession();
+            auto schemeSession = createSession();
 
             auto schemeResult = schemeSession.ExecuteQuery(spec.Create,
                 NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
@@ -1698,7 +1728,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             result = session.ExecuteQuery(spec.Read, NYdb::NQuery::TTxControl::Tx(*tx)).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expectedStatus, result.GetIssues().ToString());
             if (expectedStatus == EStatus::ABORTED) {
-                UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Scheme changed for table");
+                UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Scheme changed for");
             }
 
             // A mode that keeps reading past the scheme change keeps a usable transaction,

--- a/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_tx_ut.cpp
@@ -1323,7 +1323,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Strict Serializable mode is disabled");
     }
 
-    Y_UNIT_TEST(SchemeChangeBreaksRepeatableRead) {
+    Y_UNIT_TEST(SchemeChangeAbortsTx) {
         auto kikimr = DefaultKikimrRunner();
         auto db = kikimr.GetTableClient();
         auto session = db.CreateSession().GetValueSync().GetSession();
@@ -1336,7 +1336,7 @@ Y_UNIT_TEST_SUITE(KqpTx) {
 
         auto tx = result.GetTransaction();
         UNIT_ASSERT(tx);
-        const TString firstRead = FormatResultSetYson(result.GetResultSet(0));
+        CompareYson(R"([[[1u];["One"]];[[2u];["Two"]]])", FormatResultSetYson(result.GetResultSet(0)));
 
         auto alterResult = schemeSession.ExecuteSchemeQuery(R"(
             ALTER TABLE `/Root/KeyValue` ADD COLUMN Value2 Uint64;
@@ -1347,14 +1347,12 @@ Y_UNIT_TEST_SUITE(KqpTx) {
             SELECT * FROM `/Root/KeyValue` ORDER BY Key;
         )"), TTxControl::Tx(*tx)).ExtractValueSync();
 
-        // Buggy behaviour, fixed by the next commit: the second read succeeds and
-        // observes the new schema, so the transaction is not repeatable.
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-        const TString secondRead = FormatResultSetYson(result.GetResultSet(0));
-        UNIT_ASSERT_STRINGS_UNEQUAL(firstRead, secondRead);
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::ABORTED, result.GetIssues().ToString());
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Scheme changed for table");
 
+        // The aborted transaction is released, so the client cannot commit it anymore.
         auto commitResult = tx->Commit().ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(commitResult.GetStatus(), EStatus::SUCCESS, commitResult.GetIssues().ToString());
+        UNIT_ASSERT_VALUES_EQUAL_C(commitResult.GetStatus(), EStatus::NOT_FOUND, commitResult.GetIssues().ToString());
     }
 }
 

--- a/ydb/core/tx/datashard/ut_truncate/datashard_ut_truncate.cpp
+++ b/ydb/core/tx/datashard/ut_truncate/datashard_ut_truncate.cpp
@@ -299,10 +299,10 @@ Y_UNIT_TEST_SUITE(DataShardTruncate) {
         {
             NYql::TIssues issues;
             NYql::IssuesFromMessage(commitResponse.operation().issues(), issues);
-            // TRUNCATE TABLE changes the table schema version (AlterVersion+1), so a transaction
-            // that has a pending UPSERT detects a scheme mismatch (KIKIMR_SCHEME_MISMATCH) rather
-            // than a broken lock (KIKIMR_LOCKS_INVALIDATED / TLI), because the datashard rejects
-            // the write due to the schema version change before it even checks locks.
+            // TRUNCATE TABLE changes the table schema version (AlterVersion+1), so the commit is
+            // compiled against a version the transaction has not seen and KQP aborts it with
+            // KIKIMR_SCHEME_MISMATCH, rather than the transaction reaching the datashard and
+            // failing there on a broken lock (KIKIMR_LOCKS_INVALIDATED / TLI).
             UNIT_ASSERT_C(
                 NKqp::HasIssue(issues, NYql::TIssuesIds::KIKIMR_SCHEME_MISMATCH),
                 "Expected KIKIMR_SCHEME_MISMATCH issue, got: " << issues.ToString()


### PR DESCRIPTION
### Changelog entry

Fixed non-repeatable reads caused by concurrent scheme operations. A transaction that reads a table is now aborted with `ABORTED` if a parallel DDL changes that table's schema, instead of silently observing the new schema in later statements. Only modes that promise repeatable reads are affected: Serializable, Strict Serializable, Snapshot Read-Only and Snapshot Read-Write.

### Description for reviewers

KQP records the `SchemaVersion` of every table a statement was compiled against in the transaction context, and compares it on each subsequent statement of the same transaction (`PrepareQueryContext`). A mismatch aborts the transaction — the same pattern already used there for `EnableOlapSink`/`EnableHtapTx`.

Look https://nda.ya.ru/t/Kin-16L87qBK8Z.