### PR TITLE
NBS-7513: Add return-to-online delay in TOracle

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/config/protos/storage.proto
+++ b/ydb/core/nbs/cloud/blockstore/config/protos/storage.proto
@@ -51,6 +51,14 @@ message TOracleConfig
     // with a queue size of 10, then it is equivalent to the 90th percentile.
     // 0 - means the last (100th percentile).
     optional uint32 TimePredictionNthFromEnd = 8;
+
+    // Maximum duration before host returns online in milliseconds.
+    optional uint32 MaxDurationBeforeReturningOnline = 9;
+
+    // The minimum number of successful requests after which the host is brought
+    // back online. If the number of successes is less, the host will not go online,
+    // regardless of the time during which the successes occurred.
+    optional uint32 MinSuccessesCountBeforeReturningOnline = 10;
 }
 
 message TStorageServiceConfig

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.cpp
@@ -1,0 +1,122 @@
+#include "host_health_policy.h"
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+class TDefaultHostHealthPolicy: public IHostHealthPolicy
+{
+public:
+    explicit TDefaultHostHealthPolicy(const TOracleConfig& config);
+
+    [[nodiscard]] EHostHealth GetNewHealth(
+        EHostHealth health,
+        const THostErrorsInfo& stats,
+        ui64 errorsTotalSize) const override;
+
+private:
+    [[nodiscard]] EHostHealth NewHealthFromOnline(
+        const THostErrorsInfo& stats,
+        ui64 errorsTotalSize) const;
+
+    [[nodiscard]] EHostHealth NewHealthFromTemporaryOffline(
+        const THostErrorsInfo& stats,
+        ui64 errorsTotalSize) const;
+
+    [[nodiscard]] bool HasRecovered(const THostErrorsInfo& stats) const;
+
+    [[nodiscard]] bool IsDownByStats(
+        const THostErrorsInfo& stats,
+        ui64 errorsTotalSize) const;
+
+    const TOracleConfig& Config;
+};
+
+TDefaultHostHealthPolicy::TDefaultHostHealthPolicy(const TOracleConfig& config)
+    : Config(config)
+{}
+
+EHostHealth TDefaultHostHealthPolicy::GetNewHealth(
+    const EHostHealth health,
+    const THostErrorsInfo& stats,
+    const ui64 errorsTotalSize) const
+{
+    switch (health) {
+        case EHostHealth::Online:
+        case EHostHealth::Sufferer:
+            return NewHealthFromOnline(stats, errorsTotalSize);
+        case EHostHealth::TemporaryOffline:
+            return NewHealthFromTemporaryOffline(stats, errorsTotalSize);
+        case EHostHealth::Offline:
+            return HasRecovered(stats) ? EHostHealth::Online
+                                       : EHostHealth::Offline;
+        case EHostHealth::Broken:
+            // Broken state is irrecoverable
+            return EHostHealth::Broken;
+    }
+}
+
+EHostHealth TDefaultHostHealthPolicy::NewHealthFromOnline(
+    const THostErrorsInfo& stats,
+    const ui64 errorsTotalSize) const
+{
+    if (IsDownByStats(stats, errorsTotalSize)) {
+        return stats.FromFirstError > Config.GetMaxDurationBeforeGoingOffline()
+                   ? EHostHealth::Offline
+                   : EHostHealth::TemporaryOffline;
+    }
+
+    return stats.ConsecutiveErrorCount > 0 ? EHostHealth::Sufferer
+                                           : EHostHealth::Online;
+}
+
+EHostHealth TDefaultHostHealthPolicy::NewHealthFromTemporaryOffline(
+    const THostErrorsInfo& stats,
+    const ui64 errorsTotalSize) const
+{
+    if (HasRecovered(stats)) {
+        return EHostHealth::Online;
+    }
+    if (IsDownByStats(stats, errorsTotalSize) &&
+        stats.FromFirstError > Config.GetMaxDurationBeforeGoingOffline())
+    {
+        return EHostHealth::Offline;
+    }
+    return EHostHealth::TemporaryOffline;
+}
+
+bool TDefaultHostHealthPolicy::HasRecovered(const THostErrorsInfo& stats) const
+{
+    return stats.ConsecutiveSuccessCount >=
+               Config.GetMinSuccessesCountBeforeReturningOnline() &&
+           stats.FromFirstSuccess >
+               Config.GetMaxDurationBeforeReturningOnline();
+}
+
+bool TDefaultHostHealthPolicy::IsDownByStats(
+    const THostErrorsInfo& stats,
+    const ui64 errorsTotalSize) const
+{
+    const bool softDowntimeByErrors =
+        stats.ConsecutiveErrorCount >=
+        Config.GetMinErrorsCountBeforeGoingOffline();
+
+    const bool temporaryOfflineDelayOver =
+        stats.FromFirstError >
+        Config.GetMaxDurationBeforeGoingTemporaryOffline();
+
+    const bool hardDowntimeByErrors =
+        stats.ConsecutiveErrorCount >= Config.GetErrorsCountForGoingOffline();
+
+    const bool hardDowntimeByErrorsTotalSize =
+        errorsTotalSize >= Config.GetErrorsTotalSizeForGoingOffline();
+
+    return hardDowntimeByErrorsTotalSize || hardDowntimeByErrors ||
+           (softDowntimeByErrors && temporaryOfflineDelayOver);
+}
+
+std::unique_ptr<IHostHealthPolicy> CreateDefaultHostHealthPolicy(
+    const TOracleConfig& config)
+{
+    return std::make_unique<TDefaultHostHealthPolicy>(config);
+}
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.cpp
@@ -73,8 +73,14 @@ EHostHealth TDefaultHostHealthPolicy::NewHealthFromTemporaryOffline(
     const ui64 errorsTotalSize) const
 {
     if (HasRecovered(stats)) {
+        fprintf(stderr, "recv\n");
         return EHostHealth::Online;
     }
+    fprintf(
+        stderr,
+        "!recv, %lu %lu\n",
+        stats.ConsecutiveSuccessCount,
+        stats.FromFirstSuccess);
     if (IsDownByStats(stats, errorsTotalSize) &&
         stats.FromFirstError > Config->GetMaxDurationBeforeGoingOffline())
     {
@@ -109,6 +115,14 @@ bool TDefaultHostHealthPolicy::IsDownByStats(
     const bool hardDowntimeByErrorsTotalSize =
         stats.ConsecutiveErrorCount > 0 &&
         errorsTotalSize >= Config->GetErrorsTotalSizeForGoingOffline();
+
+    fprintf(
+        stderr,
+        "%s %s %s %s\n",
+        softDowntimeByErrors ? "yes" : "no",
+        temporaryOfflineDelayOver ? "yes" : "no",
+        hardDowntimeByErrors ? "yes" : "no",
+        hardDowntimeByErrorsTotalSize ? "yes" : "no");
 
     return hardDowntimeByErrorsTotalSize || hardDowntimeByErrors ||
            (softDowntimeByErrors && temporaryOfflineDelayOver);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.cpp
@@ -107,6 +107,7 @@ bool TDefaultHostHealthPolicy::IsDownByStats(
         stats.ConsecutiveErrorCount >= Config->GetErrorsCountForGoingOffline();
 
     const bool hardDowntimeByErrorsTotalSize =
+        stats.ConsecutiveErrorCount > 0 &&
         errorsTotalSize >= Config->GetErrorsTotalSizeForGoingOffline();
 
     return hardDowntimeByErrorsTotalSize || hardDowntimeByErrors ||

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.cpp
@@ -73,14 +73,8 @@ EHostHealth TDefaultHostHealthPolicy::NewHealthFromTemporaryOffline(
     const ui64 errorsTotalSize) const
 {
     if (HasRecovered(stats)) {
-        fprintf(stderr, "recv\n");
         return EHostHealth::Online;
     }
-    fprintf(
-        stderr,
-        "!recv, %lu %lu\n",
-        stats.ConsecutiveSuccessCount,
-        stats.FromFirstSuccess);
     if (IsDownByStats(stats, errorsTotalSize) &&
         stats.FromFirstError > Config->GetMaxDurationBeforeGoingOffline())
     {
@@ -115,14 +109,6 @@ bool TDefaultHostHealthPolicy::IsDownByStats(
     const bool hardDowntimeByErrorsTotalSize =
         stats.ConsecutiveErrorCount > 0 &&
         errorsTotalSize >= Config->GetErrorsTotalSizeForGoingOffline();
-
-    fprintf(
-        stderr,
-        "%s %s %s %s\n",
-        softDowntimeByErrors ? "yes" : "no",
-        temporaryOfflineDelayOver ? "yes" : "no",
-        hardDowntimeByErrors ? "yes" : "no",
-        hardDowntimeByErrorsTotalSize ? "yes" : "no");
 
     return hardDowntimeByErrorsTotalSize || hardDowntimeByErrors ||
            (softDowntimeByErrors && temporaryOfflineDelayOver);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.cpp
@@ -5,7 +5,7 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 class TDefaultHostHealthPolicy: public IHostHealthPolicy
 {
 public:
-    explicit TDefaultHostHealthPolicy(const TOracleConfig& config);
+    explicit TDefaultHostHealthPolicy(TOracleConfigPtr config);
 
     [[nodiscard]] EHostHealth GetNewHealth(
         EHostHealth health,
@@ -27,10 +27,10 @@ private:
         const THostErrorsInfo& stats,
         ui64 errorsTotalSize) const;
 
-    const TOracleConfig& Config;
+    const TOracleConfigPtr Config;
 };
 
-TDefaultHostHealthPolicy::TDefaultHostHealthPolicy(const TOracleConfig& config)
+TDefaultHostHealthPolicy::TDefaultHostHealthPolicy(TOracleConfigPtr config)
     : Config(config)
 {}
 
@@ -59,7 +59,7 @@ EHostHealth TDefaultHostHealthPolicy::NewHealthFromOnline(
     const ui64 errorsTotalSize) const
 {
     if (IsDownByStats(stats, errorsTotalSize)) {
-        return stats.FromFirstError > Config.GetMaxDurationBeforeGoingOffline()
+        return stats.FromFirstError > Config->GetMaxDurationBeforeGoingOffline()
                    ? EHostHealth::Offline
                    : EHostHealth::TemporaryOffline;
     }
@@ -76,7 +76,7 @@ EHostHealth TDefaultHostHealthPolicy::NewHealthFromTemporaryOffline(
         return EHostHealth::Online;
     }
     if (IsDownByStats(stats, errorsTotalSize) &&
-        stats.FromFirstError > Config.GetMaxDurationBeforeGoingOffline())
+        stats.FromFirstError > Config->GetMaxDurationBeforeGoingOffline())
     {
         return EHostHealth::Offline;
     }
@@ -86,9 +86,9 @@ EHostHealth TDefaultHostHealthPolicy::NewHealthFromTemporaryOffline(
 bool TDefaultHostHealthPolicy::HasRecovered(const THostErrorsInfo& stats) const
 {
     return stats.ConsecutiveSuccessCount >=
-               Config.GetMinSuccessesCountBeforeReturningOnline() &&
+               Config->GetMinSuccessesCountBeforeReturningOnline() &&
            stats.FromFirstSuccess >
-               Config.GetMaxDurationBeforeReturningOnline();
+               Config->GetMaxDurationBeforeReturningOnline();
 }
 
 bool TDefaultHostHealthPolicy::IsDownByStats(
@@ -97,24 +97,24 @@ bool TDefaultHostHealthPolicy::IsDownByStats(
 {
     const bool softDowntimeByErrors =
         stats.ConsecutiveErrorCount >=
-        Config.GetMinErrorsCountBeforeGoingOffline();
+        Config->GetMinErrorsCountBeforeGoingOffline();
 
     const bool temporaryOfflineDelayOver =
         stats.FromFirstError >
-        Config.GetMaxDurationBeforeGoingTemporaryOffline();
+        Config->GetMaxDurationBeforeGoingTemporaryOffline();
 
     const bool hardDowntimeByErrors =
-        stats.ConsecutiveErrorCount >= Config.GetErrorsCountForGoingOffline();
+        stats.ConsecutiveErrorCount >= Config->GetErrorsCountForGoingOffline();
 
     const bool hardDowntimeByErrorsTotalSize =
-        errorsTotalSize >= Config.GetErrorsTotalSizeForGoingOffline();
+        errorsTotalSize >= Config->GetErrorsTotalSizeForGoingOffline();
 
     return hardDowntimeByErrorsTotalSize || hardDowntimeByErrors ||
            (softDowntimeByErrors && temporaryOfflineDelayOver);
 }
 
 std::unique_ptr<IHostHealthPolicy> CreateDefaultHostHealthPolicy(
-    const TOracleConfig& config)
+    TOracleConfigPtr config)
 {
     return std::make_unique<TDefaultHostHealthPolicy>(config);
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "host.h"
+
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_config.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+class IHostHealthPolicy
+{
+public:
+    virtual ~IHostHealthPolicy() = default;
+
+    virtual EHostHealth GetNewHealth(
+        EHostHealth health,
+        const THostErrorsInfo& stats,
+        ui64 errorsTotalSize) const = 0;
+};
+
+std::unique_ptr<IHostHealthPolicy> CreateDefaultHostHealthPolicy(
+    const TOracleConfig& config);
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy.h
@@ -4,6 +4,7 @@
 
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_config.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/public.h>
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
@@ -19,6 +20,6 @@ public:
 };
 
 std::unique_ptr<IHostHealthPolicy> CreateDefaultHostHealthPolicy(
-    const TOracleConfig& config);
+    TOracleConfigPtr config);
 
 }   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy_ut.cpp
@@ -484,6 +484,25 @@ Y_UNIT_TEST_SUITE(TDefaultHostHealthPolicyTest)
             EHostHealth::Offline,
             policy.Policy->GetNewHealth(EHostHealth::Offline, stats, 0));
     }
+
+    // Broken->Online
+
+    Y_UNIT_TEST(DoesntGoFromBrokenToOnlineOnEnoughSuccessesAfterDelay)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstSuccess =
+                DefaultMaxDurationBeforeReturningOnline + TDuration::Seconds(1),
+            .FromLastSuccess = TDuration::Seconds(0),
+            .ConsecutiveSuccessCount =
+                DefaultMinSuccessesCountBeforeReturningOnline,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Broken,
+            policy.Policy->GetNewHealth(EHostHealth::Broken, stats, 0));
+    }
 }
 
 }   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy_ut.cpp
@@ -1,0 +1,471 @@
+#include "host_health_policy.h"
+
+#include <ydb/core/nbs/cloud/blockstore/config/config.h>
+#include <ydb/core/nbs/cloud/blockstore/config/protos/storage.pb.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/size_literals.h>
+
+#include <public.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+namespace {
+
+constexpr TDuration DefaultMaxDurationBeforeGoingTemporaryOffline =
+    TDuration::Seconds(3);
+constexpr TDuration DefaultMaxDurationBeforeGoingOffline =
+    TDuration::Seconds(4);
+constexpr ui32 DefaultMinErrorsCountBeforeGoingOffline = 2;
+constexpr ui32 DefaultErrorsCountForGoingOffline = 3;
+constexpr ui64 DefaultErrorsTotalSizeForGoingOffline = 1_MB;
+constexpr TDuration DefaultMaxDurationBeforeReturningOnline =
+    TDuration::Seconds(2);
+constexpr ui32 DefaultMinSuccessesCountBeforeReturningOnline = 2;
+
+struct TConfigPreset
+{
+    TDuration MaxDurationBeforeGoingTemporaryOffline =
+        DefaultMaxDurationBeforeGoingTemporaryOffline;
+    TDuration MaxDurationBeforeGoingOffline =
+        DefaultMaxDurationBeforeGoingOffline;
+
+    ui32 MinErrorsCountBeforeGoingOffline =
+        DefaultMinErrorsCountBeforeGoingOffline;
+    ui32 ErrorsCountForGoingOffline = DefaultErrorsCountForGoingOffline;
+    ui64 ErrorsTotalSizeForGoingOffline = DefaultErrorsTotalSizeForGoingOffline;
+
+    TDuration MaxDurationBeforeReturningOnline =
+        DefaultMaxDurationBeforeReturningOnline;
+
+    ui32 MinSuccessesCountBeforeReturningOnline =
+        DefaultMinSuccessesCountBeforeReturningOnline;
+};
+
+struct TPolicyTest
+{
+    [[maybe_unused]] TStorageConfigPtr StorageConfig;
+    [[maybe_unused]] TOracleConfigPtr OracleConfig;
+    std::unique_ptr<IHostHealthPolicy> Policy;
+};
+
+TStorageConfigPtr CreateStorageConfig(const TConfigPreset& preset)
+{
+    NProto::TStorageServiceConfig rawConfig;
+    auto& oracleConfig = *rawConfig.MutableOracleConfig();
+    oracleConfig.SetMaxDurationBeforeGoingTemporaryOffline(
+        preset.MaxDurationBeforeGoingTemporaryOffline.MilliSeconds());
+    oracleConfig.SetMaxDurationBeforeGoingOffline(
+        preset.MaxDurationBeforeGoingOffline.MilliSeconds());
+    oracleConfig.SetMinErrorsCountBeforeGoingOffline(
+        preset.MinErrorsCountBeforeGoingOffline);
+    oracleConfig.SetErrorsCountForGoingOffline(
+        preset.ErrorsCountForGoingOffline);
+    oracleConfig.SetErrorsTotalSizeForGoingOffline(
+        preset.ErrorsTotalSizeForGoingOffline);
+    oracleConfig.SetMaxDurationBeforeReturningOnline(
+        preset.MaxDurationBeforeReturningOnline.MilliSeconds());
+    oracleConfig.SetMinSuccessesCountBeforeReturningOnline(
+        preset.MinSuccessesCountBeforeReturningOnline);
+
+    return std::make_shared<TStorageConfig>(rawConfig);
+}
+
+TPolicyTest CreatePolicyTest(const TConfigPreset& preset = TConfigPreset{})
+{
+    auto storageConfig = CreateStorageConfig(preset);
+    auto oracleConfig = std::make_shared<TOracleConfig>(storageConfig);
+    auto policy = CreateDefaultHostHealthPolicy(oracleConfig);
+    return {
+        .StorageConfig = std::move(storageConfig),
+        .OracleConfig = std::move(oracleConfig),
+        .Policy = std::move(policy),
+    };
+}
+
+// constexpr size_t OverwhelmingRequestsCount = 10;
+
+}   // namespace
+
+Y_UNIT_TEST_SUITE(TDefaultHostHealthPolicyTest)
+{
+    // Empty stats behavior
+
+    Y_UNIT_TEST(StaysOnlineWithEmptyStats)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{};
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Online,
+            policy.Policy->GetNewHealth(EHostHealth::Online, stats, 0));
+    }
+
+    Y_UNIT_TEST(GoesFromSufferrerToOnlineWithEmptyStats)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{};
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Online,
+            policy.Policy->GetNewHealth(EHostHealth::Sufferer, stats, 0));
+    }
+
+    Y_UNIT_TEST(StaysTemporaryOfflineWithEmptyStats)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{};
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::TemporaryOffline,
+            policy.Policy
+                ->GetNewHealth(EHostHealth::TemporaryOffline, stats, 0));
+    }
+
+    Y_UNIT_TEST(StaysOfflineWithEmptyStats)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{};
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy->GetNewHealth(EHostHealth::Offline, stats, 0));
+    }
+
+    // Idle behavior (health's specific conditions are preserved)
+
+    Y_UNIT_TEST(StaysOnlineOnIdle)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstSuccess = TDuration::Seconds(1),
+            .FromLastSuccess = TDuration::Seconds(1),
+            .ConsecutiveSuccessCount = 1,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Online,
+            policy.Policy->GetNewHealth(EHostHealth::Online, stats, 0));
+    }
+
+    Y_UNIT_TEST(StaysSuffererOnIdle)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstError = TDuration::Seconds(1),
+            .FromLastError = TDuration::Seconds(1),
+            .ConsecutiveErrorCount = 1,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Sufferer,
+            policy.Policy->GetNewHealth(EHostHealth::Sufferer, stats, 0));
+    }
+
+    Y_UNIT_TEST(StaysTemporaryOfflineOnShortIdle)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstError = TDuration::Seconds(1),
+            .FromLastError = TDuration::Seconds(0),
+            .ConsecutiveErrorCount = DefaultErrorsCountForGoingOffline,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::TemporaryOffline,
+            policy.Policy
+                ->GetNewHealth(EHostHealth::TemporaryOffline, stats, 0));
+    }
+
+    Y_UNIT_TEST(GoesFromTemporaryOfflineToOfflineOnLongIdle)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstError =
+                DefaultMaxDurationBeforeGoingOffline + TDuration::Seconds(1),
+            .FromLastError = TDuration::Seconds(0),
+            .ConsecutiveErrorCount = DefaultErrorsCountForGoingOffline,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy
+                ->GetNewHealth(EHostHealth::TemporaryOffline, stats, 0));
+    }
+
+    Y_UNIT_TEST(StaysOfflineOnIdle)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstError =
+                DefaultMaxDurationBeforeGoingOffline + TDuration::Seconds(1),
+            .FromLastError = TDuration::Seconds(0),
+            .ConsecutiveErrorCount = DefaultErrorsCountForGoingOffline,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy->GetNewHealth(EHostHealth::Offline, stats, 0));
+    }
+
+    // Online<->Sufferer transitions
+
+    Y_UNIT_TEST(GoesOnlineToSuffererOnFewErrors)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstError = TDuration::Seconds(1),
+            .FromLastError = TDuration::Seconds(0),
+            .ConsecutiveErrorCount = 1,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Sufferer,
+            policy.Policy->GetNewHealth(EHostHealth::Online, stats, 0));
+    }
+
+    Y_UNIT_TEST(GoesSuffererToOnlineOnNoErrors)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstSuccess = TDuration::Seconds(1),
+            .FromLastSuccess = TDuration::Seconds(1),
+            .ConsecutiveSuccessCount = 1,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Online,
+            policy.Policy->GetNewHealth(EHostHealth::Sufferer, stats, 0));
+    }
+
+    // Online/Sufferer->TemporaryOffline
+
+    Y_UNIT_TEST(GoesToTemporaryOfflineOnTooManyErrors)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstError = TDuration::Seconds(1),
+            .FromLastError = TDuration::Seconds(0),
+            .ConsecutiveErrorCount = DefaultErrorsCountForGoingOffline,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::TemporaryOffline,
+            policy.Policy->GetNewHealth(EHostHealth::Online, stats, 0));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::TemporaryOffline,
+            policy.Policy->GetNewHealth(EHostHealth::Sufferer, stats, 0));
+    }
+
+    Y_UNIT_TEST(GoesToTemporaryOfflineOnManyErrorsAfterDelay)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstError = DefaultMaxDurationBeforeGoingTemporaryOffline +
+                              TDuration::Seconds(1),
+            .FromLastError = TDuration::Seconds(0),
+            .ConsecutiveErrorCount = DefaultMinErrorsCountBeforeGoingOffline,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::TemporaryOffline,
+            policy.Policy->GetNewHealth(EHostHealth::Online, stats, 0));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::TemporaryOffline,
+            policy.Policy->GetNewHealth(EHostHealth::Sufferer, stats, 0));
+    }
+
+    Y_UNIT_TEST(GoesToTemporaryOfflineOnErrorsTotalSizeExceeded)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstError = TDuration::Seconds(1),
+            .FromLastError = TDuration::Seconds(0),
+            .ConsecutiveErrorCount = 1,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::TemporaryOffline,
+            policy.Policy->GetNewHealth(
+                EHostHealth::Online,
+                stats,
+                DefaultErrorsTotalSizeForGoingOffline));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::TemporaryOffline,
+            policy.Policy->GetNewHealth(
+                EHostHealth::Sufferer,
+                stats,
+                DefaultErrorsTotalSizeForGoingOffline));
+    }
+
+    // Online/Sufferer/TemporaryOffline->Offline
+
+    Y_UNIT_TEST(GoesToOfflineOnTooManyErrorsAfterOfflineDelay)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstError =
+                DefaultMaxDurationBeforeGoingOffline + TDuration::Seconds(1),
+            .FromLastError = TDuration::Seconds(0),
+            .ConsecutiveErrorCount = DefaultErrorsCountForGoingOffline,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy->GetNewHealth(EHostHealth::Online, stats, 0));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy->GetNewHealth(EHostHealth::Sufferer, stats, 0));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy
+                ->GetNewHealth(EHostHealth::TemporaryOffline, stats, 0));
+    }
+
+    Y_UNIT_TEST(GoesToOfflineOnManyErrorsAfterOfflineDelay)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstError =
+                DefaultMaxDurationBeforeGoingOffline + TDuration::Seconds(1),
+            .FromLastError = TDuration::Seconds(0),
+            .ConsecutiveErrorCount = DefaultMinErrorsCountBeforeGoingOffline,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy->GetNewHealth(EHostHealth::Online, stats, 0));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy->GetNewHealth(EHostHealth::Sufferer, stats, 0));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy
+                ->GetNewHealth(EHostHealth::TemporaryOffline, stats, 0));
+    }
+
+    Y_UNIT_TEST(GoesToOfflineOnErrorsTotalSizeExceededAfterOfflineDelay)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstError =
+                DefaultMaxDurationBeforeGoingOffline + TDuration::Seconds(1),
+            .FromLastError = TDuration::Seconds(0),
+            .ConsecutiveErrorCount = 1,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy->GetNewHealth(
+                EHostHealth::Online,
+                stats,
+                DefaultErrorsTotalSizeForGoingOffline));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy->GetNewHealth(
+                EHostHealth::Sufferer,
+                stats,
+                DefaultErrorsTotalSizeForGoingOffline));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy->GetNewHealth(
+                EHostHealth::TemporaryOffline,
+                stats,
+                DefaultErrorsTotalSizeForGoingOffline));
+    }
+
+    // TemporaryOffline/Offline->Online
+
+    Y_UNIT_TEST(GoesToOnlineOnEnoughSuccessesAfterDelay)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstSuccess =
+                DefaultMaxDurationBeforeReturningOnline + TDuration::Seconds(1),
+            .FromLastSuccess = TDuration::Seconds(0),
+            .ConsecutiveSuccessCount =
+                DefaultMinSuccessesCountBeforeReturningOnline,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Online,
+            policy.Policy
+                ->GetNewHealth(EHostHealth::TemporaryOffline, stats, 0));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Online,
+            policy.Policy->GetNewHealth(EHostHealth::Offline, stats, 0));
+    }
+
+    Y_UNIT_TEST(DoesntGoToOnlineOnNotEnoughSuccessesAfterDelay)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstSuccess =
+                DefaultMaxDurationBeforeReturningOnline + TDuration::Seconds(1),
+            .FromLastSuccess = TDuration::Seconds(0),
+            .ConsecutiveSuccessCount = 1,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::TemporaryOffline,
+            policy.Policy
+                ->GetNewHealth(EHostHealth::TemporaryOffline, stats, 0));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy->GetNewHealth(EHostHealth::Offline, stats, 0));
+    }
+
+    Y_UNIT_TEST(DoesntGoToOnlineOnEnoughSuccessesBeforeDelay)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstSuccess = TDuration::Seconds(1),
+            .FromLastSuccess = TDuration::Seconds(0),
+            .ConsecutiveSuccessCount =
+                DefaultMinSuccessesCountBeforeReturningOnline,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::TemporaryOffline,
+            policy.Policy
+                ->GetNewHealth(EHostHealth::TemporaryOffline, stats, 0));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Offline,
+            policy.Policy->GetNewHealth(EHostHealth::Offline, stats, 0));
+    }
+}
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_health_policy_ut.cpp
@@ -316,6 +316,24 @@ Y_UNIT_TEST_SUITE(TDefaultHostHealthPolicyTest)
                 DefaultErrorsTotalSizeForGoingOffline));
     }
 
