### PR TITLE
Fix PDisk log load worker initialization ordering

### DIFF
--- a/ydb/core/load_test/blobstorage/ut/pdisk_log_ut.cpp
+++ b/ydb/core/load_test/blobstorage/ut/pdisk_log_ut.cpp
@@ -1,12 +1,24 @@
-#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/blobstorage/pdisk/mock/pdisk_mock.h>
+#include <ydb/core/util/actorsys_test/testactorsys.h>
 #include <ydb/core/load_test/service_actor.h>
 
 #include <library/cpp/protobuf/util/pb_io.h>
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/generic/scope.h>
+
+using namespace NKikimr;
+using namespace NActors;
 
 Y_UNIT_TEST_SUITE(PDiskLogLoadTest) {
     Y_UNIT_TEST(DelayedFirstYardInitResult) {
-        TEnvironmentSetup env({.NodeCount = 1});
-        auto& runtime = *env.Runtime;
+        TTestActorSystem runtime(1);
+        const auto timeProvider = TAppData::TimeProvider;
+        TAppData::TimeProvider = TTestActorSystem::CreateTimeProvider();
+        Y_DEFER {
+            runtime.Stop();
+            TAppData::TimeProvider = timeProvider;
+        };
+        runtime.Start();
         constexpr ui32 nodeId = 1;
         constexpr ui32 pdiskId = 99;
         constexpr ui64 pdiskGuid = 12345;

--- a/ydb/core/load_test/blobstorage/ut/ya.make
+++ b/ydb/core/load_test/blobstorage/ut/ya.make
@@ -1,0 +1,16 @@
+UNITTEST()
+
+SIZE(MEDIUM)
+
+SRCS(
+    pdisk_log_ut.cpp
+)
+
+PEERDIR(
+    library/cpp/protobuf/util
+    ydb/core/blobstorage/pdisk/mock
+    ydb/core/load_test/blobstorage
+    ydb/core/util/actorsys_test
+)
+
+END()

--- a/ydb/core/load_test/blobstorage/ya.make
+++ b/ydb/core/load_test/blobstorage/ya.make
@@ -25,3 +25,7 @@ PEERDIR(
 )
 
 END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/core/load_test/pdisk_log.cpp
+++ b/ydb/core/load_test/pdisk_log.cpp
@@ -286,6 +286,7 @@ class TPDiskLogWriterLoadTestActor : public TActorBootstrapped<TPDiskLogWriterLo
     TDuration DelayBeforeMeasurements;
     i32 OwnerInitInProgress = 0;
     ui32 HarakiriInFlight = 0;
+    ui32 InitializingWorkerIdx = 0;
 
     TReallyFastRng32 Rng;
 
@@ -364,7 +365,7 @@ public:
                 AppData(ctx)->Dcb->RegisterLocalControl(worker->MaxInFlight,
                         Sprintf("PDiskWriteLoadActor_MaxInFlight_%04" PRIu64 "_%04" PRIu32, Tag, worker->Idx));
             }
-            InitWorker(ctx, 0);
+            InitWorker(ctx);
         } else {
             LOG_INFO_S(ctx, NKikimrServices::BS_LOAD_TEST, "Tag# " << Tag << " Send TEvRegisterPDiskLoadActor");
             Send(MakeBlobStorageNodeWardenID(ctx.SelfID.NodeId()), new TEvRegisterPDiskLoadActor());
@@ -380,14 +381,14 @@ public:
         for (auto& worker : Workers) {
             worker->OwnerRound = msg->OwnerRound + 1;
         }
-        InitWorker(ctx, 0);
+        InitWorker(ctx);
     }
 
