### PR TITLE
[US] Fix node registration

### DIFF
--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -1494,6 +1494,7 @@ public:
             cf.NodeResolveHost = cf.NodeHost;
         }
 
+        const auto& authConfig = AppConfig.GetAuthConfig();
         const TNodeRegistrationSettings settings {
             domainName,
             cf.NodeHost,
@@ -1503,7 +1504,7 @@ public:
             cf.FixedNodeID,
             cf.InterconnectPort,
             cf.CreateNodeLocation(),
-            AppConfig.GetAuthConfig().GetNodeRegistrationToken(),
+            authConfig.HasNodeRegistrationToken() ? authConfig.GetNodeRegistrationToken() : TString{},
         };
 
         auto result = NodeBrokerClient.RegisterDynamicNode(cf.GrpcSslSettings, addrs, settings, Env, Logger);

--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -1196,6 +1196,7 @@ class TInitialConfiguratorImpl
 
     NKikimrConfig::TAppConfig BaseConfig;
     NKikimrConfig::TAppConfig AppConfig;
+    bool HasStaticConfig = false;
 
     NConfig::TCommonAppOptions CommonAppOptions;
     NConfig::TMbusAppOptions MbusAppOptions;
@@ -1271,6 +1272,9 @@ public:
                 throw TInitializationException("YDBE-10012") << "YAML config is not provided for static node and no seed nodes given";
             }
         }
+
+        // Track supplied files, including empty protobuf configs, independently of their contents.
+        HasStaticConfig = !freeArgs.empty() || yamlConfigs.Main.has_value();
 
         if (yamlConfigs.Main) {
             ApplyMainYamlConfig(refs, yamlConfigs, AppConfig);
@@ -1495,6 +1499,10 @@ public:
         }
 
         const auto& authConfig = AppConfig.GetAuthConfig();
+        // Supplied auth files preserve the token default even without a full static config.
+        const bool useToken = HasStaticConfig
+            || ProtoConfigFileProvider.Has("auth-file")
+            || ProtoConfigFileProvider.Has("auth-token-file");
         const TNodeRegistrationSettings settings {
             domainName,
             cf.NodeHost,
@@ -1504,7 +1512,7 @@ public:
             cf.FixedNodeID,
             cf.InterconnectPort,
             cf.CreateNodeLocation(),
-            authConfig.HasNodeRegistrationToken() ? authConfig.GetNodeRegistrationToken() : TString{},
+            useToken ? authConfig.GetNodeRegistrationToken() : TString{},
         };
 
         auto result = NodeBrokerClient.RegisterDynamicNode(cf.GrpcSslSettings, addrs, settings, Env, Logger);

