### PR TITLE
Fix test filter name format description in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,7 @@
 - No force rebuild
 - Use `2>&1 | tail` for test output
 
-Test filters should include part of full test name. Full test name format depends on test framework:
-
-- For C++ unit test: `<suite name>::<test name>`
-- For python pytest: `<file>.<class>.<test name>[<fixture params>]`
+- Test name formats for `-F`: [`ydb/agents/TESTS.md`](ydb/agents/TESTS.md)
 
 ## C++
 

--- a/ydb/agents/TESTS.md
+++ b/ydb/agents/TESTS.md
@@ -38,10 +38,19 @@ Upgrade/downgrade tests live under `ydb/tests/compatibility/`.
 ## Running tests
 
 ```bash
-./ya make --build relwithdebinfo -tA <folder>
-./ya make --build relwithdebinfo -tA <folder> -F *test-filter*
+./ya make --build relwithdebinfo -tA <folder>               # all tests
+./ya make --build relwithdebinfo -tA <folder> -F <filter>   # matching tests
+./ya make -t <folder> -L                                    # list full test names
 ```
 
 CLI tests (`ya make -tA`) run only on Linux.
+
+`<filter>` is a full test name, its suffix, or a `*` glob (`*part*`):
+
+- C++ (`UNITTEST`, `GTEST`): `TMySuite::MyTest`; `TMySuite` runs the whole suite.
+- Python (pytest, `unittest`): `test_foo.py::TestClass::test_bar[param]`, no class
+  part for module-level tests; `test_foo.py` runs the whole module,
+  `test_foo.py::TestClass::*` the whole class. `test_foo.py::TestClass` without
+  `::*` matches nothing and still reports `Ok`.
 
 Build rules: [`GUIDE.md`](GUIDE.md).


### PR DESCRIPTION
### Changelog entry

Fixed the test filter name format description and moved it out of the always-loaded `AGENTS.md` into `ydb/agents/TESTS.md`.

### Description for reviewers

Follow-up to #52575. The formats added there were partly wrong, and the Copilot comment on that PR was wrong in the other direction — so I checked every case by actually running `ya make -t ... -F ...`.

What is fixed:

* **Python** — the separator is `::`, not a dot, and the file name keeps its `.py` extension. The documented `<file>.<class>.<test name>` matches nothing.
* **C++** — `<suite>::<test>` was correct, and it is correct for `GTEST` targets too (contrary to the Copilot review comment on #52575, which suggested `Suite.Test` for GTest). `library/cpp/testing/gtest/main.cpp` reports gtest names as `suite::test`, so both C++ frameworks share one format.
* **`unittest.TestCase`** — no separate format: those tests are collected by the same pytest plugin and get the same `file.py::Class::test` node id.
* Added a pointer to `ya make -t <folder> -L`, which prints the exact full names.
* Moved the description into `ydb/agents/TESTS.md`, next to the existing `Running tests` section; `AGENTS.md` keeps a one-line link. `AGENTS.md` is always in an agent's context, so the details now cost tokens only when tests are actually being filtered.
* Added filter templates for the common cases, including the trap that motivated the whole check: `test_foo.py::TestClass` silently selects zero tests and still reports `Ok`, while the C++ analogue `TMySuiteTest` runs the whole suite.

Why the python half-filter fails: in `library/python/pytest/plugins/ya.py` the implicit trailing `*` is only appended when the filter contains neither `::` nor `*`; otherwise the filter is matched against the full node id with `endswith`/`fnmatch`, and `test_foo.py::TestClass` is neither a suffix nor a glob of `test_foo.py::TestClass::test_x`.

#### Commands to verify the formats

All targets below are small and cheap — no `ydbd` build, no cluster.

C++ `UNITTEST` — `ydb/library/kll_median/ut` (`SIZE(SMALL)`, one `.cpp`):

```bash
./ya make -t ydb/library/kll_median/ut -L
./ya make -t ydb/library/kll_median/ut -F 'TKllMedianTest::SingleElement'   # 1 test
./ya make -t ydb/library/kll_median/ut -F 'TKllMedianTest.SingleElement'    # 0 tests
./ya make -t ydb/library/kll_median/ut -F 'TKllMedianTest'                  # 12 tests, whole suite
./ya make -t ydb/library/kll_median/ut -F 'SingleElement'                   # 0 tests, needs globs
./ya make -t ydb/library/kll_median/ut -F '*SingleElement'                  # 3 tests
```

C++ `GTEST` — `ydb/library/net/ut` (`SIZE(SMALL)`, one PEERDIR):

```bash
./ya make -t ydb/library/net/ut -L
./ya make -t ydb/library/net/ut -F 'FormatSourceAddress::IPv4'              # 1 test
./ya make -t ydb/library/net/ut -F 'FormatSourceAddress.IPv4'               # 0 tests
./ya make -t ydb/library/net/ut -F 'FormatSourceAddress'                    # 8 tests, whole suite
```

pytest with classes and parametrization — `ydb/tests/stability/nemesis/ut` (`SIZE(SMALL)`, pure python, ~16s for all 107 tests):

```bash
./ya make -t ydb/tests/stability/nemesis/ut -L
./ya make -t ydb/tests/stability/nemesis/ut -F 'test_boundary_scheduler.py'                 # 14 tests
./ya make -t ydb/tests/stability/nemesis/ut -F 'test_boundary_scheduler.py::TestTick'       # 0 tests, the trap
./ya make -t ydb/tests/stability/nemesis/ut -F 'test_boundary_scheduler.py::TestTick::*'    # 7 tests
./ya make -t ydb/tests/stability/nemesis/ut -F 'test_boundary_scheduler.py::TestTick::test_tick_respects_budget_and_fuse[block-4-2-5-2]'  # 1 test
./ya make -t ydb/tests/stability/nemesis/ut -F 'test_boundary_scheduler.TestTick.test_tick_respects_budget_and_fuse'                      # 0 tests, the old wrong format
./ya make -t ydb/tests/stability/nemesis/ut -F '*TestTick*'                                 # 7 tests
```

Module-level test function, no class:

```bash
./ya make -t ydb/tests/stability/nemesis/ut -F 'test_guard_invariants.py::test_budget_is_never_exceeded_across_many_ticks[0]'   # 1 test
./ya make -t ydb/tests/stability/nemesis/ut -F 'test_guard_invariants.py::test_budget_is_never_exceeded_across_many_ticks*'     # 3 tests
```

`unittest.TestCase` under pytest — `ydb/library/benchmarks/report/ut`:

```bash
./ya make -t ydb/library/benchmarks/report/ut -L
./ya make -t ydb/library/benchmarks/report/ut -F 'test.py::Test::test_create'   # 1 test
./ya make -t ydb/library/benchmarks/report/ut -F 'test.py::Test::*'             # 21 tests
./ya make -t ydb/library/benchmarks/report/ut -F 'test.py::Test'                # 0 tests
./ya make -t ydb/library/benchmarks/report/ut -F 'test.Test.test_create'        # 0 tests
./ya make -t ydb/library/benchmarks/report/ut -F 'test.py'                      # 22 tests (21 + flake8 subtest)
```