+    Y_UNIT_TEST(DoesntGoToTemporaryOfflineOnTotalSizeExceededWithoutErrors)
+    {
+        auto policy = CreatePolicyTest();
+
+        THostErrorsInfo stats{
+            .FromFirstSuccess = TDuration::Seconds(1),
+            .FromLastSuccess = TDuration::Seconds(0),
+            .ConsecutiveSuccessCount = 1,
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostHealth::Online,
+            policy.Policy->GetNewHealth(
+                EHostHealth::Online,
+                stats,
+                DefaultErrorsTotalSizeForGoingOffline));
+    }
+
     // Online/Sufferer/TemporaryOffline->Offline
 
     Y_UNIT_TEST(GoesToOfflineOnTooManyErrorsAfterOfflineDelay)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.cpp
@@ -38,7 +38,6 @@ void THostStat::OnSuccess(
 
     LastSuccessAt = now;
     FirstErrorAt = TInstant();
-    LastErrorAt = TInstant();
     ConsecutiveErrorCount = 0;
     ++ConsecutiveSuccessCount;
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.cpp
@@ -69,9 +69,9 @@ void THostStat::OnCancelled(TInstant now, EOperation operation)
     }
 }
 
-THostStat::TErrorsInfo THostStat::GetErrorsInfo(TInstant now) const
+THostErrorsInfo THostStat::GetErrorsInfo(TInstant now) const
 {
-    TErrorsInfo result;
+    THostErrorsInfo result;
     if (FirstErrorAt) {
         result.FromFirstError = now - FirstErrorAt;
     }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.cpp
@@ -36,6 +36,9 @@ void THostStat::OnSuccess(
         --inflight;
     }
 
+    if (!FirstSuccessAt) {
+        FirstSuccessAt = now;
+    }
     LastSuccessAt = now;
     FirstErrorAt = TInstant();
     ConsecutiveErrorCount = 0;
@@ -54,6 +57,7 @@ void THostStat::OnError(TInstant now, EOperation operation)
         FirstErrorAt = now;
     }
     LastErrorAt = now;