--- a/ydb/tests/functional/security/node_registration/canondata/result.json
+++ b/ydb/tests/functional/security/node_registration/canondata/result.json
@@ -1,0 +1,500 @@
+{
+    "test_node_authentication.test_get_node_config[body-certificate-and-token-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-certificate-and-token-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-certificate-and-token-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-certificate-and-token-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-certificate-only-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-certificate-only-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-certificate-only-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-certificate-only-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-denied-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-denied-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-denied-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-denied-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-denied-token-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-denied-token-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-denied-token-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-denied-token-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-denied-token-over-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-denied-token-over-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-denied-token-over-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-denied-token-over-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-invalid-token-over-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-invalid-token-over-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-invalid-token-over-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-invalid-token-over-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-no-credentials-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-no-credentials-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-no-credentials-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-no-credentials-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-token-only-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-token-only-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-token-only-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-token-only-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-token-over-denied-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-token-over-denied-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-token-over-denied-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-token-over-denied-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-token-over-unrecognized-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-token-over-unrecognized-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[body-token-over-unrecognized-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_body-token-over-unrecognized-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-certificate-and-token-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-certificate-and-token-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-certificate-and-token-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-certificate-and-token-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-certificate-only-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-certificate-only-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-certificate-only-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-certificate-only-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-denied-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-denied-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-denied-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-denied-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-denied-token-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-denied-token-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-denied-token-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-denied-token-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-denied-token-over-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-denied-token-over-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-denied-token-over-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-denied-token-over-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-invalid-token-over-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-invalid-token-over-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-invalid-token-over-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-invalid-token-over-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-no-credentials-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-no-credentials-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-no-credentials-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-no-credentials-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-token-only-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-token-only-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-token-only-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-token-only-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-token-over-denied-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-token-over-denied-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-token-over-denied-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-token-over-denied-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-token-over-unrecognized-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-token-over-unrecognized-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_get_node_config[metadata-token-over-unrecognized-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_get_node_config_metadata-token-over-unrecognized-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-certificate-and-token-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-certificate-and-token-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-certificate-and-token-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-certificate-and-token-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-certificate-only-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-certificate-only-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-certificate-only-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-certificate-only-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-denied-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-denied-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-denied-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-denied-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-denied-token-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-denied-token-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-denied-token-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-denied-token-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-denied-token-over-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-denied-token-over-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-denied-token-over-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-denied-token-over-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-invalid-token-over-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-invalid-token-over-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-invalid-token-over-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-invalid-token-over-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-no-credentials-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-no-credentials-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-no-credentials-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-no-credentials-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-token-only-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-token-only-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-token-only-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-token-only-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-token-over-denied-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-token-over-denied-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-token-over-denied-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-token-over-denied-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-token-over-unrecognized-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-token-over-unrecognized-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[discovery-token-over-unrecognized-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_discovery-token-over-unrecognized-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-certificate-and-token-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-certificate-and-token-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-certificate-and-token-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-certificate-and-token-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-certificate-only-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-certificate-only-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-certificate-only-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-certificate-only-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-denied-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-denied-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-denied-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-denied-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-denied-token-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-denied-token-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-denied-token-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-denied-token-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-denied-token-over-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-denied-token-over-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-denied-token-over-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-denied-token-over-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-invalid-token-over-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-invalid-token-over-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-invalid-token-over-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-invalid-token-over-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-no-credentials-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-no-credentials-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-no-credentials-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-no-credentials-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-token-only-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-token-only-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-token-only-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-token-only-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-token-over-denied-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-token-over-denied-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-token-over-denied-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-token-over-denied-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-token-over-unrecognized-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-token-over-unrecognized-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-body-token-over-unrecognized-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-body-token-over-unrecognized-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-certificate-and-token-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-certificate-and-token-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-certificate-and-token-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-certificate-and-token-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-certificate-only-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-certificate-only-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-certificate-only-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-certificate-only-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-denied-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-denied-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-denied-token-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-token-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-denied-token-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-token-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-denied-token-over-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-token-over-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-denied-token-over-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-token-over-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-invalid-token-over-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-invalid-token-over-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-invalid-token-over-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-invalid-token-over-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-no-credentials-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-no-credentials-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-no-credentials-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-no-credentials-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-token-only-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-token-only-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-token-only-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-token-only-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-token-over-denied-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-token-over-denied-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-token-over-denied-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-token-over-denied-certificate-grpcs_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-token-over-unrecognized-certificate-grpc]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-token-over-unrecognized-certificate-grpc_/result.log"
+    },
+    "test_node_authentication.test_node_registration[legacy-token-in-metadata-token-over-unrecognized-certificate-grpcs]": {
+        "uri": "file://test_node_authentication.test_node_registration_legacy-token-in-metadata-token-over-unrecognized-certificate-grpcs_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[auth-token-file-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_auth-token-file-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[auth-token-file-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_auth-token-file-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[auth-token-file-without-static-config-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_auth-token-file-without-static-config-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[auth-token-file-without-static-config-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_auth-token-file-without-static-config-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[bootstrap-custom-token-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_bootstrap-custom-token-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[bootstrap-custom-token-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_bootstrap-custom-token-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[bootstrap-empty-token-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_bootstrap-empty-token-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[bootstrap-empty-token-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_bootstrap-empty-token-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[config-directory-empty-auth-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_config-directory-empty-auth-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[config-directory-empty-auth-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_config-directory-empty-auth-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[config-directory-token-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_config-directory-token-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[config-directory-token-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_config-directory-token-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[config-directory-without-auth-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_config-directory-without-auth-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[config-directory-without-auth-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_config-directory-without-auth-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[config-without-cli-option-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_config-without-cli-option-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[config-without-cli-option-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_config-without-cli-option-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[custom-token-without-static-config-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_custom-token-without-static-config-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[custom-token-without-static-config-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_custom-token-without-static-config-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-auth-file-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-auth-file-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-auth-file-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-auth-file-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-auth-file-without-static-config-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-auth-file-without-static-config-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-auth-file-without-static-config-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-auth-file-without-static-config-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-auth-section-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-auth-section-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-auth-section-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-auth-section-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-auth-token-file-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-auth-token-file-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-auth-token-file-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-auth-token-file-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-auth-token-file-without-static-config-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-auth-token-file-without-static-config-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-auth-token-file-without-static-config-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-auth-token-file-without-static-config-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-config-directory-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-config-directory-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-config-directory-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-config-directory-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-static-config-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-static-config-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-static-config-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-static-config-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-token-without-static-config-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-token-without-static-config-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[empty-token-without-static-config-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_empty-token-without-static-config-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[explicit-custom-token-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_explicit-custom-token-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[explicit-custom-token-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_explicit-custom-token-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[explicit-empty-token-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_explicit-empty-token-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[explicit-empty-token-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_explicit-empty-token-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[explicit-root-token-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_explicit-root-token-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[explicit-root-token-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_explicit-root-token-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[missing-config-directory-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_missing-config-directory-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[missing-config-directory-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_missing-config-directory-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[missing-protobuf-file-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_missing-protobuf-file-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[missing-protobuf-file-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_missing-protobuf-file-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[missing-yaml-file-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_missing-yaml-file-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[missing-yaml-file-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_missing-yaml-file-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[multiple-protobuf-files-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_multiple-protobuf-files-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[multiple-protobuf-files-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_multiple-protobuf-files-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[only-log-config-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_only-log-config-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[only-log-config-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_only-log-config-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[protobuf-without-auth-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_protobuf-without-auth-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[protobuf-without-auth-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_protobuf-without-auth-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[root-token-without-static-config-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_root-token-without-static-config-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[root-token-without-static-config-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_root-token-without-static-config-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[without-config-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_without-config-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[without-config-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_without-config-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[yaml-custom-token-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_yaml-custom-token-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[yaml-custom-token-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_yaml-custom-token-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[yaml-empty-auth-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_yaml-empty-auth-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[yaml-empty-auth-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_yaml-empty-auth-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[yaml-empty-token-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_yaml-empty-token-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[yaml-empty-token-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_yaml-empty-token-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[yaml-without-auth-grpc-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_yaml-without-auth-grpc-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_credentials[yaml-without-auth-grpcs-startup-auth]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_credentials_yaml-without-auth-grpcs-startup-auth_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_without_config[empty-config-directory-certificate-auth-only]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_without_config_empty-config-directory-certificate-auth-only_/result.log"
+    },
+    "test_startup_credentials.test_startup_registration_without_config[no-config-certificate-auth-only]": {
+        "uri": "file://test_startup_credentials.test_startup_registration_without_config_no-config-certificate-auth-only_/result.log"
+    }
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-certificate-and-token-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-certificate-and-token-grpc_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-certificate-and-token-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-certificate-and-token-grpcs_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-certificate-only-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-certificate-only-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-certificate-only-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-certificate-only-grpcs_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-denied-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-denied-certificate-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-denied-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-denied-certificate-grpcs_/result.log
@@ -1,0 +1,8 @@
+{
+  "grpc_status": "OK",
+  "response_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# Status { Code: UNAUTHORIZED Reason: \"Cannot get node config. Access denied. Node is not authorized\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-denied-token-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-denied-token-grpc_/result.log
@@ -1,0 +1,8 @@
+{
+  "grpc_status": "OK",
+  "response_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# Status { Code: UNAUTHORIZED Reason: \"Cannot get node config. Access denied. Node is not authorized\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-denied-token-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-denied-token-grpcs_/result.log
@@ -1,0 +1,8 @@
+{
+  "grpc_status": "OK",
+  "response_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# Status { Code: UNAUTHORIZED Reason: \"Cannot get node config. Access denied. Node is not authorized\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-denied-token-over-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-denied-token-over-certificate-grpc_/result.log
@@ -1,0 +1,8 @@
+{
+  "grpc_status": "OK",
+  "response_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# Status { Code: UNAUTHORIZED Reason: \"Cannot get node config. Access denied. Node is not authorized\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-denied-token-over-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-denied-token-over-certificate-grpcs_/result.log
@@ -1,0 +1,8 @@
+{
+  "grpc_status": "OK",
+  "response_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# Status { Code: UNAUTHORIZED Reason: \"Cannot get node config. Access denied. Node is not authorized\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-invalid-token-over-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-invalid-token-over-certificate-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest nodata (unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-invalid-token-over-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-invalid-token-over-certificate-grpcs_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest nodata (unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-no-credentials-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-no-credentials-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-no-credentials-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-no-credentials-grpcs_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-token-only-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-token-only-grpc_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-token-only-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-token-only-grpcs_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-token-over-denied-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-token-over-denied-certificate-grpc_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-token-over-denied-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-token-over-denied-certificate-grpcs_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-token-over-unrecognized-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-token-over-unrecognized-certificate-grpc_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-token-over-unrecognized-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_body-token-over-unrecognized-certificate-grpcs_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-certificate-and-token-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-certificate-and-token-grpc_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-certificate-and-token-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-certificate-and-token-grpcs_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-certificate-only-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-certificate-only-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-certificate-only-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-certificate-only-grpcs_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-denied-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-denied-certificate-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-denied-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-denied-certificate-grpcs_/result.log
@@ -1,0 +1,8 @@
+{
+  "grpc_status": "OK",
+  "response_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# Status { Code: UNAUTHORIZED Reason: \"Cannot get node config. Access denied. Node is not authorized\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-denied-token-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-denied-token-grpc_/result.log
@@ -1,0 +1,8 @@
+{
+  "grpc_status": "OK",
+  "response_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# Status { Code: UNAUTHORIZED Reason: \"Cannot get node config. Access denied. Node is not authorized\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-denied-token-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-denied-token-grpcs_/result.log
@@ -1,0 +1,8 @@
+{
+  "grpc_status": "OK",
+  "response_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# Status { Code: UNAUTHORIZED Reason: \"Cannot get node config. Access denied. Node is not authorized\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-denied-token-over-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-denied-token-over-certificate-grpc_/result.log
@@ -1,0 +1,8 @@
+{
+  "grpc_status": "OK",
+  "response_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# Status { Code: UNAUTHORIZED Reason: \"Cannot get node config. Access denied. Node is not authorized\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-denied-token-over-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-denied-token-over-certificate-grpcs_/result.log
@@ -1,0 +1,8 @@
+{
+  "grpc_status": "OK",
+  "response_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# Status { Code: UNAUTHORIZED Reason: \"Cannot get node config. Access denied. Node is not authorized\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-invalid-token-over-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-invalid-token-over-certificate-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest nodata (unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-invalid-token-over-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-invalid-token-over-certificate-grpcs_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest nodata (unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-no-credentials-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-no-credentials-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-no-credentials-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-no-credentials-grpcs_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-token-only-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-token-only-grpc_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-token-only-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-token-only-grpcs_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-token-over-denied-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-token-over-denied-certificate-grpc_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-token-over-denied-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-token-over-denied-certificate-grpcs_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-token-over-unrecognized-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-token-over-unrecognized-certificate-grpc_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-token-over-unrecognized-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_get_node_config_metadata-token-over-unrecognized-certificate-grpcs_/result.log
@@ -1,0 +1,10 @@
+{
+  "config_status": "SUCCESS",
+  "grpc_status": "OK",
+  "log_config": "DefaultLevel: 5\n",
+  "response_present": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/ConsoleRequest data# GetNodeConfigResponse { Status { Code: SUCCESS } Config { LogConfig { DefaultLevel: 5 } TableProfilesConfig { TableProfiles { Name: \"default\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"default\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } TableProfiles { Name: \"log_lz4\" CompactionPolicy: \"default\" ExecutionPolicy: \"default\" PartitioningPolicy: \"default\" StoragePolicy: \"log_lz4\" ReplicationPolicy: \"default\" CachingPolicy: \"default\" } CompactionPolicies { Name: \"default\" } ExecutionPolicies { Name: \"default\" } PartitioningPolicies { Name: \"default\" AutoSplit: true AutoMerge: false SizeToSplit: 2147483648 } StoragePolicies { Name: \"log_lz4\" ColumnFamilies { ColumnCodec: ColumnCodecLZ4 StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } StoragePolicies { Name: \"default\" ColumnFamilies { StorageConfig { SysLog { PreferredPoolKind: \"hdd\" } Log { PreferredPoolKind: \"hdd\" } Data { PreferredPoolKind: \"hdd\" } } } } ReplicationPolicies { Name: \"default\" } CachingPolicies { Name: \"default\" } } Version { Items { Kind: 2 Id: 2 Generation: 1 } Items { Kind: 34 Id: 1 Generation: 1 } } } } Status { Code: SUCCESS }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-certificate-and-token-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-certificate-and-token-grpc_/result.log
@@ -1,0 +1,15 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "issues": [],
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "nodes_empty": false,
+  "ready": true,
+  "registered_endpoint_present": true,
+  "result_unpacked": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-certificate-and-token-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-certificate-and-token-grpcs_/result.log
@@ -1,0 +1,15 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "issues": [],
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "nodes_empty": false,
+  "ready": true,
+  "registered_endpoint_present": true,
+  "result_unpacked": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-certificate-only-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-certificate-only-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-certificate-only-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-certificate-only-grpcs_/result.log
@@ -1,0 +1,15 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "issues": [],
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "nodes_empty": false,
+  "ready": true,
+  "registered_endpoint_present": true,
+  "result_unpacked": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-denied-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-denied-certificate-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-denied-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-denied-certificate-grpcs_/result.log
@@ -1,0 +1,17 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "issues": [
+    "Cannot authorize node. Access denied"
+  ],
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "nodes_empty": true,
+  "ready": true,
+  "registered_endpoint_present": false,
+  "result_unpacked": true,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: UNAUTHORIZED issues { message: \"Cannot authorize node. Access denied\" severity: 1 } result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-denied-token-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-denied-token-grpc_/result.log
@@ -1,0 +1,17 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "issues": [
+    "Cannot authorize node. Access denied"
+  ],
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "nodes_empty": true,
+  "ready": true,
+  "registered_endpoint_present": false,
+  "result_unpacked": true,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: UNAUTHORIZED issues { message: \"Cannot authorize node. Access denied\" severity: 1 } result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-denied-token-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-denied-token-grpcs_/result.log
@@ -1,0 +1,17 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "issues": [
+    "Cannot authorize node. Access denied"
+  ],
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "nodes_empty": true,
+  "ready": true,
+  "registered_endpoint_present": false,
+  "result_unpacked": true,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: UNAUTHORIZED issues { message: \"Cannot authorize node. Access denied\" severity: 1 } result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-denied-token-over-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-denied-token-over-certificate-grpc_/result.log
@@ -1,0 +1,17 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "issues": [
+    "Cannot authorize node. Access denied"
+  ],
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "nodes_empty": true,
+  "ready": true,
+  "registered_endpoint_present": false,
+  "result_unpacked": true,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: UNAUTHORIZED issues { message: \"Cannot authorize node. Access denied\" severity: 1 } result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-denied-token-over-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-denied-token-over-certificate-grpcs_/result.log
@@ -1,0 +1,17 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "issues": [
+    "Cannot authorize node. Access denied"
+  ],
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "nodes_empty": true,
+  "ready": true,
+  "registered_endpoint_present": false,
+  "result_unpacked": true,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: UNAUTHORIZED issues { message: \"Cannot authorize node. Access denied\" severity: 1 } result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-invalid-token-over-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-invalid-token-over-certificate-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-invalid-token-over-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-invalid-token-over-certificate-grpcs_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-no-credentials-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-no-credentials-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-no-credentials-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-no-credentials-grpcs_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-token-only-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-token-only-grpc_/result.log
@@ -1,0 +1,15 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "issues": [],
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "nodes_empty": false,
+  "ready": true,
+  "registered_endpoint_present": true,
+  "result_unpacked": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-token-only-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-token-only-grpcs_/result.log
@@ -1,0 +1,15 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "issues": [],
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "nodes_empty": false,
+  "ready": true,
+  "registered_endpoint_present": true,
+  "result_unpacked": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-token-over-denied-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-token-over-denied-certificate-grpc_/result.log
@@ -1,0 +1,15 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "issues": [],
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "nodes_empty": false,
+  "ready": true,
+  "registered_endpoint_present": true,
+  "result_unpacked": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-token-over-denied-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-token-over-denied-certificate-grpcs_/result.log
@@ -1,0 +1,15 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "issues": [],
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "nodes_empty": false,
+  "ready": true,
+  "registered_endpoint_present": true,
+  "result_unpacked": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-token-over-unrecognized-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-token-over-unrecognized-certificate-grpc_/result.log
@@ -1,0 +1,15 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "issues": [],
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "nodes_empty": false,
+  "ready": true,
+  "registered_endpoint_present": true,
+  "result_unpacked": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-token-over-unrecognized-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_discovery-token-over-unrecognized-certificate-grpcs_/result.log
@@ -1,0 +1,15 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "issues": [],
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "nodes_empty": false,
+  "ready": true,
+  "registered_endpoint_present": true,
+  "result_unpacked": true,
+  "status": "SUCCESS",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-certificate-and-token-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-certificate-and-token-grpc_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-certificate-and-token-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-certificate-and-token-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-certificate-only-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-certificate-only-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-certificate-only-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-certificate-only-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-denied-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-denied-certificate-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-denied-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-denied-certificate-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "node_id_present": false,
+  "nodes_empty": true,
+  "registered_endpoint_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: UNAUTHORIZED Reason: \"Cannot authorize node. Access denied\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-denied-token-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-denied-token-grpc_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "node_id_present": false,
+  "nodes_empty": true,
+  "registered_endpoint_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: UNAUTHORIZED Reason: \"Cannot authorize node. Access denied\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-denied-token-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-denied-token-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "node_id_present": false,
+  "nodes_empty": true,
+  "registered_endpoint_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: UNAUTHORIZED Reason: \"Cannot authorize node. Access denied\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-denied-token-over-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-denied-token-over-certificate-grpc_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "node_id_present": false,
+  "nodes_empty": true,
+  "registered_endpoint_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: UNAUTHORIZED Reason: \"Cannot authorize node. Access denied\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-denied-token-over-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-denied-token-over-certificate-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "node_id_present": false,
+  "nodes_empty": true,
+  "registered_endpoint_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: UNAUTHORIZED Reason: \"Cannot authorize node. Access denied\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-invalid-token-over-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-invalid-token-over-certificate-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode nodata (unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-invalid-token-over-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-invalid-token-over-certificate-grpcs_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode nodata (unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-no-credentials-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-no-credentials-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-no-credentials-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-no-credentials-grpcs_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-token-only-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-token-only-grpc_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-token-only-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-token-only-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-token-over-denied-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-token-over-denied-certificate-grpc_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-token-over-denied-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-token-over-denied-certificate-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-token-over-unrecognized-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-token-over-unrecognized-certificate-grpc_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-token-over-unrecognized-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-body-token-over-unrecognized-certificate-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-certificate-and-token-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-certificate-and-token-grpc_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-certificate-and-token-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-certificate-and-token-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-certificate-only-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-certificate-only-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-certificate-only-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-certificate-only-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-certificate-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-certificate-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "node_id_present": false,
+  "nodes_empty": true,
+  "registered_endpoint_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: UNAUTHORIZED Reason: \"Cannot authorize node. Access denied\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-token-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-token-grpc_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "node_id_present": false,
+  "nodes_empty": true,
+  "registered_endpoint_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: UNAUTHORIZED Reason: \"Cannot authorize node. Access denied\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-token-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-token-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "node_id_present": false,
+  "nodes_empty": true,
+  "registered_endpoint_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: UNAUTHORIZED Reason: \"Cannot authorize node. Access denied\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-token-over-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-token-over-certificate-grpc_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "node_id_present": false,
+  "nodes_empty": true,
+  "registered_endpoint_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: UNAUTHORIZED Reason: \"Cannot authorize node. Access denied\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-token-over-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-denied-token-over-certificate-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": false,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": false,
+  "node_id_is_zero": true,
+  "node_id_present": false,
+  "nodes_empty": true,
+  "registered_endpoint_present": false,
+  "status": "UNAUTHORIZED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: UNAUTHORIZED Reason: \"Cannot authorize node. Access denied\" }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-invalid-token-over-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-invalid-token-over-certificate-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode nodata (unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-invalid-token-over-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-invalid-token-over-certificate-grpcs_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode nodata (unauthenticated, unauthenticated: { <main>: Error: Could not find correct token validator }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-no-credentials-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-no-credentials-grpc_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-no-credentials-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-no-credentials-grpcs_/result.log
@@ -1,0 +1,7 @@
+{
+  "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+  "grpc_status": "UNAUTHENTICATED",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-token-only-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-token-only-grpc_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-token-only-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-token-only-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-token-over-denied-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-token-over-denied-certificate-grpc_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-token-over-denied-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-token-over-denied-certificate-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-token-over-unrecognized-certificate-grpc_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-token-over-unrecognized-certificate-grpc_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-token-over-unrecognized-certificate-grpcs_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_node_authentication.test_node_registration_legacy-token-in-metadata-token-over-unrecognized-certificate-grpcs_/result.log
@@ -1,0 +1,13 @@
+{
+  "expiry_positive": true,
+  "grpc_status": "OK",
+  "node_id_is_dynamic": true,
+  "node_id_is_zero": false,
+  "node_id_present": true,
+  "nodes_empty": false,
+  "registered_endpoint_present": true,
+  "status": "OK",
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# NKikimrClient.TGRpcServer/RegisterNode data# Status { Code: OK } NodeId: <dynamic-node> DomainPath: \"Root\" Expire: <expiry> Nodes { NodeId: <dynamic-node> Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"127.0.0.1\" Location { } Expire: <expiry> ExpireV2: <expiry> Liveness: ALIVE } Nodes { NodeId: 1 Host: \"localhost\" Port: <port> ResolveHost: \"localhost\" Address: \"\" Location { DataCenterNum: 49 RoomNum: 0 RackNum: 1 BodyNum: 1 DataCenter: \"1\" Rack: \"1\" Unit: \"1\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_auth-token-file-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_auth-token-file-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "node@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_auth-token-file-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_auth-token-file-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "node@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_auth-token-file-without-static-config-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_auth-token-file-without-static-config-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "node@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_auth-token-file-without-static-config-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_auth-token-file-without-static-config-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "node@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_bootstrap-custom-token-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_bootstrap-custom-token-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_bootstrap-custom-token-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_bootstrap-custom-token-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_bootstrap-empty-token-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_bootstrap-empty-token-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_bootstrap-empty-token-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_bootstrap-empty-token-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-directory-empty-auth-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-directory-empty-auth-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-directory-empty-auth-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-directory-empty-auth-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-directory-token-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-directory-token-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "node@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-directory-token-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-directory-token-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "node@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-directory-without-auth-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-directory-without-auth-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-directory-without-auth-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-directory-without-auth-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-without-cli-option-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-without-cli-option-grpc-startup-auth_/result.log
@@ -1,0 +1,16 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+    "grpc_status": "UNAUTHENTICATED",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Registration error: Status: CLIENT_UNAUTHENTICATED"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-without-cli-option-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_config-without-cli-option-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_custom-token-without-static-config-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_custom-token-without-static-config-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "node@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_custom-token-without-static-config-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_custom-token-without-static-config-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "node@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-file-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-file-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-file-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-file-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-file-without-static-config-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-file-without-static-config-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-file-without-static-config-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-file-without-static-config-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-section-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-section-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-section-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-section-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-token-file-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-token-file-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-token-file-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-token-file-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-token-file-without-static-config-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-token-file-without-static-config-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-token-file-without-static-config-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-auth-token-file-without-static-config-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-config-directory-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-config-directory-grpc-startup-auth_/result.log
@@ -1,0 +1,16 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+    "grpc_status": "UNAUTHENTICATED",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Registration error: Status: CLIENT_UNAUTHENTICATED"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-config-directory-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-config-directory-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-static-config-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-static-config-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-static-config-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-static-config-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-token-without-static-config-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-token-without-static-config-grpc-startup-auth_/result.log
@@ -1,0 +1,16 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+    "grpc_status": "UNAUTHENTICATED",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Registration error: Status: CLIENT_UNAUTHENTICATED"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-token-without-static-config-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_empty-token-without-static-config-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_explicit-custom-token-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_explicit-custom-token-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "node@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_explicit-custom-token-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_explicit-custom-token-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "node@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_explicit-empty-token-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_explicit-empty-token-grpc-startup-auth_/result.log
@@ -1,0 +1,16 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+    "grpc_status": "UNAUTHENTICATED",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Registration error: Status: CLIENT_UNAUTHENTICATED"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_explicit-empty-token-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_explicit-empty-token-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_explicit-root-token-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_explicit-root-token-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_explicit-root-token-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_explicit-root-token-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_missing-config-directory-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_missing-config-directory-grpc-startup-auth_/result.log
@@ -1,0 +1,16 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+    "grpc_status": "UNAUTHENTICATED",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Registration error: Status: CLIENT_UNAUTHENTICATED"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_missing-config-directory-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_missing-config-directory-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_missing-protobuf-file-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_missing-protobuf-file-grpc-startup-auth_/result.log
@@ -1,0 +1,8 @@
+{
+  "exit_code": 1,
+  "registration": null,
+  "startup": [
+    "Error [YDBE-10025]: File <test-dir>/missing.pb does not exist"
+  ],
+  "ydb_log": []
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_missing-protobuf-file-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_missing-protobuf-file-grpcs-startup-auth_/result.log
@@ -1,0 +1,8 @@
+{
+  "exit_code": 1,
+  "registration": null,
+  "startup": [
+    "Error [YDBE-10025]: File <test-dir>/missing.pb does not exist"
+  ],
+  "ydb_log": []
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_missing-yaml-file-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_missing-yaml-file-grpc-startup-auth_/result.log
@@ -1,0 +1,8 @@
+{
+  "exit_code": 1,
+  "registration": null,
+  "startup": [
+    "Error [YDBE-10025]: File <test-dir>/missing.yaml does not exist"
+  ],
+  "ydb_log": []
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_missing-yaml-file-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_missing-yaml-file-grpcs-startup-auth_/result.log
@@ -1,0 +1,8 @@
+{
+  "exit_code": 1,
+  "registration": null,
+  "startup": [
+    "Error [YDBE-10025]: File <test-dir>/missing.yaml does not exist"
+  ],
+  "ydb_log": []
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_multiple-protobuf-files-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_multiple-protobuf-files-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_multiple-protobuf-files-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_multiple-protobuf-files-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_only-log-config-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_only-log-config-grpc-startup-auth_/result.log
@@ -1,0 +1,16 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+    "grpc_status": "UNAUTHENTICATED",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Registration error: Status: CLIENT_UNAUTHENTICATED"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_only-log-config-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_only-log-config-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_protobuf-without-auth-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_protobuf-without-auth-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_protobuf-without-auth-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_protobuf-without-auth-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_root-token-without-static-config-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_root-token-without-static-config-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_root-token-without-static-config-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_root-token-without-static-config-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_without-config-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_without-config-grpc-startup-auth_/result.log
@@ -1,0 +1,16 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+    "grpc_status": "UNAUTHENTICATED",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Registration error: Status: CLIENT_UNAUTHENTICATED"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_without-config-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_without-config-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-custom-token-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-custom-token-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "node@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-custom-token-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-custom-token-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "node@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-empty-auth-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-empty-auth-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-empty-auth-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-empty-auth-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-empty-token-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-empty-token-grpc-startup-auth_/result.log
@@ -1,0 +1,16 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "details": "unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }",
+    "grpc_status": "UNAUTHENTICATED",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Registration error: Status: CLIENT_UNAUTHENTICATED"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration nodata (unauthenticated, unauthenticated: { <main>: Error: Access denied without user token }) peer# <peer>, grpc status# (16)"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-empty-token-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-empty-token-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": null
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-without-auth-grpc-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-without-auth-grpc-startup-auth_/result.log
@@ -1,0 +1,24 @@
+{
+  "registration": {
+    "client_common_name": [],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpc://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-without-auth-grpcs-startup-auth_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_credentials_yaml-without-auth-grpcs-startup-auth_/result.log
@@ -1,0 +1,26 @@
+{
+  "registration": {
+    "client_common_name": [
+      "allowed"
+    ],
+    "expiry_positive": true,
+    "grpc_status": "OK",
+    "issues": [],
+    "node_id_is_dynamic": true,
+    "node_id_is_zero": false,
+    "nodes_empty": false,
+    "ready": true,
+    "registered_endpoint_present": true,
+    "result_unpacked": true,
+    "status": "SUCCESS",
+    "token": "root@builtin"
+  },
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_without_config_empty-config-directory-certificate-auth-only_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_without_config_empty-config-directory-certificate-auth-only_/result.log
@@ -1,0 +1,15 @@
+{
+  "exit_code": null,
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>",
+    "Trying to get dynamic config from grpcs://<node-broker>",
+    "Trying to get configs from grpcs://<node-broker>",
+    "Success.",
+    "Success. Got dynamic config from grpcs://<node-broker>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_without_config_no-config-certificate-auth-only_/result.log
+++ b/ydb/tests/functional/security/node_registration/canondata/test_startup_credentials.test_startup_registration_without_config_no-config-certificate-auth-only_/result.log
@@ -1,0 +1,15 @@
+{
+  "exit_code": null,
+  "startup": [
+    "Determined node ID: 0",
+    "Trying to register dynamic node to grpcs://<node-broker>",
+    "Success. Registered as <dynamic-node>",
+    "Trying to get dynamic config from grpcs://<node-broker>",
+    "Trying to get configs from grpcs://<node-broker>",
+    "Success.",
+    "Success. Got dynamic config from grpcs://<node-broker>"
+  ],
+  "ydb_log": [
+    "GRPC_SERVER DEBUG: issuing response Name# Ydb.Discovery.V1.DiscoveryService/NodeRegistration data# operation { ready: true status: SUCCESS result { type_url: \"type.googleapis.com/Ydb.Discovery.NodeRegistrationResult\" value: \"<registration-result>\" } }  peer# <peer>"
+  ]
+}

--- a/ydb/tests/functional/security/node_registration/conftest.py
+++ b/ydb/tests/functional/security/node_registration/conftest.py
@@ -6,6 +6,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
+from helpers import YdbGrpcLog
 
 from library.python.port_manager import PortManager
 from ydb.core.protos import grpc_pb2_grpc, msgbus_pb2
@@ -13,6 +14,7 @@ from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.tls_tools import generate_selfsigned_cert
+from ydb.tests.library.harness.util import LogLevels
 
 
 @pytest.fixture(scope='module')
@@ -58,6 +60,7 @@ def cluster(certificates, tmp_path_factory, request):
         generate_grpc_tls_data=False,
         enforce_user_token_requirement=True,
         default_clusteradmin='root@builtin',
+        additional_log_configs={'GRPC_SERVER': LogLevels.DEBUG},
     )
     security = config.yaml_config['domains_config']['security_config']
     # A nonempty allowlist is essential: otherwise anonymous registration is allowed.
@@ -100,6 +103,10 @@ def node_config(cluster):
     item.UsageScope.TenantAndNodeTypeFilter.NodeType = 'node-auth-test'
     item.Config.LogConfig.DefaultLevel = 5
     with grpc.insecure_channel(f'localhost:{cluster.nodes[1].port}') as channel:
+        server_log = YdbGrpcLog(cluster)
         response = grpc_pb2_grpc.TGRpcServerStub(channel).ConsoleRequest(request, timeout=30)
-    assert response.Status.Code == StatusIds.SUCCESS, response
+        # Flush the setup response before tests capture the same RPC method.
+        server_log.response('ConsoleRequest')
+    if response.Status.Code != StatusIds.SUCCESS:
+        pytest.fail(f'Could not install the test config: {response}')
     return item.Config

--- a/ydb/tests/functional/security/node_registration/conftest.py
+++ b/ydb/tests/functional/security/node_registration/conftest.py
@@ -1,0 +1,105 @@
+from datetime import datetime, timedelta
+
+import grpc
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from library.python.port_manager import PortManager
+from ydb.core.protos import grpc_pb2_grpc, msgbus_pb2
+from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+from ydb.tests.library.harness.tls_tools import generate_selfsigned_cert
+
+
+@pytest.fixture(scope='module')
+def certificates():
+    ca_pem, ca_key_pem = generate_selfsigned_cert('localhost')
+    ca = x509.load_pem_x509_certificate(ca_pem)
+    ca_key = serialization.load_pem_private_key(ca_key_pem, password=None)
+    result = {'ca': ca_pem, 'server': (ca_pem, ca_key_pem)}
+    for name in ('allowed', 'denied', 'unrecognized'):
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        now = datetime.utcnow()
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, name)]))
+            .issuer_name(ca.subject)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(minutes=1))
+            .not_valid_after(now + timedelta(days=1))
+            .sign(ca_key, hashes.SHA256())
+        )
+        result[name] = (
+            cert.public_bytes(serialization.Encoding.PEM),
+            key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption(),
+            ),
+        )
+    return result
+
+
+@pytest.fixture(scope='module')
+def cluster(certificates, tmp_path_factory, request):
+    tls_dir = tmp_path_factory.mktemp('node_auth_tls')
+    (tls_dir / 'ca.pem').write_bytes(certificates['ca'])
+    (tls_dir / 'cert.pem').write_bytes(certificates['server'][0])
+    (tls_dir / 'key.pem').write_bytes(certificates['server'][1])
+    config = KikimrConfigGenerator(
+        nodes=1,
+        grpc_ssl_enable=True,
+        grpc_tls_data_path=str(tls_dir),
+        generate_grpc_tls_data=False,
+        enforce_user_token_requirement=True,
+        default_clusteradmin='root@builtin',
+    )
+    security = config.yaml_config['domains_config']['security_config']
+    # A nonempty allowlist is essential: otherwise anonymous registration is allowed.
+    security['register_dynamic_node_allowed_sids'] = getattr(
+        request, 'param', ['root@builtin', 'dynamic-nodes@cert'],
+    )
+    config.yaml_config.setdefault('auth_config', {})['staff_api_user_token'] = 'root@builtin'
+    config.yaml_config['client_certificate_authorization'] = {
+        'request_client_certificate': True,
+        'client_certificate_definitions': [
+            {
+                'subject_terms': [{'short_name': 'CN', 'values': ['allowed']}],
+                'member_groups': ['dynamic-nodes@cert'],
+            },
+            {
+                'subject_terms': [{'short_name': 'CN', 'values': ['denied']}],
+                'member_groups': ['other-clients@cert'],
+            },
+        ],
+    }
+    cluster = KiKiMR(config)
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.stop()
+
+
+@pytest.fixture(scope='module')
+def registration_port():
+    with PortManager() as ports:
+        yield ports.get_port()
+
+
+@pytest.fixture(scope='module')
+def node_config(cluster):
+    # Install a recognizable config for the test node type, without changing the server.
+    request = msgbus_pb2.TConsoleRequest(SecurityToken='root@builtin')
+    item = request.ConfigureRequest.Actions.add().AddConfigItem.ConfigItem
+    item.UsageScope.TenantAndNodeTypeFilter.NodeType = 'node-auth-test'
+    item.Config.LogConfig.DefaultLevel = 5
+    with grpc.insecure_channel(f'localhost:{cluster.nodes[1].port}') as channel:
+        response = grpc_pb2_grpc.TGRpcServerStub(channel).ConsoleRequest(request, timeout=30)
+    assert response.Status.Code == StatusIds.SUCCESS, response
+    return item.Config

--- a/ydb/tests/functional/security/node_registration/helpers.py
+++ b/ydb/tests/functional/security/node_registration/helpers.py
@@ -1,0 +1,92 @@
+import json
+import re
+import time
+from pathlib import Path
+
+import pytest
+import yatest.common
+
+from ydb.core.protos import node_broker_pb2
+from ydb.public.api.protos import ydb_discovery_pb2
+from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
+
+
+def canonical_log(tmp_path, observations):
+    path = tmp_path / 'result.log'
+    path.write_text(json.dumps(observations, indent=2, sort_keys=True) + '\n')
+    return yatest.common.canonical_file(str(path), local=True, universal_lines=True)
+
+
+class YdbGrpcLog:
+    def __init__(self, cluster):
+        node = cluster.nodes[1]
+        self.path = Path(node.ydbd_log_file_path)
+        self.offset = self.path.stat().st_size
+        self.static_node_id = node.node_id
+
+    def response(self, method):
+        # Tests issue requests sequentially. Start at the pre-request offset so
+        # previous requests and cluster setup cannot supply the expected line.
+        pattern = re.compile(r'issuing response Name# [\w.]+/' + re.escape(method) + r' ')
+        deadline = time.monotonic() + 10
+        with self.path.open('rb') as log:
+            log.seek(self.offset)
+            while time.monotonic() < deadline:
+                position = log.tell()
+                line = log.readline()
+                if not line.endswith(b'\n'):
+                    log.seek(position)
+                    time.sleep(0.05)
+                    continue
+                line = line.decode()
+                match = pattern.search(line)
+                if match is not None:
+                    self.offset = log.tell()
+                    return ['GRPC_SERVER DEBUG: ' + self.normalize(line[match.start():].strip())]
+        pytest.fail(f'No YDB response log for {method} in {self.path} after offset {self.offset}')
+
+    def normalize(self, line):
+        line = re.sub(r' peer# [^,\s]+', ' peer# <peer>', line)
+        # Discovery logs the result as binary protobuf in Any.value. Its
+        # contents are checked separately by registration_result().
+        line = re.sub(
+            r'(type_url: "type.googleapis.com/Ydb.Discovery.NodeRegistrationResult" value: )"(?:[^"\\]|\\.)*"',
+            r'\1"<registration-result>"', line,
+        )
+        line = re.sub(
+            r'\bNodeId: (\d+)',
+            lambda match: 'NodeId: ' + (
+                '<dynamic-node>' if int(match[1]) > self.static_node_id else match[1]
+            ), line,
+        )
+        line = re.sub(r'\bPort: [1-9]\d*', 'Port: <port>', line)
+        return re.sub(r'\b(Expire(?:V2)?): [1-9]\d*', r'\1: <expiry>', line)
+
+
+def registration_result(response, api, static_node_id, port):
+    if api == 'discovery':
+        operation = response.operation
+        result = ydb_discovery_pb2.NodeRegistrationResult()
+        log = {
+            'ready': operation.ready,
+            'status': StatusIds.StatusCode.Name(operation.status),
+            'result_unpacked': operation.result.Unpack(result),
+            'issues': [issue.message for issue in operation.issues],
+        }
+        node_id, expire, nodes = result.node_id, result.expire, result.nodes
+        matches = [n for n in nodes if n.node_id == node_id and n.port == port]
+    else:
+        log = {
+            'status': node_broker_pb2.TStatus.ECode.Name(response.Status.Code),
+            'node_id_present': response.HasField('NodeId'),
+        }
+        node_id, expire, nodes = response.NodeId, response.Expire, response.Nodes
+        matches = [n for n in nodes if n.NodeId == node_id and n.Port == port]
+    log.update({
+        'node_id_is_dynamic': node_id > static_node_id,
+        'node_id_is_zero': node_id == 0,
+        'expiry_positive': expire > 0,
+        'registered_endpoint_present': bool(matches),
+        'nodes_empty': not nodes,
+    })
+    return log

--- a/ydb/tests/functional/security/node_registration/test_node_authentication.py
+++ b/ydb/tests/functional/security/node_registration/test_node_authentication.py
@@ -1,0 +1,143 @@
+import grpc
+import pytest
+
+from ydb.core.protos import grpc_pb2_grpc, msgbus_pb2, node_broker_pb2
+from ydb.public.api.grpc import ydb_discovery_v1_pb2_grpc
+from ydb.public.api.protos import ydb_discovery_pb2
+from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
+
+
+# Each case specifies the expected result on TLS and on plaintext separately.
+# A client certificate cannot be transmitted over plaintext gRPC.
+AUTH_CASES = [
+    pytest.param('allowed', None, 'success', 'unauthenticated', id='certificate-only'),
+    pytest.param(None, 'root@builtin', 'success', 'success', id='token-only'),
+    pytest.param('allowed', 'root@builtin', 'success', 'success', id='certificate-and-token'),
+    pytest.param(None, None, 'unauthenticated', 'unauthenticated', id='no-credentials'),
+    pytest.param(None, 'denied@builtin', 'unauthorized', 'unauthorized', id='denied-token'),
+    pytest.param('denied', None, 'unauthorized', 'unauthenticated', id='denied-certificate'),
+    pytest.param('allowed', 'denied@builtin', 'unauthorized', 'unauthorized', id='denied-token-over-certificate'),
+    pytest.param('allowed', 'invalid-token', 'unauthenticated', 'unauthenticated', id='invalid-token-over-certificate'),
+    pytest.param('denied', 'root@builtin', 'success', 'success', id='token-over-denied-certificate'),
+    pytest.param('unrecognized', 'root@builtin', 'success', 'success', id='token-over-unrecognized-certificate'),
+]
+
+
+def open_channel(cluster, certificates, protocol, certificate):
+    node = cluster.nodes[1]
+    if protocol == 'grpc':
+        return grpc.insecure_channel(f'localhost:{node.port}')
+    cert, key = certificates[certificate] if certificate else (None, None)
+    credentials = grpc.ssl_channel_credentials(
+        root_certificates=certificates['ca'], private_key=key, certificate_chain=cert,
+    )
+    return grpc.secure_channel(f'localhost:{node.grpc_ssl_port}', credentials)
+
+
+def credentials_for_request(request, token, token_location):
+    if token is None:
+        return ()
+    if token_location == 'body':
+        request.SecurityToken = token
+        return ()
+    return (('x-ydb-auth-ticket', token),)
+
+
+def invoke(call, request, metadata, expected):
+    if expected == 'unauthenticated':
+        with pytest.raises(grpc.RpcError) as error:
+            call(request, metadata=metadata, timeout=30)
+        assert error.value.code() == grpc.StatusCode.UNAUTHENTICATED, error.value
+        return None
+    return call(request, metadata=metadata, timeout=30)
+
+
+@pytest.mark.parametrize('protocol', ['grpc', 'grpcs'])
+@pytest.mark.parametrize('certificate,token,tls_result,plaintext_result', AUTH_CASES)
+@pytest.mark.parametrize('api,token_location', [
+    pytest.param('discovery', 'metadata', id='discovery'),
+    pytest.param('legacy', 'body', id='legacy-token-in-body'),
+    pytest.param('legacy', 'metadata', id='legacy-token-in-metadata'),
+])
+def test_node_registration(
+    cluster,
+    certificates,
+    registration_port,
+    protocol,
+    certificate,
+    token,
+    tls_result,
+    plaintext_result,
+    api,
+    token_location
+):
+    expected = tls_result if protocol == 'grpcs' else plaintext_result
+    # Re-register the same endpoint to exercise the normal lease renewal as well.
+    host, port, address = 'localhost', registration_port, '127.0.0.1'
+    with open_channel(cluster, certificates, protocol, certificate) as channel:
+        if api == 'discovery':
+            request = ydb_discovery_pb2.NodeRegistrationRequest(
+                host=host, port=port, resolve_host=host, address=address, domain_path='Root',
+            )
+            call = ydb_discovery_v1_pb2_grpc.DiscoveryServiceStub(channel).NodeRegistration
+        else:
+            request = msgbus_pb2.TNodeRegistrationRequest(
+                Host=host, Port=port, ResolveHost=host, Address=address, DomainPath='Root',
+            )
+            call = grpc_pb2_grpc.TGRpcServerStub(channel).RegisterNode
+        metadata = credentials_for_request(request, token, token_location)
+        if api == 'discovery':
+            metadata += (('x-ydb-database', '/Root'),)
+        response = invoke(call, request, metadata, expected)
+
+    if response is None:
+        return
+    if api == 'discovery':
+        assert response.operation.ready, response
+        status = StatusIds.SUCCESS if expected == 'success' else StatusIds.UNAUTHORIZED
+        assert response.operation.status == status, response
+        result = ydb_discovery_pb2.NodeRegistrationResult()
+        assert response.operation.result.Unpack(result), response
+        if expected == 'success':
+            assert result.node_id > cluster.nodes[1].node_id, result
+            assert result.expire > 0, result
+            assert any(n.node_id == result.node_id and n.port == port for n in result.nodes), result
+        else:
+            assert result.node_id == 0, result
+            assert not result.nodes, result
+            assert any(issue.message == 'Cannot authorize node. Access denied' for issue in response.operation.issues), response
+    else:
+        status = node_broker_pb2.TStatus.OK if expected == 'success' else node_broker_pb2.TStatus.UNAUTHORIZED
+        assert response.Status.Code == status, response
+        if expected == 'success':
+            assert response.NodeId > cluster.nodes[1].node_id, response
+            assert response.Expire > 0, response
+            assert any(n.NodeId == response.NodeId and n.Port == port for n in response.Nodes), response
+        else:
+            assert not response.HasField('NodeId'), response
+            assert not response.Nodes, response
+
+
+@pytest.mark.parametrize('protocol', ['grpc', 'grpcs'])
+@pytest.mark.parametrize('certificate,token,tls_result,plaintext_result', AUTH_CASES)
+@pytest.mark.parametrize('token_location', ['body', 'metadata'])
+def test_get_node_config(cluster, certificates, node_config, protocol, certificate, token,
+                         tls_result, plaintext_result, token_location):
+    expected = tls_result if protocol == 'grpcs' else plaintext_result
+    request = msgbus_pb2.TConsoleRequest(DomainName='Root')
+    request.GetNodeConfigRequest.Node.Host = 'localhost'
+    request.GetNodeConfigRequest.Node.NodeType = 'node-auth-test'
+    metadata = credentials_for_request(request, token, token_location)
+    with open_channel(cluster, certificates, protocol, certificate) as channel:
+        call = grpc_pb2_grpc.TGRpcServerStub(channel).ConsoleRequest
+        response = invoke(call, request, metadata, expected)
+    if response is None:
+        return
+    status = StatusIds.SUCCESS if expected == 'success' else StatusIds.UNAUTHORIZED
+    assert response.Status.Code == status, response
+    if expected == 'success':
+        assert response.HasField('GetNodeConfigResponse'), response
+        assert response.GetNodeConfigResponse.Status.Code == StatusIds.SUCCESS, response
+        assert response.GetNodeConfigResponse.Config.LogConfig == node_config.LogConfig, response
+    else:
+        assert not response.HasField('GetNodeConfigResponse'), response

--- a/ydb/tests/functional/security/node_registration/test_node_authentication.py
+++ b/ydb/tests/functional/security/node_registration/test_node_authentication.py
@@ -1,25 +1,27 @@
 import grpc
 import pytest
 
-from ydb.core.protos import grpc_pb2_grpc, msgbus_pb2, node_broker_pb2
+from google.protobuf import text_format
+from helpers import YdbGrpcLog, canonical_log, registration_result
+
+from ydb.core.protos import grpc_pb2_grpc, msgbus_pb2
 from ydb.public.api.grpc import ydb_discovery_v1_pb2_grpc
 from ydb.public.api.protos import ydb_discovery_pb2
 from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
 
 
-# Each case specifies the expected result on TLS and on plaintext separately.
 # A client certificate cannot be transmitted over plaintext gRPC.
 AUTH_CASES = [
-    pytest.param('allowed', None, 'success', 'unauthenticated', id='certificate-only'),
-    pytest.param(None, 'root@builtin', 'success', 'success', id='token-only'),
-    pytest.param('allowed', 'root@builtin', 'success', 'success', id='certificate-and-token'),
-    pytest.param(None, None, 'unauthenticated', 'unauthenticated', id='no-credentials'),
-    pytest.param(None, 'denied@builtin', 'unauthorized', 'unauthorized', id='denied-token'),
-    pytest.param('denied', None, 'unauthorized', 'unauthenticated', id='denied-certificate'),
-    pytest.param('allowed', 'denied@builtin', 'unauthorized', 'unauthorized', id='denied-token-over-certificate'),
-    pytest.param('allowed', 'invalid-token', 'unauthenticated', 'unauthenticated', id='invalid-token-over-certificate'),
-    pytest.param('denied', 'root@builtin', 'success', 'success', id='token-over-denied-certificate'),
-    pytest.param('unrecognized', 'root@builtin', 'success', 'success', id='token-over-unrecognized-certificate'),
+    pytest.param('allowed', None, id='certificate-only'),
+    pytest.param(None, 'root@builtin', id='token-only'),
+    pytest.param('allowed', 'root@builtin', id='certificate-and-token'),
+    pytest.param(None, None, id='no-credentials'),
+    pytest.param(None, 'denied@builtin', id='denied-token'),
+    pytest.param('denied', None, id='denied-certificate'),
+    pytest.param('allowed', 'denied@builtin', id='denied-token-over-certificate'),
+    pytest.param('allowed', 'invalid-token', id='invalid-token-over-certificate'),
+    pytest.param('denied', 'root@builtin', id='token-over-denied-certificate'),
+    pytest.param('unrecognized', 'root@builtin', id='token-over-unrecognized-certificate'),
 ]
 
 
@@ -43,17 +45,15 @@ def credentials_for_request(request, token, token_location):
     return (('x-ydb-auth-ticket', token),)
 
 
-def invoke(call, request, metadata, expected):
-    if expected == 'unauthenticated':
-        with pytest.raises(grpc.RpcError) as error:
-            call(request, metadata=metadata, timeout=30)
-        assert error.value.code() == grpc.StatusCode.UNAUTHENTICATED, error.value
-        return None
-    return call(request, metadata=metadata, timeout=30)
+def invoke(call, request, metadata):
+    try:
+        return call(request, metadata=metadata, timeout=30), {'grpc_status': 'OK'}
+    except grpc.RpcError as error:
+        return None, {'grpc_status': error.code().name, 'details': error.details()}
 
 
 @pytest.mark.parametrize('protocol', ['grpc', 'grpcs'])
-@pytest.mark.parametrize('certificate,token,tls_result,plaintext_result', AUTH_CASES)
+@pytest.mark.parametrize('certificate,token', AUTH_CASES)
 @pytest.mark.parametrize('api,token_location', [
     pytest.param('discovery', 'metadata', id='discovery'),
     pytest.param('legacy', 'body', id='legacy-token-in-body'),
@@ -66,12 +66,10 @@ def test_node_registration(
     protocol,
     certificate,
     token,
-    tls_result,
-    plaintext_result,
     api,
-    token_location
+    token_location,
+    tmp_path
 ):
-    expected = tls_result if protocol == 'grpcs' else plaintext_result
     # Re-register the same endpoint to exercise the normal lease renewal as well.
     host, port, address = 'localhost', registration_port, '127.0.0.1'
     with open_channel(cluster, certificates, protocol, certificate) as channel:
@@ -88,56 +86,34 @@ def test_node_registration(
         metadata = credentials_for_request(request, token, token_location)
         if api == 'discovery':
             metadata += (('x-ydb-database', '/Root'),)
-        response = invoke(call, request, metadata, expected)
+        server_log = YdbGrpcLog(cluster)
+        response, log = invoke(call, request, metadata)
+        log['ydb_log'] = server_log.response('NodeRegistration' if api == 'discovery' else 'RegisterNode')
 
-    if response is None:
-        return
-    if api == 'discovery':
-        assert response.operation.ready, response
-        status = StatusIds.SUCCESS if expected == 'success' else StatusIds.UNAUTHORIZED
-        assert response.operation.status == status, response
-        result = ydb_discovery_pb2.NodeRegistrationResult()
-        assert response.operation.result.Unpack(result), response
-        if expected == 'success':
-            assert result.node_id > cluster.nodes[1].node_id, result
-            assert result.expire > 0, result
-            assert any(n.node_id == result.node_id and n.port == port for n in result.nodes), result
-        else:
-            assert result.node_id == 0, result
-            assert not result.nodes, result
-            assert any(issue.message == 'Cannot authorize node. Access denied' for issue in response.operation.issues), response
-    else:
-        status = node_broker_pb2.TStatus.OK if expected == 'success' else node_broker_pb2.TStatus.UNAUTHORIZED
-        assert response.Status.Code == status, response
-        if expected == 'success':
-            assert response.NodeId > cluster.nodes[1].node_id, response
-            assert response.Expire > 0, response
-            assert any(n.NodeId == response.NodeId and n.Port == port for n in response.Nodes), response
-        else:
-            assert not response.HasField('NodeId'), response
-            assert not response.Nodes, response
+    if response is not None:
+        log.update(registration_result(response, api, cluster.nodes[1].node_id, port))
+    return canonical_log(tmp_path, log)
 
 
 @pytest.mark.parametrize('protocol', ['grpc', 'grpcs'])
-@pytest.mark.parametrize('certificate,token,tls_result,plaintext_result', AUTH_CASES)
+@pytest.mark.parametrize('certificate,token', AUTH_CASES)
 @pytest.mark.parametrize('token_location', ['body', 'metadata'])
 def test_get_node_config(cluster, certificates, node_config, protocol, certificate, token,
-                         tls_result, plaintext_result, token_location):
-    expected = tls_result if protocol == 'grpcs' else plaintext_result
+                         token_location, tmp_path):
     request = msgbus_pb2.TConsoleRequest(DomainName='Root')
     request.GetNodeConfigRequest.Node.Host = 'localhost'
     request.GetNodeConfigRequest.Node.NodeType = 'node-auth-test'
     metadata = credentials_for_request(request, token, token_location)
     with open_channel(cluster, certificates, protocol, certificate) as channel:
         call = grpc_pb2_grpc.TGRpcServerStub(channel).ConsoleRequest
-        response = invoke(call, request, metadata, expected)
-    if response is None:
-        return
-    status = StatusIds.SUCCESS if expected == 'success' else StatusIds.UNAUTHORIZED
-    assert response.Status.Code == status, response
-    if expected == 'success':
-        assert response.HasField('GetNodeConfigResponse'), response
-        assert response.GetNodeConfigResponse.Status.Code == StatusIds.SUCCESS, response
-        assert response.GetNodeConfigResponse.Config.LogConfig == node_config.LogConfig, response
-    else:
-        assert not response.HasField('GetNodeConfigResponse'), response
+        server_log = YdbGrpcLog(cluster)
+        response, log = invoke(call, request, metadata)
+        log['ydb_log'] = server_log.response('ConsoleRequest')
+    if response is not None:
+        log['status'] = StatusIds.StatusCode.Name(response.Status.Code)
+        log['response_present'] = response.HasField('GetNodeConfigResponse')
+        if log['response_present']:
+            result = response.GetNodeConfigResponse
+            log['config_status'] = StatusIds.StatusCode.Name(result.Status.Code)
+            log['log_config'] = text_format.MessageToString(result.Config.LogConfig)
+    return canonical_log(tmp_path, log)

--- a/ydb/tests/functional/security/node_registration/test_startup_credentials.py
+++ b/ydb/tests/functional/security/node_registration/test_startup_credentials.py
@@ -64,6 +64,7 @@ def client_certificate_args(certificates, tmp_path):
     pytest.param('NodeRegistrationToken: "node@builtin"', 'node@builtin', id='explicit-custom-token'),
 ])
 def test_startup_registration_credentials(certificates, tmp_path, protocol, auth_config, expected_token):
+    recorder = RegistrationRecorder()
     log_path = tmp_path / 'ydbd.log'
     # An empty text protobuf is an empty TAppConfig, loaded by LoadBootstrapConfig.
     static_config = tmp_path / 'bootstrap.pb'

--- a/ydb/tests/functional/security/node_registration/test_startup_credentials.py
+++ b/ydb/tests/functional/security/node_registration/test_startup_credentials.py
@@ -1,0 +1,143 @@
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+import os
+from queue import Empty, Queue
+import subprocess
+import time
+
+import grpc
+import pytest
+import yatest.common
+
+from library.python.port_manager import PortManager
+from ydb.public.api.grpc import ydb_discovery_v1_pb2_grpc
+
+
+class RegistrationRecorder(ydb_discovery_v1_pb2_grpc.DiscoveryServiceServicer):
+    def __init__(self):
+        self.requests = Queue()
+
+    def NodeRegistration(self, request, context):
+        self.requests.put((dict(context.invocation_metadata()), context.auth_context()))
+        # Keep ydbd at registration: this test only needs its initial outgoing credentials.
+        context.abort(grpc.StatusCode.UNAVAILABLE, 'Registration recorded by the test')
+
+    def ListEndpoints(self, request, context):
+        context.abort(grpc.StatusCode.UNIMPLEMENTED, 'Use the explicitly configured endpoint')
+
+
+@contextmanager
+def running_node(command, log_path):
+    with log_path.open('w') as log:
+        process = subprocess.Popen(command, cwd=log_path.parent, stdout=log, stderr=subprocess.STDOUT)
+        try:
+            yield process
+        finally:
+            if process.poll() is None:
+                process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=10)
+
+
+def client_certificate_args(certificates, tmp_path):
+    args = []
+    for option, data in (
+        ('grpc-ca', certificates['ca']),
+        ('grpc-cert', certificates['allowed'][0]),
+        ('grpc-key', certificates['allowed'][1]),
+    ):
+        path = tmp_path / f'{option}.pem'
+        path.write_bytes(data)
+        args += [f'--{option}', str(path)]
+    return args
+
+
+@pytest.mark.parametrize('protocol', ['grpc', 'grpcs'])
+@pytest.mark.parametrize('auth_config,expected_token', [
+    pytest.param(None, None, id='empty-static-config'),
+    pytest.param('', None, id='empty-auth-config'),
+    pytest.param('NodeRegistrationToken: ""', None, id='explicit-empty-token'),
+    pytest.param('NodeRegistrationToken: "root@builtin"', 'root@builtin', id='explicit-root-token'),
+    pytest.param('NodeRegistrationToken: "node@builtin"', 'node@builtin', id='explicit-custom-token'),
+])
+def test_startup_registration_credentials(certificates, tmp_path, protocol, auth_config, expected_token):
+    log_path = tmp_path / 'ydbd.log'
+    # An empty text protobuf is an empty TAppConfig, loaded by LoadBootstrapConfig.
+    static_config = tmp_path / 'bootstrap.pb'
+    static_config.write_text('')
+    with PortManager() as ports, ThreadPoolExecutor(max_workers=1) as executor:
+        server = grpc.server(executor)
+        ydb_discovery_v1_pb2_grpc.add_DiscoveryServiceServicer_to_server(recorder, server)
+        endpoint = f'localhost:{ports.get_port()}'
+        command = [
+            yatest.common.binary_path(os.environ['YDB_DRIVER_BINARY']), 'server',
+            '--tenant', '/Root',
+            '--node-broker', f'{protocol}://{endpoint}',
+            '--ic-port', str(ports.get_port()),
+            '--grpc-port', str(ports.get_port()),
+            '--mon-port', str(ports.get_port()),
+        ]
+        if auth_config is not None:
+            auth_path = tmp_path / 'auth.txt'
+            auth_path.write_text(auth_config)
+            command += ['--auth-file', str(auth_path)]
+        if protocol == 'grpcs':
+            server_cert, server_key = certificates['server']
+            credentials = grpc.ssl_server_credentials(
+                [(server_key, server_cert)], root_certificates=certificates['ca'], require_client_auth=True,
+            )
+            assert server.add_secure_port(endpoint, credentials)
+            command += client_certificate_args(certificates, tmp_path)
+        else:
+            assert server.add_insecure_port(endpoint)
+        command.append(str(static_config))
+        server.start()
+        try:
+            with running_node(command, log_path):
+                try:
+                    metadata, peer_auth = recorder.requests.get(timeout=30)
+                except Empty:
+                    pytest.fail(f'ydbd did not send NodeRegistration: {log_path.read_text()}')
+                assert metadata.get('x-ydb-auth-ticket') == expected_token, metadata
+                if protocol == 'grpcs':
+                    assert peer_auth['x509_common_name'] == [b'allowed'], peer_auth
+        finally:
+            server.stop(0).wait()
+
+
+@pytest.mark.parametrize('cluster', [['dynamic-nodes@cert']], indirect=True, ids=['certificate-auth-only'])
+@pytest.mark.parametrize('static_config_text', ['', 'AuthConfig {}'], ids=['empty-config', 'empty-auth-section'])
+def test_startup_registration_with_empty_config(cluster, certificates, tmp_path, static_config_text):
+    # root@builtin is deliberately NOT allowed to register nodes on this cluster:
+    # its implicit transmission must fail even when a valid certificate is supplied.
+    static_config = tmp_path / 'bootstrap.pb'
+    static_config.write_text(static_config_text)
+    log_path = tmp_path / 'ydbd.log'
+    with PortManager() as ports:
+        command = [
+            yatest.common.binary_path(os.environ['YDB_DRIVER_BINARY']), 'server',
+            '--node-broker', f'grpcs://localhost:{cluster.nodes[1].grpc_ssl_port}',
+            '--node-domain', 'Root',
+            '--tenant', '/Root',
+            '--ic-port', str(ports.get_port()),
+            '--grpc-port', str(ports.get_port()),
+            '--mon-port', str(ports.get_port()),
+            *client_certificate_args(certificates, tmp_path),
+            str(static_config),
+        ]
+        with running_node(command, log_path) as process:
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                output = log_path.read_text()
+                assert 'Registration error:' not in output, output
+                assert 'Configuration error:' not in output, output
+                registered = 'Success. Registered as ' in output
+                config_result = output.partition('Trying to get configs from ')[2]
+                if registered and config_result and 'Success.' in config_result:
+                    return
+                assert process.poll() is None, output
+                time.sleep(0.1)
+            pytest.fail(f'ydbd did not register and fetch its config: {log_path.read_text()}')

--- a/ydb/tests/functional/security/node_registration/test_startup_credentials.py
+++ b/ydb/tests/functional/security/node_registration/test_startup_credentials.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 import os
+import re
 from queue import Empty, Queue
 import subprocess
 import time
@@ -8,22 +9,82 @@ import time
 import grpc
 import pytest
 import yatest.common
+import yaml
 
 from library.python.port_manager import PortManager
+from helpers import YdbGrpcLog, canonical_log, registration_result
+from test_node_authentication import open_channel
+from ydb.core.protos import grpc_pb2_grpc
 from ydb.public.api.grpc import ydb_discovery_v1_pb2_grpc
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 
-class RegistrationRecorder(ydb_discovery_v1_pb2_grpc.DiscoveryServiceServicer):
-    def __init__(self):
+class RegistrationRecorder(ydb_discovery_v1_pb2_grpc.DiscoveryServiceServicer,
+                           grpc_pb2_grpc.TGRpcServerServicer):
+    def __init__(self, channel, static_node_id):
+        self.discovery = ydb_discovery_v1_pb2_grpc.DiscoveryServiceStub(channel)
+        self.legacy = grpc_pb2_grpc.TGRpcServerStub(channel)
+        self.static_node_id = static_node_id
         self.requests = Queue()
 
     def NodeRegistration(self, request, context):
-        self.requests.put((dict(context.invocation_metadata()), context.auth_context()))
-        # Keep ydbd at registration: this test only needs its initial outgoing credentials.
-        context.abort(grpc.StatusCode.UNAVAILABLE, 'Registration recorded by the test')
+        metadata = dict(context.invocation_metadata())
+        log = {
+            'token': metadata.get('x-ydb-auth-ticket'),
+            'client_common_name': [value.decode() for value in context.auth_context().get('x509_common_name', [])],
+        }
+        try:
+            response = self.discovery.NodeRegistration(request, metadata=context.invocation_metadata(), timeout=30)
+        except grpc.RpcError as error:
+            log.update(grpc_status=error.code().name, details=error.details())
+            self.requests.put(log)
+            context.abort(error.code(), error.details())
+        log.update(grpc_status='OK')
+        log.update(registration_result(response, 'discovery', self.static_node_id, request.port))
+        self.requests.put(log)
+        return response
 
     def ListEndpoints(self, request, context):
-        context.abort(grpc.StatusCode.UNIMPLEMENTED, 'Use the explicitly configured endpoint')
+        return self.forward(self.discovery.ListEndpoints, request, context)
+
+    def ConsoleRequest(self, request, context):
+        return self.forward(self.legacy.ConsoleRequest, request, context)
+
+    @staticmethod
+    def forward(call, request, context):
+        try:
+            return call(request, metadata=context.invocation_metadata(), timeout=30)
+        except grpc.RpcError as error:
+            context.abort(error.code(), error.details())
+
+
+def capture_startup(process, log_path, *, get_config=False):
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        output = log_path.read_text()
+        for match in re.finditer(r'^.*\n', output, re.MULTILINE):
+            line = match.group()
+            if 'Registration error:' in line or 'Configuration error:' in line:
+                return output[:match.end()], None
+            if get_config:
+                if 'Success. Got dynamic config from ' in line:
+                    return output[:match.end()], None
+            elif 'Success. Registered as ' in line:
+                return output[:match.end()], None
+        if process.poll() is not None:
+            return log_path.read_text(), process.returncode
+        time.sleep(0.1)
+    pytest.fail(f'ydbd did not finish initialization: {log_path.read_text()}')
+
+
+def normalize_startup(output, tmp_path, endpoint, static_node_id):
+    output = output.replace(str(tmp_path), '<test-dir>').replace(endpoint, '<node-broker>')
+    output = re.sub(
+        r'(Success\. Registered as )(\d+)',
+        lambda match: match[1] + ('<dynamic-node>' if int(match[2]) > static_node_id else match[2]),
+        output,
+    )
+    return output.splitlines()
 
 
 @contextmanager
@@ -55,67 +116,133 @@ def client_certificate_args(certificates, tmp_path):
     return args
 
 
+@pytest.mark.parametrize('cluster', [['root@builtin', 'node@builtin', 'dynamic-nodes@cert']],
+                         indirect=True, ids=['startup-auth'])
 @pytest.mark.parametrize('protocol', ['grpc', 'grpcs'])
-@pytest.mark.parametrize('auth_config,expected_token', [
-    pytest.param(None, None, id='empty-static-config'),
-    pytest.param('', None, id='empty-auth-config'),
-    pytest.param('NodeRegistrationToken: ""', None, id='explicit-empty-token'),
-    pytest.param('NodeRegistrationToken: "root@builtin"', 'root@builtin', id='explicit-root-token'),
-    pytest.param('NodeRegistrationToken: "node@builtin"', 'node@builtin', id='explicit-custom-token'),
+@pytest.mark.parametrize('config_source,config_value', [
+    pytest.param('none', None, id='without-config'),
+    pytest.param('protobuf', '', id='empty-static-config'),
+    pytest.param('protobuf', 'LogConfig { DefaultLevel: 5 }', id='protobuf-without-auth'),
+    pytest.param('protobuf', [
+        'LogConfig { DefaultLevel: 5 }',
+        'DomainsConfig { Domain { DomainId: 1 Name: "Root" } }',
+    ], id='multiple-protobuf-files'),
+    pytest.param('protobuf', 'AuthConfig {}', id='empty-auth-section'),
+    # Bootstrap auth values are applied after registration; preserve the legacy default here.
+    pytest.param('protobuf', 'AuthConfig { NodeRegistrationToken: "" }', id='bootstrap-empty-token'),
+    pytest.param('protobuf', 'AuthConfig { NodeRegistrationToken: "node@builtin" }', id='bootstrap-custom-token'),
+    pytest.param('auth-file', '', id='empty-auth-file-without-static-config'),
+    pytest.param('auth-token-file', '', id='empty-auth-token-file-without-static-config'),
+    pytest.param('log-file', '', id='only-log-config'),
+    pytest.param('auth-file', 'NodeRegistrationToken: ""', id='empty-token-without-static-config'),
+    pytest.param('auth-file', 'NodeRegistrationToken: "root@builtin"', id='root-token-without-static-config'),
+    pytest.param('auth-file', 'NodeRegistrationToken: "node@builtin"', id='custom-token-without-static-config'),
+    pytest.param('auth-token-file', 'NodeRegistrationToken: "node@builtin"', id='auth-token-file-without-static-config'),
+    pytest.param('bootstrap-auth-file', '', id='empty-auth-file'),
+    pytest.param('bootstrap-auth-token-file', '', id='empty-auth-token-file'),
+    pytest.param('bootstrap-auth-file', 'NodeRegistrationToken: ""', id='explicit-empty-token'),
+    pytest.param('bootstrap-auth-file', 'NodeRegistrationToken: "root@builtin"', id='explicit-root-token'),
+    pytest.param('bootstrap-auth-file', 'NodeRegistrationToken: "node@builtin"', id='explicit-custom-token'),
+    pytest.param('bootstrap-auth-token-file', 'NodeRegistrationToken: "node@builtin"', id='auth-token-file'),
+    pytest.param('yaml', None, id='yaml-without-auth'),
+    pytest.param('yaml', {}, id='yaml-empty-auth'),
+    pytest.param('yaml', {'node_registration_token': ''}, id='yaml-empty-token'),
+    pytest.param('yaml', {'node_registration_token': 'node@builtin'}, id='yaml-custom-token'),
+    pytest.param('config-dir', None, id='config-directory-without-auth'),
+    pytest.param('config-dir', {}, id='config-directory-empty-auth'),
+    pytest.param('config-dir', {'node_registration_token': 'node@builtin'}, id='config-directory-token'),
+    pytest.param('empty-config-dir', None, id='empty-config-directory'),
+    pytest.param('missing-config-dir', None, id='missing-config-directory'),
+    pytest.param('unreferenced-yaml', {'node_registration_token': 'node@builtin'}, id='config-without-cli-option'),
+    pytest.param('missing-yaml', None, id='missing-yaml-file'),
+    pytest.param('missing-protobuf', None, id='missing-protobuf-file'),
 ])
-def test_startup_registration_credentials(certificates, tmp_path, protocol, auth_config, expected_token):
-    recorder = RegistrationRecorder()
+def test_startup_registration_credentials(cluster, certificates, tmp_path, protocol, config_source, config_value):
     log_path = tmp_path / 'ydbd.log'
-    # An empty text protobuf is an empty TAppConfig, loaded by LoadBootstrapConfig.
-    static_config = tmp_path / 'bootstrap.pb'
-    static_config.write_text('')
-    with PortManager() as ports, ThreadPoolExecutor(max_workers=1) as executor:
+    with (PortManager() as ports, ThreadPoolExecutor(max_workers=2) as executor,
+          open_channel(cluster, certificates, protocol, 'allowed') as upstream):
+        recorder = RegistrationRecorder(upstream, cluster.nodes[1].node_id)
         server = grpc.server(executor)
         ydb_discovery_v1_pb2_grpc.add_DiscoveryServiceServicer_to_server(recorder, server)
+        grpc_pb2_grpc.add_TGRpcServerServicer_to_server(recorder, server)
         endpoint = f'localhost:{ports.get_port()}'
         command = [
             yatest.common.binary_path(os.environ['YDB_DRIVER_BINARY']), 'server',
             '--tenant', '/Root',
+            '--node-domain', 'Root',
+            '--node-host', 'localhost',
+            '--node-resolve-host', 'localhost',
+            '--node-address', '127.0.0.1',
             '--node-broker', f'{protocol}://{endpoint}',
             '--ic-port', str(ports.get_port()),
             '--grpc-port', str(ports.get_port()),
             '--mon-port', str(ports.get_port()),
         ]
-        if auth_config is not None:
-            auth_path = tmp_path / 'auth.txt'
-            auth_path.write_text(auth_config)
-            command += ['--auth-file', str(auth_path)]
+        if config_source in ('yaml', 'config-dir', 'unreferenced-yaml'):
+            config = KikimrConfigGenerator(nodes=1).yaml_config
+            config.pop('auth_config', None)
+            if config_value is not None:
+                config['auth_config'] = config_value
+            config_path = tmp_path / 'config.yaml'
+            config_path.write_text(yaml.safe_dump(config))
+            if config_source == 'yaml':
+                command += ['--yaml-config', str(config_path)]
+            elif config_source == 'config-dir':
+                command += ['--config-dir', str(tmp_path)]
+        elif config_source == 'empty-config-dir':
+            command += ['--config-dir', str(tmp_path)]
+        elif config_source == 'missing-config-dir':
+            command += ['--config-dir', str(tmp_path / 'missing')]
+        elif config_source == 'missing-yaml':
+            command += ['--yaml-config', str(tmp_path / 'missing.yaml')]
+        elif config_source not in ('none', 'protobuf', 'missing-protobuf'):
+            config_path = tmp_path / 'config.txt'
+            config_path.write_text(config_value)
+            option = config_source.removeprefix('bootstrap-')
+            command += [f'--{option}', str(config_path)]
         if protocol == 'grpcs':
             server_cert, server_key = certificates['server']
             credentials = grpc.ssl_server_credentials(
                 [(server_key, server_cert)], root_certificates=certificates['ca'], require_client_auth=True,
             )
-            assert server.add_secure_port(endpoint, credentials)
+            server.add_secure_port(endpoint, credentials)
             command += client_certificate_args(certificates, tmp_path)
         else:
-            assert server.add_insecure_port(endpoint)
-        command.append(str(static_config))
+            server.add_insecure_port(endpoint)
+        if config_source == 'protobuf' or config_source.startswith('bootstrap-'):
+            configs = config_value if config_source == 'protobuf' else ''
+            if isinstance(configs, str):
+                configs = [configs]
+            for index, content in enumerate(configs):
+                static_config = tmp_path / f'bootstrap-{index}.pb'
+                static_config.write_text(content)
+                # Positional paths reach the configurator through freeArgs.
+                command.append(str(static_config))
+        elif config_source == 'missing-protobuf':
+            command.append(str(tmp_path / 'missing.pb'))
         server.start()
         try:
-            with running_node(command, log_path):
+            server_log = YdbGrpcLog(cluster)
+            with running_node(command, log_path) as process:
+                output, exit_code = capture_startup(process, log_path)
+                log = {'startup': normalize_startup(output, tmp_path, endpoint, cluster.nodes[1].node_id)}
+                if exit_code is not None:
+                    log['exit_code'] = exit_code
                 try:
-                    metadata, peer_auth = recorder.requests.get(timeout=30)
+                    log['registration'] = recorder.requests.get_nowait()
                 except Empty:
-                    pytest.fail(f'ydbd did not send NodeRegistration: {log_path.read_text()}')
-                assert metadata.get('x-ydb-auth-ticket') == expected_token, metadata
-                if protocol == 'grpcs':
-                    assert peer_auth['x509_common_name'] == [b'allowed'], peer_auth
+                    log['registration'] = None
+                log['ydb_log'] = server_log.response('NodeRegistration') if log['registration'] is not None else []
+                return canonical_log(tmp_path, log)
         finally:
             server.stop(0).wait()
 
 
 @pytest.mark.parametrize('cluster', [['dynamic-nodes@cert']], indirect=True, ids=['certificate-auth-only'])
-@pytest.mark.parametrize('static_config_text', ['', 'AuthConfig {}'], ids=['empty-config', 'empty-auth-section'])
-def test_startup_registration_with_empty_config(cluster, certificates, tmp_path, static_config_text):
+@pytest.mark.parametrize('empty_config_dir', [False, True], ids=['no-config', 'empty-config-directory'])
+def test_startup_registration_without_config(cluster, certificates, tmp_path, empty_config_dir):
     # root@builtin is deliberately NOT allowed to register nodes on this cluster:
     # its implicit transmission must fail even when a valid certificate is supplied.
-    static_config = tmp_path / 'bootstrap.pb'
-    static_config.write_text(static_config_text)
     log_path = tmp_path / 'ydbd.log'
     with PortManager() as ports:
         command = [
@@ -127,18 +254,15 @@ def test_startup_registration_with_empty_config(cluster, certificates, tmp_path,
             '--grpc-port', str(ports.get_port()),
             '--mon-port', str(ports.get_port()),
             *client_certificate_args(certificates, tmp_path),
-            str(static_config),
         ]
+        if empty_config_dir:
+            command += ['--config-dir', str(tmp_path)]
+        server_log = YdbGrpcLog(cluster)
         with running_node(command, log_path) as process:
-            deadline = time.monotonic() + 30
-            while time.monotonic() < deadline:
-                output = log_path.read_text()
-                assert 'Registration error:' not in output, output
-                assert 'Configuration error:' not in output, output
-                registered = 'Success. Registered as ' in output
-                config_result = output.partition('Trying to get configs from ')[2]
-                if registered and config_result and 'Success.' in config_result:
-                    return
-                assert process.poll() is None, output
-                time.sleep(0.1)
-            pytest.fail(f'ydbd did not register and fetch its config: {log_path.read_text()}')
+            output, exit_code = capture_startup(process, log_path, get_config=True)
+            endpoint = f'localhost:{cluster.nodes[1].grpc_ssl_port}'
+            return canonical_log(tmp_path, {
+                'exit_code': exit_code,
+                'startup': normalize_startup(output, tmp_path, endpoint, cluster.nodes[1].node_id),
+                'ydb_log': server_log.response('NodeRegistration'),
+            })

--- a/ydb/tests/functional/security/node_registration/ya.make
+++ b/ydb/tests/functional/security/node_registration/ya.make
@@ -1,0 +1,29 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)
+
+TEST_SRCS(
+    conftest.py
+    test_node_authentication.py
+    test_startup_credentials.py
+)
+
+PEERDIR(
+    contrib/python/cryptography
+    contrib/python/grpcio
+    library/python/port_manager
+    ydb/core/protos
+    ydb/public/api/grpc
+    ydb/public/api/protos
+    ydb/tests/library
+)
+
+IF (SANITIZER_TYPE)
+    SIZE(LARGE)
+    INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
+    REQUIREMENTS(ram:10 cpu:16)
+ELSE()
+    SIZE(MEDIUM)
+ENDIF()
+
+END()

--- a/ydb/tests/functional/security/node_registration/ya.make
+++ b/ydb/tests/functional/security/node_registration/ya.make
@@ -4,6 +4,7 @@ INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)
 
 TEST_SRCS(
     conftest.py
+    helpers.py
     test_node_authentication.py
     test_startup_credentials.py
 )

--- a/ydb/tests/functional/security/ya.make
+++ b/ydb/tests/functional/security/ya.make
@@ -2,4 +2,5 @@ RECURSE(
     lib
     acl
     mon
+    node_registration
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Dynamic nodes started without a static configuration implicitly sent `root@builtin`, the protobuf default, in registration requests. This could prevent certificate authentication because the token took precedence over the client certificate.

This change stops sending the implicit registration token when neither a static configuration nor an authentication file is supplied, allowing the node to authenticate using its client certificate.
Registration tokens are now sent only when a static configuration is loaded or `--auth-file` / `--auth-token-file` is supplied. Static configuration includes YAML and positional protobuf configuration files (`freeArgs`). Supplying positional protobuf files preserves the previous token behavior even if those files are empty or contain no `AuthConfig`. In these explicitly configured startup modes, the existing behavior - including the `root@builtin` default when `NodeRegistrationToken` is unset - is retained.

Added functional coverage for:
- Registration and GetNodeConfig over gRPC/gRPCS using a certificate, a token, both, or neither, including authentication and authorization failures.
- Startup with YAML, positional `.pb` configuration files, separate authentication files, and no static configuration.
- Canonicalized RPC results, startup logs, and YDB server logs showing successful responses and failure reasons.

### Description for reviewers <!-- (optional) description for those who read this PR -->

http://st/KIKIMR-26605