### PR TITLE
[PQ] Align persqueue/public enums with coding style

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -112,7 +112,7 @@ private:
         const auto it = ev->Get()->Topics.find(Path);
         AFL_ENSURE(it != ev->Get()->Topics.end())("path", Path);
         const auto& topicInfo = it->second;
-        if (topicInfo.Status != NDescriber::EStatus::SUCCESS) {
+        if (topicInfo.Status != NDescriber::EStatus::Success) {
             auto status = NDescriber::Convert(topicInfo.Status);
             // Missing topic → SCHEME_ERROR so Kafka auto-create / UNKNOWN_TOPIC still work.
             if (status == Ydb::StatusIds::NOT_FOUND) {

--- a/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.cpp
@@ -125,7 +125,7 @@ private:
         const auto it = ev->Get()->Topics.find(Settings.Path);
         AFL_ENSURE(it != ev->Get()->Topics.end())("path", Settings.Path);
         const auto& topicInfo = it->second;
-        if (topicInfo.Status != NDescriber::EStatus::SUCCESS) {
+        if (topicInfo.Status != NDescriber::EStatus::Success) {
             return HandleDescribeError(topicInfo);
         }
 
@@ -189,7 +189,7 @@ private:
         auto status = NDescriber::Convert(topicInfo.Status);
         if (Settings.UnauthenticatedExistenceCheck && !Settings.Token.empty()) {
             if (!DidUnauthenticatedExistenceCheck &&
-                topicInfo.Status == NDescriber::EStatus::UNAUTHORIZED)
+                topicInfo.Status == NDescriber::EStatus::Unauthorized)
             {
                 DidUnauthenticatedExistenceCheck = true;
                 StartDescribe(/*anonymous=*/true);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_dlq_mover.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_dlq_mover.cpp
@@ -80,7 +80,7 @@ void TDLQMoverActor::Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
     auto& topic = topics[TopicName];
 
     switch (topic.Status) {
-        case NDescriber::EStatus::SUCCESS:
+        case NDescriber::EStatus::Success:
             TopicInfo = std::move(topic);
             return CreateWriter();
 

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -56,7 +56,7 @@ public:
                     {"logPrefix", LOG_PREFIX},
                     {"topic", topic},
                     {"reason", resolved.error()});
-                SetErrorResult(topic, EStatus::BAD_REQUEST);
+                SetErrorResult(topic, EStatus::BadRequest);
                 continue;
             }
             YDB_LOG_DEBUG("Name resolved",
@@ -130,13 +130,13 @@ public:
                                 {"logPrefix", LOG_PREFIX},
                                 {"realPath", realPath});
 
-                            SetErrorResults(originals, EStatus::UNAUTHORIZED);
+                            SetErrorResults(originals, EStatus::Unauthorized);
                         } else {
                             YDB_LOG_DEBUG("Path not found",
                                 {"logPrefix", LOG_PREFIX},
                                 {"realPath", realPath});
 
-                            SetErrorResults(originals, EStatus::NOT_FOUND);
+                            SetErrorResults(originals, EStatus::NotFound);
                         }
                     } else {
                         unknownPaths.insert(realPath);
@@ -147,7 +147,7 @@ public:
                     YDB_LOG_DEBUG("Path ACCESS DENIED",
                         {"logPrefix", LOG_PREFIX},
                         {"realPath", realPath});
-                    SetErrorResults(originals, EStatus::UNAUTHORIZED);
+                    SetErrorResults(originals, EStatus::Unauthorized);
                     break;
                 }
                 case TSchemeCacheNavigate::EStatus::Ok: {
@@ -171,7 +171,7 @@ public:
                                 YDB_LOG_DEBUG("Path not found",
                                     {"logPrefix", LOG_PREFIX},
                                     {"realPath", realPath});
-                                SetErrorResults(originals, EStatus::NOT_FOUND);
+                                SetErrorResults(originals, EStatus::NotFound);
                             } else {
                                 unknownPaths.insert(realPath);
                             }
@@ -183,14 +183,14 @@ public:
 
                                 SetTopicResults(originals, TTopicInfo{
                                     .Status = entry.SecurityObject->CheckAccess(NACLib::EAccessRights::DescribeSchema, *Settings.UserToken)
-                                            ? EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS : EStatus::UNAUTHORIZED
+                                            ? EStatus::UnauthorizedWithDescribeAccess : EStatus::Unauthorized
                                 });
                             } else {
                                 YDB_LOG_DEBUG("Path SUCCESS",
                                     {"logPrefix", LOG_PREFIX},
                                     {"realPath", realPath});
                                 SetTopicResults(originals, TTopicInfo{
-                                    .Status = EStatus::SUCCESS,
+                                    .Status = EStatus::Success,
                                     .RealPath = realPath,
                                     .CdcStream = isCDCStream,
                                     .CdcStreamName = cdcStreamName,
@@ -211,11 +211,11 @@ public:
                                 {"logPrefix", LOG_PREFIX},
                                 {"realPath", realPath});
                             SetTopicResults(originals, TTopicInfo{
-                                .Status = EStatus::UNAUTHORIZED
+                                .Status = EStatus::Unauthorized
                             });
                         } else {
                             SetTopicResults(originals, TTopicInfo{
-                                .Status = EStatus::NOT_TOPIC,
+                                .Status = EStatus::NotTopic,
                                 .RealPath = realPath
                             });
                         }
@@ -227,7 +227,7 @@ public:
                         {"logPrefix", LOG_PREFIX},
                         {"realPath", realPath});
                     SetTopicResults(originals, TTopicInfo{
-                        .Status = EStatus::UNKNOWN_ERROR,
+                        .Status = EStatus::UnknownError,
                         .RealPath = realPath
                     });
                     break;
@@ -364,35 +364,35 @@ NActors::IActor* CreateDescriberActor(const NActors::TActorId& parent, const TSt
 
 Ydb::StatusIds::StatusCode Convert(const EStatus status) {
     switch (status) {
-        case EStatus::SUCCESS:
+        case EStatus::Success:
             return Ydb::StatusIds::SUCCESS;
-        case EStatus::NOT_FOUND:
-        case EStatus::NOT_TOPIC:
+        case EStatus::NotFound:
+        case EStatus::NotTopic:
             return Ydb::StatusIds::NOT_FOUND;
-        case EStatus::UNAUTHORIZED:
-        case EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS:
+        case EStatus::Unauthorized:
+        case EStatus::UnauthorizedWithDescribeAccess:
             return Ydb::StatusIds::UNAUTHORIZED;
-        case EStatus::BAD_REQUEST:
+        case EStatus::BadRequest:
             return Ydb::StatusIds::BAD_REQUEST;
-        case EStatus::UNKNOWN_ERROR:
+        case EStatus::UnknownError:
             return Ydb::StatusIds::INTERNAL_ERROR;
     }
 }
 
 TString Description(const TString& topicPath, const EStatus status) {
     switch (status) {
-        case EStatus::SUCCESS:
+        case EStatus::Success:
             return TStringBuilder() << "The topic '" << topicPath << "' has been successfully described";
-        case EStatus::NOT_FOUND:
-        case EStatus::UNAUTHORIZED:
+        case EStatus::NotFound:
+        case EStatus::Unauthorized:
             return TStringBuilder() << "You do not have access permissions or the '" << topicPath << "' does not exist";
-        case EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS:
+        case EStatus::UnauthorizedWithDescribeAccess:
             return TStringBuilder() << "You do not have access permissions to the '" << topicPath << "' topic";
-        case EStatus::NOT_TOPIC:
+        case EStatus::NotTopic:
             return TStringBuilder() << "The '" << topicPath << "' path is not a topic";
-        case EStatus::BAD_REQUEST:
+        case EStatus::BadRequest:
             return TStringBuilder() << "Invalid topic name '" << topicPath << "'";
-        case EStatus::UNKNOWN_ERROR:
+        case EStatus::UnknownError:
             return TStringBuilder() << "Error describing the path '" << topicPath << "'";
     }
 }

--- a/ydb/core/persqueue/public/describer/describer.h
+++ b/ydb/core/persqueue/public/describer/describer.h
@@ -10,19 +10,19 @@
 
 namespace NKikimr::NPQ::NDescriber {
 
-enum EEv : ui32 {
+enum class EEv : ui32 {
     EvDescribeTopicsResponse = InternalEventSpaceBegin(NPQ::NEvents::EServices::DESCRIBER_SERVICE),
     EvEnd
 };
 
 enum class EStatus {
-    SUCCESS,
-    NOT_FOUND,
-    NOT_TOPIC,
-    UNAUTHORIZED,
-    UNAUTHORIZED_WITH_DESCRIBE_ACCESS,
-    BAD_REQUEST,
-    UNKNOWN_ERROR
+    Success,
+    NotFound,
+    NotTopic,
+    Unauthorized,
+    UnauthorizedWithDescribeAccess,
+    BadRequest,
+    UnknownError
 };
 
 
@@ -45,7 +45,7 @@ struct TAccessRights {
 };
 
 struct TTopicInfo {
-    EStatus Status = EStatus::NOT_FOUND;
+    EStatus Status = EStatus::NotFound;
 
     // Real topic path. If original topic path is CDC than real path is different.
     TString RealPath;
@@ -58,7 +58,7 @@ struct TTopicInfo {
     TIntrusivePtr<TSecurityObject> SecurityObject;
 };
 
-struct TEvDescribeTopicsResponse : public NActors::TEventLocal<TEvDescribeTopicsResponse, EEv::EvDescribeTopicsResponse> {
+struct TEvDescribeTopicsResponse : public NActors::TEventLocal<TEvDescribeTopicsResponse, static_cast<ui32>(EEv::EvDescribeTopicsResponse)> {
 
     TEvDescribeTopicsResponse(absl::flat_hash_map<TString, TTopicInfo>&& topics, bool usedSyncVersion)
         : Topics(std::move(topics))

--- a/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
@@ -125,7 +125,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         auto ev = env.WaitResponse();
 
         UNIT_ASSERT(ev->Topics.contains("/Root/topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::UNAUTHORIZED);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::Unauthorized);
         UNIT_ASSERT(!ev->UsedSyncVersion);
     }
 
@@ -142,7 +142,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
         UNIT_ASSERT(ev->UsedSyncVersion);
         UNIT_ASSERT(ev->Topics.contains("/Root/topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::NotFound);
     }
 
     Y_UNIT_TEST(IncompleteTopicBalancerTabletIdZero) {
@@ -155,7 +155,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
         UNIT_ASSERT(ev->UsedSyncVersion);
         UNIT_ASSERT(ev->Topics.contains("/Root/topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::NotFound);
     }
 
     Y_UNIT_TEST(IncompleteTopicThenSuccessOnSync) {
@@ -175,7 +175,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         auto ev = env.WaitResponse();
 
         UNIT_ASSERT(ev->UsedSyncVersion);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Info->Description.GetBalancerTabletID(), 77u);
     }
 
@@ -195,7 +195,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
         UNIT_ASSERT(ev->UsedSyncVersion);
         UNIT_ASSERT(ev->Topics.contains("/Root/topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].RealPath, "/Root/topic1");
         UNIT_ASSERT(ev->Topics["/Root/topic1"].Info);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Info->Description.GetBalancerTabletID(), 42u);
@@ -210,7 +210,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         auto ev = env.WaitResponse();
 
         UNIT_ASSERT(ev->Topics.contains("/Root/topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::UNKNOWN_ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::UnknownError);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].RealPath, "/Root/topic1");
         UNIT_ASSERT(!ev->UsedSyncVersion);
     }
@@ -229,7 +229,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
         UNIT_ASSERT(ev->UsedSyncVersion);
         UNIT_ASSERT(ev->Topics.contains("/Root/missing"));
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/missing"].Status, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/missing"].Status, NDescriber::EStatus::NotFound);
     }
 
     Y_UNIT_TEST(CdcThenStreamImplSuccess) {
@@ -250,7 +250,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
         UNIT_ASSERT(ev->Topics.contains("/Root/table1/feed"));
         auto& info = ev->Topics["/Root/table1/feed"];
-        UNIT_ASSERT_VALUES_EQUAL(info.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(info.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(info.RealPath, "/Root/table1/feed/streamImpl");
         UNIT_ASSERT(info.CdcStream);
         UNIT_ASSERT_VALUES_EQUAL(info.CdcStreamName, "feed");
@@ -271,7 +271,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         auto ev = env.WaitResponse();
 
         UNIT_ASSERT(ev->UsedSyncVersion);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::NotFound);
     }
 
     Y_UNIT_TEST(CdcStreamImplNotFoundSkipsFederation) {
@@ -295,7 +295,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
         UNIT_ASSERT_VALUES_EQUAL(requests, 3u); // feed + streamImpl + sync streamImpl
         UNIT_ASSERT(ev->UsedSyncVersion);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::NotFound);
     }
 
     Y_UNIT_TEST(CdcWithEmptyDatabase) {
@@ -314,7 +314,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         env.StartDescribe({"/Root/table1/feed"}, {}, /*databasePath=*/"");
         auto ev = env.WaitResponse();
 
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT(ev->Topics["/Root/table1/feed"].CdcStream);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].RealPath, "/Root/table1/feed/streamImpl");
     }
@@ -331,7 +331,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         env.StartDescribe({"/Root/table1/feed"});
         auto ev = env.WaitResponse();
 
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::UNAUTHORIZED);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::Unauthorized);
     }
 
     Y_UNIT_TEST(FederationNavigateUsesAccountDatabase) {
@@ -352,7 +352,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         auto ev = env.WaitResponse();
 
         UNIT_ASSERT(ev->UsedSyncVersion);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/topic1"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/topic1"].RealPath, "/Root/Federation/account/topic1");
     }
 
@@ -371,7 +371,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         env.StartDescribe({"/Root/account/topic1"});
         auto ev = env.WaitResponse();
 
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/account/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/account/topic1"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/account/topic1"].RealPath, "/Root/Federation/account/topic1");
     }
 