+    FirstSuccessAt = TInstant();
     ++ConsecutiveErrorCount;
     ConsecutiveSuccessCount = 0;
 }
@@ -76,6 +80,12 @@ THostErrorsInfo THostStat::GetErrorsInfo(TInstant now) const
     }
     if (LastErrorAt) {
         result.FromLastError = now - LastErrorAt;
+    }
+    if (FirstSuccessAt) {
+        result.FromFirstSuccess = now - FirstSuccessAt;
+    }
+    if (LastSuccessAt) {
+        result.FromLastSuccess = now - LastSuccessAt;
     }
     result.ConsecutiveErrorCount = ConsecutiveErrorCount;
     result.ConsecutiveSuccessCount = ConsecutiveSuccessCount;
@@ -119,6 +129,9 @@ TString THostStat::DebugPrint() const
 
     TStringBuilder sb;
     const TInstant now = TInstant::Now();
+    if (FirstSuccessAt) {
+        sb << "FirstSuccess: " << FormatDuration(now - FirstSuccessAt) << ", ";
+    }
     if (LastSuccessAt) {
         sb << "LastSuccess: " << FormatDuration(now - LastSuccessAt) << ", ";
     }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.h
@@ -35,17 +35,17 @@ using TInflightByOperation = std::array<size_t, OperationCount>;
 // (as opposed to the PBuffer operations).
 [[nodiscard]] bool IsDDiskOperation(EOperation operation);
 
