### PR TITLE
Fix united pool max slot accounting

### DIFF
--- a/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
+++ b/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
@@ -511,6 +511,45 @@ Y_UNIT_TEST(SharedAndUnitedAutoConfigMatrix) {
     }
 }
 
+Y_UNIT_TEST(UnitedPoolPreservesAutoConfiguredUserSlotLimit) {
+    NKikimrConfig::TActorSystemConfig config;
+    config.SetCpuCount(8);
+    config.SetUseSharedThreads(true);
+    config.SetUseUnitedPool(true);
+
+    ApplyAutoConfig(&config, true, false);
+
+    const ui32 userPoolId = config.GetSysExecutor();
+    auto setup = CreateActorSystemSetup(config);
+    const auto& userPool = FindBasicPool(setup->CpuManager, userPoolId);
+    UNIT_ASSERT_VALUES_EQUAL(userPool.PoolName, "User");
+    UNIT_ASSERT_VALUES_EQUAL(userPool.DefaultThreadCount, 4);
+    UNIT_ASSERT_VALUES_EQUAL(userPool.MaxThreadCount, 8);
+    UNIT_ASSERT(userPool.AllThreadsAreShared);
+
+    NActors::TActorSystem actorSystem(setup);
+    actorSystem.Start();
+
+    NActors::TExecutorPoolState state;
+    bool sharedQuotaObserved = false;
+    const TInstant deadline = TInstant::Now() + TDuration::Seconds(5);
+    while (TInstant::Now() < deadline) {
+        NActors::GetActorSystemStats(actorSystem).GetExecutorPoolState(userPoolId, state);
+        if (state.SharedCpuQuota > 1.0) {
+            sharedQuotaObserved = true;
+            break;
+        }
+        Sleep(TDuration::MilliSeconds(10));
+    }
+
+    actorSystem.Stop();
+    UNIT_ASSERT_C(sharedQuotaObserved,
+        "User pool did not report its owned shared slots");
+    UNIT_ASSERT_VALUES_EQUAL(state.MaxLimit, 8);
+    UNIT_ASSERT_LE(state.CurrentLimit, state.MaxLimit);
+    UNIT_ASSERT_LE(state.PossibleMaxLimit, state.MaxLimit);
+}
+
 Y_UNIT_TEST(GetManualPoolsUseExecutorIndicesDirectly) {
     NKikimrConfig::TActorSystemConfig config;
 

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -203,12 +203,17 @@ namespace NActors {
         semaphore.CurrentThreadCount = ThreadCount;
         Semaphore = semaphore.ConvertToI64();
 
-        DefaultThreadCount = DefaultFullThreadCount + HasOwnSharedThread;
-        MinThreadCount = MinFullThreadCount + HasOwnSharedThread;
-        MaxThreadCount = MaxFullThreadCount + HasOwnSharedThread;
+        const i16 ownSharedThreadCount = cfg.AllThreadsAreShared
+            ? cfg.DefaultThreadCount
+            : HasOwnSharedThread;
+        DefaultThreadCount = DefaultFullThreadCount + ownSharedThreadCount;
+        MinThreadCount = MinFullThreadCount + ownSharedThreadCount;
+        MaxThreadCount = cfg.AllThreadsAreShared
+            ? Max(cfg.MaxThreadCount, cfg.DefaultThreadCount)
+            : MaxFullThreadCount + ownSharedThreadCount;
 
         if (SharedOnly) {
-            MaxThreadCount = cfg.ForcedForeignSlotCount + 1;
+            MaxThreadCount = cfg.ForcedForeignSlotCount + ownSharedThreadCount;
         }
 
         Threads.Reset(new NThreading::TPadded<TExecutorThreadCtx>[MaxFullThreadCount]);

--- a/ydb/library/actors/core/harmonizer/cpu_consumption.cpp
+++ b/ydb/library/actors/core/harmonizer/cpu_consumption.cpp
@@ -137,8 +137,8 @@ void THarmonizerCpuConsumption::Pull(const std::vector<std::unique_ptr<TPoolInfo
             IsStarvedPresent = true;
         }
 
-        bool hasSharedThread = sharedInfo.OwnedThreads[poolIdx] != -1;
-        float expectedThreadCount = pool.GetFullThreadCount() + (hasSharedThread ? 1 : 0) + 0.5;
+        i16 ownSharedThreadCount = Max<i16>(sharedInfo.OwnedThreads[poolIdx], 0);
+        float expectedThreadCount = pool.GetFullThreadCount() + ownSharedThreadCount + 0.5;
         bool isMoreThanExpected = (PoolConsumption[poolIdx].NeedyWindowCpu >= expectedThreadCount) && (PoolFullThreadConsumption[poolIdx].NeedyWindowCpu >= currentFullThreadCount - 1);
         bool isMoreThanExpectedLastSecond = (PoolConsumption[poolIdx].LastSecondCpu >= expectedThreadCount) && (PoolFullThreadConsumption[poolIdx].LastSecondCpu >= currentFullThreadCount - 1);
         bool hasCurrentCpuDemand = (PoolConsumption[poolIdx].LastSecondCpu >= currentThreadCount || isMoreThanExpectedLastSecond);
@@ -153,7 +153,7 @@ void THarmonizerCpuConsumption::Pull(const std::vector<std::unique_ptr<TPoolInfo
             NeedyPools.push_back(poolIdx);
         }
 
-        bool isHoggish = !isNeedy && IsHoggish(PoolConsumption[poolIdx].Elapsed, currentFullThreadCount + hasSharedThread) && IsHoggish(PoolConsumption[poolIdx].LastSecondElapsed, currentFullThreadCount + hasSharedThread);
+        bool isHoggish = !isNeedy && IsHoggish(PoolConsumption[poolIdx].Elapsed, currentFullThreadCount + ownSharedThreadCount) && IsHoggish(PoolConsumption[poolIdx].LastSecondElapsed, currentFullThreadCount + ownSharedThreadCount);
         if (isHoggish) {
             float freeCpu = std::min(currentFullThreadCount - PoolFullThreadConsumption[poolIdx].Elapsed, currentFullThreadCount - PoolFullThreadConsumption[poolIdx].LastSecondElapsed);
             HoggishPools.push_back({poolIdx, freeCpu});

--- a/ydb/library/actors/core/harmonizer/harmonizer.cpp
+++ b/ydb/library/actors/core/harmonizer/harmonizer.cpp
@@ -136,10 +136,10 @@ void THarmonizer::ProcessWaitingStats() {
 
 void THarmonizer::SetForeignThreadSlotsForCurrentFullThreadCount(ui16 poolIdx) {
     if (Shared) {
-        bool hasOwnSharedThread = SharedInfo.OwnedThreads[poolIdx] != -1;
+        i16 ownSharedThreadCount = Max<i16>(SharedInfo.OwnedThreads[poolIdx], 0);
         i16 currentFullThreadCount = Pools[poolIdx]->GetFullThreadCount();
-        i16 slots = Pools[poolIdx]->MaxThreadCount - currentFullThreadCount - hasOwnSharedThread;
-        i16 maxSlots = Shared->GetSharedThreadCount() - hasOwnSharedThread;
+        i16 slots = Pools[poolIdx]->MaxThreadCount - currentFullThreadCount - ownSharedThreadCount;
+        i16 maxSlots = Shared->GetSharedThreadCount() - ownSharedThreadCount;
         Shared->SetForeignThreadSlots(poolIdx, Min<i16>(slots, maxSlots));
     }
 }
@@ -157,7 +157,8 @@ void THarmonizer::ProcessStarvedState() {
         if (CpuConsumption.PoolConsumption[poolIdx].Elapsed > pool.GetThreadCount()) {
             continue;
         }
-        i16 maxSharedCpuQuota = i16(SharedInfo.OwnedThreads[poolIdx] != -1) + SharedInfo.ForeignThreadsAllowed[poolIdx];
+        i16 maxSharedCpuQuota = Max<i16>(SharedInfo.OwnedThreads[poolIdx], 0)
+            + SharedInfo.ForeignThreadsAllowed[poolIdx];
         if (SharedInfo.CpuConsumption[poolIdx].CpuQuota > maxSharedCpuQuota) {
             continue;
         }
@@ -346,8 +347,8 @@ void THarmonizer::HarmonizeImpl(ui64 ts) {
 
         float possibleMaxSharedQuota = 0.0f;
         if (Shared) {
-            bool hasOwnSharedThread = SharedInfo.OwnedThreads[poolIdx] != -1;
-            i16 sharedThreads = std::min<i16>(SharedInfo.ForeignThreadsAllowed[poolIdx] + hasOwnSharedThread, SharedInfo.ThreadCount);
+            i16 ownSharedThreadCount = Max<i16>(SharedInfo.OwnedThreads[poolIdx], 0);
+            i16 sharedThreads = std::min<i16>(SharedInfo.ForeignThreadsAllowed[poolIdx] + ownSharedThreadCount, SharedInfo.ThreadCount);
             float poolSharedElapsedCpu = SharedInfo.CpuConsumption[poolIdx].Elapsed;
             possibleMaxSharedQuota = std::min<float>(poolSharedElapsedCpu + freeSharedCpu, sharedThreads);
         }
@@ -466,8 +467,8 @@ void THarmonizer::AddPool(IExecutorPool* pool, TSelfPingInfo *pingInfo, bool ign
     if (Shared) {
         TVector<i16> ownedThreads(Pools.size(), -1);
         Shared->FillOwnedThreads(ownedThreads);
-        bool hasOwnSharedThread = ownedThreads[pool->PoolId] != -1;
-        Shared->SetForeignThreadSlots(pool->PoolId, Min<i16>(poolInfo.MaxThreadCount, Shared->GetSharedThreadCount()) - hasOwnSharedThread);
+        i16 ownSharedThreadCount = Max<i16>(ownedThreads[pool->PoolId], 0);
+        Shared->SetForeignThreadSlots(pool->PoolId, Min<i16>(poolInfo.MaxThreadCount, Shared->GetSharedThreadCount()) - ownSharedThreadCount);
     }
     if (pingInfo) {
         poolInfo.AvgPingCounter = pingInfo->AvgPingCounter;

--- a/ydb/library/actors/core/ut/executor_pools_ut.cpp
+++ b/ydb/library/actors/core/ut/executor_pools_ut.cpp
@@ -2,6 +2,7 @@
 #include "debug.h"
 #include "executor_pool_basic.h"
 #include "executor_pool_shared.h"
+#include "harmonizer/harmonizer.h"
 #include "hfunc.h"
 #include "scheduler_basic.h"
 #include "thread_context.h"
@@ -219,6 +220,59 @@ void TieBasicPoolsAndSharedPool(const std::vector<std::unique_ptr<TBasicExecutor
 ////////////////////////////////////////////////////////////////////////////////
 
 Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
+
+    Y_UNIT_TEST(UnitedPoolSlotLimitIncludesOwnedAndForeignSlots) {
+        auto harmonizer = MakeHarmonizer(0);
+        auto sharedPool = std::make_unique<TSharedExecutorPool>(TSharedExecutorPoolConfig{
+            .United = true,
+        }, std::vector<TPoolShortInfo>{
+            TPoolShortInfo{
+                .PoolId = 0,
+                .SharedThreadCount = 4,
+                .InPriorityOrder = true,
+                .PoolName = "User",
+            },
+            TPoolShortInfo{
+                .PoolId = 1,
+                .SharedThreadCount = 4,
+                .InPriorityOrder = true,
+                .PoolName = "Other",
+            },
+        });
+        harmonizer->SetSharedPool(sharedPool.get());
+
+        TBasicExecutorPool pool(TBasicExecutorPoolConfig{
+            .PoolId = 0,
+            .PoolName = "User",
+            .Threads = 8,
+            .MaxThreadCount = 8,
+            .DefaultThreadCount = 4,
+            .HasSharedThread = true,
+            .AllThreadsAreShared = true,
+        }, harmonizer.get());
+        harmonizer->AddPool(&pool);
+
+        std::vector<i16> ownedThreads;
+        std::vector<i16> foreignThreadsAllowed;
+        sharedPool->FillOwnedThreads(ownedThreads);
+        sharedPool->FillForeignThreadsAllowed(foreignThreadsAllowed);
+
+        UNIT_ASSERT_VALUES_EQUAL(pool.GetFullThreadCount(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(pool.GetDefaultThreadCount(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(pool.GetMinThreadCount(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(pool.GetMaxThreadCount(), 8);
+        UNIT_ASSERT_VALUES_EQUAL(ownedThreads[0], 4);
+        UNIT_ASSERT_VALUES_EQUAL(foreignThreadsAllowed[0], 4);
+
+        pool.SetSharedCpuQuota(4);
+        TExecutorPoolState state;
+        pool.GetExecutorPoolState(state);
+        UNIT_ASSERT_VALUES_EQUAL(state.CurrentLimit, 4);
+        UNIT_ASSERT_VALUES_EQUAL(state.MaxLimit, 8);
+        UNIT_ASSERT_VALUES_EQUAL(state.PossibleMaxLimit, 8);
+        UNIT_ASSERT_LE(state.CurrentLimit, state.MaxLimit);
+        UNIT_ASSERT_LE(state.PossibleMaxLimit, state.MaxLimit);
+    }
 
     Y_UNIT_TEST(SharedPoolReportsUnitedMode) {
         for (const bool united : {false, true}) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed max_threads enforcement for executor pools that use united shared threads.

### Description for reviewers <!-- (optional) description for those who read this PR -->

For an auto-configured 8-CPU dynamic node, the User pool owns 4 shared slots and has max_threads=8. AllThreadsAreShared converted the basic-pool maximum to a single owner slot, while current and potential limits were measured in shared slots, so Harmonizer allowed no foreign slots and reported Current and PossibleMax above Max.

The change preserves total slot limits for all-shared pools and uses the actual owned shared-slot count instead of a boolean throughout foreign-slot, quota, and demand calculations. The resulting contract is owned_slots=4, foreign_slots=4, max_slots=8, with Current and PossibleMax bounded by Max.