### PR TITLE
[PQ] Do not abort GetWriteTimeEstimate on empty compaction zone (YDBBUGS-824)

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1499,14 +1499,19 @@ const TPartitionBlobEncoder& TPartition::GetBlobEncoder(ui64 offset) const
         offset = BlobEncoder.StartOffset;
     }
 
-    if (BlobEncoder.DataKeysBody.empty()) {
-        return CompactionBlobEncoder;
+    // Fast-write body may be empty after compaction while HeadKeys still hold data.
+    // Falling back to the compacted zone in that case picks an empty container and
+    // crashes GetWriteTimeEstimate (YDBBUGS-824).
+    std::tuple<ui64, ui16> fastWriteStart{Max<ui64>(), 0};
+    if (!BlobEncoder.DataKeysBody.empty()) {
+        const auto& key = BlobEncoder.DataKeysBody.front().Key;
+        fastWriteStart = {key.GetOffset(), key.GetPartNo()};
+    } else if (!BlobEncoder.HeadKeys.empty()) {
+        const auto& key = BlobEncoder.HeadKeys.front().Key;
+        fastWriteStart = {key.GetOffset(), key.GetPartNo()};
     }
 
-    const auto required = std::make_tuple(offset, 0);
-    const auto& key = BlobEncoder.DataKeysBody.front().Key;
-    const auto fastWriteStart = std::make_tuple(key.GetOffset(), key.GetPartNo());
-
+    const auto required = std::make_tuple(offset, ui16(0));
     if (required < fastWriteStart) {
         return CompactionBlobEncoder;
     }
@@ -1516,7 +1521,13 @@ const TPartitionBlobEncoder& TPartition::GetBlobEncoder(ui64 offset) const
 
 const std::deque<TDataKey>& GetContainer(const TPartitionBlobEncoder& zone, ui64 offset)
 {
-    return zone.PositionInBody(offset, 0) ? zone.DataKeysBody : zone.HeadKeys;
+    if (zone.PositionInBody(offset, 0) && !zone.DataKeysBody.empty()) {
+        return zone.DataKeysBody;
+    }
+    if (!zone.HeadKeys.empty()) {
+        return zone.HeadKeys;
+    }
+    return zone.DataKeysBody;
 }
 
 //zero means no such record
@@ -1528,26 +1539,39 @@ TInstant TPartition::GetWriteTimeEstimate(ui64 offset) const {
         return TInstant::Zero();
     }
 
-    const TPartitionBlobEncoder& blobEncoder = GetBlobEncoder(offset);
-    offset = Max(offset, blobEncoder.StartOffset);
-    const std::deque<TDataKey>& container = GetContainer(blobEncoder, offset);
-    PQ_ENSURE(!container.empty())
-        ("offset", offset)
-        ("cz.StartOffset", CompactionBlobEncoder.StartOffset)("cz.EndOffset", CompactionBlobEncoder.EndOffset)
-        ("fwz.StartOffset", BlobEncoder.StartOffset)("fwz.EndOffset", BlobEncoder.EndOffset)
-        ;
+    const TPartitionBlobEncoder* blobEncoder = &GetBlobEncoder(offset);
+    if (blobEncoder->IsEmpty()) {
+        blobEncoder = (blobEncoder == &CompactionBlobEncoder) ? &BlobEncoder : &CompactionBlobEncoder;
+    }
+    offset = Max(offset, blobEncoder->StartOffset);
+    if (blobEncoder->IsEmpty()) {
+        return TInstant::Zero();
+    }
+
+    // Mirroring / retention can leave a hole before the first key while StartOffset
+    // still points at the beginning of the zone. Snap to the first actual blob so
+    // upper_bound has a key at or before the requested offset (YDBBUGS-824).
+    const ui64 firstKeyOffset = !blobEncoder->DataKeysBody.empty()
+        ? blobEncoder->DataKeysBody.front().Key.GetOffset()
+        : blobEncoder->HeadKeys.front().Key.GetOffset();
+    offset = Max(offset, firstKeyOffset);
+    if (offset >= GetEndOffset()) {
+        return TInstant::Zero();
+    }
+
+    const std::deque<TDataKey>& container = GetContainer(*blobEncoder, offset);
+    if (container.empty()) {
+        return TInstant::Zero();
+    }
 
     auto it = std::upper_bound(container.begin(), container.end(), offset,
                     [](const ui64 offset, const TDataKey& p) {
                         return offset < p.Key.GetOffset() ||
                                         offset == p.Key.GetOffset() && p.Key.GetPartNo() > 0;
                     });
-    // Always greater
-    PQ_ENSURE(it != container.begin())
-        ("StartOffset", blobEncoder.StartOffset)("HeadOffset", blobEncoder.Head.Offset)
-        ("offset", offset)
-        ("containter size", container.size())("first-elem", container.front().Key.ToString())
-        ("is-fast-write", blobEncoder.ForFastWrite);
+    if (it == container.begin()) {
+        return it->Timestamp;
+    }
     PQ_ENSURE(it == container.end() ||
                    offset < it->Key.GetOffset() ||
                    it->Key.GetOffset() == offset && it->Key.GetPartNo() > 0);

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -7278,10 +7278,14 @@ void AddBodyKeyToEncoder(
     TPartitionBlobEncoder& encoder,
     const TPartitionId& partitionId,
     ui64 offset,
-    ui32 size)
+    ui32 size,
+    TInstant timestamp = TInstant::MilliSeconds(1),
+    ui16 partNo = 0,
+    ui32 count = 1,
+    ui16 internalPartsCount = 0)
 {
-    const TKey key = TKey::ForBody(TKeyPrefix::TypeData, partitionId, offset, 0, 1, 0);
-    encoder.DataKeysBody.push_back(TDataKey{key, size, TInstant::MilliSeconds(1), 0, MakeTestBlobKeyToken()});
+    const TKey key = TKey::ForBody(TKeyPrefix::TypeData, partitionId, offset, partNo, count, internalPartsCount);
+    encoder.DataKeysBody.push_back(TDataKey{key, size, timestamp, 0, MakeTestBlobKeyToken()});
     encoder.BodySize += size;
 }
 