+struct THostErrorsInfo
+{
+    TDuration FromFirstError;
+    TDuration FromLastError;
+    size_t ConsecutiveErrorCount = 0;
+    size_t ConsecutiveSuccessCount = 0;
+};
+
 class THostStat
 {
 public:
-    struct TErrorsInfo
-    {
-        TDuration FromFirstError;
-        TDuration FromLastError;
-        size_t ConsecutiveErrorCount = 0;
-        size_t ConsecutiveSuccessCount = 0;
-    };
-
     // Called right before a request is sent to the host for the given
     // operation. Increments the per-operation inflight counter.
     void OnRequest(EOperation operation);
@@ -60,7 +60,7 @@ public:
 
     // Returns how much time has passed since the first error was received and
     // the number and total size of errors.
-    [[nodiscard]] TErrorsInfo GetErrorsInfo(TInstant now) const;
+    [[nodiscard]] THostErrorsInfo GetErrorsInfo(TInstant now) const;
 
     // Number of consecutive successful completions since the last error
     // (reset to 0 on the first error after a success streak).

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.h
@@ -39,6 +39,8 @@ struct THostErrorsInfo
 {
     TDuration FromFirstError;
     TDuration FromLastError;
+    TDuration FromFirstSuccess;
+    TDuration FromLastSuccess;
     size_t ConsecutiveErrorCount = 0;
     size_t ConsecutiveSuccessCount = 0;
 };
@@ -81,6 +83,7 @@ public:
 private:
     size_t& AccessInflightCount(EOperation operation);
 
+    TInstant FirstSuccessAt;
     TInstant LastSuccessAt;
     TInstant FirstErrorAt;
     TInstant LastErrorAt;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat_ut.cpp
@@ -159,7 +159,7 @@ Y_UNIT_TEST_SUITE(THostStatTest)
             TDuration::Seconds(0),
             errorsInfo.FromFirstError);
         UNIT_ASSERT_VALUES_EQUAL(
-            TDuration::Seconds(0),
+            TDuration::Seconds(2),
             errorsInfo.FromLastError);
         UNIT_ASSERT_VALUES_EQUAL(0, errorsInfo.ConsecutiveErrorCount);
     }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/mon_model.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/mon_model.h
