### PR TITLE
Split load test libraries by component

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/lib/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/ya.make
@@ -27,7 +27,7 @@ PEERDIR(
     ydb/core/blobstorage/pdisk
     ydb/core/blobstorage/pdisk/mock
     ydb/core/blobstorage/vdisk/common
-    ydb/core/load_test
+    ydb/core/load_test/nbs
     ydb/core/mind
     ydb/core/mind/bscontroller
     ydb/core/mind/hive

--- a/ydb/core/blobstorage/ut_blobstorage/ut_ddisk/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ut_ddisk/ya.make
@@ -12,7 +12,7 @@ UNITTEST_FOR(ydb/core/blobstorage/ut_blobstorage)
 
     PEERDIR(
         ydb/core/blobstorage/ut_blobstorage/lib
-        ydb/core/load_test
+        ydb/core/load_test/nbs
     )
 
 END()

--- a/ydb/core/load_test/blobstorage/ya.make
+++ b/ydb/core/load_test/blobstorage/ya.make
@@ -1,0 +1,27 @@
+LIBRARY()
+
+SRCS(
+    ../group_write.cpp
+    ../pdisk_log.cpp
+    ../pdisk_read.cpp
+    ../pdisk_write.cpp
+    ../vdisk_write.cpp
+)
+
+PEERDIR(
+    library/cpp/monlib/service/pages
+    library/cpp/time_provider
+    ydb/core/base
+    ydb/core/blobstorage/backpressure
+    ydb/core/blobstorage/base
+    ydb/core/blobstorage/pdisk
+    ydb/core/blobstorage/vdisk/common
+    ydb/core/control/lib
+    ydb/core/jaeger_tracing
+    ydb/core/load_test/common
+    ydb/core/util
+    ydb/library/actors/util
+    ydb/library/yverify_stream
+)
+
+END()

--- a/ydb/core/load_test/common/ya.make
+++ b/ydb/core/load_test/common/ya.make
@@ -1,0 +1,36 @@
+LIBRARY()
+
+SRCS(
+    ../defs.h
+    ../events.cpp
+    ../events.h
+    ../gen.h
+    ../interval_gen.h
+    ../memory.cpp
+    ../percentile.h
+    ../quantile.h
+    ../service_actor.h
+    ../size_gen.h
+    ../speed.h
+    ../time_series.h
+    ../util.cpp
+    ../util.h
+)
+
+PEERDIR(
+    library/cpp/histogram/hdr
+    library/cpp/json/writer
+    library/cpp/monlib/dynamic_counters
+    library/cpp/monlib/dynamic_counters/percentile
+    library/cpp/monlib/service/pages
+    library/cpp/random_provider
+    library/cpp/time_provider
+    ydb/core/base
+    ydb/core/protos
+    ydb/library/actors/core
+    ydb/library/services
+)
+
+GENERATE_ENUM_SERIALIZATION(../percentile.h)
+
+END()

--- a/ydb/core/load_test/ddisk/ya.make
+++ b/ydb/core/load_test/ddisk/ya.make
@@ -1,0 +1,17 @@
+LIBRARY()
+
+SRCS(
+    ../ddisk_load.cpp
+    ../persistent_buffer_write.cpp
+)
+
+PEERDIR(
+    library/cpp/monlib/service/pages
+    library/cpp/time_provider
+    ydb/core/base
+    ydb/core/blobstorage/ddisk
+    ydb/core/control/lib
+    ydb/core/load_test/common
+)
+
+END()

--- a/ydb/core/load_test/interconnect/ya.make
+++ b/ydb/core/load_test/interconnect/ya.make
@@ -1,0 +1,13 @@
+LIBRARY()
+
+SRCS(
+    ../interconnect_load.cpp
+)
+
+PEERDIR(
+    ydb/core/load_test/common
+    ydb/library/actors/core
+    ydb/library/actors/interconnect
+)
+
+END()

--- a/ydb/core/load_test/keyvalue/ya.make
+++ b/ydb/core/load_test/keyvalue/ya.make
@@ -1,0 +1,19 @@
+LIBRARY()
+
+SRCS(
+    ../keyvalue_write.cpp
+)
+
+PEERDIR(
+    library/cpp/histogram/hdr
+    library/cpp/monlib/service/pages
+    library/cpp/time_provider
+    ydb/core/base
+    ydb/core/blobstorage/base
+    ydb/core/blobstorage/pdisk
+    ydb/core/control/lib
+    ydb/core/keyvalue
+    ydb/core/load_test/common
+)
+
+END()

--- a/ydb/core/load_test/kqp/ya.make
+++ b/ydb/core/load_test/kqp/ya.make
@@ -1,0 +1,26 @@
+LIBRARY()
+
+SRCS(
+    ../kqp.cpp
+    ../yql_single_query.cpp
+    ../yql_single_query.h
+)
+
+PEERDIR(
+    library/cpp/histogram/hdr
+    library/cpp/monlib/service/pages
+    library/cpp/time_provider
+    ydb/core/base
+    ydb/core/blobstorage/base
+    ydb/core/kqp/common
+    ydb/core/load_test/common
+    ydb/core/protos
+    ydb/library/actors/core
+    ydb/library/workload/abstract
+    ydb/library/workload/kv
+    ydb/library/workload/stock
+    ydb/public/sdk/cpp/src/client/proto
+    ydb/public/sdk/cpp/src/library/operation_id
+)
+
+END()

--- a/ydb/core/load_test/nbs/ya.make
+++ b/ydb/core/load_test/nbs/ya.make
@@ -1,0 +1,68 @@
+LIBRARY()
+
+SRCS(
+    ../nbs_dbg_like_alloc_helper.cpp
+    ../nbs_dbg_like_alloc_helper.h
+    ../nbs_dbg_like_load.cpp
+    ../nbs_dbg_like_load.h
+    ../nbs_dbg_like_load_defs.h
+    ../nbs_dbg_like_load_service.cpp
+    ../nbs_dbg_like_load_service.h
+    ../nbs_dbg_like_load_tablet.cpp
+    ../nbs_dbg_like_load_tablet.h
+)
+
+PEERDIR(
+    library/cpp/containers/absl
+    library/cpp/histogram/hdr
+    library/cpp/http/fetch
+    library/cpp/json
+    library/cpp/json/writer
+    library/cpp/monlib/dynamic_counters
+    library/cpp/monlib/dynamic_counters/percentile
+    library/cpp/monlib/service
+    library/cpp/monlib/service/pages
+    ydb/core/base
+    ydb/core/base/services
+    ydb/core/blobstorage/base
+    ydb/core/blobstorage/ddisk
+    ydb/core/keyvalue
+    ydb/core/load_test/common
+    ydb/core/mind/hive
+    ydb/core/mon
+    ydb/core/nbs/cloud/storage/core/protos
+    ydb/core/protos
+    ydb/core/scheme
+    ydb/core/tablet
+    ydb/core/tablet_flat
+    ydb/core/tx/scheme_cache
+    ydb/core/util
+    ydb/library/actors/core
+    ydb/library/actors/wilson
+    ydb/library/wilson_ids
+    ydb/public/lib/base
+)
+
+GENERATE_ENUM_SERIALIZATION_WITH_HEADER(../nbs_dbg_like_load_defs.h)
+
+IF (OS_LINUX)
+    SRCS(../nbs2_load_actor.cpp)
+
+    PEERDIR(
+        library/cpp/protobuf/json
+        library/cpp/time_provider
+        ydb/core/nbs/cloud/blockstore/libs/common
+        ydb/core/nbs/cloud/blockstore/libs/service
+        ydb/core/nbs/cloud/blockstore/libs/storage/api
+        ydb/core/nbs/cloud/blockstore/tools/testing/loadtest/lib
+        ydb/core/nbs/cloud/storage/core/libs/common
+        ydb/core/nbs/cloud/storage/core/libs/diagnostics
+        ydb/library/workload/abstract
+        ydb/library/workload/kv
+        ydb/library/workload/stock
+        ydb/public/sdk/cpp/src/client/proto
+        ydb/public/sdk/cpp/src/library/operation_id
+    )
+ENDIF()
+
+END()

--- a/ydb/core/load_test/ut/ya.make
+++ b/ydb/core/load_test/ut/ya.make
@@ -1,12 +1,14 @@
-UNITTEST_FOR(ydb/core/load_test)
+UNITTEST()
 
 FORK_SUBTESTS(MODULO)
 
 SIZE(MEDIUM)
 
 PEERDIR(
+    library/cpp/protobuf/util
     ydb/core/blobstorage/ut_blobstorage/lib
-    ydb/core/testlib/default
+    ydb/core/load_test/blobstorage
+    ydb/core/load_test/nbs
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/load_test/ut_ycsb/ya.make
+++ b/ydb/core/load_test/ut_ycsb/ya.make
@@ -1,4 +1,4 @@
-UNITTEST_FOR(ydb/core/load_test)
+UNITTEST_FOR(ydb/core/load_test/ycsb)
 
 FORK_SUBTESTS()
 
@@ -16,7 +16,6 @@ PEERDIR(
     library/cpp/regex/pcre
     library/cpp/svnversion
     ydb/core/kqp/ut/common
-    ydb/core/load_test
     ydb/core/testlib/default
     ydb/core/tx
     yql/essentials/public/udf/service/exception_policy

--- a/ydb/core/load_test/ya.make
+++ b/ydb/core/load_test/ya.make
@@ -1,99 +1,34 @@
 LIBRARY()
 
-PEERDIR(
-    contrib/libs/protobuf
-    library/cpp/containers/absl
-    library/cpp/histogram/hdr
-    library/cpp/monlib/dynamic_counters/percentile
-    library/cpp/monlib/service/pages
-    ydb/core/base
-    ydb/core/blobstorage/backpressure
-    ydb/core/blobstorage/base
-    ydb/core/blobstorage/ddisk
-    ydb/core/blobstorage/pdisk
-    ydb/core/control/lib
-    ydb/core/keyvalue
-    ydb/core/jaeger_tracing
-    ydb/core/kqp/common
-    ydb/core/kqp/rm_service
-    ydb/core/mind/hive
-    ydb/core/tablet
-    ydb/core/tablet_flat
-    ydb/core/tx/columnshard
-    ydb/core/tx/datashard
-    ydb/core/util
-    ydb/library/workload/abstract
-    ydb/library/workload/kv
-    ydb/library/workload/stock
-    ydb/public/lib/base
-    ydb/public/sdk/cpp/src/library/operation_id
-    ydb/public/sdk/cpp/src/client/proto
-    ydb/services/kesus
-    ydb/services/metadata
-    ydb/services/persqueue_cluster_discovery
-    ydb/services/ydb
-)
-
 SRCS(
     aggregated_result.cpp
     archive.cpp
     config_examples.cpp
-    ddisk_load.cpp
-    events.cpp
-    interconnect_load.cpp
-    keyvalue_write.cpp
-    kqp.cpp
-    memory.cpp
-    nbs_dbg_like_alloc_helper.cpp
-    nbs_dbg_like_load.cpp
-    nbs_dbg_like_load_service.cpp
-    nbs_dbg_like_load_tablet.cpp
-    persistent_buffer_write.cpp
-    pdisk_log.cpp
-    pdisk_read.cpp
-    pdisk_write.cpp
     service_actor.cpp
-    group_write.cpp
-    util.cpp
-    vdisk_write.cpp
-    yql_single_query.cpp
-
-    ycsb/actors.h
-    ycsb/bulk_mkql_upsert.cpp
-    ycsb/common.h
-    ycsb/common.cpp
-    ycsb/defs.h
-    ycsb/info_collector.h
-    ycsb/info_collector.cpp
-    ycsb/kqp_select.cpp
-    ycsb/kqp_upsert.cpp
-    ycsb/test_load_actor.cpp
-    ycsb/test_load_actor.h
-    ycsb/test_load_read_iterator.cpp
 )
 
-IF (OS_LINUX)
-    SRCS(
-        nbs2_load_actor.cpp
-    )
-
-    PEERDIR(
-        ydb/core/nbs/cloud/blockstore/libs/common
-        ydb/core/nbs/cloud/blockstore/libs/service
-        ydb/core/nbs/cloud/blockstore/tools/testing/loadtest/lib
-        ydb/core/nbs/cloud/storage/core/libs/common
-        ydb/core/nbs/cloud/storage/core/libs/diagnostics
-    )
-ENDIF()
-
-# Make NBS protos available for include checking on all platforms
-# even though they're only used on Linux
 PEERDIR(
-    ydb/core/nbs/cloud/storage/core/protos
+    library/cpp/json
+    library/cpp/json/writer
+    library/cpp/monlib/service/pages
+    library/cpp/time_provider
+    ydb/core/base
+    ydb/core/blobstorage/base
+    ydb/core/load_test/blobstorage
+    ydb/core/load_test/common
+    ydb/core/load_test/ddisk
+    ydb/core/load_test/interconnect
+    ydb/core/load_test/keyvalue
+    ydb/core/load_test/kqp
+    ydb/core/load_test/nbs
+    ydb/core/load_test/ycsb
+    ydb/core/protos
+    ydb/library/actors/interconnect
+    ydb/library/mkql_proto/protos
+    ydb/public/lib/base
+    ydb/public/sdk/cpp/src/client/proto
+    ydb/public/sdk/cpp/src/library/operation_id
 )
-
-GENERATE_ENUM_SERIALIZATION_WITH_HEADER(nbs_dbg_like_load_defs.h)
-GENERATE_ENUM_SERIALIZATION(percentile.h)
 
 END()
 

--- a/ydb/core/load_test/ycsb/ya.make
+++ b/ydb/core/load_test/ycsb/ya.make
@@ -1,0 +1,42 @@
+LIBRARY()
+
+SRCS(
+    actors.h
+    bulk_mkql_upsert.cpp
+    common.cpp
+    common.h
+    defs.h
+    info_collector.cpp
+    info_collector.h
+    kqp_select.cpp
+    kqp_upsert.cpp
+    test_load_actor.cpp
+    test_load_actor.h
+    test_load_read_iterator.cpp
+)
+
+PEERDIR(
+    library/cpp/histogram/hdr
+    library/cpp/monlib/service/pages
+    ydb/core/base
+    ydb/core/kqp/common
+    ydb/core/load_test/common
+    ydb/core/protos
+    ydb/core/tx/columnshard
+    ydb/core/tx/datashard
+    ydb/core/tx/schemeshard
+    ydb/core/tx/tx_proxy
+    ydb/core/ydb_convert
+    ydb/library/actors/core
+    ydb/library/services
+    ydb/public/api/protos
+    ydb/public/lib/base
+    ydb/public/sdk/cpp/src/client/proto
+    ydb/public/sdk/cpp/src/library/operation_id
+    ydb/services/kesus
+    ydb/services/metadata
+    ydb/services/persqueue_cluster_discovery
+    ydb/services/ydb
+)
+
+END()

--- a/ydb/tools/stress_tool/lib/ya.make
+++ b/ydb/tools/stress_tool/lib/ya.make
@@ -5,7 +5,7 @@ PEERDIR(
     contrib/libs/protobuf
     library/cpp/monlib/dynamic_counters/percentile
     ydb/core/blobstorage/lwtrace_probes
-    ydb/core/load_test
+    ydb/core/load_test/blobstorage
     ydb/core/protos
     ydb/tools/stress_tool/proto
     ydb/library/actors/core

--- a/ydb/tools/stress_tool/ut/ya.make
+++ b/ydb/tools/stress_tool/ut/ya.make
@@ -13,6 +13,7 @@ SRC(
 
 PEERDIR(
     ydb/apps/version
+    ydb/core/load_test/ddisk
     yql/essentials/parser/pg_wrapper
     yql/essentials/sql/pg
     yql/essentials/minikql/comp_nodes/llvm16

--- a/ydb/tools/stress_tool/ya.make
+++ b/ydb/tools/stress_tool/ya.make
@@ -8,7 +8,9 @@ IF (OS_LINUX)
         ydb/core/blobstorage/crypto
         ydb/core/blobstorage/lwtrace_probes
         ydb/core/blobstorage/pdisk
-        ydb/core/load_test
+        ydb/core/load_test/blobstorage
+        ydb/core/load_test/ddisk
+        ydb/core/load_test/interconnect
         ydb/core/node_whiteboard
         ydb/core/tablet
         ydb/library/actors/dnsresolver


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Reduce unnecessary dependencies in storage load tests and tools.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Split load_test into interconnect, BlobStorage, DDisk/PersistentBuffer, NBS, KeyValue, KQP, and YCSB libraries with shared helpers in common. Keep the existing dispatcher as an aggregate library and switch BlobStorage test environments and stress-tool targets to the components they use. Source files and public include paths are unchanged.