@@ -7293,7 +7297,8 @@ void AddHeadKeyWithPartNo(
     ui16 partNo,
     char fill,
     ui64 seqNo,
-    ui32 levelIndex = 0)
+    ui32 levelIndex = 0,
+    TInstant timestamp = TInstant::MilliSeconds(1))
 {
     std::deque<TClientBlob> dq;
     dq.push_back(MakeSinglePartBodyReadBlob(seqNo, fill));
@@ -7309,10 +7314,23 @@ void AddHeadKeyWithPartNo(
         }
     }
     encoder.DataKeysHead[levelIndex].AddKey(key, blobSize);
-    encoder.HeadKeys.push_back(TDataKey{key, blobSize, TInstant::MilliSeconds(1), 0, MakeTestBlobKeyToken()});
+    encoder.HeadKeys.push_back(TDataKey{key, blobSize, timestamp, 0, MakeTestBlobKeyToken()});
     encoder.Head.AddBatch(batch);
     encoder.Head.Offset = offset;
     encoder.Head.PartNo = partNo;
+}
+
+void SetEncoderRange(TPartitionBlobEncoder& encoder, ui64 startOffset, ui64 endOffset) {
+    encoder.StartOffset = startOffset;
+    encoder.EndOffset = endOffset;
+    encoder.Head.Offset = endOffset;
+    encoder.Head.PartNo = 0;
+}
+
+void ClearEncoderKeys(TPartitionBlobEncoder& encoder) {
+    encoder.DataKeysBody.clear();
+    encoder.HeadKeys.clear();
+    encoder.BodySize = 0;
 }
 
 Y_UNIT_TEST_F(GetCompactionZoneEmptyStartOffsetUsesFwzBodyStart, TPartitionFixture) {
@@ -7486,6 +7504,228 @@ Y_UNIT_TEST_F(GetWriteTimeEstimateReturnsTimestampFromBodyKeys, TPartitionFixtur
     const TInstant ts = TPartitionTestWrapper::GetWriteTimeEstimate(*partition, begin);
     UNIT_ASSERT_GT(ts, TInstant::Zero());
     UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetWriteTimeEstimate(*partition, end), TInstant::Zero());
+}
+
+Y_UNIT_TEST_F(GetWriteTimeEstimateEmptyCompactionZoneUsesFastWriteHead, TPartitionFixture) {
+    // YDBBUGS-824: compacted zone reports [0, End) with no keys after body compaction,
+    // fast-write zone keeps data only in HeadKeys. GetWriteTimeEstimate used to pick the
+    // empty compacted zone because BlobEncoder.DataKeysBody was empty and abort.
+    UNIT_ASSERT(Ctx.Defined());
+
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+    const TPartitionId partitionId(1);
+
+    constexpr ui64 compactedEnd = 273561;
+    constexpr ui64 fastWriteEnd = 282336;
+    constexpr ui64 laggingOffset = 272449;
+    const TInstant headTs = TInstant::MilliSeconds(42);
+
+    auto& cz = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    ClearEncoderKeys(cz);
+    SetEncoderRange(cz, 0, compactedEnd);
+
+    auto& fwz = TPartitionTestWrapper::BlobEncoder(*partition);
+    ClearEncoderKeys(fwz);
+    SetEncoderRange(fwz, compactedEnd, fastWriteEnd);
+    AddHeadKeyWithPartNo(fwz, 8_MB, partitionId, compactedEnd, 0, 'm', 1, 0, headTs);
+
+    UNIT_ASSERT(cz.IsEmpty());
+    UNIT_ASSERT(!fwz.IsEmpty());
+    UNIT_ASSERT(fwz.DataKeysBody.empty());
+    UNIT_ASSERT(!fwz.HeadKeys.empty());
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        TPartitionTestWrapper::GetWriteTimeEstimate(*partition, laggingOffset), headTs);
+    UNIT_ASSERT_VALUES_EQUAL(
+        TPartitionTestWrapper::GetWriteTimeEstimate(*partition, compactedEnd), headTs);
+    UNIT_ASSERT_VALUES_EQUAL(
+        TPartitionTestWrapper::GetWriteTimeEstimate(*partition, fastWriteEnd), TInstant::Zero());
+}
+
+Y_UNIT_TEST_F(GetWriteTimeEstimateSnapsAcrossGapBeforeFirstCompactedKey, TPartitionFixture) {
+    // YDBBUGS-824 / #27934: mirroring leaves a hole before the first compacted blob while
+    // CompactionBlobEncoder.StartOffset stays 0. Offset inside the hole must not abort.
+    UNIT_ASSERT(Ctx.Defined());
+
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+    const TPartitionId partitionId(1);
+
+    constexpr ui64 firstCompactedOffset = 273000;
+    constexpr ui64 compactedEnd = 273561;
+    constexpr ui64 fastWriteEnd = 282336;
+    constexpr ui64 offsetInGap = 272449;
+    const TInstant compactedTs = TInstant::MilliSeconds(11);
+    const TInstant fastWriteTs = TInstant::MilliSeconds(22);
+
+    auto& cz = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    ClearEncoderKeys(cz);
+    SetEncoderRange(cz, 0, compactedEnd);
+    AddBodyKeyToEncoder(cz, partitionId, firstCompactedOffset, 1000, compactedTs);
+
+    auto& fwz = TPartitionTestWrapper::BlobEncoder(*partition);
+    ClearEncoderKeys(fwz);
+    SetEncoderRange(fwz, compactedEnd, fastWriteEnd);
+    AddBodyKeyToEncoder(fwz, partitionId, compactedEnd, 1000, fastWriteTs);
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        TPartitionTestWrapper::GetWriteTimeEstimate(*partition, offsetInGap), compactedTs);
+}
+
+Y_UNIT_TEST_F(GetWriteTimeEstimateGapBetweenZonesUsesFastWriteStart, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+    const TPartitionId partitionId(1);
+
+    constexpr ui64 compactedEnd = 200;
+    constexpr ui64 fastWriteStart = 300;
+    constexpr ui64 fastWriteEnd = 400;
+    const TInstant compactedTs = TInstant::MilliSeconds(11);
+    const TInstant fastWriteTs = TInstant::MilliSeconds(22);
+
+    auto& cz = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    ClearEncoderKeys(cz);
+    SetEncoderRange(cz, 0, compactedEnd);
+    AddBodyKeyToEncoder(cz, partitionId, 100, 1000, compactedTs);
+
+    auto& fwz = TPartitionTestWrapper::BlobEncoder(*partition);
+    ClearEncoderKeys(fwz);
+    SetEncoderRange(fwz, fastWriteStart, fastWriteEnd);
+    AddBodyKeyToEncoder(fwz, partitionId, fastWriteStart, 1000, fastWriteTs);
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 250), fastWriteTs);
+}
+
+Y_UNIT_TEST_F(GetWriteTimeEstimateEmptyZonesReturnsZero, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+
+    auto& cz = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    ClearEncoderKeys(cz);
+    SetEncoderRange(cz, 0, 273561);
+
+    auto& fwz = TPartitionTestWrapper::BlobEncoder(*partition);
+    ClearEncoderKeys(fwz);
+    SetEncoderRange(fwz, 273561, 282336);
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 272449), TInstant::Zero());
+}
+
+Y_UNIT_TEST_F(GetWriteTimeEstimateCompactionHeadOnlyGapBeforeHead, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+    const TPartitionId partitionId(1);
+
+    constexpr ui64 headOffset = 273000;
+    constexpr ui64 compactedEnd = 273561;
+    constexpr ui64 fastWriteEnd = 282336;
+    const TInstant headTs = TInstant::MilliSeconds(17);
+    const TInstant fastWriteTs = TInstant::MilliSeconds(33);
+
+    auto& cz = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    ClearEncoderKeys(cz);
+    SetEncoderRange(cz, 0, compactedEnd);
+    AddHeadKeyWithPartNo(cz, 8_MB, partitionId, headOffset, 0, 'h', 1, 0, headTs);
+
+    auto& fwz = TPartitionTestWrapper::BlobEncoder(*partition);
+    ClearEncoderKeys(fwz);
+    SetEncoderRange(fwz, compactedEnd, fastWriteEnd);
+    AddBodyKeyToEncoder(fwz, partitionId, compactedEnd, 1000, fastWriteTs);
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 272449), headTs);
+}
+
+Y_UNIT_TEST_F(GetWriteTimeEstimateNativeSmallAndKafkaBatch, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+    const TPartitionId partitionId(1);
+    const TInstant smallTs = TInstant::MilliSeconds(5);
+    const TInstant batchTs = TInstant::MilliSeconds(7);
+
+    auto& cz = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    auto& fwz = TPartitionTestWrapper::BlobEncoder(*partition);
+
+    ClearEncoderKeys(cz);
+    SetEncoderRange(cz, 0, 1);
+    AddBodyKeyToEncoder(cz, partitionId, 0, 100, smallTs, 0, 1);
+    ClearEncoderKeys(fwz);
+    SetEncoderRange(fwz, 1, 1);
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 0), smallTs);
+
+    ClearEncoderKeys(cz);
+    SetEncoderRange(cz, 10, 20);
+    AddBodyKeyToEncoder(cz, partitionId, 10, 1000, batchTs, 0, 10);
+    ClearEncoderKeys(fwz);
+    SetEncoderRange(fwz, 20, 20);
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 10), batchTs);
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 15), batchTs);
+}
+
+Y_UNIT_TEST_F(GetWriteTimeEstimateLargeMessagePartsInOneBlob, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+    const TPartitionId partitionId(1);
+    const TInstant ts = TInstant::MilliSeconds(9);
+
+    auto& cz = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    ClearEncoderKeys(cz);
+    SetEncoderRange(cz, 0, 1);
+    AddBodyKeyToEncoder(cz, partitionId, 0, 600_KB, ts, 0, 1, /*internalPartsCount=*/3);
+
+    auto& fwz = TPartitionTestWrapper::BlobEncoder(*partition);
+    ClearEncoderKeys(fwz);
+    SetEncoderRange(fwz, 1, 1);
+
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 0), ts);
+}
+
+Y_UNIT_TEST_F(GetWriteTimeEstimateLargeMessagePartsAcrossBlobs, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+    const TPartitionId partitionId(1);
+    const TInstant firstPartTs = TInstant::MilliSeconds(3);
+    const TInstant secondPartTs = TInstant::MilliSeconds(4);
+
+    auto& cz = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    ClearEncoderKeys(cz);
+    SetEncoderRange(cz, 0, 1);
+    AddBodyKeyToEncoder(cz, partitionId, 0, 300_KB, firstPartTs, 0, 1, 1);
+    AddBodyKeyToEncoder(cz, partitionId, 0, 300_KB, secondPartTs, 1, 1, 0);
+
+    auto& fwz = TPartitionTestWrapper::BlobEncoder(*partition);
+    ClearEncoderKeys(fwz);
+    SetEncoderRange(fwz, 1, 1);
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 0), firstPartTs);
+}
+
+Y_UNIT_TEST_F(GetWriteTimeEstimateFirstKeyWithPartNoDoesNotAbort, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+    const TPartitionId partitionId(1);
+    const TInstant ts = TInstant::MilliSeconds(8);
+
+    auto& cz = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    ClearEncoderKeys(cz);
+    SetEncoderRange(cz, 0, 273561);
+
+    auto& fwz = TPartitionTestWrapper::BlobEncoder(*partition);
+    ClearEncoderKeys(fwz);
+    SetEncoderRange(fwz, 273561, 282336);
+    AddHeadKeyWithPartNo(fwz, 8_MB, partitionId, 273561, 2, 'm', 1, 0, ts);
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 272449), ts);
 }
 
 Y_UNIT_TEST_F(GetClientOffsetSurvivesInitWithMetaButNoDataKeys, TPartitionFixture) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed a crash of a topic partition tablet: estimating a consumer write timestamp no longer aborts the process when the compacted zone has no keys or the offset sits in a gap.

### Description for reviewers <!-- (optional) description for those who read this PR -->

[YDBBUGS-824](https://st.yandex-team.ru/YDBBUGS-824)

`GetWriteTimeEstimate` is used from consumer snapshots / `ReportCounters`. After body compaction the fast-write zone may keep data only in `HeadKeys`, while the compacted zone still reports a non-empty offset range with no keys. `GetBlobEncoder` treated empty `DataKeysBody` as “everything is in the compacted zone”, `GetContainer` returned an empty deque, and `PQ_ENSURE(!container.empty())` killed the kikimr process (`verification=!container.empty()`).

The same abort happened for mirroring/retention holes: the requested offset is before the first actual key, so `PositionInBody` selected an empty container.

Changes:
- Choose the fast-write zone by the first body **or** head key, not only `DataKeysBody`.
- If the chosen zone is empty, fall back to the other zone.
- Snap the offset to the first real key; if there is still nothing to estimate, return `TInstant::Zero()` instead of aborting.

Unit tests cover the crash layout, gaps before the first compacted key / between zones / before compaction head, empty zones, native vs Kafka batch keys, large-message parts in one blob and across blobs, and a first key with `PartNo > 0`.