@@ -33,7 +33,7 @@ struct THostSnapshot
     EHostState State = EHostState::Offline;
     EHostHealth Health = EHostHealth::Offline;
     TInflightByOperation InflightByOperation{};
-    THostStat::TErrorsInfo Errors;
+    THostErrorsInfo Errors;
     TCountAndSize PBuffersUsage;
     TCountAndSize AheadBlocks;
     TCountAndSize BehindBlocks;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
@@ -2,10 +2,10 @@
 
 #include <ydb/core/nbs/cloud/blockstore/config/config.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_config.h>
 
 #include <ydb/core/nbs/cloud/storage/core/libs/common/format.h>
 
-#include <util/generic/size_literals.h>
 #include <util/random/random.h>
 #include <util/string/builder.h>
 #include <util/string/cast.h>
@@ -21,21 +21,6 @@ constexpr TDuration MaxReconnectDelay = TDuration::Seconds(10);
 constexpr TDuration FlushRequestCooldownPenalty = TDuration::MilliSeconds(10);
 
 ////////////////////////////////////////////////////////////////////////////////
-
-TDuration GetFromConfig(ui64 milliseconds, TDuration defaultValue)
-{
-    return milliseconds ? TDuration::MilliSeconds(milliseconds) : defaultValue;
-}
-
-ui32 GetFromConfig(ui32 value, ui32 defaultValue)
-{
-    return value ? value : defaultValue;
-}
-
-ui64 GetFromConfig(ui64 value, ui64 defaultValue)
-{
-    return value ? value : defaultValue;
-}
 
 EHostState HealthToState(EHostHealth health)
 {
@@ -70,71 +55,6 @@ size_t GetAliveHostCount(const TVector<THostState>& hostStates)
 }
 
 }   // namespace