@@ -396,7 +396,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
         UNIT_ASSERT(ev->Topics.contains("account/table1/feed"));
         auto& info = ev->Topics["account/table1/feed"];
-        UNIT_ASSERT_VALUES_EQUAL(info.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(info.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT(info.CdcStream);
         UNIT_ASSERT_VALUES_EQUAL(info.CdcStreamName, "feed");
         UNIT_ASSERT_VALUES_EQUAL(info.RealPath, "/Root/Federation/account/table1/feed/streamImpl");
@@ -418,7 +418,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         auto ev = env.WaitResponse();
 
         UNIT_ASSERT_VALUES_EQUAL(requests, 2u); // miss + sync only
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["topic1"].Status, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["topic1"].Status, NDescriber::EStatus::NotFound);
     }
 
     Y_UNIT_TEST(SetErrorResultPreservesSuccess) {
@@ -441,8 +441,8 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         auto ev = env.WaitResponse();
 
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics.size(), 2u);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/local"].Status, NDescriber::EStatus::SUCCESS);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/missing"].Status, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/local"].Status, NDescriber::EStatus::Success);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/missing"].Status, NDescriber::EStatus::NotFound);
     }
 
     Y_UNIT_TEST(LegacyRt3ResolvedUnderFederationRoot) {
@@ -463,7 +463,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
         UNIT_ASSERT(ev->Topics.contains("rt3.dc1--account--topic"));
         auto& info = ev->Topics["rt3.dc1--account--topic"];
-        UNIT_ASSERT_VALUES_EQUAL(info.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(info.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(info.RealPath, "/Root/Federation/account/topic");
     }
 
@@ -478,7 +478,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         env.StartDescribe({"rt3.dc2--account--topic"});
         auto ev = env.WaitResponse();
 
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc2--account--topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc2--account--topic"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc2--account--topic"].RealPath, "/Root/Federation/account/topic");
     }
 
@@ -492,7 +492,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         env.StartDescribe({"account--topic"});
         auto ev = env.WaitResponse();
 
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account--topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account--topic"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account--topic"].RealPath, "/Root/Federation/account/topic");
     }
 
@@ -515,7 +515,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
         UNIT_ASSERT(ev->Topics.contains("rt3.dc1--account@table1--feed"));
         auto& info = ev->Topics["rt3.dc1--account@table1--feed"];
-        UNIT_ASSERT_VALUES_EQUAL(info.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(info.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT(info.CdcStream);
         UNIT_ASSERT_VALUES_EQUAL(info.CdcStreamName, "feed");
         UNIT_ASSERT_VALUES_EQUAL(info.RealPath, "/Root/Federation/account/table1/feed/streamImpl");
@@ -530,7 +530,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         env.StartDescribe({"rt3.bad"});
         auto ev = env.WaitResponse();
 
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.bad"].Status, NDescriber::EStatus::BAD_REQUEST);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.bad"].Status, NDescriber::EStatus::BadRequest);
         UNIT_ASSERT(!ev->UsedSyncVersion);
     }
 
@@ -547,7 +547,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         env.StartDescribe({"rt3.dc1--account--topic"});
         auto ev = env.WaitResponse();
 
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].RealPath, "/Root/rt3.dc1--account--topic");
     }
 
@@ -568,8 +568,8 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
         UNIT_ASSERT_VALUES_EQUAL(navigateCalls, 1u);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics.size(), 2u);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].Status, NDescriber::EStatus::SUCCESS);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account--topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].Status, NDescriber::EStatus::Success);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account--topic"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].RealPath, "/Root/Federation/account/topic");
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account--topic"].RealPath, "/Root/Federation/account/topic");
     }
@@ -593,8 +593,8 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
         UNIT_ASSERT(ev->UsedSyncVersion);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics.size(), 2u);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].Status, NDescriber::EStatus::SUCCESS);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].Status, NDescriber::EStatus::Success);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/topic"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].RealPath, "/Root/Federation/account/topic");
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/topic"].RealPath, "/Root/Federation/account/topic");
     }
@@ -619,7 +619,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics.size(), 2u);
         for (const auto* key : {"rt3.dc1--account@table1--feed", "account/table1/feed"}) {
             auto& info = ev->Topics[key];
-            UNIT_ASSERT_VALUES_EQUAL(info.Status, NDescriber::EStatus::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(info.Status, NDescriber::EStatus::Success);
             UNIT_ASSERT(info.CdcStream);
             UNIT_ASSERT_VALUES_EQUAL(info.CdcStreamName, "feed");
             UNIT_ASSERT_VALUES_EQUAL(info.RealPath, "/Root/Federation/account/table1/feed/streamImpl");
@@ -639,8 +639,8 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         auto ev = env.WaitResponse();
 
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics.size(), 2u);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.bad"].Status, NDescriber::EStatus::BAD_REQUEST);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.bad"].Status, NDescriber::EStatus::BadRequest);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].RealPath, "/Root/Federation/account/topic");
     }
 
@@ -654,8 +654,8 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         auto ev = env.WaitResponse();
 
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics.size(), 2u);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.bad"].Status, NDescriber::EStatus::BAD_REQUEST);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.also-bad"].Status, NDescriber::EStatus::BAD_REQUEST);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.bad"].Status, NDescriber::EStatus::BadRequest);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.also-bad"].Status, NDescriber::EStatus::BadRequest);
         UNIT_ASSERT(!ev->UsedSyncVersion);
     }
 
@@ -671,7 +671,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         env.StartDescribe({"dir/topic"});
         auto ev = env.WaitResponse();
 
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["dir/topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["dir/topic"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["dir/topic"].RealPath, "/Root/dir/topic");
     }
 
@@ -692,7 +692,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
             });
         auto ev = env.WaitResponse();
 
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::UNAUTHORIZED);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::Unauthorized);
         UNIT_ASSERT(ev->UsedSyncVersion);
     }
 
@@ -712,7 +712,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
             });
         auto ev = env.WaitResponse();
 
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/dir"].Status, NDescriber::EStatus::UNAUTHORIZED);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/dir"].Status, NDescriber::EStatus::Unauthorized);
     }
 
     Y_UNIT_TEST(TopicUnauthorizedWithDescribeAccess) {
@@ -737,7 +737,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
         UNIT_ASSERT_VALUES_EQUAL(
             ev->Topics["/Root/topic1"].Status,
-            NDescriber::EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS);
+            NDescriber::EStatus::UnauthorizedWithDescribeAccess);
     }
 
     Y_UNIT_TEST(AccessOrAllowsViaFakeSchemeCache) {
@@ -760,7 +760,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
             });
         auto ev = env.WaitResponse();
 
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::Success);
     }
 
     Y_UNIT_TEST(MultipleNavigateDatabasesBatched) {
@@ -776,8 +776,8 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
         UNIT_ASSERT(seenDatabases.contains("/Root/Federation/account1"));
         UNIT_ASSERT(seenDatabases.contains("/Root/Federation/account2"));
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account1/topic"].Status, NDescriber::EStatus::SUCCESS);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account2/topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account1/topic"].Status, NDescriber::EStatus::Success);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account2/topic"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account1/topic"].RealPath, "/Root/Federation/account1/topic");
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account2/topic"].RealPath, "/Root/Federation/account2/topic");
     }

--- a/ydb/core/persqueue/public/describer/describer_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_ut.cpp
@@ -206,7 +206,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("/Root/topic1"));
         auto& topicInfo = topics["/Root/topic1"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, "/Root/topic1");
     }
 
@@ -220,7 +220,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("/Root/topic_not_exists"));
         auto& topicInfo = topics["/Root/topic_not_exists"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NotFound);
     }
 
     Y_UNIT_TEST(TopicNotTopic) {
@@ -235,7 +235,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("/Root/table1"));
         auto& topicInfo = topics["/Root/table1"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NOT_TOPIC);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NotTopic);
     }
 
     Y_UNIT_TEST(CDC) {
@@ -251,7 +251,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("/Root/table1/feed"));
         auto& topicInfo = topics["/Root/table1/feed"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, "/Root/table1/feed/streamImpl");
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.CdcStream, true);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.CdcStreamName, "feed");
@@ -269,7 +269,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("topic1"));
         auto& topicInfo = topics["topic1"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, "/Root/topic1");
     }
 
@@ -285,7 +285,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("Root/topic1"));
         auto& topicInfo = topics["Root/topic1"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, "/Root/topic1");
     }
 
