### PR TITLE
Introduce a replaceable PDisk actor subsystem

### DIFF
--- a/ydb/core/base/ut/state_storage_follower_ids_ut.cpp
+++ b/ydb/core/base/ut/state_storage_follower_ids_ut.cpp
@@ -106,11 +106,7 @@ void SetupRuntimeAndHive(TTestBasicRuntime& runtime) {
         THashMap<ui32, TIntrusivePtr<TNodeWardenConfig>> allNodeWardenConfigs;
 
         for (ui32 nodeIndex = 0; nodeIndex < runtime.GetNodeCount(); ++nodeIndex) {
-            TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig = new TNodeWardenConfig(
-                !runtime.IsRealThreads()
-                    ? static_cast<IPDiskServiceFactory*>(new TStrandedPDiskServiceFactory(runtime))
-                    : static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory())
-            );
+            TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig = new TNodeWardenConfig();
 
             auto serviceSet = nodeWardenConfig->BlobStorageConfig->MutableServiceSet();
             serviceSet->AddAvailabilityDomains(0);
@@ -231,6 +227,7 @@ void SetupRuntimeAndHive(TTestBasicRuntime& runtime) {
             SetupNodeWhiteboard(runtime, nodeIndex);
         }
 
+        SetupPDiskSubsystem(&runtime);
         runtime.Initialize(app.Unwrap());
     }
 

--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -251,10 +251,7 @@ void SetupServices(TTestActorRuntime &runtime, TString extraPath, TIntrusivePtr<
 
         SubstGlobal(staticConfig, "$Node1", Sprintf("%" PRIu32, runtime.GetNodeId(0)));
 
-        TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig(
-            STRAND_PDISK && !runtime.IsRealThreads() ?
-            static_cast<IPDiskServiceFactory*>(new TStrandedPDiskServiceFactory(runtime)) :
-            static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory())));
+        TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig());
 //            nodeWardenConfig->Monitoring = monitoring;
         google::protobuf::TextFormat::ParseFromString(staticConfig, nodeWardenConfig->BlobStorageConfig->MutableServiceSet());
 
@@ -300,6 +297,7 @@ void SetupServices(TTestActorRuntime &runtime, TString extraPath, TIntrusivePtr<
         SetupTabletResolver(runtime, nodeIndex);
     }
 
+    SetupPDiskSubsystem(&runtime, STRAND_PDISK);
     runtime.Initialize(app.Unwrap());
 
     for (ui32 nodeIndex = 0; nodeIndex < runtime.GetNodeCount(); ++nodeIndex) {
@@ -603,9 +601,12 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
 
     CUSTOM_UNIT_TEST(TestFilterBadSerials) {
         TTestActorSystem runtime(1);
+        runtime.SetupNodeSubSystems = [](ui32, TActorSystemSetup* setup) {
+            setup->RegisterSubSystem<IPDiskSubsystem>(CreatePDiskSubsystem());
+        };
         runtime.Start();
 
-        TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig(static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory())));
+        TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig());
 
         IActor* ac = CreateBSNodeWarden(nodeWardenConfig.Release());
 
@@ -724,10 +725,13 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
 
     CUSTOM_UNIT_TEST(TestStopAggregatorRemovesReportedStats) {
         TTestActorSystem runtime(1);
+        runtime.SetupNodeSubSystems = [](ui32, TActorSystemSetup* setup) {
+            setup->RegisterSubSystem<IPDiskSubsystem>(CreatePDiskSubsystem());
+        };
         runtime.Start();
 
         TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(
-            new TNodeWardenConfig(static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory())));
+            new TNodeWardenConfig());
         const TActorId nodeWarden = runtime.Register(CreateBSNodeWarden(nodeWardenConfig.Release()), 1);
 
         runtime.WrapInActorContext(nodeWarden, [](IActor* wardenActor) {
@@ -1040,6 +1044,9 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
 
     Y_UNIT_TEST(TestReceivedPDiskRestartNotAllowed) {
         TTestActorSystem runtime(1, NLog::PRI_ERROR, MakeIntrusive<TDomainsInfo>());
+        runtime.SetupNodeSubSystems = [](ui32, TActorSystemSetup* setup) {
+            setup->RegisterSubSystem<IPDiskSubsystem>(CreatePDiskSubsystem());
+        };
         runtime.Start();
 
         ui32 nodeId = 1;
@@ -1049,7 +1056,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         auto &appData = runtime.GetNode(1)->AppData;
         appData->DomainsInfo->AddDomain(TDomainsInfo::TDomain::ConstructEmptyDomain("dom", 1).Release());
 
-        TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig(static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory())));
+        TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig());
 
         IActor* ac = CreateBSNodeWarden(nodeWardenConfig.Release());
 
@@ -1228,10 +1235,11 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         TAppPrepare app;
         app.AddDomain(TDomainsInfo::TDomain::ConstructEmptyDomain("dc-1").Release());
         app.AddHive(0);
+        SetupPDiskSubsystem(&runtime, false);
         runtime.Initialize(app.Unwrap());
 
         // Setup BSNodeWarden
-        TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig(static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory())));
+        TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig());
         IActor* nodeWardenActor = CreateBSNodeWarden(nodeWardenConfig.Release());
         TActorId realNodeWarden = runtime.Register(nodeWardenActor, 0);
         runtime.EnableScheduleForActor(realNodeWarden, true);
@@ -1268,7 +1276,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         )
     };
 