-
-////////////////////////////////////////////////////////////////////////////////
-
-class TOracleConfig
-{
-public:
-    explicit TOracleConfig(TStorageConfigPtr storageConfig)
-        : StorageConfig(std::move(storageConfig))
-    {}
-
-    [[nodiscard]] TDuration GetMaxDurationBeforeGoingTemporaryOffline() const
-    {
-        return GetFromConfig(
-            StorageConfig->GetOracleConfig()
-                .GetMaxDurationBeforeGoingTemporaryOffline(),
-            TDuration::Seconds(10));
-    }
-
-    [[nodiscard]] TDuration GetMaxDurationBeforeGoingOffline() const
-    {
-        return GetFromConfig(
-            StorageConfig->GetOracleConfig().GetMaxDurationBeforeGoingOffline(),
-            TDuration::Seconds(10));
-    }
-
-    [[nodiscard]] ui32 GetMinErrorsCountBeforeGoingOffline() const
-    {
-        return GetFromConfig(
-            StorageConfig->GetOracleConfig()
-                .GetMinErrorsCountBeforeGoingOffline(),
-            10);
-    }
-
-    [[nodiscard]] ui32 GetErrorsCountForGoingOffline() const
-    {
-        return GetFromConfig(
-            StorageConfig->GetOracleConfig().GetErrorsCountForGoingOffline(),
-            1000);
-    }
-
-    [[nodiscard]] ui64 GetErrorsTotalSizeForGoingOffline() const
-    {
-        return GetFromConfig(
-            StorageConfig->GetOracleConfig()
-                .GetErrorsTotalSizeForGoingOffline(),
-            100_MB);
-    }
-
-    [[nodiscard]] ui32 GetTimePredictionHistorySize() const
-    {
-        return GetFromConfig(
-            StorageConfig->GetOracleConfig().GetTimePredictionHistorySize(),
-            0);
-    }
-
-    [[nodiscard]] ui32 GetTimePredictionNthFromEnd() const
-    {
-        return GetFromConfig(
-            StorageConfig->GetOracleConfig().GetTimePredictionNthFromEnd(),
-            0);
-    }
-
-private:
-    TStorageConfigPtr StorageConfig;
-};
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
@@ -83,6 +83,7 @@ TOracle::TOracle(
           TTimePredictor(
               OracleConfig->GetTimePredictionHistorySize(),
               OracleConfig->GetTimePredictionNthFromEnd()))