-    void InitWorker(const TActorContext& ctx, ui32 workerIdx) {
+    void InitWorker(const TActorContext& ctx) {
         // YardInitResult has no VDisk ID or request cookie. Keep one initial YardInit
-        // in flight so its result belongs to the first worker without PDiskParams.
-        if (workerIdx < Workers.size()) {
-            SendRequest(ctx, Workers[workerIdx]->GetYardInit(PDiskGuid));
+        // in flight and associate its result with InitializingWorkerIdx.
+        if (InitializingWorkerIdx < Workers.size()) {
+            SendRequest(ctx, Workers[InitializingWorkerIdx]->GetYardInit(PDiskGuid));
         }
     }
 
@@ -406,19 +407,18 @@ public:
                 << " Owner# " << (ui32)msg->PDiskParams->Owner
                 << " OwnerRound# " << msg->PDiskParams->OwnerRound);
 
-        for (auto& worker : Workers) {
-            if (!worker->PDiskParams) {
-                worker->PDiskParams = std::move(msg->PDiskParams);
-                worker->OwnerRound = Max(worker->OwnerRound, worker->PDiskParams->OwnerRound);
-                auto logRead = worker->GetLogRead();
-                Y_ABORT_UNLESS(logRead);
-                LOG_INFO_S(ctx, NKikimrServices::BS_LOAD_TEST, "Tag# " << Tag << " owner# "
-                        << (ui32)worker->PDiskParams->Owner << " going to send first TEvLogRead# " << logRead->ToString());
-                SendRequest(ctx, std::move(logRead));
-                InitWorker(ctx, worker->Idx + 1);
-                break;
-            }
-        }
+        Y_ABORT_UNLESS(InitializingWorkerIdx < Workers.size());
+        auto& worker = Workers[InitializingWorkerIdx];
+        Y_ABORT_UNLESS(!worker->PDiskParams);
+        worker->PDiskParams = std::move(msg->PDiskParams);
+        worker->OwnerRound = Max(worker->OwnerRound, worker->PDiskParams->OwnerRound);
+        auto logRead = worker->GetLogRead();
+        Y_ABORT_UNLESS(logRead);
+        LOG_INFO_S(ctx, NKikimrServices::BS_LOAD_TEST, "Tag# " << Tag << " owner# "
+                << (ui32)worker->PDiskParams->Owner << " going to send first TEvLogRead# " << logRead->ToString());
+        SendRequest(ctx, std::move(logRead));
+        ++InitializingWorkerIdx;
+        InitWorker(ctx);
     }
 
     void Handle(NPDisk::TEvReadLogResult::TPtr& ev, const TActorContext& ctx) {

--- a/ydb/core/load_test/pdisk_log.cpp
+++ b/ydb/core/load_test/pdisk_log.cpp
@@ -363,8 +363,8 @@ public:
             for (auto& worker : Workers) {
                 AppData(ctx)->Dcb->RegisterLocalControl(worker->MaxInFlight,
                         Sprintf("PDiskWriteLoadActor_MaxInFlight_%04" PRIu64 "_%04" PRIu32, Tag, worker->Idx));
-                SendRequest(ctx, worker->GetYardInit(PDiskGuid));
             }
+            InitWorker(ctx, 0);
         } else {
             LOG_INFO_S(ctx, NKikimrServices::BS_LOAD_TEST, "Tag# " << Tag << " Send TEvRegisterPDiskLoadActor");
             Send(MakeBlobStorageNodeWardenID(ctx.SelfID.NodeId()), new TEvRegisterPDiskLoadActor());
@@ -379,7 +379,15 @@ public:
                 << " TEvRegisterPDiskLoadActorResult received, ownerRound# " << (ui32)msg->OwnerRound);
         for (auto& worker : Workers) {
             worker->OwnerRound = msg->OwnerRound + 1;
-            SendRequest(ctx, worker->GetYardInit(PDiskGuid));
+        }
+        InitWorker(ctx, 0);
+    }
+
+    void InitWorker(const TActorContext& ctx, ui32 workerIdx) {
+        // YardInitResult has no VDisk ID or request cookie. Keep one initial YardInit
+        // in flight so its result belongs to the first worker without PDiskParams.
+        if (workerIdx < Workers.size()) {
+            SendRequest(ctx, Workers[workerIdx]->GetYardInit(PDiskGuid));
         }
     }
 
@@ -407,6 +415,7 @@ public:
                 LOG_INFO_S(ctx, NKikimrServices::BS_LOAD_TEST, "Tag# " << Tag << " owner# "
                         << (ui32)worker->PDiskParams->Owner << " going to send first TEvLogRead# " << logRead->ToString());
                 SendRequest(ctx, std::move(logRead));
+                InitWorker(ctx, worker->Idx + 1);
                 break;
             }
         }

