### PR TITLE
Fix DDisk/PB shutdown ordering and PDisk restart ownership

### DIFF
--- a/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
@@ -285,6 +285,19 @@ namespace {
         // destroyed here, where the type is complete. sizeof fails the build otherwise.
         [[maybe_unused]] constexpr size_t CompleteTypeGuard = sizeof(TDirectIoOpBase);
 
+        // Forced runtime teardown only; normal stopping drains before destruction.
+        const auto now = [&] { return DestructionNow ? DestructionNow() : TMonotonic::Now(); };
+        const TMonotonic deadline = now() + TDuration::Seconds(10);
+        while (GetDirectIoInflight()) {
+            Y_ABORT_UNLESS(now() < deadline,
+                "DDisk %s destroyed with unresolved I/O callbacks", DDiskId.c_str());
+            if (DestructionSleep) {
+                DestructionSleep();
+            } else {
+                Sleep(TDuration::MilliSeconds(1));
+            }
+        }
+
         ClearIoStalled();
     }
 
@@ -356,11 +369,19 @@ namespace {
         BrokenReason = reason
             ? std::move(reason)
             : TString("DDisk is broken");
+        CancelRetries();
 
         YDB_LOG_ERROR("TDDiskActor entered Broken state",
             {"marker", "BSDD54"},
             {"DDiskId", DDiskId},
             {"errorReason", GetBrokenReason()});
+
+        *Counters.PersistentBuffer.PendingEventsQueueSize -= PendingPersistentBufferEvents.size();
+        while (!PendingPersistentBufferEvents.empty()) {
+            auto ev = PendingPersistentBufferEvents.front().Release();
+            PendingPersistentBufferEvents.pop();
+            RejectQuery(*ev, NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR, GetBrokenReason());
+        }
 
         // Complete actor-owned fallback operations immediately. Submitted io_uring operations
         // post their result events later; the actor normalizes those to ERROR because Broken is
@@ -455,6 +476,12 @@ namespace {
 
     void TDDiskActor::Handle(TEvents::TEvUndelivered::TPtr ev) {
         auto sourceType = ev->Get()->SourceType;
+        if (Stopping && !PersistentBufferGone && sourceType == TEvents::TSystem::Poison
+                && ev->Cookie == PBShutdownCookie && ev->Sender == PersistentBufferActorId) {
+            PersistentBufferGone = true;
+            TryCompleteStop();
+            return;
+        }
         if (sourceType == TEv::EvRead || sourceType == TEv::EvReadPersistentBuffer) {
             SyncReadCookiesInFlight.erase(ev->Cookie);
             std::vector<TSegmentManager::TSegment> segments;
@@ -514,6 +541,7 @@ namespace {
             hFunc(TEvPrivate::TEvDeallocatePersistentBufferChunk, Handle)
 
             hFunc(TEvents::TEvUndelivered, Handle)
+            hFunc(TEvents::TEvGone, HandleGone)
 
             hFunc(TEvReadResult, Handle)
             hFunc(TEvPrivate::TEvInternalSyncWriteResult, Handle)
@@ -534,6 +562,7 @@ namespace {
             hFunc(NPDisk::TEvChunkReadRawResult, Handle)
 #if defined(__linux__)
             hFunc(TEvPrivate::TEvRetryIO, HandleRetryIO)
+            hFunc(TEvPrivate::TEvRetryIODelayed, HandleRetryIODelayed)
 #endif
 
             hFunc(NPDisk::TEvCheckSpaceResult, Handle);
@@ -544,10 +573,26 @@ namespace {
 
             hFunc(TEvents::TEvWakeup, HandleWakeup);
             cFunc(TEvents::TSystem::Poison, PassAway)
+            cFunc(TEvPrivate::EvBeginStopping, HandleBeginStopping)
         )
     }
 
     STFUNC(TDDiskActor::StateFuncPersistentBuffer) {
+        if (IsBroken()) {
+            switch (ev->GetTypeRewrite()) {
+            case TEvConnect::EventType:
+            case TEvDisconnect::EventType:
+            case TEvWritePersistentBuffer::EventType:
+            case TEvReadPersistentBuffer::EventType:
+            case TEvErasePersistentBuffer::EventType:
+            case TEvBatchErasePersistentBuffer::EventType:
+            case TEvListPersistentBuffer::EventType:
+            case TEvWritePersistentBuffers::EventType:
+            case TEvReadThenWritePersistentBuffers::EventType:
+                RejectQuery(*ev, NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR, GetBrokenReason());
+                return;
+            }
+        }
         STRICT_STFUNC_BODY(
             hFunc(TEvConnect, Handle)
             hFunc(TEvDisconnect, Handle)
@@ -571,6 +616,7 @@ namespace {
             hFunc(NPDisk::TEvChunkReadRawResult, Handle)
 #if defined(__linux__)
             hFunc(TEvPrivate::TEvRetryIO, HandleRetryIO)
+            hFunc(TEvPrivate::TEvRetryIODelayed, HandleRetryIODelayed)
 #endif
 
             hFunc(NPDisk::TEvCheckSpaceResult, Handle);
@@ -579,22 +625,11 @@ namespace {
 
             hFunc(TEvents::TEvWakeup, HandleWakeup);
             cFunc(TEvents::TSystem::Poison, PassAway)
+            cFunc(TEvPrivate::EvBeginStopping, HandleBeginStopping)
 
             hFunc(TEvReadThenWritePersistentBuffers, Handle)
             hFunc(TEvWritePersistentBuffers, Handle)
         )
-    }
-
-    STFUNC(TDDiskActor::StateFuncTerminate) {
-        // Mirrors VDisk's PDISK_TERMINATE_STATE_FUNC_DEF: ignore everything except poison.
-        // Reaching this state means PDisk's session for our owner is gone (INVALID_ROUND etc).
-        // The owning environment (warden in production, test scaffolding in tests) is expected
-        // to send TEvPoison and start a replacement DDisk actor with a fresh OwnerRound.
-        switch (ev->GetTypeRewrite()) {
-            cFunc(TEvents::TSystem::Poison, PassAway)
-            default:
-                break;
-        }
     }
 
     bool TDDiskActor::CheckPDiskReply(NKikimrProto::EReplyStatus status,
@@ -607,13 +642,13 @@ namespace {
         case NKikimrProto::INVALID_ROUND:
         case NKikimrProto::CORRUPTED:
         case NKikimrProto::OUT_OF_SPACE:
-            YDB_LOG_NOTICE("TDDiskActor: PDisk session lost, switching to terminate state",
+            YDB_LOG_NOTICE("TDDiskActor: PDisk session lost, beginning shutdown",
                 {"marker", "BSDD44"},
                 {"DDiskId", DDiskId},
                 {"source", source},
                 {"status", NKikimrProto::EReplyStatus_Name(status)},
                 {"errorReason", errorReason});
-            Become(&TThis::StateFuncTerminate);
+            BeginStopping(errorReason);
             return false;
         default:
             Y_ABORT("Unexpected PDisk status %s in %.*s: %s",
@@ -784,8 +819,13 @@ namespace {
             hFunc(TEvPrivate::TEvWritePersistentBufferPart, Handle)
 #if defined(__linux__)
             hFunc(TEvPrivate::TEvRetryIO, HandleRetryIO)
+            hFunc(TEvPrivate::TEvRetryIODelayed, HandleRetryIODelayed)
 #endif
+            cFunc(TEvents::TSystem::Poison, PassAway)
+            hFunc(TEvents::TEvGone, HandleGone)
+            hFunc(TEvents::TEvUndelivered, Handle)
             cFunc(TEvPrivate::EvFinishStopping, FinishStopping)
+            cFunc(TEvPrivate::EvCompleteStop, CompleteStop)
             cFunc(TEvPrivate::EvStopIoTimeout, HandleStopIoTimeout)
             hFunc(NMon::TEvHttpInfo, Handle)
             hFunc(TEvGetPersistentBufferInfo, Handle)
@@ -797,32 +837,73 @@ namespace {
     }
 
     void TDDiskActor::PassAway() {
+        PoisonReceived = true;
+        BeginStopping(TString(StoppingReason));
+        TryCompleteStop();
+    }
+
+    void TDDiskActor::HandleBeginStopping() {
+        BeginStopping("io_uring router rejected submission");
+    }
+
+    void TDDiskActor::BeginStopping(TString reason) {
         if (Stopping) {
             return;
         }
         Stopping = true;
         Become(&TThis::StateFuncStopping);
+        YDB_LOG_NOTICE("DDisk stopping", {"DDiskId", DDiskId}, {"reason", reason});
         if (IsPersistentBufferActor) {
-            Send(WritePersistentBuffersActor, new NActors::TEvents::TEvPoison());
-        } else {
-            Send(PersistentBufferActorId, new NActors::TEvents::TEvPoison());
+            Send(WritePersistentBuffersActor, new TEvents::TEvPoison());
+        } else if (PersistentBufferActorId) {
+            PersistentBufferGone = false;
+            Send(PersistentBufferActorId, new TEvents::TEvPoison(),
+                IEventHandle::FlagTrackDelivery, PBShutdownCookie);
         }
         RejectQueuedQueries();
-#if defined(__linux__)
-        if (UringRouter) {
-            const ui64 previous = DirectIoState.fetch_or(DirectIoStopping, std::memory_order_acq_rel);
-            if (previous) {
-                Schedule(StopIoTimeout, new TEvPrivate::TEvStopIoTimeout);
-            } else {
-                // Callbacks have published their results, but those events may
-                // still be queued. Finish in a later mailbox turn to process them.
-                Send(SelfId(), new TEvPrivate::TEvFinishStopping);
+        CancelRetries();
+        for (auto* callbacks : {&ReadCallbacks, &WriteCallbacks}) {
+            while (!callbacks->empty()) {
+                auto it = callbacks->begin();
+                auto op = std::move(it->second.Op);
+                callbacks->erase(it);
+                CancelPendingIo(std::move(op));
+                Counters.DirectIO.RunningCount->Dec();
             }
+        }
+        const ui64 previous = DirectIoState.fetch_or(DirectIoStopping, std::memory_order_acq_rel);
+        if (!previous) {
+            // Includes fallback: cancellation results must precede destruction.
+            Send(SelfId(), new TEvPrivate::TEvFinishStopping);
+        }
+        if (previous || !PersistentBufferGone) {
+            Schedule(StopIoTimeout, new TEvPrivate::TEvStopIoTimeout);
+        }
+    }
+
+    void TDDiskActor::HandleGone(TEvents::TEvGone::TPtr ev) {
+        if (ev->Sender == PersistentBufferActorId) {
+            PersistentBufferGone = true;
+            TryCompleteStop();
+        }
+    }
+
+    void TDDiskActor::TryCompleteStop() {
+        if (!PoisonReceived || !OwnDrainComplete || !PersistentBufferGone) {
             return;
         }
+#if defined(__linux__)
+        UringRouter.reset();
 #endif
-        // PDisk owns fallback buffers; it is safe to restart without its replies.
-        FinishStopping();
+        CountersBase->RemoveSubgroupChain(CountersChain);
+        if (IsPersistentBufferActor) {
+            if (ParentDDiskId) {
+                Send(ParentDDiskId, new TEvents::TEvGone());
+            }
+        } else {
+            Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), new TEvents::TEvGone());
+        }
+        TActorBootstrapped::PassAway();
     }
 
     void TDDiskActor::OnDirectIODone(NActors::TActorSystem* actorSystem) {
@@ -852,6 +933,10 @@ namespace {
             YDB_LOG_ERROR("TDDiskActor I/O stalled during shutdown",
                 {"DDiskId", DDiskId}, {"persistentBuffer", IsPersistentBufferActor});
         }
+        if (!PersistentBufferGone) {
+            YDB_LOG_ERROR("DDisk waiting for PersistentBuffer shutdown", {"DDiskId", DDiskId},
+                {"child", PersistentBufferActorId});
+        }
     }
 
     void TDDiskActor::ClearIoStalled() {
@@ -862,6 +947,9 @@ namespace {
 
     void TDDiskActor::FinishStopping() {
         Y_ABORT_UNLESS(Stopping && !GetDirectIoInflight());
+        if (std::exchange(OwnDrainFinishing, true)) {
+            return;
+        }
         using TStatus = NKikimrBlobStorage::NDDisk::TReplyStatus;
         // Results whose integrity work or allocation log could not finish are
         // already represented here; no separate registry of client replies is needed.
@@ -883,11 +971,14 @@ namespace {
             FlushParkedAllocationReplies(allocation);
         }
         ClearIoStalled();
-        CountersBase->RemoveSubgroupChain(CountersChain);
-        if (!IsPersistentBufferActor) {
-            Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), new TEvents::TEvGone());
-        }
-        TActorBootstrapped::PassAway();
+        // A queued retry can have posted a cancellation result ahead of this
+        // barrier. Do not let child Gone bypass that final result turn.
+        Send(SelfId(), new TEvPrivate::TEvCompleteStop);
+    }
+
+    void TDDiskActor::CompleteStop() {
+        OwnDrainComplete = true;
+        TryCompleteStop();
     }
 
     IActor *CreateDDiskActor(TVDiskConfig::TBaseInfo&& baseInfo, TIntrusivePtr<TBlobStorageGroupInfo> info,

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.h
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.h
@@ -232,6 +232,11 @@ namespace NKikimr::NDDisk {
 
         // Separate from the shared monitoring counters: only this actor's router
         // callbacks contribute, until their last access to actor-owned state.
+    private:
+        friend class TDDiskActorTestPeer;
+        std::function<TMonotonic()> DestructionNow;
+        std::function<void()> DestructionSleep;
+    public:
         static constexpr ui64 DirectIoStopping = ui64{1} << 63;
         std::atomic<ui64> DirectIoState{0};
         ui64 GetDirectIoInflight() const {
@@ -264,8 +269,17 @@ namespace NKikimr::NDDisk {
                 EvChunkFormatIoResult,
                 EvFinishStopping,
                 EvStopIoTimeout,
+                EvBeginStopping,
+                EvCompleteStop,
+                EvRetryIODelayed,
             };
 
+            struct TEvCompleteStop : TEventLocal<TEvCompleteStop, EvCompleteStop> {};
+            struct TEvBeginStopping : TEventLocal<TEvBeginStopping, EvBeginStopping> {};
+            struct TEvRetryIODelayed : TEventLocal<TEvRetryIODelayed, EvRetryIODelayed> {
+                ui64 Id;
+                explicit TEvRetryIODelayed(ui64 id) : Id(id) {}
+            };
             struct TEvFinishStopping : TEventLocal<TEvFinishStopping, EvFinishStopping> {};
             struct TEvStopIoTimeout : TEventLocal<TEvStopIoTimeout, EvStopIoTimeout> {};
 
@@ -507,6 +521,20 @@ namespace NKikimr::NDDisk {
         static constexpr TStringBuf StoppingReason = "DDisk is stopping";
         bool Stopping = false;
         bool IoStalled = false;
+        bool PoisonReceived = false;
+        bool OwnDrainComplete = false;
+        bool OwnDrainFinishing = false;
+        void CompleteStop();
+        bool PersistentBufferGone = true;
+        TActorId ParentDDiskId;
+        static constexpr ui64 PBShutdownCookie = Max<ui64>();
+        void BeginStopping(TString reason);
+        void HandleBeginStopping();
+        void TryCompleteStop();
+        void HandleGone(TEvents::TEvGone::TPtr ev);
+        void CancelPendingIo(std::unique_ptr<TDirectIoOpBase> op);
+        void CancelRetries();
+        void HandleRetryIODelayed(TEvPrivate::TEvRetryIODelayed::TPtr ev);
 
         void RejectQueryWhenStopping(IEventHandle& ev);
         void RejectQuery(IEventHandle& ev,
@@ -545,12 +573,11 @@ namespace NKikimr::NDDisk {
         void Bootstrap();
         STFUNC(StateFuncDDisk);
         STFUNC(StateFuncPersistentBuffer);
-        STFUNC(StateFuncTerminate);
         STFUNC(StateFuncStopping);
         void PassAway() override;
 
         // Mirrors TVDiskContext::CheckPDiskResponse: returns true on OK, returns false and
-        // switches to StateFuncTerminate on session-loss statuses (ERROR / INVALID_OWNER /
+        // switches to StateFuncStopping on session-loss statuses (ERROR / INVALID_OWNER /
         // INVALID_ROUND) and device-error statuses (CORRUPTED / OUT_OF_SPACE), Y_ABORTs on
         // anything else. Caller must `return` immediately on false because the actor's
         // state has changed.
@@ -663,6 +690,8 @@ namespace NKikimr::NDDisk {
 
         THashMap<ui64, TPendingIoOp> WriteCallbacks;
         THashMap<ui64, TPendingIoOp> ReadCallbacks;
+        THashMap<ui64, TPendingIoOp> DelayedRetries;
+        ui64 NextRetryId = 0;
 
         void IssueChunkAllocation(ui64 tabletId, ui64 vChunkIndex);
         void Handle(NPDisk::TEvChunkReserveResult::TPtr ev);

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_boot.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_boot.cpp
@@ -251,6 +251,7 @@ namespace NKikimr::NDDisk {
             , UringRouter
 #endif
             );
+        pbActor->ParentDDiskId = SelfId();
         auto *as = TActivationContext::ActorSystem();
         PersistentBufferActorId = as->Register(pbActor.release(), TMailboxType::Revolving, AppData()->SystemPoolId);
         auto pbServiceId = MakeBlobStoragePersistentBufferId(BaseInfo.PDiskActorID.NodeId(), BaseInfo.PDiskId, BaseInfo.VDiskSlotId);

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_mon.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_mon.cpp
@@ -111,6 +111,8 @@ void TDDiskActor::Handle(NMon::TEvHttpInfo::TPtr ev) {
                 TABLER() { TABLED() { str << "Uptime"; } TABLED() { str << FormatDuration(TInstant::Now() - StartedAt); } }
                 TABLER() { TABLED() { str << "HandlingQueries"; } TABLED() { str << (HandlingQueries ? "true" : "false"); } }
                 TABLER() { TABLED() { str << "Stopping"; } TABLED() { str << (Stopping ? "true" : "false"); } }
+                TABLER() { TABLED() { str << "Waiting for PersistentBuffer"; } TABLED() { str << (Stopping && !PersistentBufferGone); } }
+                TABLER() { TABLED() { str << "Own I/O drained"; } TABLED() { str << OwnDrainComplete; } }
                 TABLER() { TABLED() { str << "I/O stalled"; } TABLED() { str << (IoStalled ? "true" : "false"); } }
                 TABLER() { TABLED() { str << "Router I/O in flight"; } TABLED() { str << GetDirectIoInflight(); } }
                 TABLER() { TABLED() { str << "PendingQueries"; } TABLED() { str << PendingQueries.size(); } }

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_persistent_buffer.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_persistent_buffer.cpp
@@ -184,7 +184,7 @@ namespace NKikimr::NDDisk {
 
     void TDDiskActor::StartRestorePersistentBuffer() {
         Y_ABORT_UNLESS(IsPersistentBufferActor);
-        if (PersistentBufferReady) {
+        if (Stopping || IsBroken() || PersistentBufferReady) {
             return;
         }
 
@@ -202,6 +202,7 @@ namespace NKikimr::NDDisk {
             *Counters.PersistentBuffer.AllocatedChunks = PersistentBufferSpaceAllocator.OwnedChunks.size();
             *Counters.PersistentBuffer.TotalBytes =
                 (PersistentBufferSpaceAllocator.OwnedChunks.size() * SectorInChunk - PersistentBufferSpaceAllocator.GetFreeSpace()) * SectorSize;
+            ProcessPersistentBufferQueue();
             return;
         }
         for (ui32 pos = 0; pos < PersistentBufferSpaceAllocator.OwnedChunks.size() && PersistentBufferRestoreChunksInflight < PersistentBufferFormat.MaxChunkRestoreInflight; pos++) {
@@ -369,7 +370,7 @@ namespace NKikimr::NDDisk {
     }
 
     void TDDiskActor::ProcessPersistentBufferQueue() {
-        if (Stopping || PendingPersistentBufferEvents.empty() || !PersistentBufferReady) {
+        if (Stopping || IsBroken() || PendingPersistentBufferEvents.empty() || !PersistentBufferReady) {
             return;
         }
 
@@ -581,7 +582,6 @@ namespace NKikimr::NDDisk {
     void TDDiskActor::RestorePersistentBufferChunk(TDDiskActor::TEvPrivate::TEvReadPersistentBufferPart::TPtr ev) {
         ui32 chunkIdx = ev->Get()->PartCookie;
         auto& data = ev->Get()->Data;
-        PersistentBufferRestoreChunksInflight--;
         Y_ABORT_UNLESS(data.size() == ChunkSize);
         for (ui32 sectorIdx = 0; sectorIdx < SectorInChunk; sectorIdx++) {
             auto dataPos = data.Position(sectorIdx * SectorSize);
@@ -748,7 +748,13 @@ namespace NKikimr::NDDisk {
 
     void TDDiskActor::Handle(TDDiskActor::TEvPrivate::TEvReadPersistentBufferPart::TPtr ev) {
         if (ev->Get()->IsRestore) {
-            if (Stopping) {
+            Y_ABORT_UNLESS(PersistentBufferRestoreChunksInflight);
+            --PersistentBufferRestoreChunksInflight;
+            if (Stopping || IsBroken()) {
+                return;
+            }
+            if (ev->Get()->Status != NKikimrBlobStorage::NDDisk::TReplyStatus::OK) {
+                EnterBroken(TStringBuilder() << "PersistentBuffer restore failed: " << ev->Get()->ErrorMessage);
                 return;
             }
             RestorePersistentBufferChunk(ev);
@@ -2418,6 +2424,10 @@ namespace NKikimr::NDDisk {
     }
 
     void TDDiskActor::Handle(TEvPrivate::TEvRetryListPersistentBuffer::TPtr ev) {
+        if (IsBroken()) {
+            RejectQuery(*ev->Get()->Ev, NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR, GetBrokenReason());
+            return;
+        }
         ProcessListPersistentBuffer(ev->Get()->Ev, ev->Get()->RetriesLeft);
     }
 

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_read_write.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_read_write.cpp
@@ -564,8 +564,8 @@ namespace NKikimr::NDDisk {
         }
 
         if (msg.Status != NKikimrProto::OK) {
-            if (it->second.Op->IsCriticalDDiskIo()) {
-                // Complete fallback integrity reads through the same path as an io_uring EIO.
+            if (it->second.Op->IsCriticalDDiskIo() || it->second.Op->IsRestoreIo()) {
+                // Complete fallback integrity and PB restore reads through the same path as an io_uring EIO.
                 // TEvIntegrityIoResult will latch Broken and fail every joined client request.
                 std::unique_ptr<TDirectIoOpBase> op = std::move(it->second.Op);
                 ReadCallbacks.erase(it);
@@ -618,6 +618,7 @@ namespace NKikimr::NDDisk {
             // and would violate the I/O-thread producer side of the op pool.
             op.reset(rawOp);
             FailDirectIoOp(std::move(op), "io_uring router stopped before submission");
+            Send(SelfId(), new TEvPrivate::TEvBeginStopping);
         }
 #else
         Y_UNUSED(op);
@@ -687,47 +688,57 @@ namespace NKikimr::NDDisk {
 
     TDDiskActor::TEvPrivate::TEvRetryIO::~TEvRetryIO() = default;
 
-    void TDDiskActor::HandleRetryIO(TEvPrivate::TEvRetryIO::TPtr ev) {
-        std::unique_ptr<TDirectIoOpBase> op = std::move(ev->Get()->Op);
-
-        if (Stopping) {
-            switch (op->GetOperationType()) {
-                case NPDisk::TUringOperationBase::EREAD:
-                    Counters.DirectIO.Read.Done(op->GetTotalSize());
-                    break;
-                case NPDisk::TUringOperationBase::EWRITE:
-                    Counters.DirectIO.Write.Done(op->GetTotalSize());
-                    break;
-                default:
-                    Y_ABORT("Unknown OperationType");
-            }
-            return;
-        }
-
-#if defined(__linux__)
-        if (Y_LIKELY(UringRouter)) {
-            DirectUringOp(op, /*isRetry=*/true);
-            return;
-        }
-
+    void TDDiskActor::CancelPendingIo(std::unique_ptr<TDirectIoOpBase> op) {
+        using TStatus = NKikimrBlobStorage::NDDisk::TReplyStatus;
         switch (op->GetOperationType()) {
-            case NPDisk::TUringOperationBase::EREAD:
-                Counters.DirectIO.Read.Done(op->GetTotalSize());
-                break;
-            case NPDisk::TUringOperationBase::EWRITE:
-                Counters.DirectIO.Write.Done(op->GetTotalSize());
-                break;
-            default:
-                Y_ABORT("Unknown OperationType");
+        case NPDisk::TUringOperationBase::EREAD:
+            Counters.DirectIO.Read.Done(op->GetTotalSize());
+            break;
+        case NPDisk::TUringOperationBase::EWRITE:
+            Counters.DirectIO.Write.Done(op->GetTotalSize());
+            break;
+        default:
+            Y_ABORT("Unknown OperationType");
         }
-        op->Reply(TActivationContext::ActorSystem(),
-            NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR,
-            "io_uring stopped before I/O error retry");
-        op.reset();
-#else
-        Y_UNUSED(op);
-        Y_ABORT("TEvRetryIO is only available with io_uring");
-#endif
+        op->Reply(TActivationContext::ActorSystem(), Stopping ? TStatus::SESSION_MISMATCH : TStatus::ERROR,
+            Stopping ? TString(StoppingReason) : GetBrokenReason());
+        // This is the actor thread, not the SPSC return-pool producer.
+    }
+
+    void TDDiskActor::CancelRetries() {
+        while (!DelayedRetries.empty()) {
+            auto it = DelayedRetries.begin();
+            auto op = std::move(it->second.Op);
+            DelayedRetries.erase(it);
+            CancelPendingIo(std::move(op));
+        }
+    }
+
+    void TDDiskActor::HandleRetryIO(TEvPrivate::TEvRetryIO::TPtr ev) {
+        auto op = std::move(ev->Get()->Op);
+        if (Stopping || IsBroken()) {
+            CancelPendingIo(std::move(op));
+            return;
+        }
+        Y_ABORT_UNLESS(op->RetryCount && op->RetryCount <= TDirectIoOpBase::MaxResubmissions);
+        const auto delay = TDuration::MilliSeconds(Min<ui32>(1u << (op->RetryCount - 1), 100));
+        const ui64 id = ++NextRetryId;
+        DelayedRetries.emplace(id, TPendingIoOp(std::move(op)));
+        Schedule(delay, new TEvPrivate::TEvRetryIODelayed(id));
+    }
+
+    void TDDiskActor::HandleRetryIODelayed(TEvPrivate::TEvRetryIODelayed::TPtr ev) {
+        const auto it = DelayedRetries.find(ev->Get()->Id);
+        if (it == DelayedRetries.end()) {
+            return;
+        }
+        auto op = std::move(it->second.Op);
+        DelayedRetries.erase(it);
+        if (Stopping || IsBroken()) {
+            CancelPendingIo(std::move(op));
+            return;
+        }
+        DirectUringOp(op, /*isRetry=*/true);
     }
 
     void TDDiskActor::HandleWakeup(TEvents::TEvWakeup::TPtr &ev) {

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_test_peer.h
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_test_peer.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "ddisk_actor.h"
+
+namespace NKikimr::NDDisk {
+class TDDiskActorTestPeer {
+public:
+    static bool IsBroken(const TDDiskActor& actor) { return actor.IsBroken(); }
+    static void SetDestructionClock(TDDiskActor& actor,
+            std::function<TMonotonic()> now, std::function<void()> sleep) {
+        actor.DestructionNow = std::move(now);
+        actor.DestructionSleep = std::move(sleep);
+    }
+};
+}

--- a/ydb/core/blobstorage/ddisk/direct_io_op.cpp
+++ b/ydb/core/blobstorage/ddisk/direct_io_op.cpp
@@ -103,7 +103,9 @@ void TDDiskActor::TDirectIoOpBase::OnComplete(NActors::TActorSystem* actorSystem
     // (buffers still owned here) through the actor retry path. Defer Done() until the retry
     // completes or a hard error is reported.
     if (Y_UNLIKELY(result < 0 && IsCriticalDDiskIo()
-            && UringErrorToStatus(result, opType) == TReplyStatus::OVERLOADED)) {
+            && UringErrorToStatus(result, opType) == TReplyStatus::OVERLOADED
+            && RetryCount < MaxResubmissions)) {
+        ++RetryCount;
         auto ev = std::make_unique<TDDiskActor::TEvPrivate::TEvRetryIO>(guard.Release());
         actorSystem->Send(new IEventHandle(DDiskId, {}, ev.release()));
         return;
@@ -137,7 +139,12 @@ void TDDiskActor::TDirectIoOpBase::OnComplete(NActors::TActorSystem* actorSystem
             << " chunkOffset=" << ChunkOffsetInBytes
             << " DDiskId=" << DDiskId;
         YDB_LOG_ERROR_CTX(*actorSystem, reason);
-        Reply(actorSystem, UringErrorToStatus(result, opType), std::move(reason));
+        const bool exhausted = IsCriticalDDiskIo()
+            && UringErrorToStatus(result, opType) == TReplyStatus::OVERLOADED;
+        if (exhausted) {
+            reason += TStringBuilder() << " retry exhausted: attempts=" << (RetryCount + 1);
+        }
+        Reply(actorSystem, exhausted ? TReplyStatus::ERROR : UringErrorToStatus(result, opType), std::move(reason));
         return;
     }
 
@@ -345,7 +352,7 @@ void TDDiskActor::TPersistentBufferPartIoOp::Reply(NActors::TActorSystem* actorS
 
     switch (opType) {
         case TUringOperationBase::EREAD: {
-            TRope data = ExtractData();
+            TRope data = status == TReplyStatus::OK ? ExtractData() : TRope();
             reply = std::make_unique<TEvPrivate::TEvReadPersistentBufferPart>(
                 GetCookie(), PartCookie, status, std::move(reason), std::move(data), IsRestore);
             break;
@@ -380,6 +387,7 @@ void TDDiskActor::TDirectIoOpBase::Reinit(const IEventHandle* ev) {
     ChunkIdx = 0;
     ChunkOffsetInBytes = 0;
     ReadUsedBlocksMask.reset();
+    RetryCount = 0;
 }
 
 void TDDiskActor::TDirectIoOpBase::ClearForRecycle() noexcept {
@@ -387,6 +395,7 @@ void TDDiskActor::TDirectIoOpBase::ClearForRecycle() noexcept {
     Data.reset();
     Span = {};
     ReadUsedBlocksMask.reset();
+    RetryCount = 0;
 }
 
 void TDDiskActor::TDDiskIoOp::SelfRecycle() noexcept {

--- a/ydb/core/blobstorage/ddisk/direct_io_op.h
+++ b/ydb/core/blobstorage/ddisk/direct_io_op.h
@@ -33,6 +33,9 @@ public:
     virtual void Reply(
         NActors::TActorSystem* actorSystem, NKikimrBlobStorage::NDDisk::TReplyStatus::E status,
         TString reason = {}) noexcept = 0;
+    ui32 RetryCount = 0;
+    static constexpr ui32 MaxResubmissions = 20;
+    virtual bool IsRestoreIo() const noexcept { return false; }
     virtual bool IsIntegrityIo() const noexcept { return false; }
     virtual bool IsChunkFormatIo() const noexcept { return false; }
     bool IsCriticalDDiskIo() const noexcept { return IsIntegrityIo() || IsChunkFormatIo(); }
@@ -169,6 +172,8 @@ public:
     void SetIsErase(bool isErase) {
         IsErase = isErase;
     }
+
+    bool IsRestoreIo() const noexcept override { return IsRestore; }
 
     void SetIsRestore(bool isRestore) {
         IsRestore = isRestore;

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_pdisk_common_ut.h
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_pdisk_common_ut.h
@@ -245,7 +245,7 @@ public:
     // Real-thread runtime: DDisk/PDisk complete trailing chunk-reserve refills and
     // chunk-map log replies asynchronously after write replies return to the edge.
     // Wait a quiet window so RestartPDisk does not deliver INVALID_ROUND for those
-    // still-in-flight owner-stamped ops (which would Terminate the DDisk early).
+    // still-in-flight owner-stamped ops (which would stop the DDisk early).
     void QuiesceInFlightPDiskOps(TDuration quietWindow = TDuration::MilliSeconds(200)) {
         Sleep(quietWindow);
     }
@@ -1178,29 +1178,11 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
 // SAME PDisk 0 (different VDisk owner, different SlotId) and tablet 3 writes to it --
 // this proves the restarted PDisk is functional through a fresh owner.
 //
-// Before RestartPDisk we quiesce trailing owner-stamped PDisk traffic from phase 1
-// (chunk-reserve refill / chunk-map log). Otherwise those replies can arrive after
-// restart as INVALID_ROUND and Terminate the zombie DDisk before the page-1 writes
-// that this test expects to still succeed.
-//
-// Variant restartDDisk == false (zombie):
-//   The original DDisk slot 0 keeps running. Its OwnerRound is now stale, so the first
-//   reply it gets back from PDisk for any owner-stamped request will be INVALID_ROUND,
-//   and CheckPDiskReply switches it to StateFuncTerminate. From that point client
-//   requests are silently dropped (no reply). We attempt vchunk 0 page 1 writes first:
-//   the chunk is already committed, so uring bypasses PDisk and ChunkWriteRaw (PDisk
-//   fallback) does not enforce OwnerRound — both modes still get a reply. Then vchunk 1
-//   page 0 writes need a fresh chunk reservation that always goes through PDisk, so this
-//   is guaranteed to zombify and produce no reply in either mode. The test must NOT crash.
-//   Isolation of a fresh owner from zombie uring I/O is not asserted: reserved chunks
-//   may already have been formatted, so PDisk restart can reassign those physical
-//   offsets while the zombie still holds a live ring.
-//
-// Variant restartDDisk == true (warden-style recovery):
-//   After the PDisk restart we also restart DDisk slot 0; the new DDisk instance uses
-//   the next OwnerRound and rebuilds its chunk map from the on-disk log. Tablets 1 and
-//   2 reconnect, write fresh vchunks, and we read everything back to confirm pre- and
-//   post-restart data survived.
+// Before RestartPDisk we quiesce trailing owner-stamped traffic. A requested
+// production restart drains DDisks first; this fixture also exercises direct
+// PDisk restart with a stale DDisk. Its next allocation must fail, and further
+// requests must receive SESSION_MISMATCH instead of disappearing.
+// With restartDDisk=true the new owner recovers committed data and continues I/O.
 [[maybe_unused]] void TestPDiskRestartWithReservedChunks(NDDisk::TDDiskConfig ddiskConfig,
         bool restartDDisk) {
     constexpr ui32 baseTabletId = 901;
@@ -1249,7 +1231,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
     writeBlock(0, creds2, baseTabletId + 1, 0, 0);
 
     // Finish trailing chunk-reserve refill / log replies from phase 1 before restarting
-    // PDisk, so the zombie path is not Terminated by INVALID_ROUND on those replies
+    // PDisk, so the zombie path has not begun stopping on INVALID_ROUND on those replies
     // before the page-1 writes below.
     ctx.QuiesceInFlightPDiskOps();
 
@@ -1295,33 +1277,16 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
         return;
     }
 
-    // Zombie variant: DDisk slot 0 is still the stale instance. Its OwnerRound is
-    // stale so any request that goes through PDisk (chunk reserve, log) gets
-    // INVALID_ROUND and CheckPDiskReply switches DDisk to StateFuncTerminate.
-    // After that the actor silently drops all further messages.
-    //
-    // Writes to vchunk 0 page 1 succeed in both modes: the chunk is already
-    // committed, so uring bypasses PDisk and ChunkWriteRaw does not enforce
-    // OwnerRound. QuiesceInFlightPDiskOps above ensures we are not already
-    // Terminated by a trailing phase-1 reserve/log reply.
-    writeBlock(0, creds1, baseTabletId + 0, 0, 1);
-    writeBlock(0, creds2, baseTabletId + 1, 0, 1);
+    // Force an owner-stamped allocation through the restarted PDisk. A stale
+    // router may reject its I/O first; either failure must stop the old actor.
+    auto stale = ctx.SendToAndGrab<NDDisk::TEvWriteResult>(0,
+        makeWrite(creds1, baseTabletId + 0, 1, 0).release());
+    UNIT_ASSERT(stale->Get()->Record.GetStatus() == TReplyStatus::ERROR
+        || stale->Get()->Record.GetStatus() == TReplyStatus::SESSION_MISMATCH);
+    auto rejected = ctx.SendToAndGrab<NDDisk::TEvWriteResult>(0,
+        makeWrite(creds2, baseTabletId + 1, 1, 0).release());
+    AssertStatus<NDDisk::TEvWriteResult>(rejected, TReplyStatus::SESSION_MISMATCH);
 
-    // Writes to vchunk 1 need a fresh chunk reservation that goes through PDisk,
-    // hits INVALID_ROUND, and DDisk zombifies -- no reply in either mode.
-
-    ctx.DecreaseDispatchTimeout();
-
-    ctx.SendTo(0, makeWrite(creds1, baseTabletId + 0, 1, 0).release());
-    ctx.ExpectNoReply<NDDisk::TEvWriteResult>();
-
-    ctx.SendTo(0, makeWrite(creds2, baseTabletId + 1, 1, 0).release());
-    ctx.ExpectNoReply<NDDisk::TEvWriteResult>();
-
-    // Isolation of the new owner from the zombie slot is not guaranteed: the
-    // zombie still holds a live io_uring on physical offsets that PDisk may
-    // have reassigned after restart. The fresh-owner check above already
-    // proved the restarted PDisk works.
 }
 
 // Write from 2 tablets to multiple VChunks, free all chunks of one tablet, verify the other

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_pdisk_ut.cpp
@@ -1,4 +1,5 @@
 #include "ddisk_actor_pdisk_common_ut.h"
+#include <ydb/library/pdisk_io/uring_test_support.h>
 
 namespace NKikimr {
 
@@ -72,6 +73,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(WriteAndRead_4KiB_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestWriteAndRead({}, 4_KB);
     }
 
@@ -80,6 +82,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(WriteAndRead_8KiB_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestWriteAndRead({}, 8_KB);
     }
 
@@ -88,6 +91,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(WriteAndRead_1MiB_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestWriteAndRead({}, 1_MB);
     }
 
@@ -96,6 +100,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(WriteAndReadWithoutChecksums_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestWriteAndReadWithoutChecksums({});
     }
 
@@ -104,6 +109,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(CheckVChunksArePerTablet_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestCheckVChunksArePerTablet({});
     }
 
@@ -112,6 +118,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(OverwriteSameOffset_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestOverwrite({});
     }
 
@@ -120,6 +127,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(ReadUnallocatedChunk_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestReadUnallocatedChunk({});
     }
 
@@ -128,6 +136,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(ManyVChunksPerTablet_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestManyVChunks({});
     }
 
@@ -136,6 +145,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(MultiTabletInterleavedWrites_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestMultiTabletInterleaved({});
     }
 
@@ -144,6 +154,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(MultiTabletInterleavedWritesWithDDiskRestart_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestMultiTabletInterleavedWritesWithDDiskRestart({});
     }
 
@@ -152,6 +163,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(MultipleRestarts_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestMultipleRestarts({});
     }
 
@@ -160,6 +172,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(OverwriteAfterRestart_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestOverwriteAfterRestart({});
     }
 
@@ -168,6 +181,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(EmptyRestart_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestEmptyRestart({});
     }
 
@@ -180,6 +194,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(RestartAfterCutLog_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestRestartAfterCutLog({});
     }
 
@@ -188,6 +203,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(ReadWithoutConnect_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestReadWithoutConnect({});
     }
 
@@ -196,6 +212,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(PDiskRestartWithReservedChunks_DDiskZombie_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestPDiskRestartWithReservedChunks({}, /*restartDDisk=*/false);
     }
 
@@ -204,6 +221,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(PDiskRestartWithReservedChunks_DDiskRestart_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestPDiskRestartWithReservedChunks({}, /*restartDDisk=*/true);
     }
 
@@ -216,6 +234,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
     }
 
     Y_UNIT_TEST(DeleteTabletChunks_Uring) {
+        if (!NPDisk::RequireUring()) { return; }
         TestDeleteTabletChunks({});
     }
 

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/blobstorage/ddisk/ddisk.h>
 #include <ydb/core/blobstorage/ddisk/ddisk_actor.h>
+#include <ydb/core/blobstorage/ddisk/ddisk_actor_test_peer.h>
 #include <ydb/core/blobstorage/ddisk/ddisk_checksums.h>
 #include <ydb/core/blobstorage/ddisk/persistent_buffer_header.h>
 #include <ydb/core/blobstorage/ddisk/write_persistent_buffers_request_actor.h>
@@ -23,6 +24,16 @@
 #include <map>
 #include <set>
 #include <tuple>
+
+#if defined(__linux__)
+#include <util/system/tempfile.h>
+#include <util/stream/file.h>
+#include <sys/wait.h>
+#include <sys/resource.h>
+#include <unistd.h>
+#include <thread>
+#include <chrono>
+#endif
 
 namespace NKikimr {
 namespace {
@@ -317,6 +328,8 @@ public:
         return traffic;
     }
 
+    std::function<void()> BeforePersistentBufferReady;
+
     // Fresh ids for auto-served reserve refills; far away from ids the tests assert on.
     ui32 NextAutoReserveChunkId = 900000;
 
@@ -585,6 +598,9 @@ public:
             }
             auto logReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
             logReply->Results.emplace_back(log->Get()->Lsn, log->Get()->Cookie);
+            if (i + 1 == PersistentBufferInitChunks && BeforePersistentBufferReady) {
+                std::exchange(BeforePersistentBufferReady, {})();
+            }
             SendPDiskResponse(disk, *log, logReply.release());
         }
         std::unique_ptr<TEventHandle<NPDisk::TEvCheckSpace>> checkSpace;
@@ -937,8 +953,8 @@ NPDisk::TUringOperationBase* WaitSubmittedUring(TTestContext& ctx, const TDiskHa
 
 // An existing checksummed chunk needs one data write and one integrity-slot write.
 std::array<NPDisk::TUringOperationBase*, 2> HoldUringWrite(TTestContext& ctx, const TDiskHandle& disk,
-        const NDDisk::TQueryCredentials& creds, TScriptedUringClient& router) {
-    SendToDDisk(ctx, disk.ServiceId, MakeWrite(creds, 0, 0, MakeData('S', BlockSize)).release(), 100);
+        const NDDisk::TQueryCredentials& creds, TScriptedUringClient& router, ui64 cookie = 100) {
+    SendToDDisk(ctx, disk.ServiceId, MakeWrite(creds, 0, 0, MakeData('S', BlockSize)).release(), cookie);
     std::array<NPDisk::TUringOperationBase*, 2> result;
     result[0] = WaitSubmittedUring(ctx, disk, router);
     result[1] = WaitSubmittedUring(ctx, disk, router);
@@ -1006,6 +1022,114 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
     }
 
 #if defined(__linux__)
+    Y_UNIT_TEST(FreshPersistentBufferReadinessDrainsQueuedWrite) {
+        TTestContext ctx;
+        const auto disk = ctx.RegisterDDisk(113, 1);
+        bool queued = false;
+        ctx.BeforePersistentBufferReady = [&] {
+            const auto creds = Connect(ctx, disk.PBServiceId, 913, 1);
+            auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(
+                creds, NDDisk::TBlockSelector(0, 0, BlockSize), 1, NDDisk::TWriteInstruction(0));
+            write->AddPayloadThenChecksum(MakeAlignedRope(MakeData('P', BlockSize)));
+            SendToDDisk(ctx, disk.PBServiceId, write.release(), 100);
+            auto info = SendToDDiskAndWait<NDDisk::TEvPersistentBufferInfo>(ctx, disk.PBServiceId,
+                new NDDisk::TEvGetPersistentBufferInfo(false, false));
+            UNIT_ASSERT_VALUES_EQUAL(info->Get()->PendingEvents, 1);
+            queued = true;
+        };
+        ctx.BootstrapDDisk(disk);
+        UNIT_ASSERT(queued);
+        auto raw = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+        ctx.SendPDiskResponse(disk, *raw, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto reply = WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx);
+        AssertStatus(reply, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(reply->Cookie, 100);
+        AssertNoClientReplyBeforeSentinel(ctx, "Readiness must process a queued request once");
+    }
+
+    Y_UNIT_TEST(ForcedDestructionWaitsForCallbackRetirement) {
+        const pid_t pid = fork();
+        UNIT_ASSERT(pid >= 0);
+        if (!pid) {
+            alarm(5);
+            TTestContext ctx;
+            auto router = std::make_shared<TScriptedUringClient>(ctx);
+            const auto disk = ctx.RegisterDDisk(106, 1);
+            ctx.BootstrapDDisk(disk, TTestContext::ChunkSize, MinChunksReserved, nullptr, 0, {}, nullptr, router);
+            const auto creds = Connect(ctx, disk.PBServiceId, 906, 1);
+            auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(
+                creds, NDDisk::TBlockSelector(0, 0, BlockSize), 1, NDDisk::TWriteInstruction(0));
+            write->AddPayloadThenChecksum(MakeAlignedRope(MakeData('P', BlockSize)));
+            SendToDDisk(ctx, disk.PBServiceId, write.release());
+            auto* op = WaitSubmittedUring(ctx, disk, *router);
+            TManualEvent entered, retired;
+            TMonotonic now = TMonotonic::Zero();
+            ctx.Runtime.WrapInActorContext(ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.PBServiceId), [&](IActor* actor) {
+                NDDisk::TDDiskActorTestPeer::SetDestructionClock(
+                    *static_cast<NDDisk::TDDiskActor*>(actor), [&] { return now; }, [&] {
+                        now += TDuration::MicroSeconds(9999000);
+                        entered.Signal();
+                        retired.WaitI();
+                    });
+            });
+            std::thread completion([&] {
+                entered.WaitI();
+                router->CompleteSuccessfully(op);
+                retired.Signal();
+            });
+            ctx.Runtime.Stop();
+            completion.join();
+            _exit(router->Outstanding ? 1 : 0);
+        }
+        int status = 0;
+        UNIT_ASSERT_VALUES_EQUAL(waitpid(pid, &status, 0), pid);
+        UNIT_ASSERT(WIFEXITED(status));
+        UNIT_ASSERT_VALUES_EQUAL(WEXITSTATUS(status), 0);
+    }
+
+    Y_UNIT_TEST(ForcedDestructionAbortsAtTenSecondsWithoutRetirement) {
+        TTempFile diagnostic(MakeTempName(nullptr, "ddisk_destructor_deadline"));
+        const pid_t pid = fork();
+        UNIT_ASSERT(pid >= 0);
+        if (!pid) {
+            const rlimit noCore{0, 0};
+            setrlimit(RLIMIT_CORE, &noCore);
+            alarm(5);
+            TFile output(diagnostic.Name(), CreateAlways | WrOnly);
+            Y_ABORT_UNLESS(dup2(output.GetHandle(), STDERR_FILENO) >= 0);
+            TTestContext ctx;
+            auto router = std::make_shared<TScriptedUringClient>(ctx);
+            const auto disk = ctx.RegisterDDisk(107, 1);
+            ctx.BootstrapDDisk(disk, TTestContext::ChunkSize, MinChunksReserved, nullptr, 0, {}, nullptr, router);
+            const auto creds = Connect(ctx, disk.PBServiceId, 907, 1);
+            auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(
+                creds, NDDisk::TBlockSelector(0, 0, BlockSize), 1, NDDisk::TWriteInstruction(0));
+            write->AddPayloadThenChecksum(MakeAlignedRope(MakeData('P', BlockSize)));
+            SendToDDisk(ctx, disk.PBServiceId, write.release());
+            WaitSubmittedUring(ctx, disk, *router);
+            TMonotonic now = TMonotonic::Zero();
+            ctx.Runtime.WrapInActorContext(ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.PBServiceId), [&](IActor* actor) {
+                NDDisk::TDDiskActorTestPeer::SetDestructionClock(
+                    *static_cast<NDDisk::TDDiskActor*>(actor), [&] { return now; }, [&] {
+                        now += now == TMonotonic::Zero()
+                            ? TDuration::MicroSeconds(9999000) : TDuration::MicroSeconds(1000);
+                        Y_ABORT_UNLESS(router->Outstanding == 1);
+                        Cerr << "destructor elapsed_us=" << now.MicroSeconds() << Endl;
+                    });
+            });
+            ctx.Runtime.Stop();
+            _exit(1);
+        }
+        int status = 0;
+        UNIT_ASSERT_VALUES_EQUAL(waitpid(pid, &status, 0), pid);
+        UNIT_ASSERT(WIFSIGNALED(status));
+        UNIT_ASSERT_VALUES_EQUAL(WTERMSIG(status), SIGABRT);
+        const auto output = TFileInput(diagnostic.Name()).ReadAll();
+        UNIT_ASSERT_STRING_CONTAINS(output, "destructor elapsed_us=9999000");
+        UNIT_ASSERT_STRING_CONTAINS(output, "destructor elapsed_us=10000000");
+        UNIT_ASSERT_STRING_CONTAINS(output, "destroyed with unresolved I/O callbacks");
+    }
+
     Y_UNIT_TEST(StoppingUringRejectedAndInlineSubmissionsDoNotLeaveInflight) {
         for (const bool reject : {false, true}) {
             TTestContext ctx;
@@ -1032,7 +1156,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             AssertStatus(WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx),
                 reject ? TReplyStatus::ERROR : TReplyStatus::OK);
             UNIT_ASSERT_VALUES_EQUAL(router->Outstanding, 0);
-            UNIT_ASSERT_VALUES_EQUAL(finishNotifications, 0);
+            UNIT_ASSERT(finishNotifications <= 1);
             const auto counters = GetDirectIoCounters(ctx, disk);
             UNIT_ASSERT_VALUES_EQUAL(counters->GetCounter("RunningCount", false)->Val(), 0);
             const auto writes = counters->GetSubgroup("operation", "Write");
@@ -1064,8 +1188,8 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         router->CompleteSuccessfully(held[0]);
         router->CompleteSuccessfully(held[1]);
         UNIT_ASSERT_VALUES_EQUAL(router->Outstanding, 0);
-        ctx.Runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant) {
-            UNIT_ASSERT(ev->GetTypeRewrite() != NDDisk::TDDiskActor::TEvPrivate::TEvStopIoTimeout::EventType);
+        ctx.Runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>&, ISchedulerCookie*, TInstant) {
+            // Parent may schedule a diagnostic while waiting for PB even with no own I/O.
             return true;
         };
         const auto reply = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
@@ -1196,84 +1320,195 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
     }
 
     Y_UNIT_TEST(StoppingUringStalledGaugeCountsDDiskAndPersistentBufferIndependently) {
+        for (const bool sessionLost : {false, true}) {
+            for (const bool parentFirst : {false, true}) {
+                TTestContext ctx;
+                auto router = std::make_shared<TScriptedUringClient>(ctx);
+                const TDiskHandle disk = ctx.RegisterDDisk(93, 1);
+                ctx.BootstrapDDisk(disk, TTestContext::ChunkSize, MinChunksReserved, nullptr, 0, {}, nullptr, router);
+                const auto creds = Connect(ctx, disk.ServiceId, 903, 1);
+                const auto pbCreds = Connect(ctx, disk.PBServiceId, 903, 1);
+                SendToDDisk(ctx, disk.ServiceId, MakeWrite(creds, 0, 0, MakeData('R', BlockSize)).release());
+                FinishUringWrite(ctx, disk, *router, TReplyStatus::OK);
+                const auto held = HoldUringWrite(ctx, disk, creds, *router);
+                auto pbWrite = std::make_unique<NDDisk::TEvWritePersistentBuffer>(
+                    pbCreds, NDDisk::TBlockSelector(0, 0, BlockSize), 1, NDDisk::TWriteInstruction(0));
+                pbWrite->AddPayloadThenChecksum(MakeAlignedRope(MakeData('P', BlockSize)));
+                SendToDDisk(ctx, disk.PBServiceId, pbWrite.release(), 101);
+                auto* pbOp = WaitSubmittedUring(ctx, disk, *router);
+
+                const auto actorId = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.ServiceId);
+                const auto pbActorId = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.PBServiceId);
+                const auto warden = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+                ctx.Runtime.RegisterService(MakeBlobStorageNodeWardenID(NodeId), warden);
+                const auto stalled = ctx.Counters->GetSubgroup("counters", "ddisks")->GetCounter("io_stalled", false);
+                std::map<TActorId, ui32> scheduled;
+                const auto stoppedAt = ctx.Runtime.GetClock();
+                ctx.Runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant at) {
+                    if (ev->GetTypeRewrite() == NDDisk::TDDiskActor::TEvPrivate::TEvStopIoTimeout::EventType) {
+                        UNIT_ASSERT_VALUES_EQUAL(at, stoppedAt + TDuration::Minutes(1));
+                        ++scheduled[ev->Recipient];
+                    }
+                    return true;
+                };
+                if (sessionLost) {
+                    SendToDDisk(ctx, disk.ServiceId, new NPDisk::TEvLogResult(
+                        NKikimrProto::INVALID_ROUND, 0, "session lost with native operations held", 0));
+                } else {
+                    SendToDDisk(ctx, disk.ServiceId, new TEvents::TEvPoison());
+                }
+                AssertStoppingRejects<NDDisk::TEvConnect>(ctx, disk.ServiceId);
+                AssertStoppingRejects<NDDisk::TEvConnect>(ctx, disk.PBServiceId);
+                if (!sessionLost) { SendToDDisk(ctx, disk.ServiceId, new TEvents::TEvPoison()); }
+                SendToDDisk(ctx, disk.PBServiceId, new TEvents::TEvPoison());
+                AssertStoppingRejects<NDDisk::TEvDisconnect>(ctx, disk.PBServiceId);
+                AssertStoppingRejects<NDDisk::TEvWritePersistentBuffer>(ctx, disk.PBServiceId);
+                AssertStoppingRejects<NDDisk::TEvReadPersistentBuffer>(ctx, disk.PBServiceId);
+                AssertStoppingRejects<NDDisk::TEvErasePersistentBuffer>(ctx, disk.PBServiceId);
+                AssertStoppingRejects<NDDisk::TEvBatchErasePersistentBuffer>(ctx, disk.PBServiceId);
+                AssertStoppingRejects<NDDisk::TEvListPersistentBuffer>(ctx, disk.PBServiceId);
+                AssertStoppingRejectsPlural<NDDisk::TEvWritePersistentBuffers>(ctx, disk.PBServiceId);
+                AssertStoppingRejectsPlural<NDDisk::TEvReadThenWritePersistentBuffers>(ctx, disk.PBServiceId);
+                UNIT_ASSERT_VALUES_EQUAL(scheduled[actorId], 1);
+                UNIT_ASSERT_VALUES_EQUAL(scheduled[pbActorId], 1);
+                UNIT_ASSERT_VALUES_EQUAL(stalled->Val(), 0);
+
+                const auto timerEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+                ctx.Runtime.Schedule(stoppedAt + TDuration::Minutes(1) - TDuration::MicroSeconds(1),
+                    new IEventHandle(timerEdge, {}, new TEvents::TEvWakeup()), nullptr, NodeId);
+                ctx.Runtime.WaitForEdgeActorEvent<TEvents::TEvWakeup>(timerEdge, false);
+                UNIT_ASSERT_VALUES_EQUAL(stalled->Val(), 0);
+                ctx.Runtime.Schedule(stoppedAt + TDuration::Minutes(1) + TDuration::MicroSeconds(1),
+                    new IEventHandle(timerEdge, {}, new TEvents::TEvWakeup()), nullptr, NodeId);
+                ctx.Runtime.WaitForEdgeActorEvent<TEvents::TEvWakeup>(timerEdge, false);
+                UNIT_ASSERT_VALUES_EQUAL(stalled->Val(), 2);
+                ctx.Runtime.FilterEnqueue = {};
+                SendToDDisk(ctx, disk.ServiceId, new NDDisk::TDDiskActor::TEvPrivate::TEvStopIoTimeout());
+                SendToDDisk(ctx, disk.PBServiceId, new NDDisk::TDDiskActor::TEvPrivate::TEvStopIoTimeout());
+                AssertStoppingRejects<NDDisk::TEvConnect>(ctx, disk.PBServiceId);
+                UNIT_ASSERT_VALUES_EQUAL(stalled->Val(), 2);
+
+                auto finishParent = [&] {
+                    router->CompleteSuccessfully(held[0]);
+                    router->CompleteSuccessfully(held[1]);
+                    AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+                };
+                auto finishPB = [&] {
+                    router->CompleteSuccessfully(pbOp);
+                    const auto reply = WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx);
+                    AssertStatus(reply, TReplyStatus::OK);
+                    UNIT_ASSERT_VALUES_EQUAL(reply->Cookie, 101);
+                    AssertActorDies(ctx, pbActorId);
+                };
+                if (parentFirst) {
+                    finishParent();
+                } else {
+                    finishPB();
+                    ctx.Runtime.Send(new IEventHandle(actorId, pbActorId, new TEvents::TEvGone()), NodeId);
+                    ctx.Runtime.Send(new IEventHandle(actorId, pbActorId, new TEvents::TEvGone()), NodeId);
+                }
+                // Process the first actor's completion and Gone before checking the
+                // other actor still fences the parent's notification to Warden.
+                AssertStoppingRejects<NDDisk::TEvConnect>(ctx, disk.ServiceId);
+                UNIT_ASSERT(ctx.Runtime.WrapInActorContext(actorId, [](IActor*) {}));
+                UNIT_ASSERT_VALUES_EQUAL(stalled->Val(), 1);
+                if (parentFirst) {
+                    UNIT_ASSERT(ctx.Runtime.WrapInActorContext(pbActorId, [](IActor*) {}));
+                    finishPB();
+                } else {
+                    finishParent();
+                }
+                AssertActorDies(ctx, pbActorId);
+                if (sessionLost) {
+                    AssertStoppingRejects<NDDisk::TEvConnect>(ctx, disk.ServiceId);
+                    UNIT_ASSERT(ctx.Runtime.WrapInActorContext(actorId, [](IActor*) {}));
+                    UNIT_ASSERT_VALUES_EQUAL(stalled->Val(), 0);
+                    SendToDDisk(ctx, disk.ServiceId, new TEvents::TEvPoison());
+                }
+                ctx.Runtime.WaitForEdgeActorEvent<TEvents::TEvGone>(warden, false);
+                UNIT_ASSERT(!ctx.Runtime.WrapInActorContext(actorId, [](IActor*) {}));
+                UNIT_ASSERT_VALUES_EQUAL(stalled->Val(), 0);
+                UNIT_ASSERT_VALUES_EQUAL(router->Outstanding, 0);
+            }
+        }
+    }
+
+    Y_UNIT_TEST(DelayedChildPoisonDrainsNewWriteAndUsesConcreteIncarnations) {
         TTestContext ctx;
         auto router = std::make_shared<TScriptedUringClient>(ctx);
-        const TDiskHandle disk = ctx.RegisterDDisk(93, 1);
+        const auto disk = ctx.RegisterDDisk(109, 1);
         ctx.BootstrapDDisk(disk, TTestContext::ChunkSize, MinChunksReserved, nullptr, 0, {}, nullptr, router);
-        const auto creds = Connect(ctx, disk.ServiceId, 903, 1);
-        const auto pbCreds = Connect(ctx, disk.PBServiceId, 903, 1);
+        const auto creds = Connect(ctx, disk.ServiceId, 909, 1);
+        const auto pbCreds = Connect(ctx, disk.PBServiceId, 909, 1);
         SendToDDisk(ctx, disk.ServiceId, MakeWrite(creds, 0, 0, MakeData('R', BlockSize)).release());
         FinishUringWrite(ctx, disk, *router, TReplyStatus::OK);
         const auto held = HoldUringWrite(ctx, disk, creds, *router);
-        auto pbWrite = std::make_unique<NDDisk::TEvWritePersistentBuffer>(
-            pbCreds, NDDisk::TBlockSelector(0, 0, BlockSize), 1, NDDisk::TWriteInstruction(0));
-        pbWrite->AddPayloadThenChecksum(MakeAlignedRope(MakeData('P', BlockSize)));
-        SendToDDisk(ctx, disk.PBServiceId, pbWrite.release(), 101);
-        auto* pbOp = WaitSubmittedUring(ctx, disk, *router);
-
-        const auto actorId = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.ServiceId);
-        const auto pbActorId = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.PBServiceId);
+        const auto parentId = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.ServiceId);
+        const auto pbId = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.PBServiceId);
+        NDDisk::TDDiskActor* parent = nullptr;
+        NDDisk::TDDiskActor* pb = nullptr;
+        ctx.Runtime.WrapInActorContext(parentId, [&](IActor* actor) { parent = static_cast<NDDisk::TDDiskActor*>(actor); });
+        ctx.Runtime.WrapInActorContext(pbId, [&](IActor* actor) { pb = static_cast<NDDisk::TDDiskActor*>(actor); });
         const auto warden = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
         ctx.Runtime.RegisterService(MakeBlobStorageNodeWardenID(NodeId), warden);
-        const auto stalled = ctx.Counters->GetSubgroup("counters", "ddisks")->GetCounter("io_stalled", false);
-        std::map<TActorId, ui32> scheduled;
-        const auto stoppedAt = ctx.Runtime.GetClock();
-        ctx.Runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant at) {
-            if (ev->GetTypeRewrite() == NDDisk::TDDiskActor::TEvPrivate::TEvStopIoTimeout::EventType) {
-                UNIT_ASSERT_VALUES_EQUAL(at, stoppedAt + TDuration::Minutes(1));
-                ++scheduled[ev->Recipient];
+        const auto decoy = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(disk.ServiceId, decoy);
+        ctx.Runtime.RegisterService(disk.PBServiceId, decoy);
+        std::unique_ptr<IEventHandle> poison;
+        std::vector<TActorId> gone;
+        ctx.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvents::TEvPoison::EventType && ev->Recipient == pbId) {
+                poison = std::move(ev);
+                return false;
             }
             return true;
         };
-        SendToDDisk(ctx, disk.ServiceId, new TEvents::TEvPoison());
-        AssertStoppingRejects<NDDisk::TEvConnect>(ctx, disk.ServiceId);
-        AssertStoppingRejects<NDDisk::TEvConnect>(ctx, disk.PBServiceId);
-        SendToDDisk(ctx, disk.ServiceId, new TEvents::TEvPoison());
-        SendToDDisk(ctx, disk.PBServiceId, new TEvents::TEvPoison());
-        AssertStoppingRejects<NDDisk::TEvDisconnect>(ctx, disk.PBServiceId);
-        AssertStoppingRejects<NDDisk::TEvWritePersistentBuffer>(ctx, disk.PBServiceId);
-        AssertStoppingRejects<NDDisk::TEvReadPersistentBuffer>(ctx, disk.PBServiceId);
-        AssertStoppingRejects<NDDisk::TEvErasePersistentBuffer>(ctx, disk.PBServiceId);
-        AssertStoppingRejects<NDDisk::TEvBatchErasePersistentBuffer>(ctx, disk.PBServiceId);
-        AssertStoppingRejects<NDDisk::TEvListPersistentBuffer>(ctx, disk.PBServiceId);
-        AssertStoppingRejectsPlural<NDDisk::TEvWritePersistentBuffers>(ctx, disk.PBServiceId);
-        AssertStoppingRejectsPlural<NDDisk::TEvReadThenWritePersistentBuffers>(ctx, disk.PBServiceId);
-        UNIT_ASSERT_VALUES_EQUAL(scheduled[actorId], 1);
-        UNIT_ASSERT_VALUES_EQUAL(scheduled[pbActorId], 1);
-        UNIT_ASSERT_VALUES_EQUAL(stalled->Val(), 0);
-
-        const auto timerEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
-        ctx.Runtime.Schedule(stoppedAt + TDuration::Minutes(1) - TDuration::MicroSeconds(1),
-            new IEventHandle(timerEdge, {}, new TEvents::TEvWakeup()), nullptr, NodeId);
-        ctx.Runtime.WaitForEdgeActorEvent<TEvents::TEvWakeup>(timerEdge, false);
-        UNIT_ASSERT_VALUES_EQUAL(stalled->Val(), 0);
-        ctx.Runtime.Schedule(stoppedAt + TDuration::Minutes(1) + TDuration::MicroSeconds(1),
-            new IEventHandle(timerEdge, {}, new TEvents::TEvWakeup()), nullptr, NodeId);
-        ctx.Runtime.WaitForEdgeActorEvent<TEvents::TEvWakeup>(timerEdge, false);
-        UNIT_ASSERT_VALUES_EQUAL(stalled->Val(), 2);
-        ctx.Runtime.FilterEnqueue = {};
-        SendToDDisk(ctx, disk.ServiceId, new NDDisk::TDDiskActor::TEvPrivate::TEvStopIoTimeout());
-        SendToDDisk(ctx, disk.PBServiceId, new NDDisk::TDDiskActor::TEvPrivate::TEvStopIoTimeout());
-        AssertStoppingRejects<NDDisk::TEvConnect>(ctx, disk.PBServiceId);
-        UNIT_ASSERT_VALUES_EQUAL(stalled->Val(), 2);
-
+        ctx.Runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant) {
+            if (ev->GetTypeRewrite() == TEvents::TEvGone::EventType) {
+                if (ev->Sender == pbId) {
+                    UNIT_ASSERT(!pb->UringRouter);
+                } else if (ev->Sender == parentId) {
+                    UNIT_ASSERT(!parent->UringRouter);
+                }
+                gone.push_back(ev->Sender);
+            }
+            return true;
+        };
+        SendToDDisk(ctx, parentId, new TEvents::TEvPoison());
+        AssertStoppingRejects<NDDisk::TEvConnect>(ctx, parentId);
+        UNIT_ASSERT(poison);
+        for (ui32 invalid = 0; invalid != 3; ++invalid) {
+            ctx.Runtime.Send(new IEventHandle(parentId, invalid == 0 ? decoy : pbId,
+                new TEvents::TEvUndelivered(invalid == 2 ? TEvents::TEvWakeup::EventType : TEvents::TSystem::Poison,
+                    TEvents::TEvUndelivered::ReasonActorUnknown), 0,
+                poison->Cookie + (invalid == 1)), NodeId);
+        }
+        AssertStoppingRejects<NDDisk::TEvConnect>(ctx, parentId);
+        UNIT_ASSERT(gone.empty());
         router->CompleteSuccessfully(held[0]);
         router->CompleteSuccessfully(held[1]);
         AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+        AssertStoppingRejects<NDDisk::TEvConnect>(ctx, parentId);
+        UNIT_ASSERT(gone.empty());
+        auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(
+            pbCreds, NDDisk::TBlockSelector(0, 0, BlockSize), 1, NDDisk::TWriteInstruction(0));
+        write->AddPayloadThenChecksum(MakeAlignedRope(MakeData('P', BlockSize)));
+        SendToDDisk(ctx, pbId, write.release(), 101);
+        auto* operation = WaitSubmittedUring(ctx, disk, *router);
+        ctx.Runtime.FilterFunction = {};
+        ctx.Runtime.Send(std::move(poison), NodeId);
+        AssertStoppingRejects<NDDisk::TEvConnect>(ctx, pbId);
+        UNIT_ASSERT(gone.empty());
+        SendToDDisk(ctx, parentId, new TEvents::TEvPoison());
+        SendToDDisk(ctx, pbId, new TEvents::TEvPoison());
+        router->CompleteSuccessfully(operation);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx), TReplyStatus::OK);
         ctx.Runtime.WaitForEdgeActorEvent<TEvents::TEvGone>(warden, false);
-        UNIT_ASSERT(!ctx.Runtime.WrapInActorContext(actorId, [](IActor*) {}));
-        UNIT_ASSERT(ctx.Runtime.WrapInActorContext(pbActorId, [](IActor*) {}));
-        UNIT_ASSERT_VALUES_EQUAL(stalled->Val(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(ctx.Counters->GetSubgroup("counters", "ddisks")
-            ->GetCounter("io_stalled", false)->Val(), 1);
-
-        router->CompleteSuccessfully(pbOp);
-        const auto pbReply = WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx);
-        AssertStatus(pbReply, TReplyStatus::OK);
-        UNIT_ASSERT_VALUES_EQUAL(pbReply->Cookie, 101);
-        AssertActorDies(ctx, pbActorId);
-        UNIT_ASSERT_VALUES_EQUAL(stalled->Val(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(gone.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(gone[0], pbId);
+        UNIT_ASSERT_VALUES_EQUAL(gone[1], parentId);
         UNIT_ASSERT_VALUES_EQUAL(router->Outstanding, 0);
+        ctx.Runtime.FilterEnqueue = {};
     }
 
     Y_UNIT_TEST(StoppingUringDropCompletesPersistentBufferRequest) {
@@ -1373,6 +1608,207 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         AssertActorDies(ctx, actorId);
         UNIT_ASSERT_VALUES_EQUAL(router->Outstanding, 0);
         UNIT_ASSERT_VALUES_EQUAL(router->WriteAdmissions, admissions);
+    }
+
+    Y_UNIT_TEST(CriticalRetriesUseBackoffAndExhaustAfterTwentyResubmissions) {
+        TTestContext ctx;
+        auto router = std::make_shared<TScriptedUringClient>(ctx);
+        const auto disk = ctx.RegisterDDisk(101, 1);
+        ctx.BootstrapDDisk(disk, TTestContext::ChunkSize, MinChunksReserved, nullptr, 0, {}, nullptr, router);
+        const auto creds = Connect(ctx, disk.ServiceId, 901, 1);
+        SendToDDisk(ctx, disk.ServiceId, MakeWrite(creds, 0, 0, MakeData('R', BlockSize)).release());
+        FinishUringWrite(ctx, disk, *router, TReplyStatus::OK);
+        const auto held = HoldUringWrite(ctx, disk, creds, *router);
+        router->CompleteSuccessfully(held[0]);
+        auto* op = held[1];
+        const auto initialAdmissions = router->WriteAdmissions;
+        ui32 timers = 0;
+        TInstant completedAt;
+        ctx.Runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant at) {
+            if (ev->GetTypeRewrite() == NDDisk::TDDiskActor::TEvPrivate::TEvRetryIODelayed::EventType) {
+                UNIT_ASSERT_VALUES_EQUAL(at, completedAt + TDuration::MilliSeconds(Min<ui32>(1u << timers, 100)));
+                ++timers;
+            }
+            return true;
+        };
+        for (ui32 retry = 0; retry != 20; ++retry) {
+            completedAt = ctx.Runtime.GetClock();
+            router->Complete(op, -EAGAIN);
+            UNIT_ASSERT_VALUES_EQUAL(WaitSubmittedUring(ctx, disk, *router), op);
+            UNIT_ASSERT_VALUES_EQUAL(timers, retry + 1);
+        }
+        router->Complete(op, -ENOSPC);
+        const auto reply = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
+        AssertStatus(reply, TReplyStatus::ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(timers, 20);
+        UNIT_ASSERT_VALUES_EQUAL(router->WriteAdmissions - initialAdmissions + 1, 21);
+        UNIT_ASSERT_STRING_CONTAINS(reply->Get()->Record.GetErrorReason(), "28");
+        ctx.Runtime.FilterEnqueue = {};
+        const auto writes = GetDirectIoCounters(ctx, disk)->GetSubgroup("operation", "Write");
+        UNIT_ASSERT_VALUES_EQUAL(writes->GetCounter("RequestsInFlight", false)->Val(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(writes->GetCounter("BytesInFlight", false)->Val(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(router->Outstanding, 0);
+    }
+
+    Y_UNIT_TEST(BrokenCancelsIndependentCriticalRetriesAndDuplicateTimers) {
+        for (const bool beforeInsertion : {false, true}) {
+            TTestContext ctx;
+            auto router = std::make_shared<TScriptedUringClient>(ctx);
+            const auto disk = ctx.RegisterDDisk(111, 1);
+            ctx.BootstrapDDisk(disk, TTestContext::ChunkSize, MinChunksReserved, nullptr, 0, {}, nullptr, router);
+            std::array<NDDisk::TQueryCredentials, 3> creds;
+            for (ui32 index = 0; index != 3; ++index) {
+                creds[index] = Connect(ctx, disk.ServiceId, 910 + index, 1);
+                SendToDDisk(ctx, disk.ServiceId, MakeWrite(creds[index], 0, 0, MakeData('R', BlockSize)).release());
+                FinishUringWrite(ctx, disk, *router, TReplyStatus::OK);
+            }
+            std::array<std::array<NPDisk::TUringOperationBase*, 2>, 3> held;
+            for (ui32 index = 0; index != 3; ++index) {
+                held[index] = HoldUringWrite(ctx, disk, creds[index], *router, 100 + index);
+                router->CompleteSuccessfully(held[index][0]);
+            }
+            std::vector<std::unique_ptr<IEventHandle>> timers;
+            std::unique_ptr<IEventHandle> immediate;
+            ui32 retryEvents = 0;
+            ctx.Runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant) {
+                if (ev->GetTypeRewrite() == NDDisk::TDDiskActor::TEvPrivate::TEvRetryIO::EventType
+                        && ++retryEvents == 2 && beforeInsertion) {
+                    immediate = std::move(ev);
+                    return false;
+                }
+                if (ev->GetTypeRewrite() == NDDisk::TDDiskActor::TEvPrivate::TEvRetryIODelayed::EventType) {
+                    timers.push_back(std::move(ev));
+                    return false;
+                }
+                return true;
+            };
+            router->Complete(held[0][1], -EAGAIN);
+            router->Complete(held[1][1], -ENOMEM);
+            ui32 turns = 0;
+            const size_t expectedTimers = beforeInsertion ? 1 : 2;
+            ctx.Runtime.Sim([&] { return timers.size() != expectedTimers && ++turns < 200; });
+            UNIT_ASSERT_VALUES_EQUAL(timers.size(), expectedTimers);
+            UNIT_ASSERT_VALUES_EQUAL(bool(immediate), beforeInsertion);
+            const auto admissions = router->WriteAdmissions;
+            router->Complete(held[2][1], -EIO);
+            std::set<ui64> replies;
+            for (ui32 index = 0; index != 3; ++index) {
+                auto reply = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
+                AssertStatus(reply, TReplyStatus::ERROR);
+                UNIT_ASSERT(replies.insert(reply->Cookie).second);
+            }
+            UNIT_ASSERT(replies == std::set<ui64>({100, 101, 102}));
+            ctx.Runtime.FilterEnqueue = {};
+            if (immediate) { ctx.Runtime.Send(std::move(immediate), NodeId); }
+            for (auto& timer : timers) {
+                const auto id = timer->Get<NDDisk::TDDiskActor::TEvPrivate::TEvRetryIODelayed>()->Id;
+                const auto recipient = timer->Recipient;
+                ctx.Runtime.Send(std::move(timer), NodeId);
+                ctx.Runtime.Send(new IEventHandle(recipient, {},
+                    new NDDisk::TDDiskActor::TEvPrivate::TEvRetryIODelayed(id)), NodeId);
+            }
+            AssertStatus(SendToDDiskAndWait<NDDisk::TEvReadResult>(ctx, disk.ServiceId,
+                new NDDisk::TEvRead(creds[0], {0, 0, BlockSize}, {true})), TReplyStatus::ERROR);
+            const auto actorId = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.ServiceId);
+            bool empty = false;
+            ctx.Runtime.WrapInActorContext(actorId, [&](IActor* actor) {
+                empty = static_cast<NDDisk::TDDiskActor*>(actor)->DelayedRetries.empty();
+            });
+            UNIT_ASSERT(empty);
+            UNIT_ASSERT_VALUES_EQUAL(router->Outstanding, 0);
+            UNIT_ASSERT_VALUES_EQUAL(router->WriteAdmissions, admissions);
+            const auto counters = GetDirectIoCounters(ctx, disk);
+            UNIT_ASSERT_VALUES_EQUAL(counters->GetCounter("RunningCount", false)->Val(), 0);
+            const auto writes = counters->GetSubgroup("operation", "Write");
+            UNIT_ASSERT_VALUES_EQUAL(writes->GetCounter("RequestsInFlight", false)->Val(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(writes->GetCounter("BytesInFlight", false)->Val(), 0);
+            AssertNoClientReplyBeforeSentinel(ctx, "Saved retry timers must not produce duplicate replies");
+        }
+    }
+
+    Y_UNIT_TEST(DelayedCriticalRetryRejectionBalancesAccounting) {
+        TTestContext ctx;
+        auto router = std::make_shared<TScriptedUringClient>(ctx);
+        const auto disk = ctx.RegisterDDisk(112, 1);
+        ctx.BootstrapDDisk(disk, TTestContext::ChunkSize, MinChunksReserved, nullptr, 0, {}, nullptr, router);
+        const auto creds = Connect(ctx, disk.ServiceId, 913, 1);
+        SendToDDisk(ctx, disk.ServiceId, MakeWrite(creds, 0, 0, MakeData('R', BlockSize)).release());
+        FinishUringWrite(ctx, disk, *router, TReplyStatus::OK);
+        const auto held = HoldUringWrite(ctx, disk, creds, *router);
+        std::unique_ptr<IEventHandle> timer;
+        ctx.Runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant) {
+            if (ev->GetTypeRewrite() == NDDisk::TDDiskActor::TEvPrivate::TEvRetryIODelayed::EventType) {
+                timer = std::move(ev);
+                return false;
+            }
+            return true;
+        };
+        router->CompleteSuccessfully(held[0]);
+        router->Complete(held[1], -EAGAIN);
+        ui32 turns = 0;
+        ctx.Runtime.Sim([&] { return !timer && ++turns < 200; });
+        UNIT_ASSERT(timer);
+        const auto id = timer->Get<NDDisk::TDDiskActor::TEvPrivate::TEvRetryIODelayed>()->Id;
+        const auto recipient = timer->Recipient;
+        const auto attempts = router->WriteAdmissions;
+        router->RejectSubmissions = true;
+        ctx.Runtime.FilterEnqueue = {};
+        ctx.Runtime.Send(std::move(timer), NodeId);
+        const auto reply = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
+        AssertStatus(reply, TReplyStatus::ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(reply->Cookie, 100);
+        UNIT_ASSERT_VALUES_EQUAL(router->WriteAdmissions, attempts + 1);
+        UNIT_ASSERT_VALUES_EQUAL(router->Outstanding, 0);
+        bool empty = false;
+        const auto actorId = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.ServiceId);
+        UNIT_ASSERT(ctx.Runtime.WrapInActorContext(actorId, [&](IActor* actor) {
+            empty = static_cast<NDDisk::TDDiskActor*>(actor)->DelayedRetries.empty();
+        }));
+        UNIT_ASSERT(empty);
+        const auto counters = GetDirectIoCounters(ctx, disk);
+        UNIT_ASSERT_VALUES_EQUAL(counters->GetCounter("RunningCount", false)->Val(), 0);
+        const auto writes = counters->GetSubgroup("operation", "Write");
+        UNIT_ASSERT_VALUES_EQUAL(writes->GetCounter("RequestsInFlight", false)->Val(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(writes->GetCounter("BytesInFlight", false)->Val(), 0);
+        ctx.Runtime.Send(new IEventHandle(recipient, {},
+            new NDDisk::TDDiskActor::TEvPrivate::TEvRetryIODelayed(id)), NodeId);
+        AssertNoClientReplyBeforeSentinel(ctx, "Rejected retry must finish once despite duplicate timers");
+        UNIT_ASSERT_VALUES_EQUAL(router->WriteAdmissions, attempts + 1);
+    }
+
+    Y_UNIT_TEST(StoppingCancelsParkedRetryAndIgnoresStaleTimer) {
+        TTestContext ctx;
+        auto router = std::make_shared<TScriptedUringClient>(ctx);
+        const auto disk = ctx.RegisterDDisk(102, 1);
+        ctx.BootstrapDDisk(disk, TTestContext::ChunkSize, MinChunksReserved, nullptr, 0, {}, nullptr, router);
+        const auto creds = Connect(ctx, disk.ServiceId, 902, 1);
+        SendToDDisk(ctx, disk.ServiceId, MakeWrite(creds, 0, 0, MakeData('R', BlockSize)).release());
+        FinishUringWrite(ctx, disk, *router, TReplyStatus::OK);
+        const auto held = HoldUringWrite(ctx, disk, creds, *router);
+        std::unique_ptr<IEventHandle> timer;
+        ctx.Runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant) {
+            if (ev->GetTypeRewrite() == NDDisk::TDDiskActor::TEvPrivate::TEvRetryIODelayed::EventType) {
+                timer = std::move(ev);
+                return false;
+            }
+            return true;
+        };
+        router->Complete(held[1], -ENOMEM);
+        ui32 turns = 0;
+        ctx.Runtime.Sim([&] { return !timer && ++turns < 200; });
+        UNIT_ASSERT(timer);
+        ctx.Runtime.FilterEnqueue = {};
+        const auto admissions = router->WriteAdmissions;
+        SendToDDisk(ctx, disk.ServiceId, new TEvents::TEvPoison());
+        AssertStoppingRejects<NDDisk::TEvConnect>(ctx, disk.ServiceId);
+        ctx.Runtime.Send(std::move(timer), NodeId);
+        AssertStoppingRejects<NDDisk::TEvConnect>(ctx, disk.ServiceId);
+        router->CompleteSuccessfully(held[0]);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::SESSION_MISMATCH);
+        UNIT_ASSERT_VALUES_EQUAL(router->WriteAdmissions, admissions);
+        UNIT_ASSERT_VALUES_EQUAL(router->Outstanding, 0);
+        const auto writes = GetDirectIoCounters(ctx, disk)->GetSubgroup("operation", "Write");
+        UNIT_ASSERT_VALUES_EQUAL(writes->GetCounter("RequestsInFlight", false)->Val(), 0);
     }
 
     Y_UNIT_TEST(CriticalUringErrorsRetrySameOperation) {
@@ -1520,6 +1956,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         ctx.Runtime.RegisterService(MakeBlobStorageNodeWardenID(NodeId), warden);
 
         SendToDDisk(ctx, disk.ServiceId, new TEvents::TEvPoison());
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx), TReplyStatus::SESSION_MISMATCH);
         const auto gone = ctx.Runtime.WaitForEdgeActorEvent<TEvents::TEvGone>(warden, false);
         UNIT_ASSERT_VALUES_EQUAL(gone->Sender, actorId);
         UNIT_ASSERT(!ctx.Runtime.WrapInActorContext(actorId, [](IActor*) {}));
@@ -1534,7 +1971,99 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         ctx.SendPDiskResponse(disk, *pending, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
     }
 
-    Y_UNIT_TEST(PoisonNotifiesNodeWardenImmediately) {
+    Y_UNIT_TEST(FallbackCancellationRepliesPrecedeGoneForEveryOperation) {
+        for (ui32 mode = 0; mode != 5; ++mode) {
+            const bool pb = mode >= 2;
+            const bool read = mode == 1 || mode >= 3;
+            const bool multipart = mode == 4;
+            TTestContext ctx;
+            NDDisk::TPersistentBufferFormat format;
+            format.MaxInMemoryCache = 0;
+            format.MinFreeSectorsReserve = 0;
+            format.EnableWritesBatching = false;
+            const auto disk = ctx.RegisterDDisk(112, 1, format);
+            ctx.BootstrapDDisk(disk, multipart ? 140 * 1024 : TTestContext::ChunkSize, MinChunksReserved);
+            const auto recipient = pb ? disk.PBServiceId : disk.ServiceId;
+            const auto creds = Connect(ctx, recipient, 912, 1);
+            const ui32 size = multipart ? 48 * BlockSize : BlockSize;
+            const NDDisk::TBlockSelector selector(0, 0, size);
+            auto pbWrite = [&](ui64 lsn) {
+                auto request = std::make_unique<NDDisk::TEvWritePersistentBuffer>(creds, selector, lsn, NDDisk::TWriteInstruction(0));
+                request->AddPayloadThenChecksum(MakeAlignedRope(MakeData('P', size)));
+                return request;
+            };
+            if (!pb) {
+                auto initial = DoWriteWithChunkAllocation(ctx, disk,
+                    MakeWrite(creds, 0, 0, MakeData('A', BlockSize)),
+                    disk.FirstChunkId + PersistentBufferInitChunks, 0, MakeData('A', BlockSize), true, true);
+                AssertStatus(initial.WriteResult, TReplyStatus::OK);
+            } else if (read) {
+                SendToDDisk(ctx, recipient, pbWrite(1).release());
+                for (ui32 part = 0; part != (multipart ? 2u : 1u); ++part) {
+                    auto request = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+                    ctx.SendPDiskResponse(disk, *request, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+                }
+                AssertStatus(WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx), TReplyStatus::OK);
+            }
+            if (read) {
+                if (pb) { SendToDDisk(ctx, recipient, new NDDisk::TEvReadPersistentBuffer(creds, selector, 1, 1, {true}), 100); }
+                else { SendToDDisk(ctx, recipient, new NDDisk::TEvRead(creds, selector, {true}), 100); }
+            } else {
+                if (pb) { SendToDDisk(ctx, recipient, pbWrite(2).release(), 100); }
+                else { SendToDDisk(ctx, recipient, MakeWrite(creds, 0, 0, MakeData('B', BlockSize)).release(), 100); }
+            }
+            std::vector<std::unique_ptr<TEventHandle<NPDisk::TEvChunkReadRaw>>> reads;
+            std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>> write;
+            if (read) {
+                for (ui32 part = 0; part != (multipart ? 2u : 1u); ++part) {
+                    reads.push_back(ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk));
+                }
+            } else {
+                write = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+            }
+            const auto parent = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.ServiceId);
+            const auto child = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.PBServiceId);
+            const auto warden = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+            ctx.Runtime.RegisterService(MakeBlobStorageNodeWardenID(NodeId), warden);
+            std::vector<std::pair<ui32, TActorId>> journal;
+            ctx.Runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant) {
+                if ((ev->Recipient == ctx.Edge && ev->Cookie == 100)
+                        || (ev->GetTypeRewrite() == TEvents::TEvGone::EventType && (ev->Sender == parent || ev->Sender == child))) {
+                    journal.emplace_back(ev->GetTypeRewrite(), ev->Sender);
+                }
+                return true;
+            };
+            const auto counters = GetDirectIoCounters(ctx, disk);
+            SendToDDisk(ctx, disk.ServiceId, new TEvents::TEvPoison());
+            if (pb && read) { AssertStatus(WaitFromDDisk<NDDisk::TEvReadPersistentBufferResult>(ctx), TReplyStatus::SESSION_MISMATCH); }
+            else if (pb) { AssertStatus(WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx), TReplyStatus::SESSION_MISMATCH); }
+            else if (read) { AssertStatus(WaitFromDDisk<NDDisk::TEvReadResult>(ctx), TReplyStatus::SESSION_MISMATCH); }
+            else { AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::SESSION_MISMATCH); }
+            ctx.Runtime.WaitForEdgeActorEvent<TEvents::TEvGone>(warden, false);
+            const auto source = pb ? child : parent;
+            auto replyPos = std::find_if(journal.begin(), journal.end(), [&](const auto& item) {
+                return item.first != TEvents::TEvGone::EventType && item.second == source;
+            });
+            auto gonePos = std::find(journal.begin(), journal.end(), std::make_pair(ui32(TEvents::TEvGone::EventType), source));
+            UNIT_ASSERT(replyPos != journal.end() && gonePos != journal.end() && replyPos < gonePos);
+            UNIT_ASSERT_VALUES_EQUAL(journal.size(), 3);
+            UNIT_ASSERT_VALUES_EQUAL(counters->GetCounter("RunningCount", false)->Val(), 0);
+            for (const auto* operation : {"Read", "Write"}) {
+                const auto subgroup = counters->GetSubgroup("operation", operation);
+                UNIT_ASSERT_VALUES_EQUAL(subgroup->GetCounter("RequestsInFlight", false)->Val(), 0);
+                UNIT_ASSERT_VALUES_EQUAL(subgroup->GetCounter("BytesInFlight", false)->Val(), 0);
+            }
+            if (write) { ctx.SendPDiskResponse(disk, *write, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, "")); }
+            for (const auto& request : reads) {
+                ctx.SendPDiskResponse(disk, *request, new NPDisk::TEvChunkReadRawResult(TRope(TString(size, '\0'))));
+            }
+            AssertNoClientReplyBeforeSentinel(ctx, "Late fallback results must not send duplicate cancellations");
+            UNIT_ASSERT_VALUES_EQUAL(journal.size(), 3);
+            ctx.Runtime.FilterEnqueue = {};
+        }
+    }
+
+    Y_UNIT_TEST(PoisonWaitsForPersistentBufferBeforeNotifyingNodeWarden) {
         TTestContext ctx;
         ctx.Runtime.RegisterService(MakeBlobStorageNodeWardenID(NodeId), ctx.Edge);
 
@@ -1563,13 +2092,12 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             return !blockedPersistentBufferPoison && ++eventsProcessed <= 200;
         });
         UNIT_ASSERT_C(blockedPersistentBufferPoison, "DDisk must poison its persistent buffer actor");
-        UNIT_ASSERT(!ctx.Runtime.WrapInActorContext(ddiskActorId, [](IActor*) {}));
+        UNIT_ASSERT(ctx.Runtime.WrapInActorContext(ddiskActorId, [](IActor*) {}));
         UNIT_ASSERT(ctx.Runtime.WrapInActorContext(persistentBufferActorId, [](IActor*) {}));
 
         ctx.Runtime.FilterFunction = {};
-        const auto gone = WaitFromDDisk<TEvents::TEvGone>(ctx);
-
         ctx.Runtime.Send(std::move(blockedPersistentBufferPoison), NodeId);
+        const auto gone = WaitFromDDisk<TEvents::TEvGone>(ctx);
 
         UNIT_ASSERT_VALUES_EQUAL(gone->Sender, ddiskActorId);
         UNIT_ASSERT(!ctx.Runtime.WrapInActorContext(ddiskActorId, [](IActor*) {}));
@@ -1580,6 +2108,70 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         });
         UNIT_ASSERT_C(!ctx.Runtime.WrapInActorContext(persistentBufferActorId, [](IActor*) {}),
             "Persistent buffer must stop after receiving poison");
+    }
+
+    Y_UNIT_TEST(FailedPersistentBufferRestoreIgnoresLateSuccessfulRead) {
+        TTestContext ctx;
+        const auto disk = ctx.CreateDDisk(105, 1);
+        const auto pbId = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.PBServiceId);
+        ctx.Runtime.WrapInActorContext(pbId, [&](IActor* actor) {
+            auto& pb = *dynamic_cast<NDDisk::TDDiskActor*>(actor);
+            pb.PersistentBufferReady = false;
+            pb.PersistentBufferRestoreChunksInflight = 2;
+        });
+        using TResult = NDDisk::TDDiskActor::TEvPrivate::TEvReadPersistentBufferPart;
+        SendToDDisk(ctx, disk.PBServiceId, new TResult(1, 1, TReplyStatus::ERROR, "restore EIO", {}, true));
+        // Empty data would abort if parsed. Broken must only account this result.
+        SendToDDisk(ctx, disk.PBServiceId, new TResult(2, 2, TReplyStatus::OK, {}, {}, true));
+        const auto reply = SendToDDiskAndWait<NDDisk::TEvConnectResult>(ctx, disk.PBServiceId,
+            new NDDisk::TEvConnect());
+        AssertStatus(reply, TReplyStatus::ERROR);
+        ctx.Runtime.WrapInActorContext(pbId, [&](IActor* actor) {
+            auto& pb = *dynamic_cast<NDDisk::TDDiskActor*>(actor);
+            UNIT_ASSERT_VALUES_EQUAL(pb.PersistentBufferRestoreChunksInflight, 0);
+            UNIT_ASSERT(!pb.PersistentBufferReady);
+        });
+    }
+
+    Y_UNIT_TEST(TrackedChildPoisonNondeliveryCompletesParentOnce) {
+        TTestContext ctx;
+        const auto disk = ctx.CreateDDisk(110, 1);
+        const auto child = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.PBServiceId);
+        const auto parent = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.ServiceId);
+        const auto warden = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(MakeBlobStorageNodeWardenID(NodeId), warden);
+        ctx.Runtime.DestroyActor(child);
+        ui32 undelivered = 0, gone = 0;
+        ctx.Runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant) {
+            if (ev->GetTypeRewrite() == TEvents::TEvUndelivered::EventType && ev->Recipient == parent) {
+                UNIT_ASSERT_VALUES_EQUAL(ev->Sender, child);
+                UNIT_ASSERT(ev->Get<TEvents::TEvUndelivered>()->SourceType == TEvents::TSystem::Poison);
+                ++undelivered;
+            }
+            if (ev->GetTypeRewrite() == TEvents::TEvGone::EventType && ev->Sender == parent) { ++gone; }
+            return true;
+        };
+        SendToDDisk(ctx, parent, new TEvents::TEvPoison());
+        SendToDDisk(ctx, parent, new TEvents::TEvPoison());
+        ctx.Runtime.WaitForEdgeActorEvent<TEvents::TEvGone>(warden, false);
+        UNIT_ASSERT_VALUES_EQUAL(undelivered, 1);
+        UNIT_ASSERT_VALUES_EQUAL(gone, 1);
+        ctx.Runtime.FilterEnqueue = {};
+    }
+
+    Y_UNIT_TEST(PoisonHandlesAlreadyGonePersistentBuffer) {
+        TTestContext ctx;
+        const auto disk = ctx.CreateDDisk(104, 1);
+        const auto pbId = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.PBServiceId);
+        const auto parentId = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.ServiceId);
+        SendToDDisk(ctx, disk.PBServiceId, new TEvents::TEvPoison());
+        ui32 turns = 0;
+        ctx.Runtime.Sim([&] { return ctx.Runtime.WrapInActorContext(pbId, [](IActor*) {}) && ++turns < 200; });
+        UNIT_ASSERT(!ctx.Runtime.WrapInActorContext(pbId, [](IActor*) {}));
+        ctx.Runtime.RegisterService(MakeBlobStorageNodeWardenID(NodeId), ctx.Edge);
+        SendToDDisk(ctx, disk.ServiceId, new TEvents::TEvPoison());
+        const auto gone = WaitFromDDisk<TEvents::TEvGone>(ctx);
+        UNIT_ASSERT_VALUES_EQUAL(gone->Sender, parentId);
     }
 
     Y_UNIT_TEST(SessionValidation) {
@@ -4528,23 +5120,11 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         logReply->Results.emplace_back(logSnapshot->Get()->Lsn, logSnapshot->Get()->Cookie);
         ctx.SendPDiskResponse(disk, *logSnapshot, logReply.release());
 
-        // DDisk should be in StateFuncTerminate now (not crashed).
-        // Verify it silently drops client requests.
-        SendToDDisk(ctx, disk.ServiceId, new NDDisk::TEvConnect(creds));
-
-        TActorId sentinelEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
-        ctx.Runtime.Send(new IEventHandle(sentinelEdge, ctx.Edge, new TEvents::TEvWakeup()), NodeId);
-
-        for (;;) {
-            auto ev = ctx.Runtime.WaitForEdgeActorEvent(ctx.ClientWaitEdges({sentinelEdge}));
-            if (ctx.ConsumeUnsolicitedPDiskEvent(ev)) {
-                continue;
-            }
-            UNIT_ASSERT_VALUES_EQUAL_C(ev->Recipient, sentinelEdge,
-                "DDisk should not respond to client requests after PDisk "
-                << NKikimrProto::EReplyStatus_Name(errorStatus));
-            break;
-        }
+        // Session loss fails outstanding work and rejects later requests while
+        // the actor remains alive awaiting poison from its owner.
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::SESSION_MISMATCH);
+        AssertStatus(SendToDDiskAndWait<NDDisk::TEvConnectResult>(ctx, disk.ServiceId,
+            new NDDisk::TEvConnect(creds)), TReplyStatus::SESSION_MISMATCH);
     }
 
     Y_UNIT_TEST(PDiskCorruptedStopsDDisk) {
@@ -4792,10 +5372,13 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
     // `preExistingChunkIds` – chunk IDs that were owned by the previous PB instance.
     // `oldUniqueId`         – the UniqueId that was used by the previous instance.
     // `chunkData`           – maps chunkId -> raw bytes (ChunkSize) to return during restore reads.
-    TDiskHandle CreateDDiskWithRestoredChunkData(TTestContext& ctx, ui32 pdiskId, ui32 slotId,
+    TDiskHandle BootstrapDDiskToPendingRestore(TTestContext& ctx, ui32 pdiskId, ui32 slotId,
             const std::vector<ui32>& preExistingChunkIds, ui64 persistentBufferUniqueId,
-            const std::unordered_map<ui32, TString>& chunkData,
-            NDDisk::TPersistentBufferFormat pbFormat = {256, 4, BlockSize * 128, 8, 5000, 512 * 1024}) {
+            NDDisk::TPersistentBufferFormat pbFormat = {256, 4, BlockSize * 128, 8, 5000, 512 * 1024}
+#if defined(__linux__)
+            , std::shared_ptr<NPDisk::IUringRouterClient> router = {}
+#endif
+            ) {
         const TActorId pdiskEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
         const TActorId pdiskServiceId = MakeBlobStoragePDiskID(NodeId, pdiskId);
         ctx.Runtime.RegisterService(pdiskServiceId, pdiskEdge);
@@ -4856,6 +5439,9 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             BlockSize,
             "");
 
+#if defined(__linux__)
+        initReply->UringRouter = std::move(router);
+#endif
         NPDisk::TDiskFormat format = {};
         format.Clear(false);
         initReply->DiskFormat = NPDisk::TDiskFormatPtr(new NPDisk::TDiskFormat(format), +[](NPDisk::TDiskFormat* ptr) {
@@ -4892,6 +5478,15 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             Owner);
         ctx.SendPDiskResponse(disk, *readLog, readLogReply.release());
 
+        return disk;
+    }
+
+    TDiskHandle CreateDDiskWithRestoredChunkData(TTestContext& ctx, ui32 pdiskId, ui32 slotId,
+            const std::vector<ui32>& preExistingChunkIds, ui64 persistentBufferUniqueId,
+            const std::unordered_map<ui32, TString>& chunkData,
+            NDDisk::TPersistentBufferFormat pbFormat = {256, 4, BlockSize * 128, 8, 5000, 512 * 1024}) {
+        const auto disk = BootstrapDDiskToPendingRestore(ctx, pdiskId, slotId,
+            preExistingChunkIds, persistentBufferUniqueId, std::move(pbFormat));
         // ── Step 3: TEvChunkReadRaw × preExistingChunkIds.size() ─────────────────
         // The PB actor issues a read for each pre-existing chunk to restore its contents.
         // Since the PB chunks already exist (from StartingPoints), no TEvChunkReserve is
@@ -4913,6 +5508,133 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
 
         return disk;
     }
+
+#if defined(__linux__)
+    Y_UNIT_TEST(PersistentBufferActualRestoreFailureStopsAdmissions) {
+        for (const bool useRouter : {false, true}) {
+            for (const bool afterSuccess : {false, true}) {
+                TTestContext ctx;
+                NDDisk::TPersistentBufferFormat format;
+                format.MaxChunkRestoreInflight = 2;
+                auto router = useRouter ? std::make_shared<TScriptedUringClient>(ctx) : nullptr;
+                const auto disk = BootstrapDDiskToPendingRestore(ctx, 108, 1,
+                    {100, 101, 102, 103}, 123, format, router);
+                struct TRead {
+                    std::unique_ptr<TEventHandle<NPDisk::TEvChunkReadRaw>> Raw;
+                    NPDisk::TUringOperationBase* Op = nullptr;
+                };
+                auto takeRead = [&] {
+                    TRead read;
+                    if (router) {
+                        read.Op = ctx.Runtime.WaitForEdgeActorEvent<TEvUringRequest>(router->Edge, false)->Get()->Op;
+                    } else {
+                        read.Raw = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
+                    }
+                    return read;
+                };
+                auto complete = [&](TRead& read, bool success) {
+                    if (router) {
+                        if (success) {
+                            memset(const_cast<void*>(read.Op->GetIovBase()), 0, read.Op->GetOperationBytes());
+                            router->CompleteSuccessfully(read.Op);
+                        } else {
+                            router->Complete(read.Op, -EINVAL);
+                        }
+                    } else {
+                        ctx.SendPDiskResponse(disk, *read.Raw, success
+                            ? new NPDisk::TEvChunkReadRawResult(TRope(TString(TTestContext::ChunkSize, '\0')))
+                            : new NPDisk::TEvChunkReadRawResult(NKikimrProto::ERROR, "restore EIO"));
+                    }
+                };
+                auto first = takeRead();
+                auto second = takeRead();
+                const auto creds = Connect(ctx, disk.PBServiceId, 908, 1);
+                if (afterSuccess) {
+                    complete(first, true);
+                    first = takeRead();
+                }
+                auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(
+                    creds, NDDisk::TBlockSelector(0, 0, BlockSize), 1, NDDisk::TWriteInstruction(0));
+                write->AddPayloadThenChecksum(MakeAlignedRope(MakeData('P', BlockSize)));
+                SendToDDisk(ctx, disk.PBServiceId, write.release(), 201);
+                SendToDDisk(ctx, disk.PBServiceId, new NDDisk::TEvReadPersistentBuffer(
+                    creds, {0, 0, BlockSize}, 1, 1, {true}), 202);
+                SendToDDisk(ctx, disk.PBServiceId, new NDDisk::TEvListPersistentBuffer(creds), 203);
+                SendToDDisk(ctx, disk.PBServiceId, new NDDisk::TEvErasePersistentBuffer(creds, 1), 204);
+                auto info = SendToDDiskAndWait<NDDisk::TEvPersistentBufferInfo>(ctx, disk.PBServiceId,
+                    new NDDisk::TEvGetPersistentBufferInfo(false, false));
+                UNIT_ASSERT_VALUES_EQUAL(info->Get()->PendingEvents, 4);
+                const auto pbId = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.PBServiceId);
+                ui32 scheduled = 0;
+                ctx.Runtime.WrapInActorContext(pbId, [&](IActor* actor) {
+                    auto& pb = *static_cast<NDDisk::TDDiskActor*>(actor);
+                    scheduled = pb.PersistentBufferRestoringChunks.size();
+                    UNIT_ASSERT_VALUES_EQUAL(scheduled, afterSuccess ? 3 : 2);
+                });
+                bool errorResultObserved = false;
+                ctx.Runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant) {
+                    using TResult = NDDisk::TDDiskActor::TEvPrivate::TEvReadPersistentBufferPart;
+                    if (ev->GetTypeRewrite() == TResult::EventType && ev->Get<TResult>()->Status != TReplyStatus::OK) {
+                        UNIT_ASSERT(ev->Get<TResult>()->Data.empty());
+                        errorResultObserved = true;
+                    }
+                    return true;
+                };
+                complete(first, false);
+                const auto writeReply = WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx);
+                AssertStatus(writeReply, TReplyStatus::ERROR);
+                UNIT_ASSERT_VALUES_EQUAL(writeReply->Cookie, 201);
+                const auto readReply = WaitFromDDisk<NDDisk::TEvReadPersistentBufferResult>(ctx);
+                AssertStatus(readReply, TReplyStatus::ERROR);
+                UNIT_ASSERT_VALUES_EQUAL(readReply->Cookie, 202);
+                const auto listReply = WaitFromDDisk<NDDisk::TEvListPersistentBufferResult>(ctx);
+                AssertStatus(listReply, TReplyStatus::ERROR);
+                UNIT_ASSERT_VALUES_EQUAL(listReply->Cookie, 203);
+                const auto eraseReply = WaitFromDDisk<NDDisk::TEvErasePersistentBufferResult>(ctx);
+                AssertStatus(eraseReply, TReplyStatus::ERROR);
+                UNIT_ASSERT_VALUES_EQUAL(eraseReply->Cookie, 204);
+                UNIT_ASSERT(errorResultObserved);
+                ctx.Runtime.FilterEnqueue = {};
+                if (router) {
+                    UNIT_ASSERT_VALUES_EQUAL(router->Outstanding, 1);
+                } else {
+                    const auto counters = GetDirectIoCounters(ctx, disk);
+                    UNIT_ASSERT_VALUES_EQUAL(counters->GetCounter("RunningCount", false)->Val(), 0);
+                    const auto reads = counters->GetSubgroup("operation", "Read");
+                    UNIT_ASSERT_VALUES_EQUAL(reads->GetCounter("RequestsInFlight", false)->Val(), 0);
+                    UNIT_ASSERT_VALUES_EQUAL(reads->GetCounter("BytesInFlight", false)->Val(), 0);
+                }
+                complete(second, true);
+                AssertStatus(SendToDDiskAndWait<NDDisk::TEvConnectResult>(ctx, disk.PBServiceId,
+                    new NDDisk::TEvConnect()), TReplyStatus::ERROR);
+                bool broken = false, ready = true;
+                size_t pending = 0, restoring = 0, restored = 0;
+                UNIT_ASSERT(ctx.Runtime.WrapInActorContext(pbId, [&](IActor* actor) {
+                    auto& pb = *static_cast<NDDisk::TDDiskActor*>(actor);
+                    broken = NDDisk::TDDiskActorTestPeer::IsBroken(pb);
+                    ready = pb.PersistentBufferReady;
+                    pending = pb.PendingPersistentBufferEvents.size();
+                    restoring = pb.PersistentBufferRestoringChunks.size();
+                    for (const auto& [chunk, sectors] : pb.PersistentBufferDataSectorsInfo) {
+                        Y_UNUSED(chunk);
+                        restored += std::any_of(sectors.begin(), sectors.end(), [](const auto& sector) {
+                            return sector.Checksum != 0 || sector.HeaderUniqueId != 0;
+                        });
+                    }
+                }));
+                UNIT_ASSERT(broken);
+                UNIT_ASSERT(!ready);
+                UNIT_ASSERT_VALUES_EQUAL(pending, 0);
+                UNIT_ASSERT_VALUES_EQUAL(restoring, scheduled);
+                UNIT_ASSERT_VALUES_EQUAL(restored, afterSuccess ? 1 : 0);
+                if (router) {
+                    UNIT_ASSERT_VALUES_EQUAL(router->Outstanding, 0);
+                }
+                AssertNoClientReplyBeforeSentinel(ctx, "Late restore results must not duplicate cancellation replies");
+            }
+        }
+    }
+#endif
 
     // Test: a new PersistentBuffer instance must NOT restore records written by a previous
     // instance (different PersistentBufferUniqueId) even when the same physical chunks are reused.
@@ -6414,7 +7136,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             static_cast<int>(TReplyStatus::ERROR));
     }
 
-    Y_UNIT_TEST(IncrementLogFailureTerminatesQuietly) {
+    Y_UNIT_TEST(IncrementLogFailureDrainsAndWaitsForPoison) {
         TTestContext ctx;
         const TActorId wardenEdge =
             ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
@@ -6436,30 +7158,14 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             allocation.Increment->Get()->Lsn, allocation.Increment->Get()->Cookie);
         ctx.SendPDiskResponse(disk, *allocation.Increment, error.release());
 
-        SendToDDisk(ctx, disk.ServiceId,
-            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}));
-        AssertNoClientReplyBeforeSentinel(
-            ctx, "Terminate must silently drop both the parked write and later requests");
-
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::SESSION_MISMATCH);
+        AssertStatus(SendToDDiskAndWait<NDDisk::TEvReadResult>(ctx, disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true})), TReplyStatus::SESSION_MISMATCH);
+        const auto actorId = ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.ServiceId);
+        UNIT_ASSERT(ctx.Runtime.WrapInActorContext(actorId, [](IActor*) {}));
         SendToDDisk(ctx, disk.ServiceId, new TEvents::TEvPoison());
-        bool replied = false;
-        bool gone = false;
-        while (!replied || !gone) {
-            auto ev = ctx.Runtime.WaitForEdgeActorEvent(ctx.ClientWaitEdges({wardenEdge}));
-            if (ctx.ConsumeUnsolicitedPDiskEvent(ev)) {
-                continue;
-            }
-            if (ev->GetRecipientRewrite() == wardenEdge) {
-                UNIT_ASSERT(!gone);
-                UNIT_ASSERT_VALUES_EQUAL(ev->GetTypeRewrite(), TEvents::TEvGone::EventType);
-                gone = true;
-            } else {
-                UNIT_ASSERT(!replied);
-                UNIT_ASSERT_VALUES_EQUAL(ev->GetTypeRewrite(), NDDisk::TEvWriteResult::EventType);
-                UNIT_ASSERT(ev->Get<NDDisk::TEvWriteResult>()->Record.GetStatus() == TReplyStatus::SESSION_MISMATCH);
-                replied = true;
-            }
-        }
+        ctx.Runtime.WaitForEdgeActorEvent<TEvents::TEvGone>(wardenEdge, false);
+        UNIT_ASSERT(!ctx.Runtime.WrapInActorContext(actorId, [](IActor*) {}));
     }
 
     Y_UNIT_TEST(IntegrityFormattingFailureEntersLiveBrokenState) {

--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -5,9 +5,12 @@
 #include <ydb/core/blobstorage/base/infer_pdisk_slot_count_settings.h>
 #include <ydb/core/blobstorage/nodewarden/node_warden.h>
 #include <ydb/core/blobstorage/nodewarden/node_warden_impl.h>
+#include <ydb/core/blobstorage/nodewarden/node_warden_test_peer.h>
 #include <ydb/core/blobstorage/base/blobstorage_events.h>
 #include <ydb/core/control/immediate_control_board_impl.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.h>
+#include <ydb/core/blobstorage/crypto/default.h>
+#include <ydb/library/pdisk_io/aio.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_http_request.h>
 #include <ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_events.h>
@@ -22,6 +25,16 @@
 #include <google/protobuf/text_format.h>
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/folder/tempdir.h>
+#if defined(__linux__)
+#include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_test_peer.h>
+#include <ydb/core/blobstorage/ddisk/ddisk.h>
+#include <ydb/core/blobstorage/ddisk/ddisk_actor_test_peer.h>
+#include <ydb/library/pdisk_io/uring_router_test_peer.h>
+#include <ydb/library/pdisk_io/uring_test_support.h>
+#include <sys/file.h>
+#include <atomic>
+#endif
 #include <functional>
 #include <optional>
 
@@ -34,6 +47,7 @@ const bool ENABLE_DETAILED_HIVE_LOG = false;
 
 
 namespace NKikimr {
+
 namespace NBlobStorageNodeWardenTest{
 
 #define ENABLE_FORKED_TESTS 0
@@ -1462,6 +1476,260 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         UNIT_ASSERT_UNEQUAL(retry->Get()->SlayOwnerRound, first->Get()->SlayOwnerRound);
     }
 
+    CUSTOM_UNIT_TEST(TestPDiskRestartWaitsForConcreteDDisksAndCoalescesChanges) {
+        using TWarden = NStorage::TNodeWarden;
+        TTestActorSystem runtime(1, NLog::PRI_ERROR, MakeIntrusive<TDomainsInfo>());
+        const auto wardenId = SetupNodeWardenForSlayTest(runtime);
+        const ui32 pdiskId = 2090;
+        const auto pdiskActor = runtime.AllocateEdgeActor(1);
+        runtime.RegisterService(MakeBlobStoragePDiskID(1, pdiskId), pdiskActor);
+        const auto first = runtime.AllocateEdgeActor(1);
+        const auto second = runtime.AllocateEdgeActor(1);
+        const TWarden::TVSlotId slot(1, pdiskId, 1);
+        ui32 permissions = 0;
+        runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant) {
+            if (ev->GetTypeRewrite() == TEvBlobStorage::TEvAskWardenRestartPDiskResult::EventType) {
+                ++permissions;
+            }
+            return true;
+        };
+        runtime.WrapInActorContext(wardenId, [&](IActor* actor) {
+            auto& warden = *dynamic_cast<TWarden*>(actor);
+            auto& pdisk = NStorage::TNodeWardenTestPeer::AddPDisk(warden, pdiskId);
+            pdisk.SetNodeID(1);
+            pdisk.SetPDiskID(pdiskId);
+            pdisk.SetPath("/tmp/scripted-restart-device");
+            pdisk.SetPDiskGuid(123);
+            warden.DDiskActors.emplace(first, slot);
+            warden.DDiskActors.emplace(second, TWarden::TVSlotId(1, pdiskId, 2));
+            warden.VDiskIdByActor.emplace(first, slot);
+            warden.VDiskIdByActor.emplace(second, TWarden::TVSlotId(1, pdiskId, 2));
+            auto& record = warden.LocalVDisks[slot];
+            SetSlayTestVDisk(record, 1, pdiskId, 1, TVDiskID(100590, 1, 0, 0, 0));
+            record.RuntimeData.emplace();
+            record.RuntimeData->GroupInfo = MakeIntrusive<TBlobStorageGroupInfo>(TBlobStorageGroupType::ErasureNone);
+            record.RuntimeData->ActorId = first;
+            record.RuntimeData->DDisk = true;
+            warden.DoRestartLocalPDisk(pdisk);
+            UNIT_ASSERT(record.ShutdownPending);
+            warden.PoisonLocalVDisk(record);
+            UNIT_ASSERT(record.ShutdownPending);
+            warden.StartLocalVDiskActor(record);
+            UNIT_ASSERT(!record.RuntimeData);
+            auto& restart = warden.PDiskRestartInFlight.at(pdiskId);
+            UNIT_ASSERT_VALUES_EQUAL(restart.WaitingFor.size(), 2);
+            UNIT_ASSERT(restart.Phase == TWarden::TPDiskRestart::EPhase::WaitingForDDisks);
+            auto incoming = pdisk;
+            incoming.MutablePDiskConfig()->SetExpectedSlotCount(42);
+            warden.DoRestartLocalPDisk(incoming);
+            warden.OnPDiskRestartFinished(pdiskId, NKikimrProto::OK);
+            UNIT_ASSERT(restart.Phase == TWarden::TPDiskRestart::EPhase::WaitingForDDisks);
+            UNIT_ASSERT_VALUES_EQUAL(restart.WaitingFor.size(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(permissions, 0);
+            UNIT_ASSERT(!restart.RequiresAnotherRestart);
+            // Deleted slots still fence PDisk restart; the second was already stopping.
+            warden.LocalVDisks.erase(slot);
+        });
+        runtime.WaitForEdgeActorEvent<TEvents::TEvPoison>(first, false);
+        runtime.WaitForEdgeActorEvent<TEvents::TEvPoison>(second, false);
+        runtime.Send(new IEventHandle(wardenId, first, new TEvents::TEvGone()), 1);
+        bool firstGone = false;
+        runtime.Sim([&] {
+            runtime.WrapInActorContext(wardenId, [&](IActor* actor) {
+                auto& warden = *dynamic_cast<TWarden*>(actor);
+                firstGone = !warden.DDiskActors.contains(first);
+            });
+            return !firstGone;
+        });
+        runtime.WrapInActorContext(wardenId, [&](IActor* actor) {
+            auto& warden = *dynamic_cast<TWarden*>(actor);
+            UNIT_ASSERT_VALUES_EQUAL(warden.PDiskRestartInFlight.at(pdiskId).WaitingFor.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(permissions, 0);
+        });
+        runtime.Send(new IEventHandle(wardenId, first, new TEvents::TEvGone()), 1);
+        runtime.Send(new IEventHandle(wardenId, second, new TEvents::TEvGone()), 1);
+        auto forwarded = runtime.WaitForEdgeActorEvent<TEvBlobStorage::TEvAskWardenRestartPDiskResult>(pdiskActor, false);
+        UNIT_ASSERT_VALUES_EQUAL(forwarded->Get()->Config->ExpectedSlotCount, 42);
+        runtime.WrapInActorContext(wardenId, [&](IActor* actor) {
+            auto& warden = *dynamic_cast<TWarden*>(actor);
+            auto& restart = warden.PDiskRestartInFlight.at(pdiskId);
+            UNIT_ASSERT(restart.Phase == TWarden::TPDiskRestart::EPhase::RestartSent);
+            UNIT_ASSERT(restart.WaitingFor.empty());
+            auto& recreated = warden.LocalVDisks[slot];
+            SetSlayTestVDisk(recreated, 1, pdiskId, 1, TVDiskID(100590, 1, 0, 0, 0));
+            warden.StartLocalVDiskActor(recreated);
+            UNIT_ASSERT(!recreated.RuntimeData);
+            UNIT_ASSERT_VALUES_EQUAL(permissions, 1);
+            auto incoming = NStorage::TNodeWardenTestPeer::GetPDisk(warden, pdiskId);
+            incoming.MutablePDiskConfig()->SetExpectedSlotCount(43);
+            warden.DoRestartLocalPDisk(incoming);
+            UNIT_ASSERT(restart.RequiresAnotherRestart);
+            warden.OnPDiskRestartFinished(pdiskId, NKikimrProto::OK);
+            UNIT_ASSERT(!recreated.RuntimeData);
+        });
+        auto next = runtime.WaitForEdgeActorEvent<TEvBlobStorage::TEvAskWardenRestartPDiskResult>(pdiskActor, false);
+        UNIT_ASSERT_VALUES_EQUAL(next->Get()->Config->ExpectedSlotCount, 43);
+        UNIT_ASSERT_VALUES_EQUAL(permissions, 2);
+        runtime.Send(new IEventHandle(wardenId, second, new TEvents::TEvGone()), 1);
+        const auto barrier = runtime.AllocateEdgeActor(1);
+        runtime.Send(new IEventHandle(barrier, {}, new TEvents::TEvWakeup()), 1);
+        runtime.WaitForEdgeActorEvent<TEvents::TEvWakeup>(barrier, false);
+        UNIT_ASSERT_VALUES_EQUAL(permissions, 2);
+        runtime.FilterEnqueue = {};
+    }
+
+    CUSTOM_UNIT_TEST(TestPDiskRestartImmediateHandoffAndRemovalCancelsDrain) {
+        using TWarden = NStorage::TNodeWarden;
+        TTestActorSystem runtime(1, NLog::PRI_ERROR, MakeIntrusive<TDomainsInfo>());
+        const auto wardenId = SetupNodeWardenForSlayTest(runtime);
+        for (const bool hasDDisk : {false, true}) {
+            const ui32 pdiskId = 2091 + hasDDisk;
+            const auto pdiskActor = runtime.AllocateEdgeActor(1);
+            const auto ddisk = runtime.AllocateEdgeActor(1);
+            runtime.RegisterService(MakeBlobStoragePDiskID(1, pdiskId), pdiskActor);
+            runtime.WrapInActorContext(wardenId, [&](IActor* actor) {
+                auto& warden = *dynamic_cast<TWarden*>(actor);
+                auto& pdisk = NStorage::TNodeWardenTestPeer::AddPDisk(warden, pdiskId);
+                pdisk.SetNodeID(1);
+                pdisk.SetPDiskID(pdiskId);
+                pdisk.SetPath(TStringBuilder() << "/tmp/scripted-pdisk-" << pdiskId);
+                pdisk.SetPDiskGuid(pdiskId);
+                NStorage::TNodeWardenTestPeer::TrackPath(warden, pdiskId);
+                if (hasDDisk) {
+                    warden.DDiskActors.emplace(ddisk, TWarden::TVSlotId(1, pdiskId, 1));
+                }
+                warden.DoRestartLocalPDisk(pdisk);
+                const auto& restart = warden.PDiskRestartInFlight.at(pdiskId);
+                UNIT_ASSERT(restart.Phase == (hasDDisk ? TWarden::TPDiskRestart::EPhase::WaitingForDDisks
+                    : TWarden::TPDiskRestart::EPhase::RestartSent));
+                if (hasDDisk) {
+                    warden.DestroyLocalPDisk(pdiskId);
+                    UNIT_ASSERT(!warden.PDiskRestartInFlight.contains(pdiskId));
+                }
+            });
+            if (hasDDisk) {
+                runtime.WaitForEdgeActorEvent<TEvents::TEvPoison>(ddisk, false);
+                runtime.WaitForEdgeActorEvent<TEvents::TEvPoison>(pdiskActor, false);
+                runtime.Send(new IEventHandle(wardenId, ddisk, new TEvents::TEvGone()), 1);
+            } else {
+                runtime.WaitForEdgeActorEvent<TEvBlobStorage::TEvAskWardenRestartPDiskResult>(pdiskActor, false);
+            }
+        }
+    }
+
+    CUSTOM_UNIT_TEST(TestRestartDrainReminderGenerationAndPhaseGates) {
+        using TWarden = NStorage::TNodeWarden;
+        using TReminder = NStorage::TNodeWardenTestPeer::TRestartDrainReminder;
+        TTestActorSystem runtime(1, NLog::PRI_ERROR, MakeIntrusive<TDomainsInfo>());
+        const auto wardenId = SetupNodeWardenForSlayTest(runtime);
+        const ui32 pdiskId = 2094;
+        const auto pdiskActor = runtime.AllocateEdgeActor(1);
+        const auto ddisk = runtime.AllocateEdgeActor(1);
+        const auto clockEdge = runtime.AllocateEdgeActor(1);
+        runtime.RegisterService(MakeBlobStoragePDiskID(1, pdiskId), pdiskActor);
+        std::vector<std::pair<ui64, TInstant>> reminders;
+        ui32 permissions = 0;
+        runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant at) {
+            if (ev->GetTypeRewrite() == TEvBlobStorage::TEvAskWardenRestartPDiskResult::EventType) {
+                ++permissions;
+            }
+            if (ev->GetTypeRewrite() == TReminder::EventType && at > runtime.GetClock()) {
+                reminders.emplace_back(ev->Get<TReminder>()->Generation, at);
+                return false;
+            }
+            return true;
+        };
+        runtime.WrapInActorContext(wardenId, [&](IActor* actor) {
+            auto& warden = *static_cast<TWarden*>(actor);
+            auto& pdisk = NStorage::TNodeWardenTestPeer::AddPDisk(warden, pdiskId);
+            pdisk.SetNodeID(1);
+            pdisk.SetPDiskID(pdiskId);
+            pdisk.SetPath("/tmp/reminder-pdisk");
+            pdisk.SetPDiskGuid(123);
+            NStorage::TNodeWardenTestPeer::TrackPath(warden, pdiskId);
+            warden.DDiskActors.emplace(ddisk, TWarden::TVSlotId(1, pdiskId, 1));
+            warden.DoRestartLocalPDisk(pdisk);
+        });
+        runtime.WaitForEdgeActorEvent<TEvents::TEvPoison>(ddisk, false);
+        UNIT_ASSERT_VALUES_EQUAL(reminders.size(), 1);
+        const auto generation = reminders.front().first;
+        for (ui32 count = 1; count <= 2; ++count) {
+            const auto due = reminders.back().second;
+            runtime.Schedule(due, new IEventHandle(clockEdge, {}, new TEvents::TEvWakeup()), nullptr, 1);
+            runtime.WaitForEdgeActorEvent<TEvents::TEvWakeup>(clockEdge, false);
+            runtime.Send(new IEventHandle(wardenId, {}, new TReminder(pdiskId, generation)), 1);
+            runtime.Send(new IEventHandle(clockEdge, {}, new TEvents::TEvWakeup()), 1);
+            runtime.WaitForEdgeActorEvent<TEvents::TEvWakeup>(clockEdge, false);
+            UNIT_ASSERT_VALUES_EQUAL(reminders.size(), count + 1);
+            UNIT_ASSERT_VALUES_EQUAL(reminders.back().first, generation);
+            UNIT_ASSERT_VALUES_EQUAL(reminders.back().second, due + TDuration::Seconds(30));
+        }
+        runtime.Send(new IEventHandle(wardenId, ddisk, new TEvents::TEvGone()), 1);
+        runtime.WaitForEdgeActorEvent<TEvBlobStorage::TEvAskWardenRestartPDiskResult>(pdiskActor, false);
+        auto deliverStale = [&] {
+            runtime.Send(new IEventHandle(wardenId, {}, new TReminder(pdiskId, generation)), 1);
+            runtime.Send(new IEventHandle(clockEdge, {}, new TEvents::TEvWakeup()), 1);
+            runtime.WaitForEdgeActorEvent<TEvents::TEvWakeup>(clockEdge, false);
+        };
+        deliverStale();
+        UNIT_ASSERT_VALUES_EQUAL(reminders.size(), 3);
+        runtime.WrapInActorContext(wardenId, [&](IActor* actor) {
+            auto& warden = *static_cast<TWarden*>(actor);
+            warden.OnPDiskRestartFinished(pdiskId, NKikimrProto::OK);
+            warden.DDiskActors.emplace(ddisk, TWarden::TVSlotId(1, pdiskId, 1));
+            auto incoming = NStorage::TNodeWardenTestPeer::GetPDisk(warden, pdiskId);
+            warden.DoRestartLocalPDisk(incoming);
+        });
+        runtime.WaitForEdgeActorEvent<TEvents::TEvPoison>(ddisk, false);
+        UNIT_ASSERT_VALUES_EQUAL(reminders.size(), 4);
+        UNIT_ASSERT_UNEQUAL(reminders.back().first, generation);
+        deliverStale();
+        UNIT_ASSERT_VALUES_EQUAL(reminders.size(), 4);
+        runtime.WrapInActorContext(wardenId, [&](IActor* actor) {
+            static_cast<TWarden*>(actor)->DestroyLocalPDisk(pdiskId);
+        });
+        runtime.WaitForEdgeActorEvent<TEvents::TEvPoison>(pdiskActor, false);
+        runtime.Send(new IEventHandle(wardenId, ddisk, new TEvents::TEvGone()), 1);
+        runtime.Send(new IEventHandle(wardenId, {}, new TReminder(pdiskId, reminders.back().first)), 1);
+        deliverStale();
+        UNIT_ASSERT_VALUES_EQUAL(reminders.size(), 4);
+        bool restartExists = true;
+        runtime.WrapInActorContext(wardenId, [&](IActor* actor) {
+            restartExists = static_cast<TWarden*>(actor)->PDiskRestartInFlight.contains(pdiskId);
+        });
+        UNIT_ASSERT(!restartExists);
+        UNIT_ASSERT_VALUES_EQUAL(permissions, 1);
+        runtime.FilterEnqueue = {};
+    }
+
+    CUSTOM_UNIT_TEST(TestGoneFromOldIncarnationDoesNotClearReplacementShutdown) {
+        using TWarden = NStorage::TNodeWarden;
+        TTestActorSystem runtime(1, NLog::PRI_ERROR, MakeIntrusive<TDomainsInfo>());
+        const auto wardenId = SetupNodeWardenForSlayTest(runtime);
+        const auto oldActor = runtime.AllocateEdgeActor(1);
+        const auto replacement = runtime.AllocateEdgeActor(1);
+        const TWarden::TVSlotId slot(1, 2093, 1);
+        runtime.WrapInActorContext(wardenId, [&](IActor* actor) {
+            auto& warden = *dynamic_cast<TWarden*>(actor);
+            warden.DDiskActors.emplace(oldActor, slot);
+            warden.VDiskIdByActor.emplace(oldActor, slot);
+            auto& record = warden.LocalVDisks[slot];
+            record.ShutdownPending = true;
+            record.ShutdownActorId = replacement;
+        });
+        runtime.Send(new IEventHandle(wardenId, oldActor, new TEvents::TEvGone()), 1);
+        bool removed = false;
+        runtime.Sim([&] {
+            runtime.WrapInActorContext(wardenId, [&](IActor* actor) {
+                auto& warden = *dynamic_cast<TWarden*>(actor);
+                removed = !warden.VDiskIdByActor.contains(oldActor);
+                UNIT_ASSERT(warden.LocalVDisks.at(slot).ShutdownPending);
+                UNIT_ASSERT_VALUES_EQUAL(warden.LocalVDisks.at(slot).ShutdownActorId, replacement);
+            });
+            return !removed;
+        });
+    }
+
     CUSTOM_UNIT_TEST(TestSlayIsReplayedAfterPDiskRestartWithoutLocalVDisk) {
         TTestActorSystem runtime(1, NLog::PRI_ERROR, MakeIntrusive<TDomainsInfo>());
         const TActorId nodeWardenId = SetupNodeWardenForSlayTest(runtime);
@@ -1483,7 +1751,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
 
         runtime.WrapInActorContext(nodeWardenId, [&](IActor *actor) {
             auto& nodeWarden = *dynamic_cast<NStorage::TNodeWarden*>(actor);
-            nodeWarden.PDiskRestartInFlight[pdiskId] = false;
+            nodeWarden.PDiskRestartInFlight[pdiskId].Phase = NStorage::TNodeWarden::TPDiskRestart::EPhase::RestartSent;
             nodeWarden.OnPDiskRestartFinished(pdiskId, NKikimrProto::OK);
         });
 
@@ -1507,7 +1775,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
             SetSlayTestVDisk(record, nodeId, pdiskId, vdiskSlotId, vdiskId);
             nodeWarden.SlayInFlight.emplace(vslotId,
                 NStorage::TNodeWarden::TSlayInFlight{vdiskId, NStorage::TNodeWarden::ESlayAction::WIPE});
-            nodeWarden.PDiskRestartInFlight[pdiskId] = false;
+            nodeWarden.PDiskRestartInFlight[pdiskId].Phase = NStorage::TNodeWarden::TPDiskRestart::EPhase::RestartSent;
 
             nodeWarden.OnPDiskRestartFinished(pdiskId, NKikimrProto::ERROR);
 
@@ -2017,49 +2285,71 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         static constexpr ui32 PDiskId = 1;
         static constexpr ui32 VDiskSlotId = 1;
 
+        TTempDir TempDir;
+        std::shared_ptr<NPDisk::IIoContextFactory> IoFactory = std::make_shared<NPDisk::TIoContextFactoryOSS>();
         TTestActorSystem Runtime;
         const ui32 GroupId;
         const TVDiskID VDiskId;
         const TActorId DDiskServiceId;
         TActorId NodeWardenId;
 
-        TDDiskLifecycleTestSetup()
+        TDDiskLifecycleTestSetup(bool native = false)
             : Runtime(1, NLog::PRI_ERROR, MakeIntrusive<TDomainsInfo>())
             , GroupId(TGroupID(EGroupConfigurationType::Dynamic, 1, 1).GetRaw())
             , VDiskId(GroupId, 1, 0, 0, 0)
             , DDiskServiceId(MakeBlobStorageDDiskId(NodeId, PDiskId, VDiskSlotId))
         {
+            if (native) {
+                TFile file(TempDir() + "/pdisk.dat", CreateAlways | RdWr);
+                file.Resize(ui64{16} << 30);
+                file.Close();
+                TFormatOptions options;
+                options.EnableSmallDiskOptimization = true;
+                FormatPDisk(TempDir() + "/pdisk.dat", ui64{16} << 30, 4096, 16 << 20,
+                    12345, 1, 2, 3, NPDisk::YdbDefaultPDiskSequence, "requested restart", options);
+            }
             Runtime.Start();
 
             auto& appData = *Runtime.GetNode(NodeId)->AppData;
+            appData.IoContextFactory = IoFactory.get();
             appData.DomainsInfo->AddDomain(TDomainsInfo::TDomain::ConstructEmptyDomain("dom", 1).Release());
             appData.DynamicNameserviceConfig = new TDynamicNameserviceConfig();
             appData.DynamicNameserviceConfig->MaxStaticNodeId = NodeId;
 
             TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(
-                new TNodeWardenConfig(new TSilentPDiskServiceFactory));
+                new TNodeWardenConfig(native
+                    ? static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory)
+                    : static_cast<IPDiskServiceFactory*>(new TSilentPDiskServiceFactory)));
             nodeWardenConfig->DDiskConfig.emplace();
-            nodeWardenConfig->DDiskConfig->SetForcePDiskFallback(true);
+            nodeWardenConfig->DDiskConfig->SetForcePDiskFallback(!native);
+            if (native) {
+                nodeWardenConfig->DDiskConfig->SetEnableChecksums(false);
+                nodeWardenConfig->PBufferConfig.emplace();
+                nodeWardenConfig->PBufferConfig->SetEnableWritesBatching(false);
+                nodeWardenConfig->PBufferConfig->SetMaxInMemoryCache(0);
+                nodeWardenConfig->FeatureFlags->SetEnableSmallDiskOptimization(true);
+                nodeWardenConfig->PDiskKey = {.Keys = {NPDisk::YdbDefaultPDiskSequence}, .IsInitialized = true};
+            }
 
             auto* serviceSet = nodeWardenConfig->BlobStorageConfig->MutableServiceSet();
             auto* pdisk = serviceSet->AddPDisks();
             pdisk->SetNodeID(NodeId);
             pdisk->SetPDiskID(PDiskId);
-            pdisk->SetPath("silent-pdisk");
+            pdisk->SetPath(native ? TempDir() + "/pdisk.dat" : "silent-pdisk");
             pdisk->SetPDiskGuid(12345);
             pdisk->SetPDiskCategory(TPDiskCategory(NPDisk::DEVICE_TYPE_NVME, 0).GetRaw());
 
             auto* group = serviceSet->AddGroups();
             FillGroup(group, VDiskId.GroupGeneration);
 
-            FillDDisk(serviceSet->AddVDisks());
+            if (!native) { FillDDisk(serviceSet->AddVDisks()); }
 
             NodeWardenId = Runtime.Register(CreateBSNodeWarden(nodeWardenConfig.Release()), NodeId);
             Runtime.RegisterService(MakeBlobStorageNodeWardenID(NodeId), NodeWardenId);
             UNIT_ASSERT(Runtime.WrapInActorContext(NodeWardenId, [](IActor* actor) {
                 dynamic_cast<NStorage::TNodeWarden*>(actor)->Bootstrap();
             }));
-            UNIT_ASSERT(LookupDDiskActor());
+            if (!native) { UNIT_ASSERT(LookupDDiskActor()); }
         }
 
         ~TDDiskLifecycleTestSetup() {
@@ -2124,6 +2414,275 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
 
     };
 
+#if defined(__linux__)
+    struct TRequestedPDiskRestartFixture : TDDiskLifecycleTestSetup {
+        using TStatus = NKikimrBlobStorage::NDDisk::TReplyStatus;
+        TActorId Edge;
+        TActorId PBService;
+        std::shared_ptr<NPDisk::TUringRouter> Router;
+        std::unique_ptr<TEventHandle<NPDisk::TEvYardInitResult>> RetainedInit;
+        std::atomic<bool> Armed{false};
+        std::atomic<ui32> Callbacks{0};
+        std::atomic<ui32> Admissions{0};
+        TManualEvent FirstCallback, SecondCallback, ReleaseFirst, ReleaseSecond;
+
+        TRequestedPDiskRestartFixture()
+            : TDDiskLifecycleTestSetup(true)
+            , Edge(Runtime.AllocateEdgeActor(NodeId))
+            , PBService(MakeBlobStoragePersistentBufferId(NodeId, PDiskId, VDiskSlotId))
+        {
+            NPDisk::TMainKey key{.Keys = {NPDisk::YdbDefaultPDiskSequence}, .IsInitialized = true};
+            Send(MakeBlobStoragePDiskID(NodeId, PDiskId),
+                new NPDisk::TEvYardControl(NPDisk::TEvYardControl::PDiskStart, &key));
+            auto started = Grab<NPDisk::TEvYardControlResult>();
+            UNIT_ASSERT_VALUES_EQUAL_C(started->Get()->Status, NKikimrProto::OK, started->Get()->ErrorReason);
+            Send(MakeBlobStoragePDiskID(NodeId, PDiskId),
+                new NPDisk::TEvYardControl(NPDisk::TEvYardControl::GetPDiskPointer, nullptr));
+            auto pointer = Grab<NPDisk::TEvYardControlResult>();
+            UNIT_ASSERT_VALUES_EQUAL(pointer->Get()->Status, NKikimrProto::OK);
+            auto* pdisk = reinterpret_cast<NPDisk::TPDisk*>(pointer->Get()->Cookie);
+            {
+                TGuard<TMutex> guard(pdisk->StateMutex);
+                NPDisk::TPDiskTestPeer::ConfigureRouter(*pdisk, [&](NPDisk::TUringRouter& router) {
+                    NPDisk::NUringPrivate::TRouterHooks hooks;
+                    hooks.AfterAdmission = [&] { if (Armed.load()) { ++Admissions; } };
+                    hooks.BeforeTerminalCallback = [&] {
+                        if (!Armed.load()) { return; }
+                        const auto index = ++Callbacks;
+                        if (index == 1) {
+                            FirstCallback.Signal();
+                            ReleaseFirst.WaitI();
+                        } else if (index == 2) {
+                            SecondCallback.Signal();
+                            ReleaseSecond.WaitI();
+                        }
+                    };
+                    NPDisk::TUringRouterTestPeer::SetHooks(router, std::move(hooks));
+                });
+            }
+            Runtime.WrapInActorContext(NodeWardenId, [&](IActor* actor) {
+                NKikimrBlobStorage::TNodeWardenServiceSet incoming;
+                FillDDisk(incoming.AddVDisks());
+                static_cast<NStorage::TNodeWarden*>(actor)->ApplyServiceSet(incoming, true, false, false, "attach DDisk");
+            });
+        }
+
+        ~TRequestedPDiskRestartFixture() {
+            Armed.store(false);
+            ReleaseFirst.Signal();
+            ReleaseSecond.Signal();
+            Runtime.FilterFunction = {};
+            Runtime.FilterEnqueue = {};
+            // Retire all callbacks while the instance-local hook state is alive.
+            Runtime.Stop();
+        }
+
+        void Send(TActorId recipient, IEventBase* event, ui64 cookie = 0) {
+            Runtime.Send(new IEventHandle(recipient, Edge, event, 0, cookie), NodeId);
+        }
+        template<class TEvent>
+        std::unique_ptr<TEventHandle<TEvent>> Grab() { return Runtime.WaitForEdgeActorEvent<TEvent>(Edge, false); }
+        template<class TEvent>
+        void ExpectOk() {
+            auto reply = Grab<TEvent>();
+            UNIT_ASSERT(reply->Get()->Record.GetStatus() == TStatus::OK);
+        }
+        NDDisk::TQueryCredentials Connect(TActorId recipient) {
+            auto creds = recipient == PBService
+                ? NDDisk::TQueryCredentials::ToPersistentBuffer(901, 1, std::nullopt, 0)
+                : NDDisk::TQueryCredentials::ToDDisk(901, 1, 0, std::nullopt, 0);
+            Send(recipient, new NDDisk::TEvConnect(creds));
+            auto reply = Grab<NDDisk::TEvConnectResult>();
+            UNIT_ASSERT_C(reply->Get()->Record.GetStatus() == TStatus::OK, reply->Get()->Record.DebugString());
+            creds.DDiskInstanceGuid = reply->Get()->Record.GetDDiskInstanceGuid();
+            creds.ConnectionToken.emplace(reply->Get()->Record.GetConnectionToken());
+            return creds;
+        }
+        void Write(bool pb, const NDDisk::TQueryCredentials& creds, char value, ui64 lsn) {
+            auto buffer = TRcBuf::UninitializedPageAligned(4096);
+            memset(buffer.GetDataMut(), value, 4096);
+            if (pb) {
+                auto request = std::make_unique<NDDisk::TEvWritePersistentBuffer>(
+                    creds, NDDisk::TBlockSelector(0, 0, 4096), lsn, NDDisk::TWriteInstruction(0));
+                request->AddPayload(TRope(std::move(buffer)));
+                Send(PBService, request.release(), lsn);
+            } else {
+                auto request = std::make_unique<NDDisk::TEvWrite>(
+                    creds, NDDisk::TBlockSelector(0, 0, 4096), NDDisk::TWriteInstruction(0));
+                request->AddPayload(TRope(std::move(buffer)));
+                Send(DDiskServiceId, request.release(), lsn);
+            }
+        }
+        void WriteReply(bool pb) {
+            if (pb) { ExpectOk<NDDisk::TEvWritePersistentBufferResult>(); }
+            else { ExpectOk<NDDisk::TEvWriteResult>(); }
+        }
+        void Read(bool pb, const NDDisk::TQueryCredentials& creds, char value, ui64 lsn) {
+            if (pb) {
+                Send(PBService, new NDDisk::TEvReadPersistentBuffer(creds, {0, 0, 4096}, lsn, creds.Generation, {true}));
+                auto result = Grab<NDDisk::TEvReadPersistentBufferResult>();
+                UNIT_ASSERT_C(result->Get()->Record.GetStatus() == TStatus::OK, result->Get()->Record.DebugString());
+                UNIT_ASSERT_VALUES_EQUAL(result->Get()->GetPayload(0).ConvertToString(), TString(4096, value));
+            } else {
+                Send(DDiskServiceId, new NDDisk::TEvRead(creds, {0, 0, 4096}, {true}));
+                auto result = Grab<NDDisk::TEvReadResult>();
+                UNIT_ASSERT_C(result->Get()->Record.GetStatus() == TStatus::OK, result->Get()->Record.DebugString());
+                UNIT_ASSERT_VALUES_EQUAL(result->Get()->GetPayload(0).ConvertToString(), TString(4096, value));
+            }
+        }
+
+        void Run(bool parentFirst) {
+            Cerr << "requested restart: connect parent" << Endl;
+            auto parentCreds = Connect(DDiskServiceId);
+            Cerr << "requested restart: connect PB" << Endl;
+            auto pbCreds = Connect(PBService);
+            Cerr << "requested restart: warm parent" << Endl;
+            Write(false, parentCreds, 'A', 1);
+            WriteReply(false);
+            Cerr << "requested restart: warm PB" << Endl;
+            Write(true, pbCreds, 'B', 1);
+            WriteReply(true);
+            // Keep a real additional initialization result alive across restart.
+            Send(MakeBlobStoragePDiskID(NodeId, PDiskId), new NPDisk::TEvYardInit(
+                3, TVDiskID(GroupId + 1, 1, 0, 0, 0), 12345, {}, {}, 2, 0, true));
+            Cerr << "requested restart: retain init" << Endl;
+            RetainedInit = Grab<NPDisk::TEvYardInitResult>();
+            UNIT_ASSERT_VALUES_EQUAL(RetainedInit->Get()->Status, NKikimrProto::OK);
+            Router = std::dynamic_pointer_cast<NPDisk::TUringRouter>(RetainedInit->Get()->UringRouter);
+            UNIT_ASSERT(Router);
+            Cerr << "requested restart: quiesce actors" << Endl;
+            // Checksums-disabled allocation can continue zero-formatting reserve
+            // chunks after the warm-up client reply. Retire its actor mailbox work too.
+            Runtime.Sim([&] {
+                bool busy = false;
+                for (const auto service : {DDiskServiceId, PBService}) {
+                    const auto id = Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(service);
+                    Runtime.WrapInActorContext(id, [&](IActor* actor) {
+                        auto& disk = *static_cast<NDDisk::TDDiskActor*>(actor);
+                        busy |= disk.GetDirectIoInflight() || !disk.FormattingChunks.empty() || !disk.LogCallbacks.empty();
+                    });
+                }
+                return busy;
+            });
+            NPDisk::TUringRouterTestPeer::WaitSync(*Router);
+            const auto parent = LookupDDiskActor();
+            const auto child = Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(PBService);
+            const auto oldPDisk = Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(MakeBlobStoragePDiskID(NodeId, PDiskId));
+            ui32 permissions = 0;
+            std::vector<TActorId> gone;
+            std::unique_ptr<IEventHandle> replacementBootstrap;
+            Runtime.FilterEnqueue = [&](ui32, std::unique_ptr<IEventHandle>& ev, ISchedulerCookie*, TInstant) {
+                if (ev->GetTypeRewrite() == TEvBlobStorage::TEvAskWardenRestartPDiskResult::EventType) {
+                    UNIT_ASSERT_VALUES_EQUAL(gone.size(), 2);
+                    UNIT_ASSERT_VALUES_EQUAL(gone[0], child);
+                    UNIT_ASSERT_VALUES_EQUAL(gone[1], parent);
+                    ++permissions;
+                }
+                if (ev->GetTypeRewrite() == TEvents::TEvGone::EventType && (ev->Sender == parent || ev->Sender == child)) {
+                    gone.push_back(ev->Sender);
+                }
+                return true;
+            };
+            Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+                if (permissions && ev->GetTypeRewrite() == TEvents::TSystem::Bootstrap
+                        && ev->Recipient != oldPDisk
+                        && ev->Recipient == Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(MakeBlobStoragePDiskID(NodeId, PDiskId))) {
+                    replacementBootstrap = std::move(ev);
+                    return false;
+                }
+                return true;
+            };
+            Cerr << "requested restart: arm native callbacks" << Endl;
+            Armed.store(true);
+            Write(!parentFirst, parentFirst ? parentCreds : pbCreds, parentFirst ? 'C' : 'D', 2);
+            Runtime.Sim([&] { return Callbacks.load() == 0; });
+            Cerr << "requested restart: first callback" << Endl;
+            FirstCallback.WaitI();
+            Write(parentFirst, parentFirst ? pbCreds : parentCreds, parentFirst ? 'D' : 'C', 2);
+            Cerr << "requested restart: admit second" << Endl;
+            Runtime.Sim([&] { return Admissions.load() < 2; });
+            UNIT_ASSERT_VALUES_EQUAL(Admissions.load(), 2);
+            Runtime.WrapInActorContext(NodeWardenId, [&](IActor* actor) {
+                auto& warden = *static_cast<NStorage::TNodeWarden*>(actor);
+                NKikimrBlobStorage::TNodeWardenServiceSet incoming;
+                auto* pdisk = incoming.AddPDisks();
+                *pdisk = NStorage::TNodeWardenTestPeer::GetPDisk(warden, PDiskId);
+                pdisk->SetEntityStatus(NKikimrBlobStorage::RESTART);
+                warden.ApplyServiceSet(incoming, true, false, false, "requested restart");
+            });
+            auto assertFence = [&] {
+                Send(parent, new NDDisk::TEvConnect());
+                auto rejected = Grab<NDDisk::TEvConnectResult>();
+                UNIT_ASSERT(rejected->Get()->Record.GetStatus() == TStatus::SESSION_MISMATCH);
+                UNIT_ASSERT_VALUES_EQUAL(permissions, 0);
+                UNIT_ASSERT_VALUES_EQUAL(LookupDDiskActor(), parent);
+                const auto currentChild = Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(PBService);
+                UNIT_ASSERT(!currentChild || currentChild == child);
+                UNIT_ASSERT_VALUES_EQUAL(Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(MakeBlobStoragePDiskID(NodeId, PDiskId)), oldPDisk);
+                UNIT_ASSERT(std::find(gone.begin(), gone.end(), parent) == gone.end());
+            };
+            Cerr << "requested restart: release first" << Endl;
+            assertFence();
+            ReleaseFirst.Signal();
+            WriteReply(!parentFirst);
+            Cerr << "requested restart: second callback" << Endl;
+            SecondCallback.WaitI();
+            assertFence();
+            Cerr << "requested restart: release second" << Endl;
+            ReleaseSecond.Signal();
+            WriteReply(parentFirst);
+            Armed.store(false);
+            Cerr << "requested restart: replacement bootstrap" << Endl;
+            Runtime.Sim([&] { return !replacementBootstrap; });
+            UNIT_ASSERT(replacementBootstrap);
+            UNIT_ASSERT_VALUES_EQUAL(gone.size(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(gone[0], child);
+            UNIT_ASSERT_VALUES_EQUAL(gone[1], parent);
+            UNIT_ASSERT_VALUES_EQUAL(permissions, 1);
+            UNIT_ASSERT(NPDisk::TUringRouterTestPeer::Retired(*Router));
+            struct TRejected : NPDisk::TUringOperationBase {
+                ui32 Callbacks = 0;
+                void OnComplete(TActorSystem*) noexcept override { ++Callbacks; }
+                void OnDrop(TActorSystem*) noexcept override { ++Callbacks; }
+            } rejected;
+            alignas(4096) char buffer[4096];
+            rejected.SetOperationType(NPDisk::TUringOperationBase::EREAD);
+            rejected.PrepareIov(buffer, sizeof(buffer), 0);
+            UNIT_ASSERT(!RetainedInit->Get()->UringRouter->Read(&rejected));
+            UNIT_ASSERT_VALUES_EQUAL(rejected.Callbacks, 0);
+            TFile probe(TempDir() + "/pdisk.dat", OpenExisting | RdWr);
+            UNIT_ASSERT_VALUES_EQUAL(flock(probe.GetHandle(), LOCK_EX | LOCK_NB), 0);
+            UNIT_ASSERT_VALUES_EQUAL(flock(probe.GetHandle(), LOCK_UN), 0);
+            probe.Close();
+            Runtime.FilterFunction = {};
+            Runtime.Send(std::move(replacementBootstrap), NodeId);
+            Runtime.Sim([&] { return !LookupDDiskActor() || LookupDDiskActor() == parent; });
+            UNIT_ASSERT_UNEQUAL(LookupDDiskActor(), parent);
+            Cerr << "requested restart: reconnect" << Endl;
+            parentCreds = Connect(DDiskServiceId);
+            pbCreds = Connect(PBService);
+            UNIT_ASSERT_UNEQUAL(Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(PBService), child);
+            Read(false, parentCreds, 'C', 2);
+            Read(true, pbCreds, 'D', 2);
+            Write(false, parentCreds, 'E', 3);
+            WriteReply(false);
+            Write(true, pbCreds, 'F', 3);
+            WriteReply(true);
+            Read(false, parentCreds, 'E', 3);
+            Read(true, pbCreds, 'F', 3);
+            UNIT_ASSERT_VALUES_EQUAL(permissions, 1);
+        }
+    };
+
+    Y_UNIT_TEST(RequestedPDiskRestartDrainsBothNativeCompletionOrders) {
+        if (!NPDisk::RequireUring()) { return; }
+        for (const bool parentFirst : {false, true}) {
+            TRequestedPDiskRestartFixture fixture;
+            fixture.Run(parentFirst);
+        }
+    }
+#endif
+
     Y_UNIT_TEST(TestDDiskDeleteStopsRunningActor) {
         TDDiskLifecycleTestSetup setup;
         const TActorId actorId = setup.LookupDDiskActor();
@@ -2145,6 +2704,53 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
 
         UNIT_ASSERT(!setup.IsActorAlive(previousActorId));
         UNIT_ASSERT(setup.IsActorAlive(setup.LookupDDiskActor()));
+    }
+
+    Y_UNIT_TEST(TestDeletedDDiskIncarnationFencesRecreationUntilGone) {
+        TDDiskLifecycleTestSetup setup;
+        const auto oldActor = setup.LookupDDiskActor();
+        std::unique_ptr<IEventHandle> gone;
+        std::unique_ptr<IEventHandle> slay;
+        setup.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvents::TEvGone::EventType && ev->Sender == oldActor) {
+                gone = std::move(ev);
+                return false;
+            }
+            if (ev->GetTypeRewrite() == NPDisk::TEvSlay::EventType) {
+                slay = std::move(ev);
+                return false;
+            }
+            return true;
+        };
+        setup.DeleteDDisk();
+        setup.DispatchUntil([&] { return bool(gone); }, "The real DDisk must publish Gone");
+        setup.DispatchUntil([&] { return bool(slay); }, "Slot deletion must request PDisk slay");
+        const auto* request = slay->Get<NPDisk::TEvSlay>();
+        setup.Runtime.Send(new IEventHandle(setup.NodeWardenId, slay->Recipient,
+            new NPDisk::TEvSlayResult(NKikimrProto::OK, 0, request->VDiskId,
+                request->SlayOwnerRound, setup.PDiskId, setup.VDiskSlotId, {})), setup.NodeId);
+        setup.DispatchUntil([&] {
+            bool complete = false;
+            setup.Runtime.WrapInActorContext(setup.NodeWardenId, [&](IActor* actor) {
+                complete = static_cast<NStorage::TNodeWarden*>(actor)->SlayInFlight.empty();
+            });
+            return complete;
+        }, "Slay must complete before recreating the slot");
+        setup.Runtime.WrapInActorContext(setup.NodeWardenId, [&](IActor* actor) {
+            auto& warden = *static_cast<NStorage::TNodeWarden*>(actor);
+            NKikimrBlobStorage::TNodeWardenServiceSet incoming;
+            setup.FillDDisk(incoming.AddVDisks());
+            warden.ApplyServiceSet(incoming, true, false, false, "recreate while Gone is held");
+            const auto& record = warden.LocalVDisks.at({setup.NodeId, setup.PDiskId, setup.VDiskSlotId});
+            UNIT_ASSERT(!record.RuntimeData);
+            UNIT_ASSERT(warden.DDiskActors.contains(oldActor));
+        });
+        setup.Runtime.FilterFunction = {};
+        setup.Runtime.Send(std::move(gone), setup.NodeId);
+        setup.DispatchUntil([&] {
+            const auto current = setup.LookupDDiskActor();
+            return current && current != oldActor && setup.IsActorAlive(current);
+        }, "Replacement starts only after old incarnation Gone");
     }
 
     struct TStaticGroupProxyTestSetup {

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -186,6 +186,7 @@ STATEFN(TNodeWarden::StateOnline) {
         hFunc(TEvPrivate::TEvUpdateNodeDrives, Handle);
         hFunc(TEvPrivate::TEvRetrySaveConfig, Handle);
         hFunc(TEvPrivate::TEvRetrySlay, Handle);
+        hFunc(TEvPrivate::TEvRestartDrainReminder, Handle);
 
         hFunc(NMon::TEvHttpInfo, Handle);
         cFunc(NActors::TEvents::TSystem::Poison, PassAway);

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -125,6 +125,7 @@ namespace NKikimr::NStorage {
     };
 
     class TNodeWarden : public TActorBootstrapped<TNodeWarden> {
+        friend class TNodeWardenTestPeer;
         TIntrusivePtr<TNodeWardenConfig> Cfg;
         TIntrusivePtr<TDsProxyNodeMon> DsProxyNodeMon;
         TActorId DsProxyNodeMonActor;
@@ -194,8 +195,15 @@ namespace NKikimr::NStorage {
                 EvSaveConfigResult,
                 EvRetrySaveConfig,
                 EvRetrySlay,
+                EvRestartDrainReminder,
             };
 
+            struct TEvRestartDrainReminder : TEventLocal<TEvRestartDrainReminder, EvRestartDrainReminder> {
+                ui32 PDiskId;
+                ui64 Generation;
+                TEvRestartDrainReminder(ui32 pdiskId, ui64 generation)
+                    : PDiskId(pdiskId), Generation(generation) {}
+            };
             struct TEvSendDiskMetrics : TEventLocal<TEvSendDiskMetrics, EvSendDiskMetrics> {};
             struct TEvUpdateStats : TEventLocal<TEvUpdateStats, EvUpdateStats> {};
             struct TEvUpdateNodeDrives : TEventLocal<TEvUpdateNodeDrives, EvUpdateNodeDrives> {};
@@ -512,6 +520,7 @@ namespace NKikimr::NStorage {
             };
             std::optional<TRuntimeData> RuntimeData;
             bool ShutdownPending = false;
+            TActorId ShutdownActorId;
             bool RestartAfterShutdown = false;
 
             // Last VDiskId reported to Node Whiteboard.
@@ -579,7 +588,19 @@ namespace NKikimr::NStorage {
 
         std::map<TVSlotId, TSlayInFlight> SlayInFlight;
         // PDiskId -> is another restart required after the current restart.
-        std::unordered_map<ui32, bool> PDiskRestartInFlight;
+        struct TPDiskRestart {
+            enum class EPhase { WaitingForDDisks, RestartSent };
+            EPhase Phase = EPhase::WaitingForDDisks;
+            bool RequiresAnotherRestart = false;
+            ui64 Generation = 0;
+            THashSet<TActorId> WaitingFor;
+        };
+        std::unordered_map<ui32, TPDiskRestart> PDiskRestartInFlight;
+        // Survives poison and slot deletion until the concrete actor reports Gone.
+        THashMap<TActorId, TVSlotId> DDiskActors;
+        ui64 NextPDiskRestartGeneration = 0;
+        void TrySendPDiskRestart(ui32 pdiskId);
+        void Handle(TEvPrivate::TEvRestartDrainReminder::TPtr ev);
         TIntrusiveList<TVDiskRecord, TUnreportedMetricTag> VDisksWithUnreportedMetrics;
 
         void DestroyLocalVDisk(TVDiskRecord& vdisk);

--- a/ydb/core/blobstorage/nodewarden/node_warden_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_mon.cpp
@@ -185,7 +185,9 @@ void TNodeWarden::RenderWholePage(IOutputStream& out) {
             DIV() {
                 out << "PDiskRestartInFlight# [";
                 for (const auto& item : PDiskRestartInFlight) {
-                    out << "pdiskId:" << item.first << " -> needsAnotherRestart: " << item.second << ", ";
+                    out << "pdiskId:" << item.first << " -> needsAnotherRestart: " << item.second.RequiresAnotherRestart
+                        << " phase: " << (item.second.Phase == TPDiskRestart::EPhase::WaitingForDDisks ? "waiting for DDisks" : "restart sent")
+                        << " waitingFor: " << FormatList(item.second.WaitingFor) << ", ";
                 }
                 out << "]";
             }

--- a/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
@@ -615,7 +615,10 @@ namespace NKikimr::NStorage {
             return;
         }
 
-        bool requiresAnotherRestart = it->second;
+        if (it->second.Phase != TPDiskRestart::EPhase::RestartSent) {
+            return;
+        }
+        bool requiresAnotherRestart = it->second.RequiresAnotherRestart;
 
         PDiskRestartInFlight.erase(it);
 
@@ -675,19 +678,23 @@ namespace NKikimr::NStorage {
 
     void TNodeWarden::DoRestartLocalPDisk(const NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk& pdisk) {
         ui32 pdiskId = pdisk.GetPDiskID();
+        if (auto it = LocalPDisks.find(TPDiskKey(LocalNodeId, pdiskId)); it != LocalPDisks.end()) {
+            it->second.Record = pdisk;
+        }
 
         YDB_LOG_NOTICE("DoRestartLocalPDisk",
             {"marker", "NW75"},
             {"PDiskId", pdiskId});
 
-        const auto [restartIt, inserted] = PDiskRestartInFlight.try_emplace(pdiskId, false);
+        const auto [restartIt, inserted] = PDiskRestartInFlight.try_emplace(pdiskId);
 
         if (!inserted) {
             YDB_LOG_NOTICE("Restart already in progress",
                 {"marker", "NW76"},
                 {"PDiskId", pdiskId});
             // Restart is already in progress, but we will need to make a new restart, as the configuration changed.
-            restartIt->second = true;
+            restartIt->second.RequiresAnotherRestart =
+                restartIt->second.Phase == TPDiskRestart::EPhase::RestartSent;
             return;
         }
 
@@ -706,6 +713,56 @@ namespace NKikimr::NStorage {
             return;
         }
 
+        auto& restart = restartIt->second;
+        restart.Generation = ++NextPDiskRestartGeneration;
+        for (const auto& [actorId, slot] : DDiskActors) {
+            if (slot.PDiskId == pdiskId) {
+                restart.WaitingFor.insert(actorId);
+            }
+        }
+        for (const auto& actorId : restart.WaitingFor) {
+            const auto slot = DDiskActors.at(actorId);
+            auto jt = LocalVDisks.find(slot);
+            if (jt != LocalVDisks.end() && jt->second.RuntimeData
+                    && jt->second.RuntimeData->ActorId == actorId) {
+                // Live occupant: poison and clear slot RuntimeData / ShutdownPending.
+                PoisonLocalVDisk(jt->second);
+            } else {
+                // Deleted or already-stopping incarnation: still must die to drain WaitingFor.
+                Send(actorId, new TEvents::TEvPoison());
+            }
+        }
+        if (!restart.WaitingFor.empty()) {
+            Schedule(TDuration::Seconds(30), new TEvPrivate::TEvRestartDrainReminder(pdiskId, restart.Generation));
+        }
+        TrySendPDiskRestart(pdiskId);
+    }
+
+    void TNodeWarden::Handle(TEvPrivate::TEvRestartDrainReminder::TPtr ev) {
+        const auto& msg = *ev->Get();
+        const auto it = PDiskRestartInFlight.find(msg.PDiskId);
+        if (it == PDiskRestartInFlight.end() || it->second.Generation != msg.Generation
+                || it->second.Phase != TPDiskRestart::EPhase::WaitingForDDisks) {
+            return;
+        }
+        YDB_LOG_ERROR("PDisk restart waiting for DDisk shutdown", {"PDiskId", msg.PDiskId},
+            {"waitingFor", it->second.WaitingFor});
+        Schedule(TDuration::Seconds(30), new TEvPrivate::TEvRestartDrainReminder(msg.PDiskId, msg.Generation));
+    }
+
+    void TNodeWarden::TrySendPDiskRestart(ui32 pdiskId) {
+        auto restartIt = PDiskRestartInFlight.find(pdiskId);
+        if (restartIt == PDiskRestartInFlight.end()
+                || restartIt->second.Phase != TPDiskRestart::EPhase::WaitingForDDisks
+                || !restartIt->second.WaitingFor.empty()) {
+            return;
+        }
+        auto it = LocalPDisks.find(TPDiskKey(LocalNodeId, pdiskId));
+        if (it == LocalPDisks.end()) {
+            PDiskRestartInFlight.erase(restartIt);
+            return;
+        }
+        restartIt->second.Phase = TPDiskRestart::EPhase::RestartSent;
         const TActorId actorId = MakeBlobStoragePDiskID(LocalNodeId, pdiskId);
 
         TIntrusivePtr<TPDiskConfig> pdiskConfig = CreatePDiskConfig(

--- a/ydb/core/blobstorage/nodewarden/node_warden_test_peer.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_test_peer.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "node_warden_impl.h"
+
+namespace NKikimr {
+namespace NStorage {
+class TNodeWardenTestPeer {
+public:
+    using TRestartDrainReminder = TNodeWarden::TEvPrivate::TEvRestartDrainReminder;
+    static auto& AddPDisk(TNodeWarden& warden, ui32 pdiskId) {
+        NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk record;
+        return warden.LocalPDisks.emplace(TPDiskKey(1, pdiskId), TPDiskRecord(std::move(record))).first->second.Record;
+    }
+    static void TrackPath(TNodeWarden& warden, ui32 pdiskId) {
+        const auto& record = warden.LocalPDisks.at(TPDiskKey(1, pdiskId)).Record;
+        warden.PDiskByPath.emplace(record.GetPath(), TNodeWarden::TPDiskByPathInfo{TPDiskKey(1, pdiskId), {}});
+    }
+    static const auto& GetPDisk(TNodeWarden& warden, ui32 pdiskId) {
+        return warden.LocalPDisks.at(TPDiskKey(1, pdiskId)).Record;
+    }
+};
+}
+
+}

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -38,6 +38,7 @@ namespace NKikimr::NStorage {
 
         if (vdisk.RuntimeData) {
             vdiskRunning = true;
+            vdisk.ShutdownActorId = vdisk.RuntimeData->ActorId;
             vdisk.TIntrusiveListItem<TVDiskRecord, TGroupRelationTag>::Unlink();
             TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, vdisk.RuntimeData->ActorId, {}, nullptr, 0));
             vdisk.RuntimeData.reset();
@@ -61,7 +62,7 @@ namespace NKikimr::NStorage {
         vdisk.ScrubCookie = 0; // disable reception of Scrub messages from this disk
         vdisk.ScrubCookieForController = 0; // and from controller too
         vdisk.Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
-        vdisk.ShutdownPending = vdiskRunning; // Shutdown pending only if VDisk was running before poison
+        vdisk.ShutdownPending |= vdiskRunning;
         VDiskStatusChanged = true;
     }
 
@@ -94,6 +95,14 @@ namespace NKikimr::NStorage {
             return;
         }
 
+        // A removed slot can be recreated while its old incarnation drains.
+        for (const auto& [actorId, slot] : VDiskIdByActor) {
+            if (slot == vslotId) {
+                vdisk.ShutdownPending = true;
+                vdisk.ShutdownActorId = actorId;
+                break;
+            }
+        }
         if (vdisk.ShutdownPending) {
             vdisk.RestartAfterShutdown = true;
             return;
@@ -432,6 +441,9 @@ namespace NKikimr::NStorage {
         const TActorId actorId = as->Register(actor.release(), TMailboxType::Revolving, blobStorageExecutorPoolId);
         as->RegisterLocalService(vdiskServiceId, actorId);
         VDiskIdByActor.try_emplace(actorId, vslotId);
+        if (ddisk) {
+            DDiskActors.emplace(actorId, vslotId);
+        }
 
         YDB_LOG_DEBUG("StartLocalVDiskActor done",
             {"marker", "NW24"},
@@ -470,16 +482,31 @@ namespace NKikimr::NStorage {
     }
 
     void TNodeWarden::HandleGone(STATEFN_SIG) {
+        std::optional<ui32> restartPDisk;
+        if (auto it = DDiskActors.find(ev->Sender); it != DDiskActors.end()) {
+            const ui32 pdiskId = it->second.PDiskId;
+            DDiskActors.erase(it);
+            if (auto jt = PDiskRestartInFlight.find(pdiskId); jt != PDiskRestartInFlight.end()) {
+                jt->second.WaitingFor.erase(ev->Sender);
+                restartPDisk = pdiskId;
+            }
+        }
         if (const auto it = VDiskIdByActor.find(ev->Sender); it != VDiskIdByActor.end()) {
-            if (const auto jt = LocalVDisks.find(it->second); jt != LocalVDisks.end()) {
+            const auto slot = it->second;
+            VDiskIdByActor.erase(it);
+            if (const auto jt = LocalVDisks.find(slot); jt != LocalVDisks.end()) {
                 TVDiskRecord& vdisk = jt->second;
-                Y_ABORT_UNLESS(vdisk.ShutdownPending);
-                vdisk.ShutdownPending = false;
-                if (std::exchange(vdisk.RestartAfterShutdown, false)) {
-                    StartLocalVDiskActor(vdisk);
+                if (vdisk.ShutdownActorId == ev->Sender) {
+                    vdisk.ShutdownActorId = {};
+                    vdisk.ShutdownPending = false;
+                    if (std::exchange(vdisk.RestartAfterShutdown, false)) {
+                        StartLocalVDiskActor(vdisk);
+                    }
                 }
             }
-            VDiskIdByActor.erase(it);
+        }
+        if (restartPDisk) {
+            TrySendPDiskRestart(*restartPDisk);
         }
     }
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -990,7 +990,7 @@ public:
     // the block device thread is doing concurrently.
     void Handle(NPDisk::TEvDeviceOverestimationSamples::TPtr &ev) {
         for (const auto& sample : ev->Get()->Samples) {
-            PDisk->Mon.DeviceOverestimationMerged.Push(sample);
+            PDisk->Mon.DeviceOverestimationMerged->Push(sample);
         }
     }
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_async.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_async.cpp
@@ -543,7 +543,7 @@ class TRealBlockDevice : public IBlockDevice {
                     sample.Size = opSize;
                     sample.IsWrite = (op->GetType() != IAsyncIoOperation::EType::PRead);
                     sample.BaseCostNs = completionAction->CostNs;
-                    Device.Mon.DeviceOverestimationMerged.Push(sample);
+                    Device.Mon.DeviceOverestimationMerged->Push(sample);
                 }
 
                 double duration = HPMilliSecondsFloat(HPNow() - completionAction->SubmitTime);
@@ -611,14 +611,14 @@ class TRealBlockDevice : public IBlockDevice {
                 // any samples received from IO_URING sources sharing this physical
                 // device) and derive the same overestimation ratio for the merged
                 // stream. See blobstorage_pdisk_device_overestimation.h.
-                auto windowResult = Device.Mon.DeviceOverestimationMerged.ComputeAndReset(Device.SeekCostNs);
+                auto windowResult = Device.Mon.DeviceOverestimationMerged->ComputeAndReset(Device.SeekCostNs);
                 MergedEstimatedNs += windowResult.EstimatedNs;
                 MergedActualNs += windowResult.ActualNs + OverestimationActualCostBiasNs;
                 const TOverestimationRatioResult mergedRatioResult =
                     ComputeOverestimationRatio(MergedEstimatedNs, MergedActualNs);
                 *Device.Mon.DeviceOverestimationRatioMerged = mergedRatioResult.OverestimationRatio;
                 *Device.Mon.DeviceNonperformanceMsMerged = mergedRatioResult.NonperformanceMs;
-                *Device.Mon.DeviceOverestimationDroppedSamples = Device.Mon.DeviceOverestimationMerged.GetDroppedSamples();
+                *Device.Mon.DeviceOverestimationDroppedSamples = Device.Mon.DeviceOverestimationMerged->GetDroppedSamples();
                 // Reset accumulators each window (unlike the legacy PDisk-only
                 // counters above, which are cumulative device-lifetime counters we
                 // diff against Prev*): this makes MergedEstimatedNs/MergedActualNs

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -369,15 +369,8 @@ void TPDisk::Stop() {
         {"ownerInfo", StartupOwnerInfo()});
 
 #if defined(__linux__)
-    if (UringSampleAggregator) {
-        UringSampleAggregator->store(nullptr, std::memory_order_release);
-    }
-    // Do not close admission while DDisk/PB clients still own the shared
-    // router: a zombie DDisk may continue direct I/O until its owner-stamped
-    // PDisk request detects the stale round. The last shared owner performs
-    // the blocking drain in TUringRouter's destructor.
-    if (SharedUringRouter && SharedUringRouter.use_count() == 1) {
-        SharedUringRouter->StopAsync();
+    if (SharedUringRouter) {
+        SharedUringRouter->StopSync();
         SharedUringRouter.reset();
     }
 #endif
@@ -2104,31 +2097,18 @@ void TPDisk::EnsureSharedUringRouter(ui32 idleSpinUs) {
         PCtx->ActorSystem,
         config,
         std::move(counters));
+    if (ConfigureRouterForTest) {
+        ConfigureRouterForTest(*router);
+    }
     router->RegisterFile();
 
-    const ui64 readBps = DriveModel.Speed(TDriveModel::OP_TYPE_READ);
-    const ui64 writeBps = DriveModel.Speed(TDriveModel::OP_TYPE_WRITE);
-    UringSampleAggregator = std::make_shared<std::atomic<TDeviceOverestimationAggregator*>>(
-        &Mon.DeviceOverestimationMerged);
-    auto sampleAgg = UringSampleAggregator;
-    router->SetSampleSink([readBps, writeBps, sampleAgg](const TDeviceIoSample& sample) {
-        auto* agg = sampleAgg->load(std::memory_order_acquire);
-        if (!agg) {
-            return;
-        }
-        TDeviceIoSample s = sample;
-        const ui64 speed = s.IsWrite ? writeBps : readBps;
-        s.BaseCostNs = speed ? s.Size * 1'000'000'000ull / speed : 0;
-        agg->Push(s);
-    });
+    router->SetSampleSink(MakeUringSampleSink());
 
     router->Start();
 
     if (router->IsBroken()) {
         YDB_LOG_P_LOG(PRI_WARN, "Shared UringRouter not created: startup failed, falling back to PDisk I/O",
             {"marker", "BPD99"});
-        UringSampleAggregator->store(nullptr, std::memory_order_release);
-        UringSampleAggregator.reset();
         Mon.FallbackPDiskCount->Inc();
         return;
     }
@@ -2157,6 +2137,20 @@ void TPDisk::EnsureSharedUringRouter(ui32 idleSpinUs) {
     Mon.FallbackPDiskCount->Inc();
 #endif
 }
+
+#if defined(__linux__)
+TDeviceIoSampleSink TPDisk::MakeUringSampleSink() const {
+    const ui64 readBps = DriveModel.Speed(TDriveModel::OP_TYPE_READ);
+    const ui64 writeBps = DriveModel.Speed(TDriveModel::OP_TYPE_WRITE);
+    auto sampleAgg = Mon.DeviceOverestimationMerged;
+    return [readBps, writeBps, sampleAgg](const TDeviceIoSample& sample) {
+        TDeviceIoSample s = sample;
+        const ui64 speed = s.IsWrite ? writeBps : readBps;
+        s.BaseCostNs = speed ? s.Size * 1'000'000'000ull / speed : 0;
+        sampleAgg->Push(s);
+    };
+}
+#endif
 
 void TPDisk::CheckSharedUringRouter() {
 #if defined(__linux__)

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
@@ -34,6 +34,7 @@
 #include <util/system/mutex.h>
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <queue>
 
@@ -53,6 +54,12 @@ class TCompletionEventSender;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 class TPDisk : public IPDisk {
+#if defined(__linux__)
+    friend class TPDiskTestPeer;
+    // Configured under StateMutex before the first router creation attempt.
+    std::function<void(TUringRouter&)> ConfigureRouterForTest;
+#endif
+
 public:
 #ifdef ENABLE_PDISK_SHRED
     static constexpr bool IS_SHRED_ENABLED = true;
@@ -235,7 +242,6 @@ public:
     // it during Stop() only when no clients remain; otherwise the final owner
     // destroys the router, drains accepted I/O, and closes the duplicated fd.
     std::shared_ptr<TUringRouter> SharedUringRouter;
-    std::shared_ptr<std::atomic<TDeviceOverestimationAggregator*>> UringSampleAggregator;
 #endif
     bool SharedUringCreateAttempted = false;
     bool SharedUringFailureReported = false;
@@ -415,6 +421,9 @@ public:
     bool YardInitForKnownVDisk(TYardInit &evYardInit, TOwner owner);
     void AttachSharedUringRouter(const TYardInit& evYardInit, TEvYardInitResult& result);
     void EnsureSharedUringRouter(ui32 idleSpinUs);
+#if defined(__linux__)
+    TDeviceIoSampleSink MakeUringSampleSink() const;
+#endif
     void CheckSharedUringRouter(); // Called by the PDisk worker
     void YardResize(TYardResize &evYardResize);
     void ProcessChangeExpectedSlotCount(TChangeExpectedSlotCount& request);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
@@ -16,6 +16,7 @@
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/monlib/dynamic_counters/percentile/percentile_lg.h>
 #include <util/generic/vector.h>
+#include <memory>
 
 
 namespace NKikimr {
@@ -339,7 +340,8 @@ struct TPDiskMon {
     // device thread together with samples from the shared TUringRouter I/O
     // thread (DDisk / PersistentBuffer I/O on the same physical device),
     // via TDeviceOverestimationAggregator. See blobstorage_pdisk_device_overestimation.h.
-    NPDisk::TDeviceOverestimationAggregator DeviceOverestimationMerged;
+    std::shared_ptr<NPDisk::TDeviceOverestimationAggregator> DeviceOverestimationMerged =
+        std::make_shared<NPDisk::TDeviceOverestimationAggregator>();
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceOverestimationRatioMerged;
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceNonperformanceMsMerged;
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceOverestimationDroppedSamples;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_test_peer.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_test_peer.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "blobstorage_pdisk_impl.h"
+
+namespace NKikimr::NPDisk {
+class TPDiskTestPeer {
+public:
+    // Caller holds StateMutex; installation precedes every creation attempt.
+    static void ConfigureRouter(TPDisk& pdisk, std::function<void(TUringRouter&)> configure) {
+        Y_ABORT_UNLESS(!pdisk.SharedUringCreateAttempted);
+        pdisk.ConfigureRouterForTest = std::move(configure);
+    }
+};
+}

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
@@ -14,6 +14,14 @@
 #include <ydb/library/actors/interconnect/rdma/mem_pool.h>
 
 #include <util/system/hp_timer.h>
+#include <util/generic/scope.h>
+#if defined(__linux__)
+#include "blobstorage_pdisk_test_peer.h"
+#include <ydb/library/pdisk_io/uring_router_test_peer.h>
+#include <ydb/library/pdisk_io/uring_test_support.h>
+#include <thread>
+#include <sys/file.h>
+#endif
 
 namespace NKikimr {
 
@@ -70,6 +78,87 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
     }
 
 #if defined(__linux__)
+    Y_UNIT_TEST(TestProductionStopRetiresRouterWithRetainedInitResult) {
+        if (!NPDisk::RequireUring()) {
+            return;
+        }
+        TActorTestContext::TSettings settings;
+        settings.UseSectorMap = false;
+        settings.SmallDisk = true;
+        settings.ChunkSize = 16 << 20;
+        settings.DiskSize = ui64{16} << 30;
+        TActorTestContext ctx(settings);
+        TManualEvent callback, release, joining;
+        std::shared_ptr<NPDisk::TUringRouter> router;
+        ctx.SafeRunOnPDisk([&](NPDisk::TPDisk* pdisk) {
+            NPDisk::TPDiskTestPeer::ConfigureRouter(*pdisk, [&](NPDisk::TUringRouter& instance) {
+                NPDisk::NUringPrivate::TRouterHooks hooks;
+                hooks.BeforeTerminalCallback = [&] { callback.Signal(); release.WaitI(); };
+                hooks.BeforeJoin = [&] { joining.Signal(); };
+                NPDisk::TUringRouterTestPeer::SetHooks(instance, std::move(hooks));
+            });
+        });
+        auto init = ctx.TestResponse<NPDisk::TEvYardInitResult>(new NPDisk::TEvYardInit(
+            2, TVDiskID(0, 1, 0, 0, 0), ctx.TestCtx.PDiskGuid, {}, {}, 1, 0, true), NKikimrProto::OK);
+        UNIT_ASSERT(init->UringRouter);
+        router = std::dynamic_pointer_cast<NPDisk::TUringRouter>(init->UringRouter);
+        UNIT_ASSERT(router);
+        struct TRead : NPDisk::TUringOperationBase {
+            ui32 Completed = 0;
+            ui32 Dropped = 0;
+            void OnComplete(TActorSystem*) noexcept override { ++Completed; }
+            void OnDrop(TActorSystem*) noexcept override { ++Dropped; }
+        } op;
+        alignas(4096) char buffer[4096];
+        auto* pdisk = ctx.GetPDisk();
+        std::atomic<bool> stopped = false;
+        std::thread stop;
+        Y_DEFER {
+            release.Signal();
+            if (stop.joinable()) { stop.join(); }
+        };
+        op.SetOperationType(NPDisk::TUringOperationBase::EREAD);
+        op.PrepareIov(buffer, sizeof(buffer), 0);
+        UNIT_ASSERT(router->Read(&op));
+        callback.WaitI();
+        stop = std::thread([&] { pdisk->Stop(); stopped.store(true); });
+        joining.WaitI();
+        // The native callback owns one inflight operation until released.
+        const bool premature = stopped.load();
+        release.Signal();
+        stop.join();
+        UNIT_ASSERT(!premature);
+        UNIT_ASSERT_VALUES_EQUAL(op.Completed, 1);
+        UNIT_ASSERT_VALUES_EQUAL(op.Dropped, 0);
+        UNIT_ASSERT_VALUES_EQUAL(router->GetInflight(), 0);
+        UNIT_ASSERT(NPDisk::TUringRouterTestPeer::Retired(*router));
+        UNIT_ASSERT(!pdisk->BlockDevice->DuplicateFd().IsOpen());
+        UNIT_ASSERT(!init->UringRouter->Read(&op));
+        UNIT_ASSERT_VALUES_EQUAL(op.Completed, 1);
+        TFile independent(ctx.TestCtx.Path, OpenExisting | RdWr);
+        UNIT_ASSERT_VALUES_EQUAL(flock(independent.GetHandle(), LOCK_EX | LOCK_NB), 0);
+        UNIT_ASSERT_VALUES_EQUAL(flock(independent.GetHandle(), LOCK_UN), 0);
+    }
+
+    Y_UNIT_TEST(TestUringSampleSinkOutlivesPDiskAndMonitor) {
+        auto cfg = MakeIntrusive<TPDiskConfig>("", ui64{12345}, ui32{12345},
+            TPDiskCategory(NPDisk::DEVICE_TYPE_ROT, 0).GetRaw());
+        auto pdisk = MakeHolder<NPDisk::TPDisk>(std::make_shared<NPDisk::TPDiskCtx>(), cfg,
+            MakeIntrusive<::NMonitoring::TDynamicCounters>());
+        auto sink = pdisk->MakeUringSampleSink();
+        std::weak_ptr<NPDisk::TDeviceOverestimationAggregator> aggregator = pdisk->Mon.DeviceOverestimationMerged;
+        pdisk.Reset();
+        UNIT_ASSERT(!aggregator.expired());
+        NPDisk::TDeviceIoSample sample;
+        sample.Size = 4096;
+        sample.SubmitCycles = 1;
+        sample.CompleteCycles = 2;
+        sink(sample);
+        UNIT_ASSERT_VALUES_EQUAL(aggregator.lock()->ComputeAndReset(0).SampleCount, 1);
+        sink = {};
+        UNIT_ASSERT(aggregator.expired());
+    }
+
     Y_UNIT_TEST(TestSharedUringRouterFailureNotification) {
         TTestActorRuntimeBase runtime;
         runtime.Initialize();

--- a/ydb/library/pdisk_io/uring_router.cpp
+++ b/ydb/library/pdisk_io/uring_router.cpp
@@ -19,6 +19,8 @@
 #include "liburing_compat.h"
 
 #include <cerrno>
+#include <chrono>
+#include <optional>
 #include <cstdio>
 #include <cstring>
 #include <utility>
@@ -331,14 +333,14 @@ void TUringRouter::StopAsync(bool makeBroken) {
             [[fallthrough]];
         case EUringRouterState::Running:
             if (State.compare_exchange_weak(state, target,
-                    std::memory_order_acq_rel, std::memory_order_acquire)) {
+                    std::memory_order_seq_cst, std::memory_order_acquire)) {
                 WakeIoThreadIfParked(Parked, WakeEventFd);
                 return;
             }
             break;
         case EUringRouterState::Broken:
             if (State.compare_exchange_weak(state, EUringRouterState::StoppingBroken,
-                    std::memory_order_acq_rel, std::memory_order_acquire)) {
+                    std::memory_order_seq_cst, std::memory_order_acquire)) {
                 WakeIoThreadIfParked(Parked, WakeEventFd);
                 return;
             }
@@ -348,15 +350,18 @@ void TUringRouter::StopAsync(bool makeBroken) {
                 return;
             }
             if (State.compare_exchange_weak(state, EUringRouterState::StoppingBroken,
-                    std::memory_order_acq_rel, std::memory_order_acquire)) {
+                    std::memory_order_seq_cst, std::memory_order_acquire)) {
                 WakeIoThreadIfParked(Parked, WakeEventFd);
                 return;
             }
             break;
-        case EUringRouterState::StoppingBroken:
-            [[fallthrough]];
         case EUringRouterState::Stopped:
-            [[fallthrough]];
+            if (makeBroken && !State.compare_exchange_weak(state, EUringRouterState::StoppedBroken,
+                    std::memory_order_seq_cst, std::memory_order_acquire)) {
+                break;
+            }
+            return;
+        case EUringRouterState::StoppingBroken:
         case EUringRouterState::StoppedBroken:
             return;
         default:
@@ -366,17 +371,23 @@ void TUringRouter::StopAsync(bool makeBroken) {
 }
 
 void TUringRouter::StopSync() {
+    std::lock_guard guard(StopMutex);
     const EUringRouterState state = State.load(std::memory_order_acquire);
     if (state == EUringRouterState::Stopped || state == EUringRouterState::StoppedBroken) {
         return;
     }
     StopAsync();
+    while (Publishers.load(std::memory_order_seq_cst)) {
+        if (TestHooks && TestHooks->WaitingForPublishers) { TestHooks->WaitingForPublishers(); }
+        Sleep(TDuration::MilliSeconds(1));
+    }
 
     if (IoThread) {
         if (RingEnabled) {
             Queue.Push(QueueStopSentinel());
             WakeIoThreadIfParked(Parked, WakeEventFd);
         }
+        if (TestHooks && TestHooks->BeforeJoin) { TestHooks->BeforeJoin(); }
         IoThread->Join();
         IoThread.reset();
     }
@@ -396,8 +407,14 @@ void TUringRouter::StopSync() {
         Ring.reset();
     }
 
-    State.store(IsBroken() ? EUringRouterState::StoppedBroken : EUringRouterState::Stopped,
-        std::memory_order_release);
+    Fd.Close();
+    if (TestHooks && TestHooks->Retired) { TestHooks->Retired(); }
+    auto finalState = State.load(std::memory_order_acquire);
+    if (TestHooks && TestHooks->BeforeFinalStopCas) { TestHooks->BeforeFinalStopCas(); }
+    while (!State.compare_exchange_weak(finalState,
+            finalState == EUringRouterState::StoppingBroken ? EUringRouterState::StoppedBroken : EUringRouterState::Stopped,
+            std::memory_order_acq_rel, std::memory_order_acquire)) {
+    }
 }
 
 void TUringRouter::WaitSync() {
@@ -534,9 +551,13 @@ bool TUringRouter::Submit(TUringOperationBase* op) {
     Y_ABORT_UNLESS(op->GetOperationType() != TUringOperationBase::ENOT_SET,
         "Submit() called with an unprepared operation");
 
+    Publishers.fetch_add(1, std::memory_order_seq_cst);
     if (State.load(std::memory_order_seq_cst) != EUringRouterState::Running) {
+        Publishers.fetch_sub(1, std::memory_order_seq_cst);
         return false;
     }
+
+    if (TestHooks && TestHooks->AfterAdmission) { TestHooks->AfterAdmission(); }
 
     // A client may resubmit after a terminal negative CQE. This is a new
     // admission, even though its advanced iovec/progress remains intact.
@@ -545,7 +566,10 @@ bool TUringRouter::Submit(TUringOperationBase* op) {
 
     NSan::Release(op);
     Queue.Push(op);
+    if (TestHooks && TestHooks->AfterPublication) { TestHooks->AfterPublication(); }
     WakeIoThreadIfParked(Parked, WakeEventFd);
+    if (TestHooks && TestHooks->AfterWake) { TestHooks->AfterWake(); }
+    Publishers.fetch_sub(1, std::memory_order_seq_cst);
     return true;
 }
 
@@ -626,6 +650,7 @@ void TUringRouter::DropOperation(TUringOperationBase* op) {
         CompleteOperation(op, -ECANCELED);
         return;
     }
+    if (TestHooks && TestHooks->BeforeTerminalCallback) { TestHooks->BeforeTerminalCallback(); }
     op->OnDrop(ActorSystem);
     const ui64 previous = InFlightCount.fetch_sub(1, std::memory_order_release);
     Y_DEBUG_ABORT_UNLESS(previous > 0);
@@ -633,6 +658,7 @@ void TUringRouter::DropOperation(TUringOperationBase* op) {
 
 void TUringRouter::CompleteOperation(TUringOperationBase* op, i64 result) {
     op->Result = result;
+    if (TestHooks && TestHooks->BeforeTerminalCallback) { TestHooks->BeforeTerminalCallback(); }
     op->OnComplete(ActorSystem);
     // OnComplete may destroy or immediately recycle op, including a new
     // admission on this router. Do not access it after the callback.
@@ -865,6 +891,20 @@ void TUringRouter::ParkAndWait() {
 }
 
 void TUringRouter::HandleStop() {
+    std::optional<std::chrono::steady_clock::time_point> fatalDeadline;
+    auto checkFatalDrain = [&] {
+        if (!FatalRingError) {
+            return;
+        }
+        const auto now = Backend->Now();
+        if (!fatalDeadline) {
+            fatalDeadline = now + std::chrono::milliseconds(200);
+        }
+        Y_ABORT_UNLESS(now < *fatalDeadline,
+            "io_uring fatal shutdown timed out: inflight=%llu sq=%u wake=%d stop=%d",
+            static_cast<unsigned long long>(GetInflight()), io_uring_sq_ready(Ring.get()),
+            WakePollArmed, StopCqePending);
+    };
     // No fresh data work may be started after stop. Drop pending, continuation,
     // and staged work that has not been published to the kernel.
     if (PendingSubmit) {
@@ -892,6 +932,7 @@ void TUringRouter::HandleStop() {
     }
 
     while (WakePollArmed || io_uring_sq_ready(Ring.get()) != 0) {
+        checkFatalDrain();
         SubmitPendingSqes(/*allowWhileStopping=*/true);
         if (ReapCompletions() == 0) {
             WaitForProgress();
@@ -907,6 +948,7 @@ void TUringRouter::HandleStop() {
         StopCqePending = true;
 
         do {
+            checkFatalDrain();
             SubmitPendingSqes(/*allowWhileStopping=*/true);
             if (ReapCompletions() == 0) {
                 WaitForProgress();
@@ -914,6 +956,12 @@ void TUringRouter::HandleStop() {
         } while (StopCqePending || io_uring_sq_ready(Ring.get()) != 0);
     }
 
+    while (GetInflight() || WakePollArmed || StopCqePending || io_uring_sq_ready(Ring.get())) {
+        checkFatalDrain();
+        if (ReapCompletions() == 0) {
+            WaitForProgress();
+        }
+    }
     Y_ABORT_UNLESS(!Queue.Pop(),
         "operation found behind io_uring stop sentinel");
 }

--- a/ydb/library/pdisk_io/uring_router.h
+++ b/ydb/library/pdisk_io/uring_router.h
@@ -18,6 +18,7 @@
 #include <deque>
 #include <functional>
 #include <memory>
+#include <mutex>
 
 struct io_uring;
 struct io_uring_sqe;
@@ -30,6 +31,18 @@ namespace NKikimr::NPDisk {
 
 namespace NUringPrivate {
     class IUringRouterBackend;
+
+    // Installed by the test peer before Start; immutable throughout concurrent use.
+    struct TRouterHooks {
+        std::function<void()> AfterAdmission;
+        std::function<void()> AfterPublication;
+        std::function<void()> AfterWake;
+        std::function<void()> WaitingForPublishers;
+        std::function<void()> BeforeTerminalCallback;
+        std::function<void()> BeforeJoin;
+        std::function<void()> Retired;
+        std::function<void()> BeforeFinalStopCas;
+    };
 }
 
 enum class EUringFavor {
@@ -63,38 +76,24 @@ struct TUringCounters {
 //
 // RegisterFile(), RegisterBuffers(), SetSampleSink(), and Start() are setup
 // operations and must be called by one thread before concurrent submission.
-// StopAsync() closes admission without waiting; that is the non-blocking path
-// to stop PDisk.
+// StopAsync() closes admission without waiting. StopSync() is the owner-side
+// retirement barrier: it waits for publishers through queue publication and
+// wake, joins the issuer, destroys the ring, and closes the duplicated device
+// fd even if IUringRouterClient references survive. Concurrent StopSync calls
+// are serialized. Keep the router alive throughout every client call.
 //
-// DDisk and PersistentBuffer should hold IUringRouterClient, not TUringRouter,
-// so they cannot start or stop a shared ring. PDisk is the logical owner and
-// is the entity responsible for constructing, starting, and stopping a
-// TUringRouter instance.
+// PDisk owns lifecycle; DDisk and PersistentBuffer hold only IUringRouterClient.
+// For requested PDisk restarts, Warden first waits for every DDisk incarnation
+// and its PB child to drain. PDisk then calls StopSync before replacement.
+// The wake descriptor survives StopSync until object destruction so concurrent
+// rejected submissions and StopAsync calls cannot wake a reused descriptor.
 //
-// If PDisk is being restarted, then all TUringRouters must also be restarted.
-// It is safe to restart them after PDisk:
-// 1. A restarted PDisk instance doesn't wait for I/O to be completed.
-// 2. The next PDisk reincarnation must take an exclusive lock on the device,
-//    thus it waits for all the previous I/O (the previous lock will be held
-//    until I/O is completed, even when the process is reaped).
-// This means that PDisk can safely restart without waiting for slots that use
-// a shared TUringRouter.
-//
-// TUringRouter is responsible for detecting device and I/O issues and switching
-// to the Broken state. A fatal ring failure closes admission and freezes
-// submission. It is up to PDisk to see this and initiate restart (itself and
-// slots).
-//
-// When a TUringRouter client is requested to stop, it is always responsible
-// for waiting for its own I/O. Even if the router is in the Broken state, the
-// client waits for completions. This allows completions to safely reference
-// the actors that started I/O. Client must set timer and if I/O is not completed
-// within assumed timeout, client should report itself as broken.
-//
-// The last owner of the shared router instance destroys the router.
-// Its destructor drops accepted operations (calls their OnDrop() method),
-// that have not reached the kernel, drains submitted operations, and stops
-// the I/O thread.
+// Accepted operations receive exactly one terminal callback. Clients retain
+// their callback state and buffers until retirement, including on Broken rings.
+// StopAsync alone never times out stalled I/O. During explicit teardown a fatal
+// ring gets 200 ms to retire late data, published SQ entries and control CQEs;
+// unresolved ownership aborts the process before any of that storage is freed.
+// Unpublished operations are dropped during teardown.
 //
 // Optional device I/O sample sink: if set via SetSampleSink() before Start(),
 // the I/O thread invokes it once per successfully completed Read/Write CQE.
@@ -141,19 +140,20 @@ public:
     // Required initialization failures leave IsBroken() true and admission closed.
     void Start();
 
-    // Close admission without waiting for accepted operations. A Submit() that
-    // already observed Running may still be accepted; it will receive exactly
-    // one terminal callback. The duplicated device fd remains open until the
-    // last owner destroys the router, so a replacement PDisk waits for the old
-    // I/O at flock acquisition.
+    // Close admission without waiting for accepted operations. An in-progress
+    // publisher may still be accepted and gets exactly one terminal callback.
+    // Call StopSync to retire resources independently of surviving client refs.
     void StopAsync(bool makeBroken = false);
 
-private:
-    // Called only by the destructor. Close admission and post the stop sentinel.
+    // Owner-side synchronous retirement, also used by the destructor. Client
+    // references may survive; subsequent submissions are rejected.
+    // Close admission and post the stop sentinel.
     // HandleStop drops unsubmitted operations and drains submitted I/O before
     // Join returns. Abort if any operations remain unresolved, then tear down
     // the ring.
     void StopSync();
+
+private:
 
     // Test-only. Blocks until every accepted operation has received its
     // terminal callback. Unlike StopSync() it does not close admission, so a
@@ -178,10 +178,8 @@ public:
     // callback: OnComplete() after kernel submission, or OnDrop() if shutdown
     // reaches it first.
     //
-    // Concurrent callers must keep the router alive for the entire call. With
-    // shared ownership, each submitting component therefore retains its own
-    // shared_ptr. Destruction cannot race a Submit() that observed Running and
-    // will see its queue publication without a separate submitter counter.
+    // Concurrent callers must keep the router alive for the entire call.
+    // Accepted publishers are fenced through publication and wake by StopSync.
     [[nodiscard]] bool Submit(TUringOperationBase* op);
 
     [[nodiscard]] bool Read(TUringOperationBase* op) override;
@@ -229,6 +227,7 @@ private:
     void HandleStop();
 
 private:
+    std::unique_ptr<const NUringPrivate::TRouterHooks> TestHooks;
     TFileHandle Fd;
     NActors::TActorSystem* ActorSystem;
     TUringRouterConfig Config;
@@ -271,8 +270,10 @@ private:
 
     NThreading::TObstructiveConsumerQueue<TUringOperationBase, /*DeleteItems=*/false> Queue;
 
-    // Lifetime ownership makes destruction the synchronization point after the
-    // last possible queue publication; State only controls admission.
+    // Publishers remain counted through queue publication and wake. StopSync
+    // closes admission before waiting for this count and serializes join/exit.
+    std::mutex StopMutex;
+    std::atomic<ui64> Publishers{0};
     alignas(64) std::atomic<EUringRouterState> State{EUringRouterState::Created};
     alignas(64) std::atomic<ui64> InFlightCount{0};
 

--- a/ydb/library/pdisk_io/uring_router_backend.h
+++ b/ydb/library/pdisk_io/uring_router_backend.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <util/system/types.h>
+#include <chrono>
 
 struct io_uring;
 struct io_uring_params;
@@ -15,6 +16,7 @@ namespace NKikimr::NPDisk::NUringPrivate {
 class IUringRouterBackend {
 public:
     virtual ~IUringRouterBackend() = default;
+    virtual std::chrono::steady_clock::time_point Now() const { return std::chrono::steady_clock::now(); }
     virtual int Init(unsigned entries, io_uring* ring, io_uring_params* params) = 0;
     virtual int Enable(io_uring* ring) = 0;
     virtual int RegisterFiles(io_uring* ring, const int* files, unsigned count) = 0;

--- a/ydb/library/pdisk_io/uring_router_test_peer.h
+++ b/ydb/library/pdisk_io/uring_router_test_peer.h
@@ -1,0 +1,58 @@
+#pragma once
+#include "uring_router.h"
+#include "uring_router_backend.h"
+#include "liburing_compat.h"
+
+namespace NKikimr::NPDisk {
+
+// Shared test-only access for scripted issuers and actor integration fixtures.
+class TUringRouterTestPeer {
+public:
+    static void SetHooks(TUringRouter& router, NUringPrivate::TRouterHooks hooks) {
+        Y_ABORT_UNLESS(router.State.load() == EUringRouterState::Created);
+        router.TestHooks = std::make_unique<const NUringPrivate::TRouterHooks>(std::move(hooks));
+    }
+    static bool Retired(const TUringRouter& router) {
+        return !router.IoThread && !router.Ring && !router.Fd.IsOpen();
+    }
+    static int WakeFd(const TUringRouter& router) { return router.WakeEventFd; }
+    static std::unique_ptr<TUringRouter> Create(
+            std::unique_ptr<NUringPrivate::IUringRouterBackend> backend, ui32 depth = 16) {
+        return std::unique_ptr<TUringRouter>(new TUringRouter(TFileHandle(), nullptr,
+            TUringRouterConfig{.QueueDepth = depth, .IdleSpinUs = 0}, {}, std::move(backend)));
+    }
+
+    static void SetFd(TUringRouter& router, TFileHandle fd) { router.Fd = std::move(fd); }
+
+    static void Initialize(TUringRouter& router) {
+        if (router.RingInitialized) {
+            router.InitializeOnIoThread();
+        }
+        auto expected = EUringRouterState::Created;
+        router.State.compare_exchange_strong(expected, EUringRouterState::Running);
+    }
+
+    static bool Drain(TUringRouter& router) { return router.DrainSubmitQueue(); }
+    static bool Submit(TUringRouter& router, bool stopping = false) { return router.SubmitPendingSqes(stopping); }
+    static ui32 Reap(TUringRouter& router) { return router.ReapCompletions(); }
+    static void Park(TUringRouter& router) { router.ParkAndWait(); }
+    static void Stop(TUringRouter& router) { router.HandleStop(); }
+    static void WaitProgress(TUringRouter& router) { router.WaitForProgress(); }
+    static void WaitSync(TUringRouter& router) { router.WaitSync(); }
+    static EUringRouterState State(const TUringRouter& router) { return router.State.load(); }
+    static unsigned Ready(const TUringRouter& router) { return io_uring_sq_ready(router.Ring.get()); }
+    static unsigned Staged(const TUringRouter& router) { return router.Ring->sq.sqe_tail - router.Ring->sq.sqe_head; }
+
+    static void AbandonFakeOperations(TUringRouter& router) {
+        // Assertion unwinding must not abort StopSync. This is only safe for the
+        // fake below: no kernel can retain an operation or buffer reference.
+        router.PendingSubmit = nullptr;
+        router.Continuations.clear();
+        while (router.Queue.Pop()) {
+        }
+        router.InFlightCount.store(0);
+    }
+};
+
+} // namespace NKikimr::NPDisk
+

--- a/ydb/library/pdisk_io/uring_test_support.h
+++ b/ydb/library/pdisk_io/uring_test_support.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "uring_router.h"
+#include <library/cpp/testing/common/env.h>
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/stream/output.h>
+
+namespace NKikimr::NPDisk {
+inline bool RequireUring(TUringRouterConfig config = {}) {
+#if defined(__linux__)
+    if (TUringRouter::Probe(config)) {
+        return true;
+    }
+#else
+    Y_UNUSED(config);
+#endif
+    UNIT_ASSERT_C(GetTestParam("require_io_uring", "0") != "1",
+        "require_io_uring=1: native io_uring is unavailable");
+    Cerr << "SKIP: native io_uring is unavailable" << Endl;
+    return false;
+}
+}

--- a/ydb/library/pdisk_io/ut/uring_router_ut.cpp
+++ b/ydb/library/pdisk_io/ut/uring_router_ut.cpp
@@ -4,11 +4,16 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/generic/scope.h>
 #include <util/system/tempfile.h>
+#include <util/stream/file.h>
 #include <util/system/file.h>
 #include <util/system/event.h>
 
 #include <sys/uio.h>
+#include <sys/file.h>
+#include <sys/wait.h>
+#include <sys/resource.h>
 #include <poll.h>
 
 #include <unistd.h>
@@ -23,53 +28,11 @@
 #include <thread>
 
 // Keep liburing after project/system headers that may define conflicting macros.
-#include <ydb/library/pdisk_io/liburing_compat.h>
+#include <ydb/library/pdisk_io/uring_router_test_peer.h>
+#include <ydb/library/pdisk_io/uring_test_support.h>
 
 using NActors::TActorSystem;
 using namespace NKikimr::NPDisk;
-
-namespace NKikimr::NPDisk {
-
-// These tests drive the sole issuer synchronously against a userspace ring.
-class TUringRouterTestPeer {
-public:
-    static std::unique_ptr<TUringRouter> Create(
-            std::unique_ptr<NUringPrivate::IUringRouterBackend> backend, ui32 depth = 16) {
-        return std::unique_ptr<TUringRouter>(new TUringRouter(TFileHandle(), nullptr,
-            TUringRouterConfig{.QueueDepth = depth, .IdleSpinUs = 0}, {}, std::move(backend)));
-    }
-
-    static void Initialize(TUringRouter& router) {
-        if (router.RingInitialized) {
-            router.InitializeOnIoThread();
-        }
-        auto expected = EUringRouterState::Created;
-        router.State.compare_exchange_strong(expected, EUringRouterState::Running);
-    }
-
-    static bool Drain(TUringRouter& router) { return router.DrainSubmitQueue(); }
-    static bool Submit(TUringRouter& router, bool stopping = false) { return router.SubmitPendingSqes(stopping); }
-    static ui32 Reap(TUringRouter& router) { return router.ReapCompletions(); }
-    static void Park(TUringRouter& router) { router.ParkAndWait(); }
-    static void Stop(TUringRouter& router) { router.HandleStop(); }
-    static void WaitProgress(TUringRouter& router) { router.WaitForProgress(); }
-    static void WaitSync(TUringRouter& router) { router.WaitSync(); }
-    static EUringRouterState State(const TUringRouter& router) { return router.State.load(); }
-    static unsigned Ready(const TUringRouter& router) { return io_uring_sq_ready(router.Ring.get()); }
-    static unsigned Staged(const TUringRouter& router) { return router.Ring->sq.sqe_tail - router.Ring->sq.sqe_head; }
-
-    static void AbandonFakeOperations(TUringRouter& router) {
-        // Assertion unwinding must not abort StopSync. This is only safe for the
-        // fake below: no kernel can retain an operation or buffer reference.
-        router.PendingSubmit = nullptr;
-        router.Continuations.clear();
-        while (router.Queue.Pop()) {
-        }
-        router.InFlightCount.store(0);
-    }
-};
-
-} // namespace NKikimr::NPDisk
 
 namespace {
 
@@ -197,8 +160,7 @@ struct TShortCompletionOp : TUringOperationBase {
 
 #define SKIP_IF_NO_URING(config) \
     do { \
-        if (!TUringRouter::Probe(config)) { \
-            Cerr << "io_uring not available on this system, skipping test" << Endl; \
+        if (!RequireUring(config)) { \
             return; \
         } \
     } while (false)
@@ -1044,7 +1006,7 @@ void DoMultiProducerConcurrentSubmit(TUringRouterConfig config) {
     router.reset();
 }
 
-void DoSubmitStopAsyncRace(TUringRouterConfig config) {
+void DoSubmitStopAsyncRace(TUringRouterConfig config, bool sync = false) {
     config.QueueDepth = 4;
     SKIP_IF_NO_URING(config);
     TTempFile tmp(MakeTempName(nullptr, "uring_test"));
@@ -1099,7 +1061,11 @@ void DoSubmitStopAsyncRace(TUringRouterConfig config) {
     while (attempted.load(std::memory_order_relaxed) < NumThreads) {
         std::this_thread::yield();
     }
-    router->StopAsync();
+    if (sync) {
+        router->StopSync();
+    } else {
+        router->StopAsync();
+    }
     for (auto& producer : producers) {
         producer.join();
     }
@@ -1117,7 +1083,7 @@ void DoSubmitStopAsyncRace(TUringRouterConfig config) {
         accepted.load(std::memory_order_relaxed));
 }
 
-void DoConcurrentStopAsync(TUringRouterConfig config) {
+void DoConcurrentStopAsync(TUringRouterConfig config, bool sync = false) {
     SKIP_IF_NO_URING(config);
     TTempFile tmp(MakeTempName(nullptr, "uring_test"));
     TFile f(tmp.Name(), CreateAlways | RdWr);
@@ -1142,8 +1108,9 @@ void DoConcurrentStopAsync(TUringRouterConfig config) {
     }
 
     TManualEvent go;
-    std::thread stopper1([&] { go.WaitI(); router->StopAsync(); });
-    std::thread stopper2([&] { go.WaitI(); router->StopAsync(); });
+    auto stop = [&] { go.WaitI(); if (sync) { router->StopSync(); } else { router->StopAsync(); } };
+    std::thread stopper1(stop);
+    std::thread stopper2(stop);
     go.Signal();
     stopper1.join();
     stopper2.join();
@@ -1507,6 +1474,14 @@ Y_UNIT_TEST_SUITE(TUringRouterTest) {
         DoMultiProducerConcurrentSubmit(DefaultConfig());
     }
 
+    Y_UNIT_TEST(SubmitStopSyncRaceWithSurvivingClients) {
+        DoSubmitStopAsyncRace(DefaultConfig(), true);
+    }
+
+    Y_UNIT_TEST(ConcurrentStopSync) {
+        DoConcurrentStopAsync(DefaultConfig(), true);
+    }
+
     Y_UNIT_TEST(SubmitStopAsyncRace) {
         DoSubmitStopAsyncRace(DefaultConfig());
     }
@@ -1564,7 +1539,13 @@ struct TScriptedUringBackend : NUringPrivate::IUringRouterBackend {
     std::deque<int> ControlResults;
     unsigned Features = IORING_FEAT_EXT_ARG;
     bool AutoComplete = false;
+    bool HoldControls = false;
     std::function<void()> OnBackoff;
+    std::function<void()> OnWait;
+    std::function<std::chrono::steady_clock::time_point()> Clock;
+    std::chrono::steady_clock::time_point Now() const override {
+        return Clock ? Clock() : IUringRouterBackend::Now();
+    }
 
     io_uring* Ring = nullptr;
     unsigned SqHead = 0;
@@ -1663,8 +1644,10 @@ struct TScriptedUringBackend : NUringPrivate::IUringRouterBackend {
             const auto submission = Snapshot(SqHead++);
             Stats->Consumed.push_back(submission);
             if (submission.Sqe.opcode == IORING_OP_NOP || submission.Sqe.opcode == IORING_OP_POLL_ADD) {
-                PushCqe(submission.Sqe.user_data,
-                    Next(ControlResults, submission.Sqe.opcode == IORING_OP_POLL_ADD ? POLLIN : 0));
+                if (!HoldControls) {
+                    PushCqe(submission.Sqe.user_data,
+                        Next(ControlResults, submission.Sqe.opcode == IORING_OP_POLL_ADD ? POLLIN : 0));
+                }
             } else if (AutoComplete) {
                 size_t bytes = submission.Sqe.len;
                 if (!submission.Iovs.empty()) {
@@ -1714,6 +1697,7 @@ struct TScriptedUringBackend : NUringPrivate::IUringRouterBackend {
 
     int WaitCqeTimeout(io_uring*, io_uring_cqe** cqe, __kernel_timespec*) override {
         ++Stats->WaitCalls;
+        if (OnWait) { OnWait(); }
         *cqe = nullptr;
         const int result = Next(WaitResults, CqHead == CqTail ? -ETIME : 0);
         if (!result) {
@@ -1792,6 +1776,269 @@ void AssertSqe(const TScriptedUringBackend::TSubmission& submission, int opcode,
 } // anonymous namespace
 
 Y_UNIT_TEST_SUITE(TUringRouterScriptedTest) {
+    Y_UNIT_TEST(StopSyncWaitsForEveryPublisherPhase) {
+        for (ui32 phase = 0; phase != 3; ++phase) {
+            auto backend = std::make_unique<TScriptedUringBackend>();
+            backend->AutoComplete = true;
+            auto stats = backend->Stats;
+            auto router = TUringRouterTestPeer::Create(std::move(backend));
+            TTempFile tmp(MakeTempName(nullptr, "uring_publisher_stop"));
+            TFile file(tmp.Name(), CreateAlways | RdWr);
+            TUringRouterTestPeer::SetFd(*router, DupOwned(file));
+            TManualEvent entered, release, waiting;
+            std::atomic<bool> returned = false;
+            NUringPrivate::TRouterHooks hooks;
+            auto gate = [&] { entered.Signal(); release.WaitI(); };
+            if (phase == 0) { hooks.AfterAdmission = gate; }
+            if (phase == 1) { hooks.AfterPublication = gate; }
+            if (phase == 2) { hooks.AfterWake = gate; }
+            hooks.WaitingForPublishers = [&] { waiting.Signal(); };
+            TUringRouterTestPeer::SetHooks(*router, std::move(hooks));
+            router->Start();
+            TScriptedOp op;
+            char buffer[4096] = {};
+            PrepareWriteOp(op, buffer, sizeof(buffer), 0);
+            bool accepted = false;
+            std::thread producer([&] { accepted = router->Write(&op); });
+            std::thread stopper;
+            Y_DEFER {
+                release.Signal();
+                if (producer.joinable()) { producer.join(); }
+                if (stopper.joinable()) { stopper.join(); }
+            };
+            entered.WaitI();
+            stopper = std::thread([&] { router->StopSync(); returned.store(true); });
+            waiting.WaitI();
+            const bool premature = returned.load();
+            release.Signal();
+            producer.join();
+            stopper.join();
+            UNIT_ASSERT(!premature);
+            UNIT_ASSERT(accepted);
+            UNIT_ASSERT_VALUES_EQUAL(router->GetInflight(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(op.Completions + op.Drops, 1);
+            UNIT_ASSERT(TUringRouterTestPeer::Retired(*router));
+            UNIT_ASSERT(fcntl(TUringRouterTestPeer::WakeFd(*router), F_GETFD) >= 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats->ExitCalls, 1);
+            TScriptedOp rejected;
+            PrepareWriteOp(rejected, buffer, sizeof(buffer), 0);
+            UNIT_ASSERT(!router->Write(&rejected));
+            UNIT_ASSERT_VALUES_EQUAL(rejected.Completions + rejected.Drops, 0);
+        }
+    }
+
+    Y_UNIT_TEST(BrokenUpgradeWinsFinalStopCasWithConcurrentStopSync) {
+        auto backend = std::make_unique<TScriptedUringBackend>();
+        auto stats = backend->Stats;
+        auto router = TUringRouterTestPeer::Create(std::move(backend));
+        TManualEvent loaded, release;
+        NUringPrivate::TRouterHooks hooks;
+        hooks.BeforeFinalStopCas = [&] { loaded.Signal(); release.WaitI(); };
+        TUringRouterTestPeer::SetHooks(*router, std::move(hooks));
+        router->Start();
+        std::thread first([&] { router->StopSync(); });
+        std::thread second;
+        Y_DEFER {
+            release.Signal();
+            if (first.joinable()) { first.join(); }
+            if (second.joinable()) { second.join(); }
+        };
+        loaded.WaitI();
+        router->StopAsync(true);
+        second = std::thread([&] { router->StopSync(); });
+        release.Signal();
+        first.join();
+        second.join();
+        UNIT_ASSERT(TUringRouterTestPeer::State(*router) == EUringRouterState::StoppedBroken);
+        UNIT_ASSERT(TUringRouterTestPeer::Retired(*router));
+        UNIT_ASSERT_VALUES_EQUAL(stats->ExitCalls, 1);
+    }
+
+    Y_UNIT_TEST(StopSyncReleasesDeviceLockWithRetainedClient) {
+        TTempFile tmp(MakeTempName(nullptr, "uring_retained_lock"));
+        TFile file(tmp.Name(), CreateAlways | RdWr);
+        UNIT_ASSERT_VALUES_EQUAL(flock(file.GetHandle(), LOCK_EX | LOCK_NB), 0);
+        auto backend = std::make_unique<TScriptedUringBackend>();
+        auto stats = backend->Stats;
+        std::shared_ptr<TUringRouter> router = TUringRouterTestPeer::Create(std::move(backend));
+        TUringRouterTestPeer::SetFd(*router, DupOwned(file));
+        file.Close();
+        std::shared_ptr<IUringRouterClient> retained = router;
+        TFile replacement(tmp.Name(), OpenExisting | RdWr);
+        UNIT_ASSERT_VALUES_EQUAL(flock(replacement.GetHandle(), LOCK_EX | LOCK_NB), -1);
+        router->StopSync();
+        UNIT_ASSERT_VALUES_EQUAL(stats->ExitCalls, 1);
+        UNIT_ASSERT_VALUES_EQUAL(flock(replacement.GetHandle(), LOCK_EX | LOCK_NB), 0);
+        router->StopSync();
+        UNIT_ASSERT_VALUES_EQUAL(stats->ExitCalls, 1);
+        router.reset();
+        TScriptedOp rejected;
+        char buffer[4096] = {};
+        PrepareWriteOp(rejected, buffer, sizeof(buffer), 0);
+        UNIT_ASSERT(!retained->Write(&rejected));
+        UNIT_ASSERT_VALUES_EQUAL(rejected.Completions + rejected.Drops, 0);
+    }
+
+    Y_UNIT_TEST(FatalStopAbortsBeforeReleasingUnresolvedResourcesInEveryPhase) {
+        for (ui32 phase = 0; phase != 5; ++phase) {
+            TTempFile diagnostic(MakeTempName(nullptr, "uring_fatal_deadline"));
+            const pid_t pid = fork();
+            UNIT_ASSERT(pid >= 0);
+            if (!pid) {
+                const rlimit noCore{0, 0};
+                setrlimit(RLIMIT_CORE, &noCore);
+                alarm(5);
+                TFile output(diagnostic.Name(), CreateAlways | WrOnly);
+                Y_ABORT_UNLESS(dup2(output.GetHandle(), STDERR_FILENO) >= 0);
+                TScriptedRouter fixture;
+                if (phase != 4) {
+                    fixture.Initialize();
+                }
+                TScriptedOp op;
+                char buffer[4096] = {};
+                if (phase < 2) {
+                    PrepareWriteOp(op, buffer, sizeof(buffer), 0);
+                    Y_ABORT_UNLESS(fixture.Router->Write(&op));
+                    if (phase == 1) {
+                        fixture.Backend->SubmitResults = {{-EBADF, 0}};
+                    }
+                    fixture.Issue();
+                } else {
+                    fixture.Backend->HoldControls = true;
+                    if (phase == 2) {
+                        TUringRouterTestPeer::Park(*fixture.Router);
+                    }
+                }
+                fixture.Backend->PeekResults = {-EBADF};
+                if (phase != 3 && phase != 4) {
+                    TUringRouterTestPeer::Reap(*fixture.Router);
+                }
+                unsigned clockCalls = 0;
+                fixture.Backend->Clock = [&] {
+                    Y_ABORT_UNLESS(fixture.Backend->Stats->ExitCalls == 0);
+                    Y_ABORT_UNLESS(op.Completions + op.Drops == 0);
+                    const unsigned millis = clockCalls++ == 0 ? 0 : clockCalls == 2 ? 199 : 200;
+                    Cerr << "fatal phase=" << phase << " elapsed=" << millis << Endl;
+                    return std::chrono::steady_clock::time_point{} + std::chrono::milliseconds(millis);
+                };
+                if (phase == 4) {
+                    // Force a fatal published stop marker through the public issuer path.
+                    fixture.Backend->PeekResults.clear();
+                    fixture.Backend->SubmitResults = {{-EBADF, 0}};
+                    fixture.Router->Start();
+                    fixture.Router->StopSync();
+                } else {
+                    fixture.Router->StopAsync();
+                    TUringRouterTestPeer::Stop(*fixture.Router);
+                }
+                _exit(1);
+            }
+            int status = 0;
+            UNIT_ASSERT_VALUES_EQUAL(waitpid(pid, &status, 0), pid);
+            UNIT_ASSERT(WIFSIGNALED(status));
+            UNIT_ASSERT_VALUES_EQUAL(WTERMSIG(status), SIGABRT);
+            const auto output = TFileInput(diagnostic.Name()).ReadAll();
+            UNIT_ASSERT_STRING_CONTAINS(output, "elapsed=199");
+            UNIT_ASSERT_STRING_CONTAINS(output, "elapsed=200");
+            UNIT_ASSERT_STRING_CONTAINS(output, "io_uring fatal shutdown timed out:");
+        }
+    }
+
+    Y_UNIT_TEST(FatalStopAcceptsLateCompletionWithinDrainDeadline) {
+        TScriptedRouter fixture;
+        fixture.Initialize();
+        TScriptedOp op;
+        char buffer[4096] = {};
+        PrepareWriteOp(op, buffer, sizeof(buffer), 0);
+        UNIT_ASSERT(fixture.Router->Write(&op));
+        fixture.Issue();
+        fixture.Backend->PeekResults = {-EBADF};
+        TUringRouterTestPeer::Reap(*fixture.Router);
+        bool completed = false;
+        fixture.Backend->OnBackoff = [&] {
+            if (!std::exchange(completed, true)) {
+                fixture.Backend->Complete(op, sizeof(buffer));
+            }
+        };
+        TUringRouterTestPeer::Stop(*fixture.Router);
+        UNIT_ASSERT_VALUES_EQUAL(op.Completions, 1);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Router->GetInflight(), 0);
+    }
+
+    Y_UNIT_TEST(HealthyDrainHasNoFatalDeadline) {
+        TScriptedRouter fixture;
+        fixture.Initialize();
+        TScriptedOp op;
+        char buffer[4096] = {};
+        PrepareWriteOp(op, buffer, sizeof(buffer), 0);
+        UNIT_ASSERT(fixture.Router->Write(&op));
+        fixture.Issue();
+        ui32 elapsed = 0;
+        ui32 clockCalls = 0;
+        fixture.Backend->Clock = [&] {
+            ++clockCalls;
+            return std::chrono::steady_clock::time_point{} + std::chrono::milliseconds(elapsed);
+        };
+        fixture.Backend->OnWait = [&] {
+            elapsed += 100;
+            if (elapsed == 500) { fixture.Backend->Complete(op, sizeof(buffer)); }
+        };
+        fixture.Router->StopAsync();
+        TUringRouterTestPeer::Stop(*fixture.Router);
+        UNIT_ASSERT_VALUES_EQUAL(elapsed, 500);
+        UNIT_ASSERT_VALUES_EQUAL(clockCalls, 0);
+        UNIT_ASSERT_VALUES_EQUAL(op.Completions, 1);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Router->GetInflight(), 0);
+    }
+
+    Y_UNIT_TEST(FatalDrainRetiresLateDataAndControlAt199Milliseconds) {
+        for (ui32 phase = 0; phase != 4; ++phase) {
+            TScriptedRouter fixture;
+            fixture.Initialize();
+            TScriptedOp op;
+            char buffer[4096] = {};
+            if (phase < 2) {
+                PrepareWriteOp(op, buffer, sizeof(buffer), 0);
+                UNIT_ASSERT(fixture.Router->Write(&op));
+                if (phase == 1) { fixture.Backend->SubmitResults = {{-EBADF, 0}}; }
+                fixture.Issue();
+            } else {
+                fixture.Backend->HoldControls = true;
+                if (phase == 2) { TUringRouterTestPeer::Park(*fixture.Router); }
+            }
+            fixture.Backend->PeekResults = {-EBADF};
+            if (phase != 3) { TUringRouterTestPeer::Reap(*fixture.Router); }
+            unsigned elapsed = 0;
+            bool deadlineStarted = false;
+            fixture.Backend->Clock = [&] {
+                deadlineStarted = true;
+                return std::chrono::steady_clock::time_point{} + std::chrono::milliseconds(elapsed);
+            };
+            bool retired = false;
+            fixture.Backend->OnBackoff = [&] {
+                if (!deadlineStarted) { return; }
+                if (std::exchange(retired, true)) { return; }
+                elapsed = 199;
+                if (phase == 1) {
+                    fixture.Backend->ConsumePublished(TUringRouterTestPeer::Ready(*fixture.Router));
+                }
+                if (phase < 2) {
+                    fixture.Backend->Complete(op, sizeof(buffer));
+                } else {
+                    const auto& marker = fixture.Backend->Stats->Consumed.back().Sqe;
+                    fixture.Backend->PushCqe(marker.user_data, phase == 2 ? POLLIN : 0);
+                }
+            };
+            fixture.Router->StopAsync();
+            TUringRouterTestPeer::Stop(*fixture.Router);
+            UNIT_ASSERT(retired);
+            UNIT_ASSERT_VALUES_EQUAL(elapsed, 199);
+            UNIT_ASSERT_VALUES_EQUAL(op.Completions, phase < 2 ? 1 : 0);
+            UNIT_ASSERT_VALUES_EQUAL(fixture.Router->GetInflight(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(TUringRouterTestPeer::Ready(*fixture.Router), 0);
+        }
+    }
+
     Y_UNIT_TEST(IssuerRetriesWithoutNewIngressAndBacksOffUntilProgress) {
         auto backend = std::make_unique<TScriptedUringBackend>();
         auto stats = backend->Stats;


### PR DESCRIPTION
- Drain DDisk and PB before reporting Gone; handle session loss, repeated poison, child nondelivery, deferred rejection and fallback replies safely.
- Gate PDisk restarts on concrete DDisk incarnations, including deleted slots; track restart phases, coalesce config changes and cancel on removal.
- Fail PB recovery safely on read errors and account late completions without parsing payloads or publishing readiness.
- Limit critical overload retries to 20 resubmissions with capped exponential backoff, actor-owned cancellation and balanced accounting.
- Retire the router synchronously before releasing PDisk ownership; fence publishers and concurrent stops and release the device lock even when clients retain router references.
- Preserve indefinite normal drains; abort unresolved fatal router teardown after 200 ms and forced actor callback retirement after 60 seconds.
- Give sample callbacks shared ownership of their aggregator.
- Add shutdown, retry, recovery and concurrency regression coverage; update drain diagnostics and shutdown/ownership documentation.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