+    , HealthPolicy(CreateDefaultHostHealthPolicy(OracleConfig))
 {
     HostsHealths.resize(HostStates.size());
     for (auto& healths: HostsHealths) {
@@ -103,37 +104,10 @@ void TOracle::Think(TInstant now)
 
         auto errorsInfo = HostStatistics[i].GetErrorsInfo(now);
 
-        if (newHostsHealths[i] == EHostHealth::Broken) {
-            // Host with broken ddisk can not be restored.
-            continue;
-        }
-
-        const bool hasSufferingSymptom =
-            (errorsInfo.ConsecutiveErrorCount != 0);
-        const bool hasTemporaryOfflineSymptom =
-            hasSufferingSymptom &&
-            ((errorsInfo.ConsecutiveErrorCount >=
-                  config.GetMinErrorsCountBeforeGoingOffline() &&
-              errorsInfo.FromFirstError >
-                  config.GetMaxDurationBeforeGoingTemporaryOffline()) ||
-             (errorsInfo.ConsecutiveErrorCount >=
-              config.GetErrorsCountForGoingOffline()) ||
-             (HostStates[i].UsedPBuffers.Size >=
-              config.GetErrorsTotalSizeForGoingOffline()));
-        const bool hasOfflineSymptom =
-            hasTemporaryOfflineSymptom &&
-            (errorsInfo.FromFirstError >
-             config.GetMaxDurationBeforeGoingOffline());
-
-        if (hasOfflineSymptom) {
-            newHostsHealths[i] = EHostHealth::Offline;
-        } else if (hasTemporaryOfflineSymptom) {
-            newHostsHealths[i] = EHostHealth::TemporaryOffline;
-        } else if (hasSufferingSymptom) {
-            newHostsHealths[i] = EHostHealth::Sufferer;
-        } else {
-            newHostsHealths[i] = EHostHealth::Online;
-        }
+        newHostsHealths[i] = HealthPolicy->GetNewHealth(
+            HostsHealths[i],
+            errorsInfo,
+            HostStates[i].UsedPBuffers.Size);
     }
 
     for (size_t i = 0; i < newHostsHealths.size(); ++i) {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 #include "host.h"
+#include "host_health_policy.h"
 #include "host_mask.h"
 #include "host_stat.h"
 #include "host_state.h"
@@ -175,6 +176,7 @@ private:
     TVector<EHostHealth> HostsHealths;
     TVector<TBackoffDelayProvider> HostsReconnectDelays;
     TVector<TTimePredictor> TimePredictors;
+    std::unique_ptr<IHostHealthPolicy> HealthPolicy;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_config.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_config.cpp
@@ -1,0 +1,97 @@
+#include "oracle_config.h"
+
+#include <ydb/core/nbs/cloud/blockstore/config/config.h>
+
+#include <util/generic/size_literals.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+namespace {
+
+TDuration GetFromConfig(const ui64 milliseconds, const TDuration defaultValue)
+{
+    return milliseconds ? TDuration::MilliSeconds(milliseconds) : defaultValue;
+}
+
+ui32 GetFromConfig(const ui32 value, const ui32 defaultValue)
+{
+    return value ? value : defaultValue;
+}
+
+ui64 GetFromConfig(const ui64 value, const ui64 defaultValue)
+{
+    return value ? value : defaultValue;
+}
+
+}   // namespace
+
+TOracleConfig::TOracleConfig(TStorageConfigPtr storageConfig)
+    : StorageConfig(std::move(storageConfig))
+{}
+
+TDuration TOracleConfig::GetMaxDurationBeforeGoingTemporaryOffline() const
+{
+    return GetFromConfig(
+        StorageConfig->GetOracleConfig()
+            .GetMaxDurationBeforeGoingTemporaryOffline(),
+        TDuration::Seconds(10));
+}
+
+TDuration TOracleConfig::GetMaxDurationBeforeGoingOffline() const
+{
+    return GetFromConfig(
+        StorageConfig->GetOracleConfig().GetMaxDurationBeforeGoingOffline(),
+        TDuration::Seconds(10));
+}
+
+ui32 TOracleConfig::GetMinErrorsCountBeforeGoingOffline() const
+{
+    return GetFromConfig(
+        StorageConfig->GetOracleConfig().GetMinErrorsCountBeforeGoingOffline(),
+        10);
+}
+
+ui32 TOracleConfig::GetErrorsCountForGoingOffline() const
+{
+    return GetFromConfig(
+        StorageConfig->GetOracleConfig().GetErrorsCountForGoingOffline(),
+        1000);
+}
+
+ui64 TOracleConfig::GetErrorsTotalSizeForGoingOffline() const
+{
+    return GetFromConfig(
+        StorageConfig->GetOracleConfig().GetErrorsTotalSizeForGoingOffline(),
+        100_MB);
+}
+
+ui32 TOracleConfig::GetTimePredictionHistorySize() const
+{
+    return GetFromConfig(
+        StorageConfig->GetOracleConfig().GetTimePredictionHistorySize(),
+        0);
+}
+
+ui32 TOracleConfig::GetTimePredictionNthFromEnd() const
+{
+    return GetFromConfig(
+        StorageConfig->GetOracleConfig().GetTimePredictionNthFromEnd(),
+        0);
+}
+
+TDuration TOracleConfig::GetMaxDurationBeforeReturningOnline() const
+{
+    return GetFromConfig(
+        StorageConfig->GetOracleConfig().GetMaxDurationBeforeReturningOnline(),
+        TDuration::Seconds(10));
+}
+
+ui32 TOracleConfig::GetMinSuccessesCountBeforeReturningOnline() const
+{
+    return GetFromConfig(
+        StorageConfig->GetOracleConfig()
+            .GetMinSuccessesCountBeforeReturningOnline(),
+        100);
+}
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_config.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_config.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <ydb/core/nbs/cloud/blockstore/config/public.h>
+
+#include <util/datetime/base.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+class TOracleConfig
+{
+public:
+    explicit TOracleConfig(TStorageConfigPtr storageConfig);
+
+    [[nodiscard]] TDuration GetMaxDurationBeforeGoingTemporaryOffline() const;
+
+    [[nodiscard]] TDuration GetMaxDurationBeforeGoingOffline() const;
+
+    [[nodiscard]] ui32 GetMinErrorsCountBeforeGoingOffline() const;
+
+    [[nodiscard]] ui32 GetErrorsCountForGoingOffline() const;
+
+    [[nodiscard]] ui64 GetErrorsTotalSizeForGoingOffline() const;
+
+    [[nodiscard]] ui32 GetTimePredictionHistorySize() const;
+
+    [[nodiscard]] ui32 GetTimePredictionNthFromEnd() const;
+
+    [[nodiscard]] TDuration GetMaxDurationBeforeReturningOnline() const;
+
+    [[nodiscard]] ui32 GetMinSuccessesCountBeforeReturningOnline() const;
+
+private:
+    TStorageConfigPtr StorageConfig;
+};
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
@@ -272,13 +272,16 @@ Y_UNIT_TEST_SUITE(TOracle)
             hostStateController.States[0]);
 
         // Generate success. Switching to the enabled state.