--- a/ydb/core/load_test/ut/pdisk_log_ut.cpp
+++ b/ydb/core/load_test/ut/pdisk_log_ut.cpp
@@ -1,0 +1,78 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/load_test/service_actor.h>
+
+#include <library/cpp/protobuf/util/pb_io.h>
+
+Y_UNIT_TEST_SUITE(PDiskLogLoadTest) {
+    Y_UNIT_TEST(DelayedFirstYardInitResult) {
+        TEnvironmentSetup env({.NodeCount = 1});
+        auto& runtime = *env.Runtime;
+        constexpr ui32 nodeId = 1;
+        constexpr ui32 pdiskId = 99;
+        constexpr ui64 pdiskGuid = 12345;
+        TIntrusivePtr<TPDiskMockState> state = new TPDiskMockState(nodeId, pdiskId, pdiskGuid, 1ULL << 30);
+        const auto pdisk = runtime.Register(CreatePDiskMockActor(state), nodeId);
+        runtime.RegisterService(MakeBlobStoragePDiskID(nodeId, pdiskId), pdisk);
+
+        TStringInput config(R"(
+            PDiskId: 99
+            PDiskGuid: 12345
+            DurationSeconds: 1
+            DelayBeforeMeasurementsSeconds: 0
+            IsWardenlessTest: true
+            Workers: {
+                VDiskId: {GroupID: 1 GroupGeneration: 1 Ring: 0 Domain: 0 VDisk: 0}
+                MaxInFlight: 1
+                SizeIntervalMin: 128
+                SizeIntervalMax: 128
+                BurstInterval: 2147483647
+                BurstSize: 1024
+                StorageDuration: 1048576
+            }
+            Workers: {
+                VDiskId: {GroupID: 2 GroupGeneration: 1 Ring: 0 Domain: 0 VDisk: 0}
+                MaxInFlight: 1
+                SizeIntervalMin: 256
+                SizeIntervalMax: 256
+                BurstInterval: 2147483647
+                BurstSize: 1024
+                StorageDuration: 1048576
+            }
+        )");
+        const auto command = ParseFromTextFormat<NKikimr::TEvLoadTestRequest::TPDiskLogLoad>(config);
+        const auto edge = runtime.AllocateEdgeActor(nodeId, __FILE__, __LINE__);
+        TIntrusivePtr<::NMonitoring::TDynamicCounters> counters = new ::NMonitoring::TDynamicCounters();
+        const auto load = runtime.Register(CreatePDiskLogWriterLoadTest(command, edge, counters, 0, 42), nodeId);
+
+        bool delayed = false;
+        ui32 readsChecked = 0;
+        std::map<NPDisk::TOwner, NPDisk::TOwnerRound> ownerRounds;
+        runtime.FilterFunction = [&](ui32 eventNodeId, std::unique_ptr<IEventHandle>& event) {
+            if (event->Recipient == load && event->GetTypeRewrite() == NPDisk::TEvYardInitResult::EventType) {
+                const auto* result = event->Get<NPDisk::TEvYardInitResult>();
+                UNIT_ASSERT_VALUES_EQUAL(result->Status, NKikimrProto::OK);
+                ownerRounds[result->PDiskParams->Owner] = result->PDiskParams->OwnerRound;
+                if (!delayed) {
+                    delayed = true;
+                    // PDisk may finish the second owner's initialization before the first one's.
+                    runtime.Schedule(TDuration::MilliSeconds(10), event.release(), nullptr, eventNodeId);
+                    return false;
+                }
+            } else if (event->Sender == load && event->GetTypeRewrite() == NPDisk::TEvReadLog::EventType) {
+                const auto* request = event->Get<NPDisk::TEvReadLog>();
+                UNIT_ASSERT_VALUES_EQUAL(request->OwnerRound, ownerRounds.at(request->Owner));
+                ++readsChecked;
+            }
+            return true;
+        };
+
+        const auto finished = env.WaitForEdgeActorEvent<TEvLoad::TEvLoadTestFinished>(
+            edge, true, runtime.GetClock() + TDuration::Seconds(10));
+        UNIT_ASSERT(finished);
+        UNIT_ASSERT_C(finished->Get()->Report, finished->Get()->ErrorReason);
+        UNIT_ASSERT_VALUES_EQUAL(finished->Get()->Tag, 42);
+        UNIT_ASSERT(delayed);
+        UNIT_ASSERT_C(readsChecked >= 4, readsChecked);
+        runtime.FilterFunction = {};
+    }
+}