@@ -313,7 +313,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("/Root/topic1"));
         auto& topicInfo = topics["/Root/topic1"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT(topicInfo.Info);
         UNIT_ASSERT(topicInfo.Self);
         UNIT_ASSERT(topicInfo.SecurityObject);
@@ -334,7 +334,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("/Root/topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::UNAUTHORIZED);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::Unauthorized);
     }
 
     Y_UNIT_TEST(UnauthorizedWithDescribe) {
@@ -356,7 +356,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("/Root/topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::UnauthorizedWithDescribeAccess);
     }
 
     Y_UNIT_TEST(AccessOrAllows) {
@@ -378,7 +378,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("/Root/topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::Success);
     }
 
     Y_UNIT_TEST(AccessOrDenied) {
@@ -396,7 +396,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("/Root/topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::UNAUTHORIZED);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::Unauthorized);
     }
 
     Y_UNIT_TEST(NotTopicWithoutDescribe) {
@@ -414,7 +414,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("/Root/table1"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1"].Status, NDescriber::EStatus::UNAUTHORIZED);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1"].Status, NDescriber::EStatus::Unauthorized);
     }
 
     Y_UNIT_TEST(CustomAccessRightsAlterSchema) {
@@ -436,7 +436,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("/Root/topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::Success);
     }
 
     // -------------------------------------------------------------------------
@@ -458,7 +458,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(ev->UsedSyncVersion);
         UNIT_ASSERT(ev->Topics.contains("/Root/topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::Success);
     }
 
     // Scheme-cache error / incomplete-topic branches that need a controllable
@@ -470,31 +470,31 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
     // -------------------------------------------------------------------------
 
     Y_UNIT_TEST(ConvertStatuses) {
-        UNIT_ASSERT_VALUES_EQUAL(NDescriber::Convert(NDescriber::EStatus::SUCCESS), Ydb::StatusIds::SUCCESS);
-        UNIT_ASSERT_VALUES_EQUAL(NDescriber::Convert(NDescriber::EStatus::NOT_FOUND), Ydb::StatusIds::NOT_FOUND);
-        UNIT_ASSERT_VALUES_EQUAL(NDescriber::Convert(NDescriber::EStatus::NOT_TOPIC), Ydb::StatusIds::NOT_FOUND);
-        UNIT_ASSERT_VALUES_EQUAL(NDescriber::Convert(NDescriber::EStatus::UNAUTHORIZED), Ydb::StatusIds::UNAUTHORIZED);
+        UNIT_ASSERT_VALUES_EQUAL(NDescriber::Convert(NDescriber::EStatus::Success), Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(NDescriber::Convert(NDescriber::EStatus::NotFound), Ydb::StatusIds::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(NDescriber::Convert(NDescriber::EStatus::NotTopic), Ydb::StatusIds::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(NDescriber::Convert(NDescriber::EStatus::Unauthorized), Ydb::StatusIds::UNAUTHORIZED);
         UNIT_ASSERT_VALUES_EQUAL(
-            NDescriber::Convert(NDescriber::EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS),
+            NDescriber::Convert(NDescriber::EStatus::UnauthorizedWithDescribeAccess),
             Ydb::StatusIds::UNAUTHORIZED
         );
-        UNIT_ASSERT_VALUES_EQUAL(NDescriber::Convert(NDescriber::EStatus::UNKNOWN_ERROR), Ydb::StatusIds::INTERNAL_ERROR);
-        UNIT_ASSERT_VALUES_EQUAL(NDescriber::Convert(NDescriber::EStatus::BAD_REQUEST), Ydb::StatusIds::BAD_REQUEST);
+        UNIT_ASSERT_VALUES_EQUAL(NDescriber::Convert(NDescriber::EStatus::UnknownError), Ydb::StatusIds::INTERNAL_ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(NDescriber::Convert(NDescriber::EStatus::BadRequest), Ydb::StatusIds::BAD_REQUEST);
     }
 
     Y_UNIT_TEST(DescriptionMessages) {
         const TString path = "/Root/topic1";
 
-        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::SUCCESS).Contains("successfully described"));
-        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::NOT_FOUND).Contains("does not exist"));
-        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::UNAUTHORIZED).Contains("does not exist"));
-        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS)
+        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::Success).Contains("successfully described"));
+        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::NotFound).Contains("does not exist"));
+        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::Unauthorized).Contains("does not exist"));
+        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::UnauthorizedWithDescribeAccess)
             .Contains("do not have access permissions to"));
-        UNIT_ASSERT(!NDescriber::Description(path, NDescriber::EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS)
+        UNIT_ASSERT(!NDescriber::Description(path, NDescriber::EStatus::UnauthorizedWithDescribeAccess)
             .Contains("does not exist"));
-        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::NOT_TOPIC).Contains("is not a topic"));
-        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::BAD_REQUEST).Contains("Invalid topic name"));
-        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::UNKNOWN_ERROR).Contains("Error describing"));
+        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::NotTopic).Contains("is not a topic"));
+        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::BadRequest).Contains("Invalid topic name"));
+        UNIT_ASSERT(NDescriber::Description(path, NDescriber::EStatus::UnknownError).Contains("Error describing"));
     }
 
     // -------------------------------------------------------------------------
@@ -513,9 +513,9 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT_VALUES_EQUAL(topics.size(), 3u);
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::SUCCESS);
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/missing"].Status, NDescriber::EStatus::NOT_FOUND);
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1"].Status, NDescriber::EStatus::NOT_TOPIC);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::Success);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/missing"].Status, NDescriber::EStatus::NotFound);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1"].Status, NDescriber::EStatus::NotTopic);
     }
 
     Y_UNIT_TEST(MultipleWithCDC) {
@@ -531,9 +531,9 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT_VALUES_EQUAL(topics.size(), 2u);
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].CdcStream, false);
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed"].CdcStream, true);
         UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed"].RealPath, "/Root/table1/feed/streamImpl");
     }
@@ -549,7 +549,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("/Root/table1/missing_feed"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/missing_feed"].Status, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/missing_feed"].Status, NDescriber::EStatus::NotFound);
     }
 
     Y_UNIT_TEST(CDCUnauthorized) {
@@ -570,8 +570,8 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         UNIT_ASSERT(topics.contains("/Root/table1/feed"));
         auto status = topics["/Root/table1/feed"].Status;
         UNIT_ASSERT_C(
-            status == NDescriber::EStatus::UNAUTHORIZED ||
-                status == NDescriber::EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS,
+            status == NDescriber::EStatus::Unauthorized ||
+                status == NDescriber::EStatus::UnauthorizedWithDescribeAccess,
             static_cast<int>(status)
         );
     }
@@ -600,7 +600,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("/Root/topic1"));
         auto& topicInfo = topics["/Root/topic1"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, "/Root/topic1");
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.CdcStream, false);
         UNIT_ASSERT(topicInfo.CdcStreamName.empty());
@@ -623,7 +623,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("/Root"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root"].Status, NDescriber::EStatus::NOT_TOPIC);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root"].Status, NDescriber::EStatus::NotTopic);
     }
 
     Y_UNIT_TEST(DoubleSlashPath) {
@@ -637,7 +637,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("/Root//topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root//topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root//topic1"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topics["/Root//topic1"].RealPath, "/Root/topic1");
     }
 
@@ -652,7 +652,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("/Root/topic1/"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1/"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1/"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1/"].RealPath, "/Root/topic1");
     }
 
@@ -693,7 +693,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains(shortTopicName));
         auto& topicInfo = topics[shortTopicName];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, fullTopicPath);
     }
 
@@ -718,7 +718,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains(absoluteTopicName));
         auto& topicInfo = topics[absoluteTopicName];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, fullTopicPath);
     }
 
@@ -741,7 +741,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains(shortTopicName));
         auto& topicInfo = topics[shortTopicName];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, fullTopicPath);
     }
 
@@ -758,7 +758,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("account/topic_not_exists"));
         auto& topicInfo = topics["account/topic_not_exists"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NotFound);
     }
 
     Y_UNIT_TEST(TopicWithFederationRootIgnoredForFirstClassCitizen) {
@@ -779,7 +779,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains(shortTopicName));
         auto& topicInfo = topics[shortTopicName];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NotFound);
     }
 
     Y_UNIT_TEST(TopicWithFederationRootMultipleAccounts) {
@@ -822,11 +822,11 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         UNIT_ASSERT_VALUES_EQUAL(topics.size(), 2);
 
         UNIT_ASSERT(topics.contains("account1/topic"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["account1/topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["account1/topic"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topics["account1/topic"].RealPath, "/Root/account1/topic");
 
         UNIT_ASSERT(topics.contains("account2/topic"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["account2/topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["account2/topic"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topics["account2/topic"].RealPath, "/Root/account2/topic");
     }
 
@@ -846,7 +846,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["topic1"].Status, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(topics["topic1"].Status, NDescriber::EStatus::NotFound);
     }
 
     Y_UNIT_TEST(CDCWithFederationRoot) {
@@ -865,7 +865,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("account/table1/feed"));
         auto& topicInfo = topics["account/table1/feed"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.CdcStream, true);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.CdcStreamName, "feed");
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, "/Root/Federation/account/table1/feed/streamImpl");
@@ -885,7 +885,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("/Root/table1/feed"));
         auto& topicInfo = topics["/Root/table1/feed"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, "/Root/table1/feed/streamImpl");
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.CdcStream, true);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.CdcStreamName, "feed");
@@ -902,7 +902,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("/Root/topic1"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].RealPath, "/Root/topic1");
     }
 
@@ -925,7 +925,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("/Root/table1"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1"].Status, NDescriber::EStatus::NOT_TOPIC);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1"].Status, NDescriber::EStatus::NotTopic);
     }
 
     Y_UNIT_TEST(MultipleCDC) {
@@ -941,10 +941,10 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT_VALUES_EQUAL(topics.size(), 2u);
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed1"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed1"].CdcStream, true);
         UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed1"].RealPath, "/Root/table1/feed1/streamImpl");
-        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed2"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed2"].Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed2"].CdcStream, true);
         UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed2"].RealPath, "/Root/table1/feed2/streamImpl");
     }
@@ -969,7 +969,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("rt3.dc1--account--topic1"));
         auto& topicInfo = topics["rt3.dc1--account--topic1"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, federationRoot + "/account/topic1");
     }
 
@@ -989,7 +989,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("account--topic1"));
         auto& topicInfo = topics["account--topic1"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, federationRoot + "/account/topic1");
     }
 
@@ -1010,7 +1010,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("rt3.dc1--account@table1--feed"));
         auto& topicInfo = topics["rt3.dc1--account@table1--feed"];
-        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.CdcStream, true);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.CdcStreamName, "feed");
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, "/Root/Federation/account/table1/feed/streamImpl");
@@ -1028,7 +1028,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("rt3.bad"));
-        UNIT_ASSERT_VALUES_EQUAL(topics["rt3.bad"].Status, NDescriber::EStatus::BAD_REQUEST);
+        UNIT_ASSERT_VALUES_EQUAL(topics["rt3.bad"].Status, NDescriber::EStatus::BadRequest);
     }
 
     Y_UNIT_TEST(TopicInDatabaseWithSlashInName) {
@@ -1065,7 +1065,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
             StartDescribe(runtime, {"my-topic"}, {}, dbPath);
             auto topics = WaitResult(runtime);
             UNIT_ASSERT(topics.contains("my-topic"));
-            UNIT_ASSERT_VALUES_EQUAL(topics["my-topic"].Status, NDescriber::EStatus::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(topics["my-topic"].Status, NDescriber::EStatus::Success);
             UNIT_ASSERT_VALUES_EQUAL(topics["my-topic"].RealPath, "/Root/my/db/my-topic");
         }
 
@@ -1075,7 +1075,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
             StartDescribe(runtime, {topic}, {}, dbPath);
             auto topics = WaitResult(runtime);
             UNIT_ASSERT(topics.contains(topic));
-            UNIT_ASSERT_VALUES_EQUAL(topics[topic].Status, NDescriber::EStatus::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(topics[topic].Status, NDescriber::EStatus::Success);
             UNIT_ASSERT_VALUES_EQUAL(topics[topic].RealPath, "/Root/my/db/my-topic");
         }
 
@@ -1087,7 +1087,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
             StartDescribe(runtime, {topic}, {}, "/Root");
             auto topics = WaitResult(runtime);
             UNIT_ASSERT(topics.contains(topic));
-            UNIT_ASSERT_VALUES_EQUAL(topics[topic].Status, NDescriber::EStatus::NOT_FOUND);
+            UNIT_ASSERT_VALUES_EQUAL(topics[topic].Status, NDescriber::EStatus::NotFound);
         }
 
         // Topic in a subdirectory; DatabaseName points at that subdirectory
@@ -1097,7 +1097,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
             StartDescribe(runtime, {"my-topic"}, {}, "/Root/my/db/my-dir");
             auto topics = WaitResult(runtime);
             UNIT_ASSERT(topics.contains("my-topic"));
-            UNIT_ASSERT_VALUES_EQUAL(topics["my-topic"].Status, NDescriber::EStatus::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(topics["my-topic"].Status, NDescriber::EStatus::Success);
             UNIT_ASSERT_VALUES_EQUAL(topics["my-topic"].RealPath, "/Root/my/db/my-dir/my-topic");
         }
     }