-        now += TDuration::Seconds(1);
-        oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
-        oracle.OnRequestSucceeded(
-            0,
-            EOperation::WriteToPBuffer,
-            now,
-            TDuration());
+        now += TDuration::Seconds(11);
+        for (size_t i = 0; i < 1000; ++i) {
+            oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
+            oracle.OnRequestSucceeded(
+                0,
+                EOperation::WriteToPBuffer,
+                now,
+                TDuration());
+        }
+        now += TDuration::Seconds(11);
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(1, hostStateController.States.size());
@@ -363,12 +366,15 @@ Y_UNIT_TEST_SUITE(TOracle)
 
         // Generate success. Switching to the enabled state.
         now += TDuration::Seconds(1);
-        oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
-        oracle.OnRequestSucceeded(
-            0,
-            EOperation::WriteToPBuffer,
-            now,
-            TDuration());
+        for (size_t i = 0; i < 1000; ++i) {
+            oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
+            oracle.OnRequestSucceeded(
+                0,
+                EOperation::WriteToPBuffer,
+                now,
+                TDuration());
+        }
+        now += TDuration::Seconds(11);
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(1, hostStateController.States.size());
@@ -408,13 +414,16 @@ Y_UNIT_TEST_SUITE(TOracle)
             hostStateController.States[0]);
 
         // Generate success. Switching to the enabled state.
-        now += TDuration::Seconds(1);
-        oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
-        oracle.OnRequestSucceeded(
-            0,
-            EOperation::WriteToPBuffer,
-            now,
-            TDuration());
+        now += TDuration::Seconds(11);
+        for (size_t i = 0; i < 1000; ++i) {
+            oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
+            oracle.OnRequestSucceeded(
+                0,
+                EOperation::WriteToPBuffer,
+                now,
+                TDuration());
+        }
+        now += TDuration::Seconds(11);
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(1, hostStateController.States.size());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/ut/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/ut/ya.make
@@ -2,6 +2,7 @@ UNITTEST_FOR(ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model)
 
 SRCS(
     count_size_ut.cpp
+    host_health_policy_ut.cpp
     host_mask_ut.cpp
     host_roles_ut.cpp
     host_stat_ut.cpp

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/ya.make
@@ -9,6 +9,7 @@ GENERATE_ENUM_SERIALIZATION(vchunk_config.h)
 
 SRCS(
     count_size.cpp
+    host_health_policy.cpp
     host_mask.cpp
     host_roles.cpp
     host_stat.cpp
@@ -16,6 +17,7 @@ SRCS(
     host.cpp
     mon_model.cpp
     oracle.cpp
+    oracle_config.cpp
     region_geometry.cpp
     time_predictor.cpp
     vchunk_config.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Теперь оракл не будет сразу возвращать хосты в онлайн при первом успешном запросе: для выхода в онлайн нужно набрать пороговое кол-во успешных запросов И выздать задержку возврата

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