-    class TNoReplyPDiskServiceFactory : public IPDiskServiceFactory {
+    class TNoReplyPDiskSubsystem : public IPDiskSubsystem {
         TActorId Observer;
 
     public:
@@ -1276,7 +1284,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
             Observer = observer;
         }
 
-        void Create(const TActorContext& ctx, ui32 pdiskId, const TIntrusivePtr<TPDiskConfig>&,
+        void Start(const TActorContext& ctx, ui32 pdiskId, const TIntrusivePtr<TPDiskConfig>&,
                 const NPDisk::TMainKey&, ui32 poolId, ui32 nodeId) override {
             Y_ABORT_UNLESS(Observer);
             const TActorId actorId = ctx.Register(new TNoReplyPDiskActor(Observer), TMailboxType::HTSwap, poolId);
@@ -1284,18 +1292,19 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         }
     };
 
-    TActorId SetupNodeWardenForSlayTest(TTestActorSystem& runtime,
-            TIntrusivePtr<IPDiskServiceFactory> pdiskServiceFactory = {}) {
+    TActorId SetupNodeWardenForSlayTest(TTestActorSystem& runtime) {
+        if (!runtime.SetupNodeSubSystems) {
+            runtime.SetupNodeSubSystems = [](ui32, TActorSystemSetup* setup) {
+                setup->RegisterSubSystem<IPDiskSubsystem>(CreatePDiskSubsystem());
+            };
+        }
         runtime.Start();
 
         auto& appData = *runtime.GetNode(1)->AppData;
         appData.DomainsInfo->AddDomain(TDomainsInfo::TDomain::ConstructEmptyDomain("dom", 1).Release());
         appData.DynamicNameserviceConfig = new TDynamicNameserviceConfig();
 
-        if (!pdiskServiceFactory) {
-            pdiskServiceFactory.Reset(new TRealPDiskServiceFactory());
-        }
-        TIntrusivePtr<TNodeWardenConfig> config(new TNodeWardenConfig(pdiskServiceFactory));
+        TIntrusivePtr<TNodeWardenConfig> config(new TNodeWardenConfig());
         ObtainStaticKey(&config->StaticKey);
         const TActorId nodeWardenId = runtime.Register(CreateBSNodeWarden(config.Release()), 1);
         runtime.RegisterService(MakeBlobStorageNodeWardenID(1), nodeWardenId);
@@ -1316,15 +1325,20 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
 
     CUSTOM_UNIT_TEST(TestSlayCompletesWhenPDiskIsDestroyedBeforeReply) {
         TTestActorSystem runtime(1, NLog::PRI_ERROR, MakeIntrusive<TDomainsInfo>());
-        TIntrusivePtr<TNoReplyPDiskServiceFactory> pdiskServiceFactory = new TNoReplyPDiskServiceFactory;
-        const TActorId nodeWardenId = SetupNodeWardenForSlayTest(runtime, pdiskServiceFactory);
+        runtime.SetupNodeSubSystems = [](ui32, TActorSystemSetup* setup) {
+            setup->RegisterSubSystem<IPDiskSubsystem>(std::make_unique<TNoReplyPDiskSubsystem>());
+        };
+        const TActorId nodeWardenId = SetupNodeWardenForSlayTest(runtime);
         const ui32 nodeId = 1;
         const ui32 pdiskId = 2007;
         const ui32 vdiskSlotId = 10;
         const NStorage::TNodeWarden::TVSlotId vslotId(nodeId, pdiskId, vdiskSlotId);
         const TVDiskID vdiskId(100507, 15, 0, 0, 0);
         const TActorId slayObserver = runtime.AllocateEdgeActor(nodeId);
-        pdiskServiceFactory->SetObserver(slayObserver);
+        runtime.WrapInActorContext(nodeWardenId, [slayObserver](IActor*) {
+            auto* subsystem = TActivationContext::ActorSystem()->GetSubSystem<IPDiskSubsystem>();
+            dynamic_cast<TNoReplyPDiskSubsystem*>(subsystem)->SetObserver(slayObserver);
+        });
 
         NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk pdisk;
         pdisk.SetNodeID(nodeId);
@@ -2271,9 +2285,9 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         }
     };
 
-    class TSilentPDiskServiceFactory : public IPDiskServiceFactory {
+    class TSilentPDiskSubsystem : public IPDiskSubsystem {
     public:
-        void Create(const TActorContext& ctx, ui32 pdiskId, const TIntrusivePtr<TPDiskConfig>&,
+        void Start(const TActorContext& ctx, ui32 pdiskId, const TIntrusivePtr<TPDiskConfig>&,
                 const NPDisk::TMainKey&, ui32 poolId, ui32 nodeId) override {
             const TActorId actorId = ctx.Register(new TSilentPDiskActor, TMailboxType::HTSwap, poolId);
             ctx.ActorSystem()->RegisterLocalService(MakeBlobStoragePDiskID(nodeId, pdiskId), actorId);
@@ -2308,6 +2322,13 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
                 FormatPDisk(TempDir() + "/pdisk.dat", ui64{16} << 30, 4096, 16 << 20,
                     12345, 1, 2, 3, NPDisk::YdbDefaultPDiskSequence, "requested restart", options);
             }
+            Runtime.SetupNodeSubSystems = [native](ui32, TActorSystemSetup* setup) {
+                if (native) {
+                    setup->RegisterSubSystem<IPDiskSubsystem>(CreatePDiskSubsystem());
+                } else {
+                    setup->RegisterSubSystem<IPDiskSubsystem>(std::make_unique<TSilentPDiskSubsystem>());
+                }
+            };
             Runtime.Start();
 
             auto& appData = *Runtime.GetNode(NodeId)->AppData;
@@ -2317,9 +2338,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
             appData.DynamicNameserviceConfig->MaxStaticNodeId = NodeId;
 
             TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(
-                new TNodeWardenConfig(native
-                    ? static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory)
-                    : static_cast<IPDiskServiceFactory*>(new TSilentPDiskServiceFactory)));
+                new TNodeWardenConfig());
             nodeWardenConfig->DDiskConfig.emplace();
             nodeWardenConfig->DDiskConfig->SetForcePDiskFallback(!native);
             if (native) {
@@ -2763,6 +2782,9 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
             : Runtime(1, NLog::PRI_ERROR, MakeIntrusive<TDomainsInfo>())
             , StaticGroupId(TGroupID(EGroupConfigurationType::Static, 1, 0).GetRaw())
         {
+            Runtime.SetupNodeSubSystems = [](ui32, TActorSystemSetup* setup) {
+                setup->RegisterSubSystem<IPDiskSubsystem>(CreatePDiskSubsystem());
+            };
             Runtime.Start();
 
             auto& appData = *Runtime.GetNode(1)->AppData;
@@ -2770,8 +2792,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
             appData.DynamicNameserviceConfig = new TDynamicNameserviceConfig();
             appData.DynamicNameserviceConfig->MaxStaticNodeId = maxStaticNodeId;
 
-            TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig(
-                static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory())));
+            TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig());
             ObtainStaticKey(&nodeWardenConfig->StaticKey);
 
             auto* serviceSet = nodeWardenConfig->BlobStorageConfig->MutableServiceSet();

--- a/ydb/core/blobstorage/nodewarden/node_warden.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden.h
@@ -42,7 +42,6 @@ namespace NKikimr {
         std::optional<NKikimrBlobStorage::TYamlConfig> YamlConfig;
         TString StartupConfigYaml;
         std::optional<TString> StartupStorageYaml;
-        TIntrusivePtr<IPDiskServiceFactory> PDiskServiceFactory;
         TIntrusivePtr<TAllVDiskKinds> AllVDiskKinds;
         TIntrusivePtr<NPDisk::TDriveModelDb> AllDriveModels;
         NKikimrBlobStorage::TPDiskConfig PDiskConfigOverlay;
@@ -72,7 +71,7 @@ namespace NKikimr {
 
         std::function<void(TVDiskConfig&)> VDiskConfigPreprocessor;
 
-        TNodeWardenConfig(const TIntrusivePtr<IPDiskServiceFactory>& pDiskServiceFactory = {});
+        TNodeWardenConfig();
         ~TNodeWardenConfig();
 
         bool IsCacheEnabled() const {

--- a/ydb/core/blobstorage/nodewarden/node_warden.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden.h
@@ -72,7 +72,7 @@ namespace NKikimr {
 
         std::function<void(TVDiskConfig&)> VDiskConfigPreprocessor;
 
-        TNodeWardenConfig(const TIntrusivePtr<IPDiskServiceFactory>& pDiskServiceFactory);
+        TNodeWardenConfig(const TIntrusivePtr<IPDiskServiceFactory>& pDiskServiceFactory = {});
         ~TNodeWardenConfig();
 
         bool IsCacheEnabled() const {

--- a/ydb/core/blobstorage/nodewarden/node_warden_cache_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_cache_ut.cpp
@@ -35,7 +35,7 @@ namespace {
     }
 
     void UpdateCache(TServiceSet& cache, const TServiceSet& update, bool comprehensive) {
-        auto config = MakeIntrusive<TNodeWardenConfig>(TIntrusivePtr<IPDiskServiceFactory>{});
+        auto config = MakeIntrusive<TNodeWardenConfig>();
         TNodeWarden nodeWarden(config);
         nodeWarden.UpdateServiceSet(update, comprehensive, [] {})(&cache)();
     }

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -32,10 +32,9 @@
 using namespace NKikimr;
 using namespace NStorage;
 
-TNodeWardenConfig::TNodeWardenConfig(const TIntrusivePtr<IPDiskServiceFactory>& pDiskServiceFactory)
+TNodeWardenConfig::TNodeWardenConfig()
     : BlobStorageConfig(std::make_unique<NKikimrConfig::TBlobStorageConfig>())
     , NameserviceConfig(std::make_unique<NKikimrConfig::TStaticNameserviceConfig>())
-    , PDiskServiceFactory(pDiskServiceFactory)
     , AllVDiskKinds(new TAllVDiskKinds)
     , AllDriveModels(new NPDisk::TDriveModelDb)
     , FeatureFlags(std::make_unique<NKikimrConfig::TFeatureFlags>())

--- a/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
@@ -484,8 +484,15 @@ namespace NKikimr::NStorage {
         const ui64 pdiskGuid = pdisk.GetPDiskGuid();
         const ui64 pdiskCategory = pdisk.GetPDiskCategory();
         Cfg->PDiskKey.Initialize();
-        Cfg->PDiskServiceFactory->Create(ActorContext(), pdiskID, pdiskConfig, Cfg->PDiskKey,
-            blobStorageExecutorPoolId, LocalNodeId);
+        if (auto* subsystem = ActorContext().ActorSystem()->GetSubSystem<IPDiskSubsystem>()) {
+            subsystem->Start(ActorContext(), pdiskID, pdiskConfig, Cfg->PDiskKey,
+                blobStorageExecutorPoolId, LocalNodeId);
+        } else {
+            // Compatibility for test runtimes that still inject a per-warden factory.
+            Y_ABORT_UNLESS(Cfg->PDiskServiceFactory, "IPDiskSubsystem is not registered");
+            Cfg->PDiskServiceFactory->Create(ActorContext(), pdiskID, pdiskConfig, Cfg->PDiskKey,
+                blobStorageExecutorPoolId, LocalNodeId);
+        }
         if (!temporary) {
             Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvPDiskStateUpdate(pdiskID, path, pdiskGuid, pdiskCategory));
             Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvSystemStateAddRole("Storage"));

--- a/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
@@ -484,15 +484,10 @@ namespace NKikimr::NStorage {
         const ui64 pdiskGuid = pdisk.GetPDiskGuid();
         const ui64 pdiskCategory = pdisk.GetPDiskCategory();
         Cfg->PDiskKey.Initialize();
-        if (auto* subsystem = ActorContext().ActorSystem()->GetSubSystem<IPDiskSubsystem>()) {
-            subsystem->Start(ActorContext(), pdiskID, pdiskConfig, Cfg->PDiskKey,
-                blobStorageExecutorPoolId, LocalNodeId);
-        } else {
-            // Compatibility for test runtimes that still inject a per-warden factory.
-            Y_ABORT_UNLESS(Cfg->PDiskServiceFactory, "IPDiskSubsystem is not registered");
-            Cfg->PDiskServiceFactory->Create(ActorContext(), pdiskID, pdiskConfig, Cfg->PDiskKey,
-                blobStorageExecutorPoolId, LocalNodeId);
-        }
+        auto* subsystem = ActorContext().ActorSystem()->GetSubSystem<IPDiskSubsystem>();
+        Y_ABORT_UNLESS(subsystem, "IPDiskSubsystem is not registered");
+        subsystem->Start(ActorContext(), pdiskID, pdiskConfig, Cfg->PDiskKey,
+            blobStorageExecutorPoolId, LocalNodeId);
         if (!temporary) {
             Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvPDiskStateUpdate(pdiskID, path, pdiskGuid, pdiskCategory));
             Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvSystemStateAddRole("Storage"));

--- a/ydb/core/blobstorage/nodewarden/ut_sequence/dsproxy_config_retrieval.cpp
+++ b/ydb/core/blobstorage/nodewarden/ut_sequence/dsproxy_config_retrieval.cpp
@@ -98,7 +98,7 @@ void SetupServices(TTestBasicRuntime& runtime) {
 
     for (ui32 i = 0; i < runtime.GetNodeCount(); ++i) {
         SetupStateStorage(runtime, i);
-        auto config = MakeIntrusive<TNodeWardenConfig>(new TStrandedPDiskServiceFactory(runtime));
+        auto config = MakeIntrusive<TNodeWardenConfig>();
         config->SectorMaps[paths[i]] = sectorMaps[i];
         config->BlobStorageConfig->MutableServiceSet()->CopyFrom(configs[i]);
         SetupBSNodeWarden(runtime, i, config);
@@ -106,6 +106,7 @@ void SetupServices(TTestBasicRuntime& runtime) {
         SetupNodeWhiteboard(runtime, i);
     }
 
+    SetupPDiskSubsystem(&runtime);
     runtime.Initialize(app.Unwrap());
 
     CreateTestBootstrapper(runtime, CreateTestTabletInfo(MakeBSControllerID(), TTabletTypes::BSController), &CreateFlatBsController);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -1706,9 +1706,5 @@ std::unique_ptr<IPDiskSubsystem> CreatePDiskSubsystem() {
     return std::make_unique<TPDiskSubsystem>();
 }
 
-void TRealPDiskServiceFactory::Create(const TActorContext &ctx, ui32 pDiskID,
-        const TIntrusivePtr<TPDiskConfig> &cfg, const NPDisk::TMainKey &mainKey, ui32 poolId, ui32 nodeId) {
-    CreatePDiskActor(ctx.ExecutorThread, AppData(ctx)->Counters, cfg, mainKey, pDiskID, poolId, nodeId);
-}
 
 } // NKikimr

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -1692,6 +1692,20 @@ IActor* CreatePDisk(const TIntrusivePtr<TPDiskConfig> &cfg, const NPDisk::TMainK
     return new NPDisk::TPDiskActor(cfg, mainKey, counters);
 }
 
+namespace {
+    class TPDiskSubsystem final : public IPDiskSubsystem {
+    public:
+        void Start(const TActorContext& ctx, ui32 pdiskId, const TIntrusivePtr<TPDiskConfig>& config,
+                const NPDisk::TMainKey& mainKey, ui32 poolId, ui32 nodeId) override {
+            CreatePDiskActor(ctx.ExecutorThread, AppData(ctx)->Counters, config, mainKey, pdiskId, poolId, nodeId);
+        }
+    };
+}
+
+std::unique_ptr<IPDiskSubsystem> CreatePDiskSubsystem() {
+    return std::make_unique<TPDiskSubsystem>();
+}
+
 void TRealPDiskServiceFactory::Create(const TActorContext &ctx, ui32 pDiskID,
         const TIntrusivePtr<TPDiskConfig> &cfg, const NPDisk::TMainKey &mainKey, ui32 poolId, ui32 nodeId) {
     CreatePDiskActor(ctx.ExecutorThread, AppData(ctx)->Counters, cfg, mainKey, pDiskID, poolId, nodeId);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_factory.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_factory.h
@@ -11,18 +11,6 @@ namespace NActors {
 
 namespace NKikimr {
 
-class IPDiskServiceFactory : public TThrRefBase {
-public:
-    virtual void Create(const TActorContext &ctx, ui32 pDiskID, const TIntrusivePtr<TPDiskConfig> &cfg,
-        const NPDisk::TMainKey &mainKey, ui32 poolId, ui32 nodeId) = 0;
-};
-
 std::unique_ptr<IPDiskSubsystem> CreatePDiskSubsystem();
-
-class TRealPDiskServiceFactory : public IPDiskServiceFactory {
-public:
-    void Create(const TActorContext &ctx, ui32 pDiskID, const TIntrusivePtr<TPDiskConfig> &cfg,
-        const NPDisk::TMainKey &mainKey, ui32 poolId, ui32 nodeId) override;
-};
 
 } // NKikimr

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_factory.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_factory.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "defs.h"
+#include <ydb/core/blobstorage/pdisk/subsystem/subsystem.h>
 #include "blobstorage_pdisk_config.h"
 #include "blobstorage_pdisk_defs.h"
 #include <library/cpp/monlib/dynamic_counters/counters.h>
@@ -15,6 +16,8 @@ public:
     virtual void Create(const TActorContext &ctx, ui32 pDiskID, const TIntrusivePtr<TPDiskConfig> &cfg,
         const NPDisk::TMainKey &mainKey, ui32 poolId, ui32 nodeId) = 0;
 };
+
+std::unique_ptr<IPDiskSubsystem> CreatePDiskSubsystem();
 
 class TRealPDiskServiceFactory : public IPDiskServiceFactory {
 public:

--- a/ydb/core/blobstorage/pdisk/mock/subsystem.cpp
+++ b/ydb/core/blobstorage/pdisk/mock/subsystem.cpp
@@ -1,0 +1,30 @@
+#include "subsystem.h"
+
+#include <ydb/core/base/blobstorage.h>
+#include <ydb/library/actors/core/actor.h>
+
+namespace NKikimr {
+
+TMockPDiskSubsystem::TMockPDiskSubsystem(TPDiskMockStates* states, TCreateState createState,
+        TActorCreated actorCreated)
+    : States(*states)
+    , CreateState(std::move(createState))
+    , ActorCreated(std::move(actorCreated))
+{}
+
+void TMockPDiskSubsystem::Start(const NActors::TActorContext& ctx, ui32 pdiskId,
+        const TIntrusivePtr<TPDiskConfig>& config, const NPDisk::TMainKey&,
+        ui32 poolId, ui32 nodeId) {
+    auto& state = States[{nodeId, pdiskId}];
+    if (!state) {
+        state = CreateState(nodeId, pdiskId, *config);
+        Y_ABORT_UNLESS(state);
+    }
+    const auto actorId = ctx.Register(CreatePDiskMockActor(state), NActors::TMailboxType::HTSwap, poolId);
+    ctx.ActorSystem()->RegisterLocalService(MakeBlobStoragePDiskID(nodeId, pdiskId), actorId);
+    if (ActorCreated) {
+        ActorCreated(actorId);
+    }
+}
+
+} // namespace NKikimr

--- a/ydb/core/blobstorage/pdisk/mock/subsystem.h
+++ b/ydb/core/blobstorage/pdisk/mock/subsystem.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "pdisk_mock.h"
+#include <ydb/core/blobstorage/pdisk/subsystem/subsystem.h>
+
+#include <functional>
+#include <map>
+
+namespace NKikimr {
+
+using TPDiskMockStates = std::map<std::pair<ui32, ui32>, TIntrusivePtr<TPDiskMockState>>;
+
+// The state store belongs to the test and must outlive the node actor systems.
+class TMockPDiskSubsystem final : public IPDiskSubsystem {
+public:
+    using TCreateState = std::function<TIntrusivePtr<TPDiskMockState>(
+        ui32, ui32, const TPDiskConfig&)>;
+    using TActorCreated = std::function<void(NActors::TActorId)>;
+
+    TMockPDiskSubsystem(TPDiskMockStates* states, TCreateState createState,
+        TActorCreated actorCreated = {});
+
+    void Start(const NActors::TActorContext& ctx, ui32 pdiskId,
+        const TIntrusivePtr<TPDiskConfig>& config, const NPDisk::TMainKey& mainKey,
+        ui32 poolId, ui32 nodeId) override;
+
+private:
+    TPDiskMockStates& States;
+    TCreateState CreateState;
+    TActorCreated ActorCreated;
+};
+
+} // namespace NKikimr

--- a/ydb/core/blobstorage/pdisk/mock/ya.make
+++ b/ydb/core/blobstorage/pdisk/mock/ya.make
@@ -3,6 +3,8 @@ LIBRARY()
 SRCS(
     pdisk_mock.cpp
     pdisk_mock.h
+    subsystem.cpp
+    subsystem.h
 )
 
 PEERDIR(

--- a/ydb/core/blobstorage/pdisk/subsystem/subsystem.h
+++ b/ydb/core/blobstorage/pdisk/subsystem/subsystem.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <ydb/library/actors/core/subsystem.h>
+#include <util/generic/ptr.h>
+#include <util/system/types.h>
+
+namespace NActors {
+    struct TActorContext;
+}
+
+namespace NKikimr {
+    struct TPDiskConfig;
+
+    namespace NPDisk {
+        struct TMainKey;
+    }
+
+    class IPDiskSubsystem : public NActors::ISubSystem {
+    public:
+        // Called from the owning NodeWarden actor. Registers the PDisk local service;
+        // initialization and restart completion use the existing actor protocol.
+        virtual void Start(const NActors::TActorContext& ctx, ui32 pdiskId,
+            const TIntrusivePtr<TPDiskConfig>& config, const NPDisk::TMainKey& mainKey,
+            ui32 poolId, ui32 nodeId) = 0;
+    };
+}

--- a/ydb/core/blobstorage/pdisk/subsystem/ya.make
+++ b/ydb/core/blobstorage/pdisk/subsystem/ya.make
@@ -1,0 +1,11 @@
+LIBRARY()
+
+SRCS(
+    subsystem.h
+)
+
+PEERDIR(
+    ydb/library/actors/core
+)
+
+END()

--- a/ydb/core/blobstorage/pdisk/ya.make
+++ b/ydb/core/blobstorage/pdisk/ya.make
@@ -26,6 +26,7 @@ PEERDIR(
     ydb/core/base
     ydb/core/base/services
     ydb/core/blobstorage/base
+    ydb/core/blobstorage/pdisk/subsystem
     ydb/core/blobstorage/crypto
     ydb/core/blobstorage/groupinfo
     ydb/core/blobstorage/lwtrace_probes

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -87,15 +87,15 @@ struct TEnvironmentSetup {
 
     const TSettings Settings;
 
-    class TMockPDiskServiceFactory : public IPDiskServiceFactory {
+    class TMockPDiskSubsystem : public IPDiskSubsystem {
         TEnvironmentSetup& Env;
 
     public:
-        TMockPDiskServiceFactory(TEnvironmentSetup& env)
-            : Env(env)
+        TMockPDiskSubsystem(TEnvironmentSetup* env)
+            : Env(*env)
         {}
 
-        void Create(const TActorContext& ctx, ui32 pdiskId, const TIntrusivePtr<TPDiskConfig>& cfg,
+        void Start(const TActorContext& ctx, ui32 pdiskId, const TIntrusivePtr<TPDiskConfig>& cfg,
                 const NPDisk::TMainKey& /*mainKey*/, ui32 poolId, ui32 nodeId) override {
             const auto key = std::make_pair(nodeId, pdiskId);
             TIntrusivePtr<TPDiskMockState>& state = Env.PDiskMockStates[key];
@@ -305,6 +305,9 @@ struct TEnvironmentSetup {
 
     void Initialize() {
         Runtime = MakeRuntime();
+        Runtime->SetupNodeSubSystems = [this](ui32, TActorSystemSetup* setup) {
+            setup->RegisterSubSystem<IPDiskSubsystem>(std::make_unique<TMockPDiskSubsystem>(this));
+        };
         TAppData::TimeProvider = TTestActorSystem::CreateTimeProvider();
         if (Settings.PrepareRuntime) {
             Settings.PrepareRuntime(*Runtime);
@@ -441,7 +444,7 @@ struct TEnvironmentSetup {
             if (Settings.NodeWardenMockSetup) {
                 warden.reset(new TNodeWardenMockActor(Settings.NodeWardenMockSetup));
             } else {
-                auto config = MakeIntrusive<TNodeWardenConfig>(new TMockPDiskServiceFactory(*this));
+                auto config = MakeIntrusive<TNodeWardenConfig>();
                 if (Settings.SelfManagementConfig) {
                     config->SelfManagementConfig = std::make_unique<NKikimrConfig::TSelfManagementConfig>();
                     config->SelfManagementConfig->SetEnabled(true);

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "defs.h"
+#include <ydb/core/blobstorage/pdisk/mock/subsystem.h>
 
 #include "node_warden_mock.h"
 #include "ydb/core/blobstorage/dsproxy/dsproxy.h"
@@ -26,7 +27,7 @@ struct TEnvironmentSetup {
     const TString StoragePoolName = "test";
     const ui32 NumGroups = 1;
     TIntrusivePtr<NFake::TProxyDS> Group0 = MakeIntrusive<NFake::TProxyDS>();
-    std::map<std::pair<ui32, ui32>, TIntrusivePtr<TPDiskMockState>> PDiskMockStates;
+    TPDiskMockStates PDiskMockStates;
     TVector<TActorId> PDiskActors;
     std::set<TActorId> CommencedReplication;
     std::unordered_map<ui32, TString> Cache;
@@ -86,35 +87,6 @@ struct TEnvironmentSetup {
     };
 
     const TSettings Settings;
-
-    class TMockPDiskSubsystem : public IPDiskSubsystem {
-        TEnvironmentSetup& Env;
-
-    public:
-        TMockPDiskSubsystem(TEnvironmentSetup* env)
-            : Env(*env)
-        {}
-
-        void Start(const TActorContext& ctx, ui32 pdiskId, const TIntrusivePtr<TPDiskConfig>& cfg,
-                const NPDisk::TMainKey& /*mainKey*/, ui32 poolId, ui32 nodeId) override {
-            const auto key = std::make_pair(nodeId, pdiskId);
-            TIntrusivePtr<TPDiskMockState>& state = Env.PDiskMockStates[key];
-            if (!state) {
-                ui64 chunkSize = Env.Settings.PDiskChunkSize ? Env.Settings.PDiskChunkSize : cfg->ChunkSize;
-                TPDiskMockState::ESpaceColorPolicy spaceColorPolicy = Env.Settings.TrackSharedQuotaInPDiskMock
-                        ? TPDiskMockState::ESpaceColorPolicy::SharedQuota
-                        : TPDiskMockState::ESpaceColorPolicy::None;
-                state.Reset(new TPDiskMockState(nodeId, pdiskId, cfg->PDiskGuid, Env.Settings.PDiskSize, chunkSize,
-                        cfg->ReadOnly, Env.Settings.DiskType, spaceColorPolicy));
-                state->SetReportVDiskMetrics(Env.Settings.ReportVDiskMetricsInPDiskMock);
-            }
-            const TActorId& actorId = ctx.Register(CreatePDiskMockActor(state), TMailboxType::HTSwap, poolId);
-            const TActorId& serviceId = MakeBlobStoragePDiskID(nodeId, pdiskId);
-            ctx.ActorSystem()->RegisterLocalService(serviceId, actorId);
-            Env.PDiskActors.push_back(actorId);
-        }
-    };
-
 
     class TFakeConfigDispatcher : public TActor<TFakeConfigDispatcher> {
         std::unordered_set<TActorId> Subscribers;
@@ -306,7 +278,19 @@ struct TEnvironmentSetup {
     void Initialize() {
         Runtime = MakeRuntime();
         Runtime->SetupNodeSubSystems = [this](ui32, TActorSystemSetup* setup) {
-            setup->RegisterSubSystem<IPDiskSubsystem>(std::make_unique<TMockPDiskSubsystem>(this));
+            setup->RegisterSubSystem<IPDiskSubsystem>(std::make_unique<TMockPDiskSubsystem>(&PDiskMockStates,
+                [this](ui32 nodeId, ui32 pdiskId, const TPDiskConfig& cfg) {
+                    const ui32 chunkSize = Settings.PDiskChunkSize
+                        ? static_cast<ui32>(Settings.PDiskChunkSize) : cfg.ChunkSize;
+                    const auto policy = Settings.TrackSharedQuotaInPDiskMock
+                        ? TPDiskMockState::ESpaceColorPolicy::SharedQuota
+                        : TPDiskMockState::ESpaceColorPolicy::None;
+                    auto state = MakeIntrusive<TPDiskMockState>(nodeId, pdiskId, cfg.PDiskGuid,
+                        Settings.PDiskSize, chunkSize, cfg.ReadOnly, Settings.DiskType, policy);
+                    state->SetReportVDiskMetrics(Settings.ReportVDiskMetricsInPDiskMock);
+                    return state;
+                },
+                [this](TActorId actorId) { PDiskActors.push_back(actorId); }));
         };
         TAppData::TimeProvider = TTestActorSystem::CreateTimeProvider();
         if (Settings.PrepareRuntime) {

--- a/ydb/core/blobstorage/ut_blobstorage/pdisk_subsystem_ut.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/pdisk_subsystem_ut.cpp
@@ -1,0 +1,45 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+
+Y_UNIT_TEST_SUITE(PDiskSubsystem) {
+    Y_UNIT_TEST(MetadataSurvivesNodeRestart) {
+        ui32 registrations = 0;
+        TEnvironmentSetup env({
+            .NodeCount = 1,
+            .PrepareRuntime = [&registrations](TTestActorSystem& runtime) {
+                auto configure = std::move(runtime.SetupNodeSubSystems);
+                runtime.SetupNodeSubSystems = [configure = std::move(configure), &registrations](
+                        ui32 nodeId, TActorSystemSetup* setup) {
+                    ++registrations;
+                    configure(nodeId, setup);
+                };
+            },
+        });
+        UNIT_ASSERT_VALUES_EQUAL(registrations, 1);
+        const ui32 nodeId = *env.Runtime->GetNodes().begin();
+        const TString path = "/mock/pdisk-subsystem-metadata";
+        const TActorId wardenId = MakeBlobStorageNodeWardenID(nodeId);
+        NKikimrBlobStorage::TPDiskMetadataRecord record;
+        record.MutableCommittedStorageConfig()->SetGeneration(42);
+
+        auto edge = env.Runtime->AllocateEdgeActor(nodeId);
+        env.Runtime->Send(new IEventHandle(wardenId, edge,
+            new NStorage::TEvNodeWardenWriteMetadata(path, record)), nodeId);
+        auto written = env.Runtime->WaitForEdgeActorEvent<NStorage::TEvNodeWardenWriteMetadataResult>(edge);
+        UNIT_ASSERT(written->Get()->Outcome == NPDisk::EPDiskMetadataOutcome::OK);
+
+        const auto states = env.PDiskMockStates;
+        UNIT_ASSERT(!states.empty());
+        env.RestartNode(nodeId);
+        UNIT_ASSERT_VALUES_EQUAL(registrations, 2);
+
+        edge = env.Runtime->AllocateEdgeActor(nodeId);
+        env.Runtime->Send(new IEventHandle(wardenId, edge,
+            new NStorage::TEvNodeWardenReadMetadata(path)), nodeId);
+        auto read = env.Runtime->WaitForEdgeActorEvent<NStorage::TEvNodeWardenReadMetadataResult>(edge);
+        UNIT_ASSERT(read->Get()->Outcome == NPDisk::EPDiskMetadataOutcome::OK);
+        UNIT_ASSERT_VALUES_EQUAL(read->Get()->Record.SerializeAsString(), record.SerializeAsString());
+        for (const auto& [key, state] : states) {
+            UNIT_ASSERT(env.PDiskMockStates.at(key) == state);
+        }
+    }
+}

--- a/ydb/core/blobstorage/ut_blobstorage/ut_restart_pdisk/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ut_restart_pdisk/ya.make
@@ -6,6 +6,7 @@ UNITTEST_FOR(ydb/core/blobstorage/ut_blobstorage)
 
     SRCS(
         restart_pdisk.cpp
+        pdisk_subsystem_ut.cpp
     )
 
     PEERDIR(

--- a/ydb/core/blobstorage/ut_testshard/env.h
+++ b/ydb/core/blobstorage/ut_testshard/env.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "defs.h"
+#include <ydb/core/blobstorage/pdisk/mock/subsystem.h>
 
 #include <ydb/core/protos/blob_depot_config.pb.h>
 
@@ -14,7 +15,7 @@ struct TEnvironmentSetup {
     const ui32 StaticGroupId = 0;
     const TString StoragePoolName = "test";
     TIntrusivePtr<NFake::TProxyDS> Group0 = MakeIntrusive<NFake::TProxyDS>();
-    std::map<std::pair<ui32, ui32>, TIntrusivePtr<TPDiskMockState>> PDiskMockStates;
+    TPDiskMockStates PDiskMockStates;
     NKikimr::NTestShard::TTestShardContext::TPtr TestShardContext = NKikimr::NTestShard::TTestShardContext::Create();
     NKikimr::NTesting::TGroupOverseer GroupOverseer;
 
@@ -25,27 +26,6 @@ struct TEnvironmentSetup {
     };
 
     const TSettings Settings;
-
-    class TMockPDiskServiceFactory : public IPDiskServiceFactory {
-        TEnvironmentSetup& Env;
-
-    public:
-        TMockPDiskServiceFactory(TEnvironmentSetup& env)
-            : Env(env)
-        {}
-
-        void Create(const TActorContext& ctx, ui32 pdiskId, const TIntrusivePtr<TPDiskConfig>& cfg,
-                const NPDisk::TMainKey& /*mainKey*/, ui32 poolId, ui32 nodeId) override {
-            const auto key = std::make_pair(nodeId, pdiskId);
-            TIntrusivePtr<TPDiskMockState>& state = Env.PDiskMockStates[key];
-            if (!state) {
-                state.Reset(new TPDiskMockState(nodeId, pdiskId, cfg->PDiskGuid, ui64(10) << 40, cfg->ChunkSize));
-            }
-            const TActorId& actorId = ctx.Register(CreatePDiskMockActor(state), TMailboxType::HTSwap, poolId);
-            const TActorId& serviceId = MakeBlobStoragePDiskID(nodeId, pdiskId);
-            ctx.ActorSystem()->RegisterLocalService(serviceId, actorId);
-        }
-    };
 
     static TEnvironmentSetup *Env;
 
@@ -98,6 +78,13 @@ struct TEnvironmentSetup {
         };
 
         SetupLogging();
+        Runtime->SetupNodeSubSystems = [this](ui32, TActorSystemSetup* setup) {
+            setup->RegisterSubSystem<IPDiskSubsystem>(std::make_unique<TMockPDiskSubsystem>(&PDiskMockStates,
+                [](ui32 nodeId, ui32 pdiskId, const TPDiskConfig& cfg) {
+                    return MakeIntrusive<TPDiskMockState>(nodeId, pdiskId, cfg.PDiskGuid,
+                        ui64(10) << 40, cfg.ChunkSize);
+                }));
+        };
         Runtime->Start();
         Runtime->SetupTabletRuntime(1, Settings.ControllerNodeId);
         SetupStaticStorage();
@@ -217,7 +204,7 @@ struct TEnvironmentSetup {
                 continue;
             }
 
-            auto config = MakeIntrusive<TNodeWardenConfig>(new TMockPDiskServiceFactory(*this));
+            auto config = MakeIntrusive<TNodeWardenConfig>();
             config->BlobStorageConfig->MutableServiceSet()->AddAvailabilityDomains(DomainId);
             std::unique_ptr<IActor> warden(CreateBSNodeWarden(config));
 

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -540,9 +540,7 @@ static void SetupServices(TTestBasicRuntime &runtime, const TTestEnvOpts &option
         SubstGlobal(staticConfig, "$Node1", Sprintf("%" PRIu32, runtime.GetNodeId(0)));
 
         TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig =
-            new TNodeWardenConfig(STRAND_PDISK && !runtime.IsRealThreads()
-                                  ? static_cast<IPDiskServiceFactory*>(new TStrandedPDiskServiceFactory(runtime))
-                                  : static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory()));
+            new TNodeWardenConfig();
         google::protobuf::TextFormat::ParseFromString(staticConfig, nodeWardenConfig->BlobStorageConfig->MutableServiceSet());
 
         if (nodeIndex == 0) {
@@ -619,6 +617,7 @@ static void SetupServices(TTestBasicRuntime &runtime, const TTestEnvOpts &option
         0);
 
     runtime.LocationCallback = options.NodeLocationCallback;
+    SetupPDiskSubsystem(&runtime, STRAND_PDISK);
     runtime.Initialize(app.Unwrap());
     auto dnsConfig = new TDynamicNameserviceConfig();
     dnsConfig->MaxStaticNodeId = 1000;

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -1179,9 +1179,7 @@ TBSNodeWardenInitializer::TBSNodeWardenInitializer(const TKikimrRunConfig& runCo
 
 void TBSNodeWardenInitializer::InitializeServices(NActors::TActorSystemSetup* setup,
                                                   const NKikimr::TAppData* appData) {
-    if (!NActors::GetSubSystem<IPDiskSubsystem>(setup->SubSystems)) {
-        setup->RegisterSubSystem<IPDiskSubsystem>(CreatePDiskSubsystem());
-    }
+    setup->RegisterSubSystem<IPDiskSubsystem>(CreatePDiskSubsystem());
     TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig());
     nodeWardenConfig->BlobStorageExecutorPoolIds =
         NActorSystemConfigHelpers::GetBlobStorageExecutorPoolIds(Config.GetActorSystemConfig());

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -1179,7 +1179,10 @@ TBSNodeWardenInitializer::TBSNodeWardenInitializer(const TKikimrRunConfig& runCo
 
 void TBSNodeWardenInitializer::InitializeServices(NActors::TActorSystemSetup* setup,
                                                   const NKikimr::TAppData* appData) {
-    TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig(new TRealPDiskServiceFactory()));
+    if (!NActors::GetSubSystem<IPDiskSubsystem>(setup->SubSystems)) {
+        setup->RegisterSubSystem<IPDiskSubsystem>(CreatePDiskSubsystem());
+    }
+    TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig());
     nodeWardenConfig->BlobStorageExecutorPoolIds =
         NActorSystemConfigHelpers::GetBlobStorageExecutorPoolIds(Config.GetActorSystemConfig());
     if (Config.HasBlobStorageConfig()) {

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -150,10 +150,9 @@ namespace {
     }
 
     void SetupNodeWarden(TTestActorRuntime &runtime) {
+        SetupPDiskSubsystem(&runtime, STRAND_PDISK);
         for (ui32 nodeIndex = 0; nodeIndex < runtime.GetNodeCount(); ++nodeIndex) {
-            TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig = new TNodeWardenConfig(
-                    STRAND_PDISK && !runtime.IsRealThreads() ? static_cast<IPDiskServiceFactory*>(new TStrandedPDiskServiceFactory(runtime)) :
-                    static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory()));
+            TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig = new TNodeWardenConfig();
                 //nodeWardenConfig->Monitoring = monitoring;
             auto* serviceSet = nodeWardenConfig->BlobStorageConfig->MutableServiceSet();
             serviceSet->AddAvailabilityDomains(0);

--- a/ydb/core/mind/node_broker_ut.cpp
+++ b/ydb/core/mind/node_broker_ut.cpp
@@ -133,9 +133,7 @@ void SetupServices(TTestActorRuntime &runtime,
         SubstGlobal(staticConfig, "$Node1", Sprintf("%" PRIu32, runtime.GetNodeId(0)));
 
         TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig =
-            new TNodeWardenConfig(STRAND_PDISK && !runtime.IsRealThreads()
-                                  ? static_cast<IPDiskServiceFactory*>(new TStrandedPDiskServiceFactory(runtime))
-                                  : static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory()));
+            new TNodeWardenConfig();
         google::protobuf::TextFormat::ParseFromString(staticConfig, nodeWardenConfig->BlobStorageConfig->MutableServiceSet());
 
         TIntrusivePtr<TNodeWardenConfig> existingNodeWardenConfig = NodeWardenConfigs[nodeIndex];
@@ -204,6 +202,7 @@ void SetupServices(TTestActorRuntime &runtime,
     // distconf, which is incidental to the node broker / nameservice under test.
     app.FeatureFlags.SetForceDistconfDisable(forceDistconfDisable);
 
+    SetupPDiskSubsystem(&runtime, STRAND_PDISK);
     runtime.Initialize(app.Unwrap());
 
     runtime.GetAppData().DynamicNameserviceConfig = new TDynamicNameserviceConfig;

--- a/ydb/core/mind/ut_fat/blobstorage_node_warden_ut_fat.cpp
+++ b/ydb/core/mind/ut_fat/blobstorage_node_warden_ut_fat.cpp
@@ -216,10 +216,7 @@ void SetupServices(TTestActorRuntime &runtime) {
 
         SubstGlobal(staticConfig, "$Node1", Sprintf("%" PRIu32, runtime.GetNodeId(0)));
 
-        TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig(
-            STRAND_PDISK && !runtime.IsRealThreads() ?
-            static_cast<IPDiskServiceFactory*>(new TStrandedPDiskServiceFactory(runtime)) :
-            static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory())));
+        TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig());
 //            nodeWardenConfig->Monitoring = monitoring;
         google::protobuf::TextFormat::ParseFromString(staticConfig, nodeWardenConfig->BlobStorageConfig->MutableServiceSet());
 
@@ -246,6 +243,7 @@ void SetupServices(TTestActorRuntime &runtime) {
         SetupTabletResolver(runtime, nodeIndex);
     }
 
+    SetupPDiskSubsystem(&runtime, STRAND_PDISK);
     runtime.Initialize(app.Unwrap());
 
     for (ui32 nodeIndex = 0; nodeIndex < runtime.GetNodeCount(); ++nodeIndex) {

--- a/ydb/core/testlib/basics/helpers.cpp
+++ b/ydb/core/testlib/basics/helpers.cpp
@@ -76,7 +76,7 @@ namespace NKikimr {
         TMaybe<ui64> LastLsn;
     };
 
-    void TStrandedPDiskServiceFactory::Create(const TActorContext &ctx, ui32 pDiskID,
+    void TStrandedPDiskSubsystem::Start(const TActorContext &ctx, ui32 pDiskID,
             const TIntrusivePtr<TPDiskConfig> &cfg, const NPDisk::TMainKey &mainKey, ui32 poolId, ui32 nodeId)
     {
         Y_UNUSED(ctx);
@@ -95,4 +95,22 @@ namespace NKikimr {
         TActorId wrappedActorId = Runtime.Register(wrappedActor, nodeIndex, poolId, TMailboxType::Revolving);
         Runtime.RegisterService(pDiskServiceId, wrappedActorId, nodeIndex);
     }
+
+    void SetupPDiskSubsystem(TTestActorRuntime* runtime, bool stranded) {
+        auto previous = std::move(runtime->SetupNodeSubSystems);
+        runtime->SetupNodeSubSystems = [runtime, stranded, previous = std::move(previous)](
+                ui32 nodeIndex, TActorSystemSetup* setup) {
+            if (previous) {
+                previous(nodeIndex, setup);
+            }
+            if (!NActors::GetSubSystem<IPDiskSubsystem>(setup->SubSystems)) {
+                if (stranded && !runtime->IsRealThreads()) {
+                    setup->RegisterSubSystem<IPDiskSubsystem>(std::make_unique<TStrandedPDiskSubsystem>(runtime));
+                } else {
+                    setup->RegisterSubSystem<IPDiskSubsystem>(CreatePDiskSubsystem());
+                }
+            }
+        };
+    }
+
 }

--- a/ydb/core/testlib/basics/helpers.cpp
+++ b/ydb/core/testlib/basics/helpers.cpp
@@ -103,12 +103,10 @@ namespace NKikimr {
             if (previous) {
                 previous(nodeIndex, setup);
             }
-            if (!NActors::GetSubSystem<IPDiskSubsystem>(setup->SubSystems)) {
-                if (stranded && !runtime->IsRealThreads()) {
-                    setup->RegisterSubSystem<IPDiskSubsystem>(std::make_unique<TStrandedPDiskSubsystem>(runtime));
-                } else {
-                    setup->RegisterSubSystem<IPDiskSubsystem>(CreatePDiskSubsystem());
-                }
+            if (stranded && !runtime->IsRealThreads()) {
+                setup->RegisterSubSystem<IPDiskSubsystem>(std::make_unique<TStrandedPDiskSubsystem>(runtime));
+            } else {
+                setup->RegisterSubSystem<IPDiskSubsystem>(CreatePDiskSubsystem());
             }
         };
     }

--- a/ydb/core/testlib/basics/helpers.h
+++ b/ydb/core/testlib/basics/helpers.h
@@ -81,7 +81,7 @@ namespace NFake {
 
     };
 
-    // Configure before runtime initialization; keep a subsystem supplied by the test.
+    // Configure before runtime initialization; replace any earlier PDisk subsystem registration.
     void SetupPDiskSubsystem(TTestActorRuntime* runtime, bool stranded = true);
 
     TActorId MakeBoardReplicaID(ui32 node, ui32 replicaIndex);

--- a/ydb/core/testlib/basics/helpers.h
+++ b/ydb/core/testlib/basics/helpers.h
@@ -69,20 +69,20 @@ namespace NFake {
                             NFake::INode *factory = nullptr, NFake::TStorage storage = {}, const NSharedCache::TSharedCacheConfig* sharedCacheConfig = nullptr, bool forceFollowers = false,
                             TVector<TIntrusivePtr<NFake::TProxyDS>> dsProxies = {});
 
-    ///
-    class TStrandedPDiskServiceFactory : public IPDiskServiceFactory {
+    class TStrandedPDiskSubsystem final : public IPDiskSubsystem {
         TTestActorRuntime &Runtime;
     public:
-        TStrandedPDiskServiceFactory(TTestActorRuntime &runtime)
-            : Runtime(runtime)
+        TStrandedPDiskSubsystem(TTestActorRuntime* runtime)
+            : Runtime(*runtime)
         {}
 
-        void Create(const TActorContext &ctx, ui32 pDiskID, const TIntrusivePtr<TPDiskConfig> &cfg,
+        void Start(const TActorContext &ctx, ui32 pDiskID, const TIntrusivePtr<TPDiskConfig> &cfg,
             const NPDisk::TMainKey &mainKey, ui32 poolId, ui32 nodeId) override;
 
-        virtual ~TStrandedPDiskServiceFactory()
-        {}
     };
+
+    // Configure before runtime initialization; keep a subsystem supplied by the test.
+    void SetupPDiskSubsystem(TTestActorRuntime* runtime, bool stranded = true);
 
     TActorId MakeBoardReplicaID(ui32 node, ui32 replicaIndex);
 

--- a/ydb/core/testlib/basics/storage.h
+++ b/ydb/core/testlib/basics/storage.h
@@ -44,12 +44,7 @@ namespace NKikimr {
                 }
             }
 
-            const bool strandedPDisk = STRAND_PDISK && !Runtime.IsRealThreads();
-            if (strandedPDisk) {
-                Factory = new TStrandedPDiskServiceFactory(Runtime);
-            } else {
-                Factory = new TRealPDiskServiceFactory();
-            }
+            SetupPDiskSubsystem(&Runtime, STRAND_PDISK);
 
             NPDisk::TKey mainKey = NPDisk::YdbDefaultPDiskSequence;
 
@@ -87,7 +82,7 @@ namespace NKikimr {
 
         TIntrusivePtr<TNodeWardenConfig> MakeWardenConf(const TDomainsInfo &domains, const NKikimrProto::TKeyConfig& keyConfig) const
         {
-            TIntrusivePtr<TNodeWardenConfig> conf(new TNodeWardenConfig(Factory));
+            TIntrusivePtr<TNodeWardenConfig> conf(new TNodeWardenConfig());
 
             {
                 auto text = MakeTextConf(domains);
@@ -181,7 +176,6 @@ namespace NKikimr {
 
     private:
         TTestActorRuntime &Runtime;
-        TIntrusivePtr<IPDiskServiceFactory> Factory;
         TString PDiskPath;
         TIntrusivePtr<NPDisk::TSectorMap> SectorMap;
     };

--- a/ydb/core/util/actorsys_test/testactorsys.h
+++ b/ydb/core/util/actorsys_test/testactorsys.h
@@ -209,6 +209,8 @@ public:
 public:
     std::function<bool(ui32, std::unique_ptr<IEventHandle>&)> FilterFunction;
     std::function<bool(ui32, std::unique_ptr<IEventHandle>&, ISchedulerCookie*, TInstant)> FilterEnqueue;
+    // Invoked for every new node actor system, including after StopNode.
+    std::function<void(ui32, TActorSystemSetup*)> SetupNodeSubSystems;
     IOutputStream *LogStream = &Cerr;
     std::function<TIntrusivePtr<TStateStorageInfo>(std::function<TActorId(ui32, ui32)>, ui32)> StateStorageInfoGenerator
         = [](std::function<TActorId(ui32, ui32)> generateId, ui32 stateStorageNodeId) {
@@ -331,6 +333,9 @@ public:
             }
         }
 
+        if (SetupNodeSubSystems) {
+            SetupNodeSubSystems(nodeId, setup.Get());
+        }
         info.AppData = std::move(MakeAppData());
         info.ActorSystem = std::make_unique<TActorSystem>(setup, info.AppData.get(), LoggerSettings_);
         info.MailboxTable = std::make_unique<TMailboxTable>();

--- a/ydb/library/actors/testlib/subsystem_ut.cpp
+++ b/ydb/library/actors/testlib/subsystem_ut.cpp
@@ -1,0 +1,61 @@
+#include "test_runtime.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NActors;
+
+namespace {
+    class ITestSubsystem : public ISubSystem {
+    public:
+        virtual ui32 GetNodeIndex() const = 0;
+    };
+
+    class TTestSubsystem final : public ITestSubsystem {
+        const ui32 NodeIndex;
+
+    public:
+        bool Started = false;
+
+        explicit TTestSubsystem(ui32 nodeIndex)
+            : NodeIndex(nodeIndex)
+        {}
+
+        ui32 GetNodeIndex() const override {
+            return NodeIndex;
+        }
+
+        void OnBeforeStart(TActorSystem&) override {
+            Started = true;
+        }
+    };
+
+    void CheckNodeSubsystems(bool realThreads) {
+        TTestActorRuntimeBase runtime(2, realThreads);
+        ui32 registrations = 0;
+        runtime.SetupNodeSubSystems = [&registrations](ui32 nodeIndex, TActorSystemSetup* setup) {
+            ++registrations;
+            setup->RegisterSubSystem<ITestSubsystem>(std::make_unique<TTestSubsystem>(nodeIndex));
+        };
+        runtime.Initialize();
+
+        UNIT_ASSERT_VALUES_EQUAL(registrations, 2);
+        for (ui32 nodeIndex = 0; nodeIndex < 2; ++nodeIndex) {
+            auto* subsystem = runtime.GetActorSystem(nodeIndex)->GetSubSystem<ITestSubsystem>();
+            UNIT_ASSERT(subsystem);
+            UNIT_ASSERT_VALUES_EQUAL(subsystem->GetNodeIndex(), nodeIndex);
+            UNIT_ASSERT(dynamic_cast<TTestSubsystem*>(subsystem)->Started);
+        }
+        UNIT_ASSERT(runtime.GetActorSystem(0)->GetSubSystem<ITestSubsystem>() !=
+            runtime.GetActorSystem(1)->GetSubSystem<ITestSubsystem>());
+    }
+}
+
+Y_UNIT_TEST_SUITE(TestRuntimeSubsystems) {
+    Y_UNIT_TEST(SimulatedRuntime) {
+        CheckNodeSubsystems(false);
+    }
+
+    Y_UNIT_TEST(RealThreadsRuntime) {
+        CheckNodeSubsystems(true);
+    }
+}

--- a/ydb/library/actors/testlib/test_runtime.cpp
+++ b/ydb/library/actors/testlib/test_runtime.cpp
@@ -1779,6 +1779,9 @@ namespace NActors {
         }
 
         InitActorSystemSetup(*setup, node);
+        if (SetupNodeSubSystems) {
+            SetupNodeSubSystems(nodeIndex, setup.Get());
+        }
 
         return setup;
     }

--- a/ydb/library/actors/testlib/test_runtime.h
+++ b/ydb/library/actors/testlib/test_runtime.h
@@ -710,6 +710,9 @@ namespace NActors {
             return future.ExtractValue();
         }
 
+        // Called with the node index before constructing each node actor system.
+        std::function<void(ui32, TActorSystemSetup*)> SetupNodeSubSystems;
+
     protected:
         struct TNodeDataBase;
         TNodeDataBase* GetRawNode(ui32 node) const {

--- a/ydb/library/actors/testlib/ut/ya.make
+++ b/ydb/library/actors/testlib/ut/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
 
 SRCS(
     decorator_ut.cpp
+    subsystem_ut.cpp
 )
 
 END()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Allow PDisk implementations to be replaced through actor-system subsystems.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Route all NodeWarden PDisk startup through IPDiskSubsystem and remove per-warden factories. Production registers real PDisk; test runtimes register real, stranded, a shared in-memory mock, or local protocol stubs before actor-system startup. The shared mock retains externally owned disk state across node restarts. This introduces the injection boundary; removing the remaining production build dependencies is a separate step.