--- a/ydb/core/load_test/ut/pdisk_log_ut.cpp
+++ b/ydb/core/load_test/ut/pdisk_log_ut.cpp
@@ -14,7 +14,7 @@ Y_UNIT_TEST_SUITE(PDiskLogLoadTest) {
         const auto pdisk = runtime.Register(CreatePDiskMockActor(state), nodeId);
         runtime.RegisterService(MakeBlobStoragePDiskID(nodeId, pdiskId), pdisk);
 
-        TStringInput config(R"(
+        const TString configText(R"(
             PDiskId: 99
             PDiskGuid: 12345
             DurationSeconds: 1
@@ -39,6 +39,7 @@ Y_UNIT_TEST_SUITE(PDiskLogLoadTest) {
                 StorageDuration: 1048576
             }
         )");
+        TStringInput config(configText);
         const auto command = ParseFromTextFormat<NKikimr::TEvLoadTestRequest::TPDiskLogLoad>(config);
         const auto edge = runtime.AllocateEdgeActor(nodeId, __FILE__, __LINE__);
         TIntrusivePtr<::NMonitoring::TDynamicCounters> counters = new ::NMonitoring::TDynamicCounters();
@@ -66,13 +67,11 @@ Y_UNIT_TEST_SUITE(PDiskLogLoadTest) {
             return true;
         };
 
-        const auto finished = env.WaitForEdgeActorEvent<TEvLoad::TEvLoadTestFinished>(
-            edge, true, runtime.GetClock() + TDuration::Seconds(10));
-        UNIT_ASSERT(finished);
-        UNIT_ASSERT_C(finished->Get()->Report, finished->Get()->ErrorReason);
-        UNIT_ASSERT_VALUES_EQUAL(finished->Get()->Tag, 42);
+        const auto deadline = runtime.GetClock() + TDuration::Seconds(1);
+        runtime.Sim([&] { return readsChecked < 2 && runtime.GetClock() < deadline; });
         UNIT_ASSERT(delayed);
-        UNIT_ASSERT_C(readsChecked >= 4, readsChecked);
+        UNIT_ASSERT_VALUES_EQUAL(ownerRounds.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(readsChecked, 2);
         runtime.FilterFunction = {};
     }
 }

--- a/ydb/core/load_test/ut/ya.make
+++ b/ydb/core/load_test/ut/ya.make
@@ -15,6 +15,7 @@ YQL_LAST_ABI_VERSION()
 
 SRCS(
     group_test_ut.cpp
+    pdisk_log_ut.cpp
     nbs_dbg_like_alloc_helper_ut.cpp
     util_ut.cpp
 )

--- a/ydb/core/load_test/ut/ya.make
+++ b/ydb/core/load_test/ut/ya.make
@@ -15,7 +15,6 @@ YQL_LAST_ABI_VERSION()
 
 SRCS(
     group_test_ut.cpp
-    pdisk_log_ut.cpp
     nbs_dbg_like_alloc_helper_ut.cpp
     util_ut.cpp
 )

--- a/ydb/core/load_test/ya.make
+++ b/ydb/core/load_test/ya.make
@@ -33,6 +33,7 @@ PEERDIR(
 END()
 
 RECURSE_FOR_TESTS(
+    blobstorage
     ut
     ut_ycsb
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Prevent PDisk log load tests from mixing up workers during initialization.

### Description for reviewers <!-- (optional) description for those who read this PR -->

The load actor sends all initial YardInit requests concurrently and assigns each result to the first worker without PDiskParams, assuming that completion order matches request order. Actor-system delivery ordering does not make this assumption valid: the PDisk actor forwards requests to its internal processing queues instead of replying immediately. ProcessFastOperationsQueue calls YardInitStart and inserts requests into PendingYardInits, a std::set<std::unique_ptr<TYardInit>> ordered by pointer rather than arrival order. ProcessYardInitSet then calls YardInitFinish in set order for owners without requests in flight, skipping those still busy. Two requests processed in the same batch can therefore finish as B, A even when they arrived as A, B; this does not require actor messages or disk completions to be reordered.

With two wardenless workers using rounds 1000 and 1001, reversed results assign owner B to worker A and owner A to worker B. Max(local round, returned round) then produces ReadLog(owner A expecting 1000, round 1001), leading to an invalid OwnerRound response and the load actor's status assertion. This matches the error recorded for PDiskTestLogWrite in #50117. The internal reordering mechanism is present in the code, and the regression test reproduces the load actor's mismatch by delaying the first response; the actual ordering in the historical CI failure was not captured.

Keep only one initial YardInit in flight and associate its response with an explicit InitializingWorkerIdx. Advance the index and initialize the next worker after assigning PDiskParams, so response matching no longer relies on PDisk completion order. The regression test checks owner/round consistency for both workers during initialization. It lives in load_test/blobstorage/ut and uses TTestActorSystem and a PDisk mock directly, avoiding the shared BlobStorage test environment and its unrelated dependencies.