--- a/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
@@ -194,7 +194,7 @@ public:
 
         for (auto& [topicPath, info] : ev->Get()->Topics) {
             switch (info.Status) {
-                case NDescriber::EStatus::SUCCESS: {
+                case NDescriber::EStatus::Success: {
                     // Describer keys responses by the original request path; TopicInfo is keyed by CanonizePath.
                     auto& topicInfo = TopicInfo[CanonizePath(topicPath)];
                     topicInfo.PQInfo = info.Info;
@@ -204,9 +204,9 @@ public:
                 default:
                     return SendReplyAndDie(
                         CreateErrorReply(
-                            info.Status == NDescriber::EStatus::UNAUTHORIZED
+                            info.Status == NDescriber::EStatus::Unauthorized
                                 ? Ydb::StatusIds::UNAUTHORIZED
-                                : (info.Status == NDescriber::EStatus::BAD_REQUEST
+                                : (info.Status == NDescriber::EStatus::BadRequest
                                     ? Ydb::StatusIds::BAD_REQUEST
                                     : Ydb::StatusIds::SCHEME_ERROR),
                             NDescriber::Description(topicPath, info.Status)

--- a/ydb/core/persqueue/public/mlp/mlp.h
+++ b/ydb/core/persqueue/public/mlp/mlp.h
@@ -21,7 +21,7 @@ enum class EOperationResult : ui8 {
     Failed = 3,
 };
 
-enum EEv : ui32 {
+enum class EEv : ui32 {
     EvReadResponse = InternalEventSpaceBegin(NPQ::NEvents::EServices::MLP),
     EvWriteResponse,
     EvChangeResponse,
@@ -35,7 +35,7 @@ struct TMessageId {
     ui64 Offset;
 };
 
-struct TEvWriteResponse : public NActors::TEventLocal<TEvWriteResponse, EEv::EvWriteResponse> {
+struct TEvWriteResponse : public NActors::TEventLocal<TEvWriteResponse, static_cast<ui32>(EEv::EvWriteResponse)> {
 
     NDescriber::EStatus DescribeStatus;
     ui64 BalancerTabletId = 0;
@@ -49,7 +49,7 @@ struct TEvWriteResponse : public NActors::TEventLocal<TEvWriteResponse, EEv::EvW
     std::vector<TMessage> Messages;
 };
 
-struct TEvReadResponse : public NActors::TEventLocal<TEvReadResponse, EEv::EvReadResponse> {
+struct TEvReadResponse : public NActors::TEventLocal<TEvReadResponse, static_cast<ui32>(EEv::EvReadResponse)> {
 
     TEvReadResponse(Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS, TString&& errorDescription = {})
         : Status(status)
@@ -76,7 +76,7 @@ struct TEvReadResponse : public NActors::TEventLocal<TEvReadResponse, EEv::EvRea
 };
 
 
-struct TEvChangeResponse : public NActors::TEventLocal<TEvChangeResponse, EEv::EvChangeResponse> {
+struct TEvChangeResponse : public NActors::TEventLocal<TEvChangeResponse, static_cast<ui32>(EEv::EvChangeResponse)> {
 
     TEvChangeResponse(Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS, TString&& errorDescription = {})
         : Status(status)
@@ -95,7 +95,7 @@ struct TEvChangeResponse : public NActors::TEventLocal<TEvChangeResponse, EEv::E
     std::vector<TResult> Messages;
 };
 
-struct TEvPurgeResponse : public NActors::TEventLocal<TEvPurgeResponse, EEv::EvPurgeResponse> {
+struct TEvPurgeResponse : public NActors::TEventLocal<TEvPurgeResponse, static_cast<ui32>(EEv::EvPurgeResponse)> {
 
     TEvPurgeResponse(Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS, TString&& errorDescription = {})
         : Status(status)
@@ -107,7 +107,7 @@ struct TEvPurgeResponse : public NActors::TEventLocal<TEvPurgeResponse, EEv::EvP
     TString ErrorDescription;
 };
 
-struct TEvDescribeResponse : public NActors::TEventLocal<TEvDescribeResponse, EEv::EvDescribeResponse> {
+struct TEvDescribeResponse : public NActors::TEventLocal<TEvDescribeResponse, static_cast<ui32>(EEv::EvDescribeResponse)> {
     TEvDescribeResponse(Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS, TString&& errorDescription = {})
         : Status(status)
         , ErrorDescription(std::move(errorDescription))

--- a/ydb/core/persqueue/public/mlp/mlp_changer.h
+++ b/ydb/core/persqueue/public/mlp/mlp_changer.h
@@ -78,7 +78,7 @@ private:
 
         auto& topic = topics.begin()->second;
         switch(topic.Status) {
-            case NDescriber::EStatus::SUCCESS: {
+            case NDescriber::EStatus::Success: {
                 TopicInfo = topic.Info;
 
                 if (!HasConsumer(TopicInfo->Description.GetPQTabletConfig(), Settings.Consumer)) {
@@ -88,7 +88,7 @@ private:
 
                 return DoChanges();
             }
-            case NDescriber::EStatus::BAD_REQUEST: {
+            case NDescriber::EStatus::BadRequest: {
                 return ReplyErrorAndDie(Ydb::StatusIds::BAD_REQUEST,
                     NDescriber::Description(Settings.TopicName, topic.Status));
             }

--- a/ydb/core/persqueue/public/mlp/mlp_describer.cpp
+++ b/ydb/core/persqueue/public/mlp/mlp_describer.cpp
@@ -41,7 +41,7 @@ void TDescriberActor::Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
 
     auto& topic = topics.begin()->second;
     switch(topic.Status) {
-        case NDescriber::EStatus::SUCCESS: {
+        case NDescriber::EStatus::Success: {
             TopicInfo = std::move(topic);
             auto consumerConfig = GetConsumer(TopicInfo.Info->Description.GetPQTabletConfig(), Settings.Consumer);
             if (!consumerConfig) {
@@ -50,7 +50,7 @@ void TDescriberActor::Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             }
             return DoRuntimeAttributes();
         }
-        case NDescriber::EStatus::BAD_REQUEST: {
+        case NDescriber::EStatus::BadRequest: {
             return ReplyErrorAndDie(Ydb::StatusIds::BAD_REQUEST,
                 NDescriber::Description(Settings.TopicName, topic.Status));
         }

--- a/ydb/core/persqueue/public/mlp/mlp_pipe_ut.cpp
+++ b/ydb/core/persqueue/public/mlp/mlp_pipe_ut.cpp
@@ -28,7 +28,7 @@ Y_UNIT_TEST(WriterPipeBreakReturnsInternalError) {
 
     auto response = GetWriteResponse(runtime);
     UNIT_ASSERT(response);
-    UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::Success);
     UNIT_ASSERT_VALUES_EQUAL(response->Messages.size(), 1);
     UNIT_ASSERT_VALUES_EQUAL(response->Messages[0].Status, Ydb::StatusIds::INTERNAL_ERROR);
     UNIT_ASSERT(!response->Messages[0].MessageId.has_value());

--- a/ydb/core/persqueue/public/mlp/mlp_purger.cpp
+++ b/ydb/core/persqueue/public/mlp/mlp_purger.cpp
@@ -38,11 +38,11 @@ void TPurgerActor::Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
 
     auto& topic = topics.begin()->second;
     switch(topic.Status) {
-        case NDescriber::EStatus::SUCCESS: {
+        case NDescriber::EStatus::Success: {
             TopicInfo = topic;
             return DoPurge();
         }
-        case NDescriber::EStatus::BAD_REQUEST: {
+        case NDescriber::EStatus::BadRequest: {
             return ReplyErrorAndDie(Ydb::StatusIds::BAD_REQUEST,
                 NDescriber::Description(Settings.TopicName, topic.Status));
         }

--- a/ydb/core/persqueue/public/mlp/mlp_reader.cpp
+++ b/ydb/core/persqueue/public/mlp/mlp_reader.cpp
@@ -54,7 +54,7 @@ void TReaderActor::Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
 
     auto& topic = topics.begin()->second;
     switch(topic.Status) {
-        case NDescriber::EStatus::SUCCESS: {
+        case NDescriber::EStatus::Success: {
             Info = topic.Info;
             ConsumerConfig = GetConsumer(Info->Description.GetPQTabletConfig(), Settings.Consumer);
             if (!ConsumerConfig) {
@@ -63,7 +63,7 @@ void TReaderActor::Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             }
             return DoSelectPartition();
         }
-        case NDescriber::EStatus::BAD_REQUEST: {
+        case NDescriber::EStatus::BadRequest: {
             return ReplyErrorAndDie(Ydb::StatusIds::BAD_REQUEST,
                 NDescriber::Description(Settings.TopicName, topic.Status));
         }

--- a/ydb/core/persqueue/public/mlp/mlp_writer.cpp
+++ b/ydb/core/persqueue/public/mlp/mlp_writer.cpp
@@ -53,7 +53,7 @@ void TWriterActor::Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
     auto& topic = topics.begin()->second;
     DescribeStatus = topic.Status;
     switch(topic.Status) {
-        case NDescriber::EStatus::SUCCESS: {
+        case NDescriber::EStatus::Success: {
             TopicInfo = topic.Info;
             return DoWrite();
         }

--- a/ydb/core/persqueue/public/mlp/mlp_writer.h
+++ b/ydb/core/persqueue/public/mlp/mlp_writer.h
@@ -58,7 +58,7 @@ private:
         ui64 Offset = 0;
     };
     std::vector<TPendingMessage> PendingMessages;
-    NDescriber::EStatus DescribeStatus = NDescriber::EStatus::UNKNOWN_ERROR;
+    NDescriber::EStatus DescribeStatus = NDescriber::EStatus::UnknownError;
 };
 
 } // namespace NKikimr::NPQ::NMLP

--- a/ydb/core/persqueue/public/mlp/mlp_writer_ut.cpp
+++ b/ydb/core/persqueue/public/mlp/mlp_writer_ut.cpp
@@ -20,7 +20,7 @@ Y_UNIT_TEST_SUITE(TMLPWriterTests) {
         });
 
         auto response = GetWriteResponse(runtime);
-        UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::NotFound);
     }
 
     Y_UNIT_TEST(EmptyWrite) {
@@ -36,7 +36,7 @@ Y_UNIT_TEST_SUITE(TMLPWriterTests) {
         });
 
         auto response = GetWriteResponse(runtime);
-        UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(response->Messages.size(), 0);
     }
 
@@ -311,7 +311,7 @@ Y_UNIT_TEST_SUITE(TMLPWriterTests) {
         });
 
         auto response = GetWriteResponse(runtime);
-        UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(response->Messages.size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(response->Messages[0].Status, Ydb::StatusIds::SUCCESS);
         UNIT_ASSERT(response->Messages[0].MessageId.has_value());
@@ -437,7 +437,7 @@ Y_UNIT_TEST_SUITE(TMLPWriterTests) {
         });
 
         auto response = GetWriteResponse(runtime);
-        UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(response->Messages.size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(response->Messages[0].Status, Ydb::StatusIds::SUCCESS);
         UNIT_ASSERT(response->Messages[0].MessageId.has_value());
@@ -465,7 +465,7 @@ Y_UNIT_TEST_SUITE(TMLPWriterTests) {
         });
 
         auto response = GetWriteResponse(runtime);
-        UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::UNAUTHORIZED);
+        UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::Unauthorized);
     }
 
     Y_UNIT_TEST(WriteToAutopartitioningTopic) {

--- a/ydb/core/persqueue/public/mlp/ut/common/common.cpp
+++ b/ydb/core/persqueue/public/mlp/ut/common/common.cpp
@@ -105,7 +105,7 @@ void WriteViaMlp(std::shared_ptr<TMlpPipeSetup>& setup, const TString& topic, co
     // Longer timeout: under UseRealThreads=false MLP consumer may flood the mailbox.
     auto response = GetWriteResponse(runtime, TDuration::Seconds(30));
     UNIT_ASSERT(response);
-    UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::Success);
     UNIT_ASSERT_VALUES_EQUAL(response->Messages.size(), 1);
     UNIT_ASSERT_VALUES_EQUAL(response->Messages[0].Status, Ydb::StatusIds::SUCCESS);
 }
@@ -116,7 +116,7 @@ ui64 GetTabletId(std::shared_ptr<TMlpPipeSetup>& setup, const TString& database,
     CreateDescriberActor(setup->GetRuntime(), database, topic);
     auto result = GetDescriberResponse(setup->GetRuntime(), TDuration::Seconds(30));
     UNIT_ASSERT(result);
-    UNIT_ASSERT_VALUES_EQUAL(result->Topics[topic].Status, NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(result->Topics[topic].Status, NDescriber::EStatus::Success);
     return result->Topics[topic].Info->PartitionGraph->GetPartition(partitionId)->TabletId;
 }
 
@@ -380,21 +380,21 @@ void WriteManyGroups(const std::shared_ptr<TTopicSdkTestSetup>& setup, const std
     };
     CreateWriterActor(runtime, std::move(settings));
     auto response = GetWriteResponse(runtime);
-    UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(response->DescribeStatus, NDescriber::EStatus::Success);
     UNIT_ASSERT_VALUES_EQUAL(response->Messages.size(), messageCount);
 }
 
 ui64 GetTabletId(std::shared_ptr<TTopicSdkTestSetup>& setup, const TString& database, const TString& topic, ui32 partitionId) {
     CreateDescriberActor(setup->GetRuntime(), database, topic);
     auto result = GetDescriberResponse(setup->GetRuntime());
-    UNIT_ASSERT_VALUES_EQUAL(result->Topics[topic].Status, NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(result->Topics[topic].Status, NDescriber::EStatus::Success);
     return result->Topics[topic].Info->PartitionGraph->GetPartition(partitionId)->TabletId;
 }
 
 ui64 GetPQRBTabletId(std::shared_ptr<TTopicSdkTestSetup>& setup, const TString& database, const TString& topic) {
     CreateDescriberActor(setup->GetRuntime(), database, topic);
     auto result = GetDescriberResponse(setup->GetRuntime());
-    UNIT_ASSERT_VALUES_EQUAL(result->Topics[topic].Status, NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(result->Topics[topic].Status, NDescriber::EStatus::Success);
     return result->Topics[topic].Info->Description.GetBalancerTabletID();
 }
 

--- a/ydb/core/persqueue/public/ru_quoter/ru_quoter.cpp
+++ b/ydb/core/persqueue/public/ru_quoter/ru_quoter.cpp
@@ -73,7 +73,7 @@ public:
         SetMeteringMode(NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS);
         Become(&TRequestUnitsQuoter::StateWork);
         if (Settings_.Ru == 0) {
-            return Reply(EStatus::SUCCESS);
+            return Reply(EStatus::Success);
         }
         SendDatabaseNavigate();
     }
@@ -85,7 +85,7 @@ public:
     void OnException(const std::exception& exc) override {
         // Do not PassAway here: TBaseActor::OnUnhandledException will.
         Send(Parent_, new TEvChargeRequestUnitsResponse(
-            EStatus::UNKNOWN_ERROR,
+            EStatus::UnknownError,
             TStringBuilder() << "Unhandled exception: " << exc.what()));
     }
 
@@ -140,7 +140,7 @@ private:
             return;
         }
         WriteBill(ctx);
-        Reply(EStatus::SUCCESS);
+        Reply(EStatus::Success);
     }
 
     void HandleWakeup(NActors::TEvents::TEvWakeup::TPtr& ev) {
@@ -150,13 +150,13 @@ private:
         switch (tag) {
             case EWakeupTag::RlAllowed:
                 WriteBill(ctx);
-                Reply(EStatus::SUCCESS);
+                Reply(EStatus::Success);
                 return;
             case EWakeupTag::RlNoResource:
-                Reply(EStatus::THROTTLED);
+                Reply(EStatus::Throttled);
                 return;
             default:
-                Reply(EStatus::UNKNOWN_ERROR);
+                Reply(EStatus::UnknownError);
                 return;
         }
     }
@@ -213,22 +213,22 @@ NActors::IActor* CreateRequestUnitsQuoter(const NActors::TActorId& parent, TRequ
 
 Ydb::StatusIds::StatusCode Convert(const EStatus status) {
     switch (status) {
-        case EStatus::SUCCESS:
+        case EStatus::Success:
             return Ydb::StatusIds::SUCCESS;
-        case EStatus::THROTTLED:
+        case EStatus::Throttled:
             return Ydb::StatusIds::OVERLOADED;
-        case EStatus::UNKNOWN_ERROR:
+        case EStatus::UnknownError:
             return Ydb::StatusIds::INTERNAL_ERROR;
     }
 }
 
 TString Description(const EStatus status) {
     switch (status) {
-        case EStatus::SUCCESS:
+        case EStatus::Success:
             return "Request units have been charged";
-        case EStatus::THROTTLED:
+        case EStatus::Throttled:
             return "Request was throttled by the rate limiter";
-        case EStatus::UNKNOWN_ERROR:
+        case EStatus::UnknownError:
             return "Unexpected rate limiter wakeup";
     }
 }

--- a/ydb/core/persqueue/public/ru_quoter/ru_quoter.h
+++ b/ydb/core/persqueue/public/ru_quoter/ru_quoter.h
@@ -21,15 +21,15 @@
 
 namespace NKikimr::NPQ::NRuQuoter {
 
-enum EEv : ui32 {
+enum class EEv : ui32 {
     EvChargeRequestUnitsResponse = InternalEventSpaceBegin(NPQ::NEvents::EServices::RU_QUOTER),
     EvEnd
 };
 
 enum class EStatus {
-    SUCCESS,
-    THROTTLED,
-    UNKNOWN_ERROR
+    Success,
+    Throttled,
+    UnknownError
 };
 
 
@@ -39,7 +39,7 @@ struct TRequestUnitsQuoterSettings {
     TString Token;
 };
 
-struct TEvChargeRequestUnitsResponse : public NActors::TEventLocal<TEvChargeRequestUnitsResponse, EEv::EvChargeRequestUnitsResponse> {
+struct TEvChargeRequestUnitsResponse : public NActors::TEventLocal<TEvChargeRequestUnitsResponse, static_cast<ui32>(EEv::EvChargeRequestUnitsResponse)> {
 
     TEvChargeRequestUnitsResponse() = default;
 
@@ -49,7 +49,7 @@ struct TEvChargeRequestUnitsResponse : public NActors::TEventLocal<TEvChargeRequ
     {
     }
 
-    EStatus Status = EStatus::SUCCESS;
+    EStatus Status = EStatus::Success;
     TString Message;
 };
 

--- a/ydb/core/persqueue/public/ru_quoter/ru_quoter_ut.cpp
+++ b/ydb/core/persqueue/public/ru_quoter/ru_quoter_ut.cpp
@@ -233,13 +233,13 @@ TRequestUnitsQuoterSettings MakeSettings(ui64 ru) {
 Y_UNIT_TEST_SUITE(TRuQuoterTests) {
 
     Y_UNIT_TEST(ConvertAndDescription) {
-        UNIT_ASSERT_VALUES_EQUAL(Convert(EStatus::SUCCESS), Ydb::StatusIds::SUCCESS);
-        UNIT_ASSERT_VALUES_EQUAL(Convert(EStatus::THROTTLED), Ydb::StatusIds::OVERLOADED);
-        UNIT_ASSERT_VALUES_EQUAL(Convert(EStatus::UNKNOWN_ERROR), Ydb::StatusIds::INTERNAL_ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(Convert(EStatus::Success), Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(Convert(EStatus::Throttled), Ydb::StatusIds::OVERLOADED);
+        UNIT_ASSERT_VALUES_EQUAL(Convert(EStatus::UnknownError), Ydb::StatusIds::INTERNAL_ERROR);
 
-        UNIT_ASSERT(Description(EStatus::SUCCESS).Contains("have been charged"));
-        UNIT_ASSERT_VALUES_EQUAL(Description(EStatus::THROTTLED), "Request was throttled by the rate limiter");
-        UNIT_ASSERT_VALUES_EQUAL(Description(EStatus::UNKNOWN_ERROR), "Unexpected rate limiter wakeup");
+        UNIT_ASSERT(Description(EStatus::Success).Contains("have been charged"));
+        UNIT_ASSERT_VALUES_EQUAL(Description(EStatus::Throttled), "Request was throttled by the rate limiter");
+        UNIT_ASSERT_VALUES_EQUAL(Description(EStatus::UnknownError), "Unexpected rate limiter wakeup");
     }
 
     Y_UNIT_TEST(ParseRlContextRequiresBothAttrs) {
@@ -290,8 +290,8 @@ Y_UNIT_TEST_SUITE(TRuQuoterTests) {
         env.Start(MakeSettings(0));
         auto ev = env.WaitResponse();
         UNIT_ASSERT(ev);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::SUCCESS);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Message, Description(EStatus::SUCCESS));
+        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::Success);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Message, Description(EStatus::Success));
         UNIT_ASSERT_VALUES_EQUAL(navigates, 0u);
         UNIT_ASSERT(env.Bills.empty());
     }
@@ -305,7 +305,7 @@ Y_UNIT_TEST_SUITE(TRuQuoterTests) {
         env.Start(MakeSettings(2));
         auto ev = env.WaitResponse();
         UNIT_ASSERT(ev);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::Success);
         UNIT_ASSERT(env.Bills.empty());
         UNIT_ASSERT_VALUES_EQUAL(env.QuoterService->RequestCount, 0u);
     }
@@ -318,7 +318,7 @@ Y_UNIT_TEST_SUITE(TRuQuoterTests) {
         env.Start(MakeSettings(2));
         auto ev = env.WaitResponse();
         UNIT_ASSERT(ev);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::Success);
         UNIT_ASSERT(env.Bills.empty());
     }
 
@@ -331,7 +331,7 @@ Y_UNIT_TEST_SUITE(TRuQuoterTests) {
         env.Start(MakeSettings(7));
         auto ev = env.WaitResponse();
         UNIT_ASSERT(ev);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(env.QuoterService->RequestCount, 0u);
         UNIT_ASSERT_VALUES_EQUAL(env.Bills.size(), 1u);
         NJson::TJsonValue json;
@@ -349,7 +349,7 @@ Y_UNIT_TEST_SUITE(TRuQuoterTests) {
         env.Start(MakeSettings(2));
         auto ev = env.WaitResponse();
         UNIT_ASSERT(ev);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::Success);
         UNIT_ASSERT(env.Bills.empty());
     }
 
@@ -362,7 +362,7 @@ Y_UNIT_TEST_SUITE(TRuQuoterTests) {
         env.Start(MakeSettings(3));
         auto ev = env.WaitResponse();
         UNIT_ASSERT(ev);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::Success);
         UNIT_ASSERT_VALUES_EQUAL(env.QuoterService->RequestCount, 1u);
         UNIT_ASSERT_VALUES_EQUAL(env.Bills.size(), 1u);
     }
@@ -376,8 +376,8 @@ Y_UNIT_TEST_SUITE(TRuQuoterTests) {
         env.Start(MakeSettings(3));
         auto ev = env.WaitResponse();
         UNIT_ASSERT(ev);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::THROTTLED);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Message, Description(EStatus::THROTTLED));
+        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::Throttled);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Message, Description(EStatus::Throttled));
         UNIT_ASSERT(env.Bills.empty());
     }
 
@@ -387,8 +387,8 @@ Y_UNIT_TEST_SUITE(TRuQuoterTests) {
         env.Runtime.Send(new IEventHandle(id, env.EdgeId, new TEvents::TEvWakeup(/*RecheckAcl*/ 4)), 0, true);
         auto ev = env.WaitResponse();
         UNIT_ASSERT(ev);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::UNKNOWN_ERROR);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Message, Description(EStatus::UNKNOWN_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::UnknownError);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Message, Description(EStatus::UnknownError));
         UNIT_ASSERT_VALUES_EQUAL(env.Cache->RequestCount, 1u);
     }
 
@@ -398,7 +398,7 @@ Y_UNIT_TEST_SUITE(TRuQuoterTests) {
         env.Runtime.Send(new IEventHandle(id, env.EdgeId, new TEvents::TEvWakeup(/*RlAllowed*/ 2)), 0, true);
         auto ev = env.WaitResponse();
         UNIT_ASSERT(ev);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::Success);
         UNIT_ASSERT(env.Bills.empty());
     }
 
@@ -408,7 +408,7 @@ Y_UNIT_TEST_SUITE(TRuQuoterTests) {
         env.Runtime.Send(new IEventHandle(id, env.EdgeId, new TEvents::TEvWakeup(/*RlNoResource*/ 3)), 0, true);
         auto ev = env.WaitResponse();
         UNIT_ASSERT(ev);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::THROTTLED);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::Throttled);
     }
 
     Y_UNIT_TEST(UnhandledExceptionRepliesUnknownError) {
@@ -434,7 +434,7 @@ Y_UNIT_TEST_SUITE(TRuQuoterTests) {
 
         auto ev = env.WaitResponse();
         UNIT_ASSERT(ev);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::UNKNOWN_ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::UnknownError);
         UNIT_ASSERT(ev->Message.Contains("Unhandled exception"));
         UNIT_ASSERT(env.Bills.empty());
     }
@@ -466,13 +466,13 @@ Y_UNIT_TEST_SUITE(TRuQuoterTests) {
             new TEvTxProxySchemeCache::TEvNavigateKeySetResult(TAutoPtr<TSchemeCacheNavigate>())), 0, true);
         auto ev = env.WaitResponse();
         UNIT_ASSERT(ev);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Status, EStatus::Success);
         UNIT_ASSERT(env.Bills.empty());
     }
 
     Y_UNIT_TEST(TEvChargeRequestUnitsResponseDefaultCtor) {
         TEvChargeRequestUnitsResponse ev;
-        UNIT_ASSERT_VALUES_EQUAL(ev.Status, EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev.Status, EStatus::Success);
         UNIT_ASSERT(ev.Message.empty());
     }
 }

--- a/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
@@ -65,23 +65,23 @@ private:
 
         TopicInfo = std::move(topics.begin()->second);
         switch(TopicInfo.Status) {
-            case NDescriber::EStatus::SUCCESS: {
+            case NDescriber::EStatus::Success: {
                 if (AppData()->PQConfig.GetTopicsAreFirstClassCitizen()) {
                     return DoAlter();
                 } else {
                     return DoGetClustersList();
                 }
             }
-            case NDescriber::EStatus::NOT_FOUND: {
+            case NDescriber::EStatus::NotFound: {
                 if (Settings.IfExists) {
                     return ReplyAndDie(Ydb::StatusIds::SUCCESS, "");
                 }
-                return ReplyAndDie(Ydb::StatusIds::SCHEME_ERROR, NDescriber::Description(Settings.Strategy->GetTopicName(), NDescriber::EStatus::NOT_FOUND));
+                return ReplyAndDie(Ydb::StatusIds::SCHEME_ERROR, NDescriber::Description(Settings.Strategy->GetTopicName(), NDescriber::EStatus::NotFound));
             }
-            case NDescriber::EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS: {
+            case NDescriber::EStatus::UnauthorizedWithDescribeAccess: {
                 return ReplyAndDie(Ydb::StatusIds::UNAUTHORIZED, NDescriber::Description(Settings.Strategy->GetTopicName(), TopicInfo.Status));
             }
-            case NDescriber::EStatus::BAD_REQUEST: {
+            case NDescriber::EStatus::BadRequest: {
                 return ReplyAndDie(Ydb::StatusIds::BAD_REQUEST, NDescriber::Description(Settings.Strategy->GetTopicName(), TopicInfo.Status));
             }
             default: {

--- a/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
+++ b/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
@@ -139,7 +139,7 @@ private:
 
     std::optional<TStatusAndMessage> MapStatus(const TString& path, const NDescriber::TTopicInfo& info) const {
         switch (info.Status) {
-            case NDescriber::EStatus::SUCCESS:
+            case NDescriber::EStatus::Success:
                 if (IsCdcDlqTarget(info)) {
                     return TStatusAndMessage{
                         Ydb::StatusIds::BAD_REQUEST,
@@ -147,28 +147,28 @@ private:
                     };
                 }
                 return std::nullopt;
-            case NDescriber::EStatus::NOT_TOPIC:
+            case NDescriber::EStatus::NotTopic:
                 return TStatusAndMessage{
                     Ydb::StatusIds::BAD_REQUEST,
                     TStringBuilder() << "Dead letter queue path must be a topic, got " << path
                 };
-            case NDescriber::EStatus::NOT_FOUND:
+            case NDescriber::EStatus::NotFound:
                 return TStatusAndMessage{
                     Ydb::StatusIds::SCHEME_ERROR,
                     TStringBuilder() << "Path `" << path << "` does not exist"
                 };
-            case NDescriber::EStatus::UNAUTHORIZED:
-            case NDescriber::EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS:
+            case NDescriber::EStatus::Unauthorized:
+            case NDescriber::EStatus::UnauthorizedWithDescribeAccess:
                 return TStatusAndMessage{
                     Ydb::StatusIds::UNAUTHORIZED,
                     AccessDeniedMessage(Settings.UserToken, path)
                 };
-            case NDescriber::EStatus::BAD_REQUEST:
+            case NDescriber::EStatus::BadRequest:
                 return TStatusAndMessage{
                     Ydb::StatusIds::BAD_REQUEST,
                     NDescriber::Description(path, info.Status)
                 };
-            case NDescriber::EStatus::UNKNOWN_ERROR:
+            case NDescriber::EStatus::UnknownError:
                 return TStatusAndMessage{
                     Ydb::StatusIds::INTERNAL_ERROR,
                     NDescriber::Description(path, info.Status)

--- a/ydb/core/persqueue/public/schema/check_dlq_topics.h
+++ b/ydb/core/persqueue/public/schema/check_dlq_topics.h
@@ -22,7 +22,7 @@ class TPQTabletConfig;
 namespace NKikimr::NPQ::NSchema {
 
 struct TEvCheckDlqTopicsResponse
-    : public NActors::TEventLocal<TEvCheckDlqTopicsResponse, EEv::EvCheckDlqTopicsResponse>
+    : public NActors::TEventLocal<TEvCheckDlqTopicsResponse, static_cast<ui32>(EEv::EvCheckDlqTopicsResponse)>
 {
     TEvCheckDlqTopicsResponse(
         Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS,

--- a/ydb/core/persqueue/public/schema/create_topic_ut.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_ut.cpp
@@ -52,7 +52,7 @@ Y_UNIT_TEST(CreateTopicKeepsLiteralDashDashName) {
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
     const auto it = response->Topics.find(name);
     UNIT_ASSERT(it != response->Topics.end());
-    UNIT_ASSERT_VALUES_EQUAL(it->second.Status, NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(it->second.Status, NDescriber::EStatus::Success);
     UNIT_ASSERT_VALUES_EQUAL(it->second.RealPath, path);
 
     // "--" is not a path separator: the converted legacy path must not exist.
@@ -60,7 +60,7 @@ Y_UNIT_TEST(CreateTopicKeepsLiteralDashDashName) {
     runtime.Register(NDescriber::CreateDescriberActor(convertedEdge, "/Root", {TString("TestSchemeList/test-topic-1")}));
     auto converted = runtime.GrabEdgeEvent<NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
     UNIT_ASSERT_VALUES_EQUAL(converted->Topics.size(), 1u);
-    UNIT_ASSERT_VALUES_EQUAL(converted->Topics.begin()->second.Status, NDescriber::EStatus::NOT_FOUND);
+    UNIT_ASSERT_VALUES_EQUAL(converted->Topics.begin()->second.Status, NDescriber::EStatus::NotFound);
 }
 
 // https://github.com/ydb-platform/ydb/issues/50971

--- a/ydb/core/persqueue/public/schema/describe_operation.cpp
+++ b/ydb/core/persqueue/public/schema/describe_operation.cpp
@@ -179,17 +179,17 @@ private:
         LOG_D("Handle TEvDescribeTopicsResponse. Status=" << TopicInfo.Status
                                                          << " usedSyncVersion=" << UsedSyncVersion);
 
-        if (TopicInfo.Status != NDescriber::EStatus::SUCCESS) {
+        if (TopicInfo.Status != NDescriber::EStatus::Success) {
             const auto status = [&]() {
                 switch (TopicInfo.Status) {
-                    case NDescriber::EStatus::NOT_FOUND:
-                    case NDescriber::EStatus::NOT_TOPIC:
-                    case NDescriber::EStatus::UNAUTHORIZED:
-                    case NDescriber::EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS:
+                    case NDescriber::EStatus::NotFound:
+                    case NDescriber::EStatus::NotTopic:
+                    case NDescriber::EStatus::Unauthorized:
+                    case NDescriber::EStatus::UnauthorizedWithDescribeAccess:
                         return Ydb::StatusIds::SCHEME_ERROR;
-                    case NDescriber::EStatus::BAD_REQUEST:
+                    case NDescriber::EStatus::BadRequest:
                         return Ydb::StatusIds::BAD_REQUEST;
-                    case NDescriber::EStatus::UNKNOWN_ERROR:
+                    case NDescriber::EStatus::UnknownError:
                         return Ydb::StatusIds::INTERNAL_ERROR;
                     default:
                         return Ydb::StatusIds::INTERNAL_ERROR;
@@ -197,13 +197,13 @@ private:
             }();
             const auto issueCode = [&]() {
                 switch (TopicInfo.Status) {
-                    case NDescriber::EStatus::NOT_FOUND:
-                    case NDescriber::EStatus::UNAUTHORIZED:
-                    case NDescriber::EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS:
+                    case NDescriber::EStatus::NotFound:
+                    case NDescriber::EStatus::Unauthorized:
+                    case NDescriber::EStatus::UnauthorizedWithDescribeAccess:
                         return Ydb::PersQueue::ErrorCode::ACCESS_DENIED;
-                    case NDescriber::EStatus::NOT_TOPIC:
+                    case NDescriber::EStatus::NotTopic:
                         return Ydb::PersQueue::ErrorCode::VALIDATION_ERROR;
-                    case NDescriber::EStatus::BAD_REQUEST:
+                    case NDescriber::EStatus::BadRequest:
                         return Ydb::PersQueue::ErrorCode::BAD_REQUEST;
                     default:
                         return Ydb::PersQueue::ErrorCode::BAD_REQUEST;

--- a/ydb/core/persqueue/public/schema/describe_operation.h
+++ b/ydb/core/persqueue/public/schema/describe_operation.h
@@ -33,7 +33,7 @@ struct TPartitionDescribeInfo {
 };
 
 struct TEvDescribeOperationResponse
-    : public NActors::TEventLocal<TEvDescribeOperationResponse, EEv::EvDescribeOperationResponse>
+    : public NActors::TEventLocal<TEvDescribeOperationResponse, static_cast<ui32>(EEv::EvDescribeOperationResponse)>
 {
     Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::SUCCESS;
     TString ErrorMessage;

--- a/ydb/core/persqueue/public/schema/drop_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/drop_topic_operation.cpp
@@ -65,22 +65,22 @@ private:
 
         TopicInfo = std::move(topics.begin()->second);
         switch(TopicInfo.Status) {
-            case NDescriber::EStatus::SUCCESS: {
+            case NDescriber::EStatus::Success: {
                 if (TopicInfo.CdcStream) {
-                    return ReplyAndDie(Ydb::StatusIds::SCHEME_ERROR, NDescriber::Description(Settings.Path, NDescriber::EStatus::NOT_FOUND));
+                    return ReplyAndDie(Ydb::StatusIds::SCHEME_ERROR, NDescriber::Description(Settings.Path, NDescriber::EStatus::NotFound));
                 }
                 return DoDrop();
             }
-            case NDescriber::EStatus::NOT_FOUND: {
+            case NDescriber::EStatus::NotFound: {
                 if (Settings.IfExists) {
                     return ReplyAndDie(Ydb::StatusIds::SUCCESS, "");
                 }
-                return ReplyAndDie(Ydb::StatusIds::SCHEME_ERROR, NDescriber::Description(Settings.Path, NDescriber::EStatus::NOT_FOUND));
+                return ReplyAndDie(Ydb::StatusIds::SCHEME_ERROR, NDescriber::Description(Settings.Path, NDescriber::EStatus::NotFound));
             }
-            case NDescriber::EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS: {
+            case NDescriber::EStatus::UnauthorizedWithDescribeAccess: {
                 return ReplyAndDie(Ydb::StatusIds::UNAUTHORIZED, NDescriber::Description(Settings.Path, TopicInfo.Status));
             }
-            case NDescriber::EStatus::BAD_REQUEST: {
+            case NDescriber::EStatus::BadRequest: {
                 return ReplyAndDie(Ydb::StatusIds::BAD_REQUEST, NDescriber::Description(Settings.Path, TopicInfo.Status));
             }
             default: {

--- a/ydb/core/persqueue/public/schema/schema.h
+++ b/ydb/core/persqueue/public/schema/schema.h
@@ -15,7 +15,7 @@ class TUserToken;
 
 namespace NKikimr::NPQ::NSchema {
 
-enum EEv : ui32 {
+enum class EEv : ui32 {
     EvReadResponse = InternalEventSpaceBegin(NPQ::NEvents::EServices::SCHEMA),
     EvSchemaOperationResponse,
     EvSchemaResponse,
@@ -24,7 +24,7 @@ enum EEv : ui32 {
     EvEnd
 };
 
-struct TEvSchemaOperationResponse: public NActors::TEventLocal<TEvSchemaOperationResponse, EEv::EvSchemaOperationResponse> {
+struct TEvSchemaOperationResponse: public NActors::TEventLocal<TEvSchemaOperationResponse, static_cast<ui32>(EEv::EvSchemaOperationResponse)> {
     TEvSchemaOperationResponse(
         Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS,
         TString&& errorMessage = {}
@@ -45,7 +45,7 @@ struct TSchemaResponse {
     NKikimrSchemeOp::TModifyScheme ModifyScheme;
 };
 
-struct TEvSchemaResponse: public NActors::TEventLocal<TEvSchemaResponse, EEv::EvSchemaResponse>
+struct TEvSchemaResponse: public NActors::TEventLocal<TEvSchemaResponse, static_cast<ui32>(EEv::EvSchemaResponse)>
                         , public TSchemaResponse {
     TEvSchemaResponse(
         const TString& path,

--- a/ydb/core/persqueue/public/schema/schema_ops_ut.cpp
+++ b/ydb/core/persqueue/public/schema/schema_ops_ut.cpp
@@ -283,7 +283,7 @@ Y_UNIT_TEST(CreateAlterDropPrepareOnlyAndIfFlags) {
         auto edge = runtime.AllocateEdgeActor();
         runtime.Register(NDescriber::CreateDescriberActor(edge, "/Root", {path}));
         auto response = runtime.GrabEdgeEvent<NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
-        UNIT_ASSERT_VALUES_EQUAL(response->Topics.begin()->second.Status, NDescriber::EStatus::NOT_FOUND);
+        UNIT_ASSERT_VALUES_EQUAL(response->Topics.begin()->second.Status, NDescriber::EStatus::NotFound);
     }
 
     AssertStatus(DoCreate(runtime, MakeCreateTopicRequest(path)), Ydb::StatusIds::SUCCESS);

--- a/ydb/core/persqueue/public/schema/schema_ut_helpers.h
+++ b/ydb/core/persqueue/public/schema/schema_ut_helpers.h
@@ -209,7 +209,7 @@ inline NKikimrPQ::TPartitionConfig DescribePartitionConfig(
     auto response = runtime.GrabEdgeEvent<NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
     const auto& topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NDescriber::EStatus::Success);
     return topic.Info->Description.GetPQTabletConfig().GetPartitionConfig();
 }
 
@@ -223,7 +223,7 @@ inline NKikimrPQ::TPQTabletConfig DescribeTabletConfig(
     auto response = runtime.GrabEdgeEvent<NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
     const auto& topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NDescriber::EStatus::Success);
     return topic.Info->Description.GetPQTabletConfig();
 }
 

--- a/ydb/core/persqueue/ut/common/autoscaling_ut_common.cpp
+++ b/ydb/core/persqueue/ut/common/autoscaling_ut_common.cpp
@@ -703,7 +703,7 @@ THolder<NDescriber::TEvDescribeTopicsResponse> GetDescriberResponse(NActors::TTe
 ui64 GetPQRBTabletId(NActors::TTestActorRuntime& runtime, const TString& database, const TString& topic) {
     CreateDescriberActor(runtime, database, topic);
     auto result = GetDescriberResponse(runtime);
-    UNIT_ASSERT_VALUES_EQUAL(result->Topics[topic].Status, NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(result->Topics[topic].Status, NDescriber::EStatus::Success);
     return result->Topics[topic].Info->Description.GetBalancerTabletID();
 }
 

--- a/ydb/core/ymq/actor/send_message.cpp
+++ b/ydb/core/ymq/actor/send_message.cpp
@@ -439,8 +439,8 @@ private:
                 : Response_.MutableSendMessage();
             auto* currentRequest = IsBatch_ ? &BatchRequest().GetEntries(RequestToReplyIndexMapping_[i]) : &Request();
 
-            if (response->DescribeStatus != NPQ::NDescriber::EStatus::SUCCESS) {
-                if (response->DescribeStatus == NPQ::NDescriber::EStatus::NOT_FOUND) {
+            if (response->DescribeStatus != NPQ::NDescriber::EStatus::Success) {
+                if (response->DescribeStatus == NPQ::NDescriber::EStatus::NotFound) {
                     // The topic is temporarily missing (the queue is being deleted or
                     // recreated). Report a generic retryable internal failure instead of
                     // leaking the internal topic path.

--- a/ydb/core/ymq/actor/topic_pqrb_metrics.cpp
+++ b/ydb/core/ymq/actor/topic_pqrb_metrics.cpp
@@ -48,7 +48,7 @@ private:
         DescriberActorId_ = {};
 
         const auto it = ev->Get()->Topics.find(TopicPath_);
-        if (it == ev->Get()->Topics.end() || it->second.Status != NPQ::NDescriber::EStatus::SUCCESS || !it->second.Info) {
+        if (it == ev->Get()->Topics.end() || it->second.Status != NPQ::NDescriber::EStatus::Success || !it->second.Info) {
             PassAway();
             return;
         }

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/alter_topic_sdk_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/alter_topic_sdk_ut.cpp
@@ -55,7 +55,7 @@ Y_UNIT_TEST(AddStreamingConsumer) {
 
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
     const auto& topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::Success);
 
     const auto* consumer = NPQ::GetConsumer(topic.Info->Description.GetPQTabletConfig(), DEFAULT_STREAMING_CONSUMER);
     UNIT_ASSERT(consumer);
@@ -111,7 +111,7 @@ Y_UNIT_TEST(AddSharedConsumer) {
 
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
     const auto& topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::Success);
 
     const auto& config = topic.Info->Description.GetPQTabletConfig();
     const auto* consumer = NPQ::GetConsumer(config, DEFAULT_SHARED_CONSUMER);
@@ -291,7 +291,7 @@ Y_UNIT_TEST(AlterSharedConsumer) {
 
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
     const auto& topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::Success);
 
     const auto* consumer = NPQ::GetConsumer(topic.Info->Description.GetPQTabletConfig(), DEFAULT_SHARED_CONSUMER);
     UNIT_ASSERT(consumer);
@@ -354,7 +354,7 @@ Y_UNIT_TEST(AlterStreamingConsumer) {
 
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
     const auto& topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::Success);
 
     const auto* consumer = NPQ::GetConsumer(topic.Info->Description.GetPQTabletConfig(), DEFAULT_STREAMING_CONSUMER);
     UNIT_ASSERT(consumer);

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/create_topic_sdk_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/create_topic_sdk_ut.cpp
@@ -79,7 +79,7 @@ Y_UNIT_TEST(CreateTopicWithStreamingConsumer) {
 
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
     const auto& topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::Success);
 
     const auto* consumer = NPQ::GetConsumer(topic.Info->Description.GetPQTabletConfig(), DEFAULT_STREAMING_CONSUMER);
     UNIT_ASSERT(consumer);
@@ -126,7 +126,7 @@ Y_UNIT_TEST(CreateTopicWithSharedConsumer) {
 
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
     const auto& topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::Success);
 
     const auto& config = topic.Info->Description.GetPQTabletConfig();
     const auto* consumer = NPQ::GetConsumer(config, DEFAULT_SHARED_CONSUMER);

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/create_topic_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/create_topic_ut.cpp
@@ -125,7 +125,7 @@ Y_UNIT_TEST(SharedConsumer) {
 
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1);
     auto topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::Success);
 
     auto config = topic.Info->Description.GetPQTabletConfig();
     const auto* consumer = NPQ::GetConsumer(config, "test_consumer");
@@ -173,7 +173,7 @@ Y_UNIT_TEST(MessageWriteBurstDefaultsToSpeed) {
 
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1);
     auto topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::Success);
 
     const auto& partitionConfig = topic.Info->Description.GetPQTabletConfig().GetPartitionConfig();
     UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetWriteSpeedInMessagesPerSecond(), 777);
@@ -225,7 +225,7 @@ Y_UNIT_TEST(ContentBasedDeduplication) {
 
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1);
     auto topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::Success);
 
     auto config = topic.Info->Description.GetPQTabletConfig();
     UNIT_ASSERT_VALUES_EQUAL(config.GetContentBasedDeduplication(), true);

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/schema_ops_ut.cpp
@@ -120,7 +120,7 @@ void AssertDescribeAliases(
         UNIT_ASSERT_VALUES_EQUAL_C(response->Topics.size(), 1u, name);
         const auto it = response->Topics.find(name);
         UNIT_ASSERT_C(it != response->Topics.end(), name);
-        UNIT_ASSERT_VALUES_EQUAL_C(it->second.Status, NPQ::NDescriber::EStatus::SUCCESS, name);
+        UNIT_ASSERT_VALUES_EQUAL_C(it->second.Status, NPQ::NDescriber::EStatus::Success, name);
         UNIT_ASSERT_VALUES_EQUAL_C(it->second.RealPath, expectedRealPath, name);
     }
 }
@@ -141,7 +141,7 @@ NKikimrPQ::TPQTabletConfig DescribeTabletConfig(
     auto response = runtime.GrabEdgeEvent<NPQ::NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
     const auto& topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::Success);
     return topic.Info->Description.GetPQTabletConfig();
 }
 
@@ -383,7 +383,7 @@ Y_UNIT_TEST(CreateWithRetentionStorageBytes) {
     auto response = runtime.GrabEdgeEvent<NPQ::NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
     const auto& topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::Success);
     UNIT_ASSERT_VALUES_EQUAL(
         topic.Info->Description.GetPQTabletConfig().GetPartitionConfig().GetStorageLimitBytes(),
         10_MB);

--- a/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
@@ -207,7 +207,7 @@ NKikimrPQ::TPQTabletConfig DescribeTabletConfig(
     auto response = runtime.GrabEdgeEvent<NPQ::NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
     const auto& topic = response->Topics.begin()->second;
-    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::Success);
     return topic.Info->Description.GetPQTabletConfig();
 }
 
@@ -237,7 +237,7 @@ void AssertDescribeAliases(
         UNIT_ASSERT_VALUES_EQUAL_C(response->Topics.size(), 1u, name);
         const auto it = response->Topics.find(name);
         UNIT_ASSERT_C(it != response->Topics.end(), name);
-        UNIT_ASSERT_VALUES_EQUAL_C(it->second.Status, NPQ::NDescriber::EStatus::SUCCESS, name);
+        UNIT_ASSERT_VALUES_EQUAL_C(it->second.Status, NPQ::NDescriber::EStatus::Success, name);
         UNIT_ASSERT_VALUES_EQUAL_C(it->second.RealPath, expectedRealPath, name);
 
         const auto describe = DescribeTopic(runtime, name);

--- a/ydb/services/persqueue_v1/ut/describes_ut/describe_topic_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/describes_ut/describe_topic_ut.cpp
@@ -206,7 +206,7 @@ Y_UNIT_TEST_SUITE(TTopicApiDescribes) {
         };
 
         auto info = getDescribe();
-        UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(info.Status), static_cast<int>(NPQ::NDescriber::EStatus::SUCCESS));
+        UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(info.Status), static_cast<int>(NPQ::NDescriber::EStatus::Success));
         UNIT_ASSERT(info.Info);
         UNIT_ASSERT(info.Self);
         UNIT_ASSERT_VALUES_EQUAL(info.Info->Description.PartitionsSize(), 15u);
@@ -218,7 +218,7 @@ Y_UNIT_TEST_SUITE(TTopicApiDescribes) {
         info = getDescribe();
         UNIT_ASSERT_VALUES_EQUAL(
             static_cast<int>(info.Status),
-            static_cast<int>(NPQ::NDescriber::EStatus::NOT_FOUND));
+            static_cast<int>(NPQ::NDescriber::EStatus::NotFound));
     }
     Y_UNIT_TEST(GetPartitionDescribe) {
         ui32 partsCount = 15;

--- a/ydb/services/sqs_topic/actor.h
+++ b/ydb/services/sqs_topic/actor.h
@@ -177,16 +177,16 @@ namespace NKikimr::NSqsTopic::V1 {
             }
             const auto& ctx = TlsActivationContext->AsActorContext();
             switch (ev->Get()->Status) {
-                case NPQ::NRuQuoter::EStatus::SUCCESS:
+                case NPQ::NRuQuoter::EStatus::Success:
                     static_cast<TDerived*>(this)->OnRequestUnitsCharged(ctx);
                     return;
-                case NPQ::NRuQuoter::EStatus::THROTTLED:
+                case NPQ::NRuQuoter::EStatus::Throttled:
                     ReplyWithError(MakeError(NSQS::NErrors::THROTTLING_EXCEPTION,
                         ev->Get()->Message.empty()
                             ? NPQ::NRuQuoter::Description(ev->Get()->Status)
                             : ev->Get()->Message));
                     return;
-                case NPQ::NRuQuoter::EStatus::UNKNOWN_ERROR:
+                case NPQ::NRuQuoter::EStatus::UnknownError:
                     ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                         ev->Get()->Message.empty()
                             ? NPQ::NRuQuoter::Description(ev->Get()->Status)

--- a/ydb/services/sqs_topic/create_queue.cpp
+++ b/ydb/services/sqs_topic/create_queue.cpp
@@ -115,7 +115,7 @@ namespace NKikimr::NSqsTopic::V1 {
         }
 
         void OnTopicDescribed(const NPQ::NDescriber::TTopicInfo& topicInfo) {
-            if (topicInfo.Status == NPQ::NDescriber::EStatus::NOT_FOUND) {
+            if (topicInfo.Status == NPQ::NDescriber::EStatus::NotFound) {
                 PendingAction_ = EPendingAction::CreateNewTopic;
                 this->ChargeRequestUnits(ActorContext());
                 return;

--- a/ydb/services/sqs_topic/list_queues.cpp
+++ b/ydb/services/sqs_topic/list_queues.cpp
@@ -139,7 +139,7 @@ namespace NKikimr::NSqsTopic::V1 {
         TVector<TTopicConsumerPair> tc(Reserve(topicsMap.size()));
 
         for (const auto& [name, describeResult] : topicsMap) {
-            if (describeResult.Status != NPQ::NDescriber::EStatus::SUCCESS) {
+            if (describeResult.Status != NPQ::NDescriber::EStatus::Success) {
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE, std::format("Description of topic \"{}\" is unsuccessful", name.ConstRef())));
             }
             const auto& info = describeResult.Info;

--- a/ydb/services/sqs_topic/send_message.cpp
+++ b/ydb/services/sqs_topic/send_message.cpp
@@ -182,7 +182,7 @@ namespace NKikimr::NSqsTopic::V1 {
         void Handle(NPQ::NMLP::TEvWriteResponse::TPtr& ev) {
             WriterActor_ = {};
 
-            if (ev->Get()->DescribeStatus != NPQ::NDescriber::EStatus::SUCCESS) {
+            if (ev->Get()->DescribeStatus != NPQ::NDescriber::EStatus::Success) {
                 auto describerStatus = MapDescriberStatus(FullTopicPath_, ev->Get()->DescribeStatus);
                 this->ReplyWithError(*describerStatus.Error);
                 return;

--- a/ydb/services/sqs_topic/statuses.cpp
+++ b/ydb/services/sqs_topic/statuses.cpp
@@ -11,20 +11,20 @@ namespace NKikimr::NSqsTopic::V1 {
         };
         switch (status) {
             using enum NKikimr::NPQ::NDescriber::EStatus;
-            case SUCCESS:
+            case Success:
                 break;
-            case NOT_FOUND:
-            case NOT_TOPIC:
+            case NotFound:
+            case NotTopic:
                 MakeError(&result.Error.ConstructInPlace(), NKikimr::NSQS::NErrors::NON_EXISTENT_QUEUE, NPQ::NDescriber::Description(topicPath, status));
                 break;
-            case UNAUTHORIZED:
-            case UNAUTHORIZED_WITH_DESCRIBE_ACCESS:
+            case Unauthorized:
+            case UnauthorizedWithDescribeAccess:
                 MakeError(&result.Error.ConstructInPlace(), NKikimr::NSQS::NErrors::ACCESS_DENIED, NPQ::NDescriber::Description(topicPath, status));
                 break;
-            case BAD_REQUEST:
+            case BadRequest:
                 MakeError(&result.Error.ConstructInPlace(), NKikimr::NSQS::NErrors::INVALID_PARAMETER_VALUE, NPQ::NDescriber::Description(topicPath, status));
                 break;
-            case UNKNOWN_ERROR:
+            case UnknownError:
                 MakeError(&result.Error.ConstructInPlace(), NKikimr::NSQS::NErrors::INTERNAL_FAILURE, NPQ::NDescriber::Description(topicPath, status));
                 break;
         }
@@ -81,7 +81,7 @@ namespace NKikimr::NSqsTopic::V1 {
         using enum NPQ::NDescriber::EStatus;
         const TString describePath = info.RealPath ? info.RealPath : topicPath;
         switch (info.Status) {
-            case SUCCESS:
+            case Success:
                 if (info.CdcStream && policy.CdcUnsupportedMessage) {
                     return MakeError(NSQS::NErrors::UNSUPPORTED_OPERATION, *policy.CdcUnsupportedMessage);
                 }
@@ -90,21 +90,21 @@ namespace NKikimr::NSqsTopic::V1 {
                         "Failed to describe topic: creation is not completed");
                 }
                 return Nothing();
-            case NOT_TOPIC:
+            case NotTopic:
                 return MakeError(*policy.NotTopicError, policy.NotTopicMessage);
-            case NOT_FOUND:
+            case NotFound:
                 if (!policy.NotFoundIsError) {
                     return Nothing();
                 }
                 return MakeError(NSQS::NErrors::NON_EXISTENT_QUEUE, policy.NotFoundMessage);
-            case UNAUTHORIZED:
+            case Unauthorized:
                 return MakeError(NSQS::NErrors::NON_EXISTENT_QUEUE, policy.NotFoundMessage);
-            case UNAUTHORIZED_WITH_DESCRIBE_ACCESS:
+            case UnauthorizedWithDescribeAccess:
                 return MakeError(NSQS::NErrors::ACCESS_DENIED, "Access denied");
-            case BAD_REQUEST:
+            case BadRequest:
                 return MakeError(NSQS::NErrors::INVALID_PARAMETER_VALUE,
                     NPQ::NDescriber::Description(topicPath, info.Status));
-            case UNKNOWN_ERROR:
+            case UnknownError:
                 if (!policy.UnknownErrorMessage.empty()) {
                     return MakeError(NSQS::NErrors::INTERNAL_FAILURE, policy.UnknownErrorMessage);
                 }

--- a/ydb/services/sqs_topic/ut/utils_ut.cpp
+++ b/ydb/services/sqs_topic/ut/utils_ut.cpp
@@ -313,7 +313,7 @@ Y_UNIT_TEST_SUITE(SqsTopicDescribeStatus) {
         using NKikimr::NPQ::NDescriber::EStatus;
 
         TTopicInfo notTopic;
-        notTopic.Status = EStatus::NOT_TOPIC;
+        notTopic.Status = EStatus::NotTopic;
         {
             auto error = MapTopicInfoToSqsError("/Root/q", notTopic, ExistingQueuePolicy());
             UNIT_ASSERT(error.Defined());
@@ -328,12 +328,12 @@ Y_UNIT_TEST_SUITE(SqsTopicDescribeStatus) {
         }
 
         TTopicInfo missing;
-        missing.Status = EStatus::NOT_FOUND;
+        missing.Status = EStatus::NotFound;
         UNIT_ASSERT(MapTopicInfoToSqsError("/Root/q", missing, ExistingQueuePolicy()).Defined());
         UNIT_ASSERT(!MapTopicInfoToSqsError("/Root/q", missing, CreateQueueDescribePolicy()).Defined());
 
         TTopicInfo cdc;
-        cdc.Status = EStatus::SUCCESS;
+        cdc.Status = EStatus::Success;
         cdc.CdcStream = true;
         cdc.Info = new NKikimr::NSchemeCache::TSchemeCacheNavigate::TPQGroupInfo();
         {
@@ -351,7 +351,7 @@ Y_UNIT_TEST_SUITE(SqsTopicDescribeStatus) {
         using NKikimr::NPQ::NDescriber::EStatus;
 
         TTopicInfo unauthorized;
-        unauthorized.Status = EStatus::UNAUTHORIZED;
+        unauthorized.Status = EStatus::Unauthorized;
         for (const auto& policy : {
                  ExistingQueuePolicy(),
                  CreateQueueDescribePolicy(),
@@ -367,7 +367,7 @@ Y_UNIT_TEST_SUITE(SqsTopicDescribeStatus) {
         }
 
         TTopicInfo describeDenied;
-        describeDenied.Status = EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS;
+        describeDenied.Status = EStatus::UnauthorizedWithDescribeAccess;
         {
             auto error = MapTopicInfoToSqsError("/Root/q", describeDenied, ExistingQueuePolicy());
             UNIT_ASSERT(error.Defined());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Internal coding-style change only. No user-visible behavior.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Bring actor event and status enums in `ydb/core/persqueue/public` in line with `ydb/agents/CODESTYLE.md`:

* `enum class` members are PascalCase (same rule as class members).
* Unscoped global enums would use `UPPER_CASE` with an initials prefix; these event lists never followed that, so they become `enum class EEv` instead.
* `TEventLocal` takes `static_cast<ui32>(EEv::...)` because `enum class` is not implicitly convertible to `ui32`.

Per directory:

* **describer** — `enum class EEv`; `EStatus` enumerators renamed (`Success`, `NotFound`, `NotTopic`, `Unauthorized`, `UnauthorizedWithDescribeAccess`, `BadRequest`, `UnknownError`). Call sites outside `public/` (fetch, Kafka, YMQ, SQS-over-topic, Topics API tests) updated here.
* **schema** — `NSchema::EEv` is now `enum class`; describer status switches updated.
* **mlp** — `NMLP::EEv` is now `enum class` (`EOperationResult` was already fine); describer status switches updated.
* **ru_quoter** — `enum class EEv`; `EStatus` renamed (`Success`, `Throttled`, `UnknownError`); SQS request-unit charging updated.

No intended functional change.