### PR TITLE
Allow gtest tests with TTestActorRuntime

### DIFF
--- a/library/cpp/testing/common/network.cpp
+++ b/library/cpp/testing/common/network.cpp
@@ -16,6 +16,7 @@
 #include <util/system/error.h>
 #include <util/system/file_lock.h>
 #include <util/system/fs.h>
+#include <util/system/mutex.h>
 #include <util/system/sysstat.h>
 
 #ifdef _darwin_
@@ -103,10 +104,10 @@ namespace {
         return ranges;
     }
 
-    class TPortManager {
+    class TPortAllocator {
         static constexpr size_t Retries = 20;
     public:
-        TPortManager()
+        TPortAllocator()
         {
             InitFromEnv();
         }
@@ -222,23 +223,88 @@ namespace {
 
 namespace NTesting {
     void InitPortManagerFromEnv() {
-        Singleton<TPortManager>()->InitFromEnv();
+        Singleton<TPortAllocator>()->InitFromEnv();
     }
 
     TPortHolder GetFreePort() {
-        return Singleton<TPortManager>()->GetFreePort();
+        return Singleton<TPortAllocator>()->GetFreePort();
     }
 
     namespace NLegacy {
         TPortHolder GetPort( ui16 port ) {
-            return Singleton<TPortManager>()->GetPort(port);
+            return Singleton<TPortAllocator>()->GetPort(port);
         }
         TVector<TPortHolder> GetFreePortsRange(size_t count) {
-            return Singleton<TPortManager>()->GetFreePortsRange(count);
+            return Singleton<TPortAllocator>()->GetFreePortsRange(count);
         }
     }
 
     IOutputStream& operator<<(IOutputStream& out, const TPortHolder& port) {
         return out << static_cast<ui16>(port);
+    }
+
+    class TPortManager::TImpl {
+    public:
+        TImpl()
+            : DisableRandomPorts_(!GetEnv("NO_RANDOM_PORTS").empty())
+        {
+        }
+
+        ui16 GetPort(ui16 port) {
+            if (port && DisableRandomPorts_) {
+                return port;
+            }
+
+            TPortHolder holder = GetFreePort();
+            const ui16 result = holder;
+
+            TGuard<TMutex> guard(Lock_);
+            Ports_.push_back(std::move(holder));
+            return result;
+        }
+
+        ui16 GetPortsRange(ui16 startPort, ui16 range) {
+            Y_UNUSED(startPort);
+            auto ports = NLegacy::GetFreePortsRange(range);
+            const ui16 first = ports.front();
+
+            TGuard<TMutex> guard(Lock_);
+            for (auto& port : ports) {
+                Ports_.push_back(std::move(port));
+            }
+            return first;
+        }
+
+    private:
+        TMutex Lock_;
+        TVector<TPortHolder> Ports_;
+        const bool DisableRandomPorts_;
+    };
+
+    TPortManager::TPortManager()
+        : Impl_(MakeHolder<TImpl>())
+    {
+    }
+
+    TPortManager::~TPortManager() = default;
+
+    ui16 TPortManager::GetPort(ui16 port) {
+        return Impl_->GetPort(port);
+    }
+
+    ui16 TPortManager::GetTcpPort(ui16 port) {
+        return Impl_->GetPort(port);
+    }
+
+    ui16 TPortManager::GetUdpPort(ui16 port) {
+        return Impl_->GetPort(port);
+    }
+
+    ui16 TPortManager::GetTcpAndUdpPort(ui16 port) {
+        return Impl_->GetPort(port);
+    }
+
+    ui16 TPortManager::GetPortsRange(ui16 startPort, ui16 range) {
+        return Impl_->GetPortsRange(startPort, range);
     }
 }

--- a/library/cpp/testing/common/network.h
+++ b/library/cpp/testing/common/network.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <util/generic/noncopyable.h>
 #include <util/generic/ptr.h>
 #include <util/generic/vector.h>
 
@@ -28,6 +29,36 @@ namespace NTesting {
     };
 
     IOutputStream& operator<<(IOutputStream& out, const TPortHolder& port);
+
+    // Holds every port it hands out until the manager itself is destroyed.
+    //
+    // Unlike the legacy ::TPortManager from library/cpp/testing/unittest, this
+    // class has no test framework dependencies, so it may be used from gtest
+    // binaries as well. The legacy one additionally releases ports as soon as
+    // the running unittest test case ends, which requires the unittest runtime.
+    class TPortManager: public TNonCopyable {
+    public:
+        TPortManager();
+        ~TPortManager();
+
+        // Gets free TCP port
+        ui16 GetPort(ui16 port = 0);
+
+        // Gets free TCP port
+        ui16 GetTcpPort(ui16 port = 0);
+
+        // Gets free UDP port
+        ui16 GetUdpPort(ui16 port = 0);
+
+        // Gets one free port for use in both TCP and UDP protocols
+        ui16 GetTcpAndUdpPort(ui16 port = 0);
+
+        ui16 GetPortsRange(ui16 startPort, ui16 range);
+
+    private:
+        class TImpl;
+        THolder<TImpl> Impl_;
+    };
 
     //@brief Get first free port.
     [[nodiscard]] TPortHolder GetFreePort();

--- a/library/cpp/testing/common/ut/network_ut.cpp
+++ b/library/cpp/testing/common/ut/network_ut.cpp
@@ -109,6 +109,60 @@ TEST_F(NetworkTest, GetPortNonRandom) {
     }
 }
 
+TEST_F(NetworkTest, PortManagerHoldsPortsUntilDestroyed) {
+    NTesting::TScopedEnvironment envGuard("PORT_SYNC_PATH", TmpDir->Name());
+    NTesting::InitPortManagerFromEnv();
+
+    ui16 port = 0;
+    ui16 rangeStart = 0;
+    {
+        NTesting::TPortManager portManager;
+        port = portManager.GetPort();
+        rangeStart = portManager.GetPortsRange(0, 3);
+
+        ASSERT_TRUE(NFs::Exists(TmpDir->Path() / ToString(port)));
+        for (ui16 i = 0; i < 3; ++i) {
+            ASSERT_TRUE(NFs::Exists(TmpDir->Path() / ToString(static_cast<ui16>(rangeStart + i))));
+        }
+    }
+
+    ASSERT_FALSE(NFs::Exists(TmpDir->Path() / ToString(port)));
+    for (ui16 i = 0; i < 3; ++i) {
+        ASSERT_FALSE(NFs::Exists(TmpDir->Path() / ToString(static_cast<ui16>(rangeStart + i))));
+    }
+}
+
+TEST_F(NetworkTest, PortManagerIgnoresRequestedPort) {
+    NTesting::TScopedEnvironment envGuard("PORT_SYNC_PATH", TmpDir->Name());
+    NTesting::InitPortManagerFromEnv();
+
+    NTesting::TPortManager portManager;
+    constexpr ui16 requested = 4285;
+    ASSERT_NE(requested, portManager.GetPort(requested));
+}
+
+TEST_F(NetworkTest, PortManagerNonRandom) {
+    NTesting::TScopedEnvironment envGuard{{
+        {"PORT_SYNC_PATH", TmpDir->Name()},
+        {"NO_RANDOM_PORTS", "1"},
+    }};
+    NTesting::InitPortManagerFromEnv();
+
+    NTesting::TPortManager portManager;
+    constexpr ui16 requested = 4285;
+    // The requested port is handed out as is and is not reserved, so that
+    // several managers may ask for the very same port. This matches the legacy
+    // unittest TPortManager, which tests with fixed ports rely upon.
+    ASSERT_EQ(requested, portManager.GetPort(requested));
+    ASSERT_FALSE(NFs::Exists(TmpDir->Path() / ToString(requested)));
+
+    NTesting::TPortManager other;
+    ASSERT_EQ(requested, other.GetPort(requested));
+
+    // A port is still allocated when none was requested.
+    ASSERT_NE(0u, portManager.GetPort());
+}
+
 TEST_F(NetworkTest, Permissions) {
     constexpr ui16 loPort = 3456;
     constexpr ui16 hiPort = 7654;

--- a/ydb/core/client/cancel_tx_ut.cpp
+++ b/ydb/core/client/cancel_tx_ut.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/engine/mkql_engine_flat.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 #include <google/protobuf/text_format.h>
 
 namespace NKikimr {

--- a/ydb/core/client/object_storage_listing_ut.cpp
+++ b/ydb/core/client/object_storage_listing_ut.cpp
@@ -1,6 +1,7 @@
 #include "flat_ut_client.h"
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 #include <ydb/public/api/protos/draft/ydb_object_storage.pb.h>
 #include <ydb/public/api/grpc/draft/ydb_object_storage_v1.grpc.pb.h>
 #include <ydb/public/api/protos/ydb_table.pb.h>

--- a/ydb/core/fq/libs/checkpoint_storage/ut/gc_ut.cpp
+++ b/ydb/core/fq/libs/checkpoint_storage/ut/gc_ut.cpp
@@ -17,6 +17,7 @@
 
 #include <library/cpp/retry/retry.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <ydb/core/testlib/actor_helpers.h>
 #include <ydb/core/testlib/basics/runtime.h>

--- a/ydb/core/fq/libs/checkpoint_storage/ut/storage_service_ydb_ut.cpp
+++ b/ydb/core/fq/libs/checkpoint_storage/ut/storage_service_ydb_ut.cpp
@@ -15,6 +15,7 @@
 #include <ydb/library/actors/core/scheduler_basic.h>
 #include <library/cpp/retry/retry.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/core/testlib/tablet_helpers.h>

--- a/ydb/core/fq/libs/row_dispatcher/ut/local_leader_election_ut.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/ut/local_leader_election_ut.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/testlib/basics/helpers.h>
 #include <ydb/core/testlib/actor_helpers.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <ydb/core/testlib/test_client.h>
 

--- a/ydb/core/fq/libs/row_dispatcher/ut/row_dispatcher_ut.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/ut/row_dispatcher_ut.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/testlib/basics/helpers.h>
 #include <ydb/core/testlib/actor_helpers.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 #include <ydb/library/yql/providers/pq/gateway/native/yql_pq_gateway.h>
 #include <ydb/core/kqp/federated_query/kqp_federated_query_helpers.h>
 #include <yql/essentials/minikql/invoke_builtins/mkql_builtins.h>

--- a/ydb/core/fq/libs/ydb/ut/ydb_ut.cpp
+++ b/ydb/core/fq/libs/ydb/ut/ydb_ut.cpp
@@ -7,6 +7,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <util/system/env.h>
 #include <ydb/core/testlib/test_client.h>

--- a/ydb/core/grpc_services/tablet/rpc_change_schema_ut.cpp
+++ b/ydb/core/grpc_services/tablet/rpc_change_schema_ut.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/grpc_services/local_rpc/local_rpc.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace NKikimr::NGRpcService {
 

--- a/ydb/core/grpc_services/tablet/rpc_execute_mkql_ut.cpp
+++ b/ydb/core/grpc_services/tablet/rpc_execute_mkql_ut.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/grpc_services/local_rpc/local_rpc.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace NKikimr::NGRpcService {
 

--- a/ydb/core/grpc_services/tablet/rpc_restart_tablet_ut.cpp
+++ b/ydb/core/grpc_services/tablet/rpc_restart_tablet_ut.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/grpc_services/local_rpc/local_rpc.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace NKikimr::NGRpcService {
 

--- a/ydb/core/grpc_streaming/grpc_streaming_ut.cpp
+++ b/ydb/core/grpc_streaming/grpc_streaming_ut.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/testlib/test_client.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::GRPC_SERVER
 

--- a/ydb/core/mind/hive/tenants_ut.cpp
+++ b/ydb/core/mind/hive/tenants_ut.cpp
@@ -7,6 +7,7 @@
 #include <ydb/public/api/grpc/draft/ydb_maintenance_v1.grpc.pb.h>
 #include <ydb/public/api/grpc/ydb_scripting_v1.grpc.pb.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 #include <library/cpp/threading/future/async.h>
 
 #include "ut_common.h"

--- a/ydb/core/mon/mon_audit_ut.cpp
+++ b/ydb/core/mon/mon_audit_ut.cpp
@@ -6,6 +6,7 @@
 #include <library/cpp/http/misc/httpcodes.h>
 #include <library/cpp/http/simple/http_client.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 #include <ydb/library/security/util.h>
 
 namespace NMonitoring::NTests {

--- a/ydb/core/mon/mon_ut.cpp
+++ b/ydb/core/mon/mon_ut.cpp
@@ -6,6 +6,7 @@
 #include <library/cpp/http/misc/httpcodes.h>
 #include <library/cpp/http/simple/http_client.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace NMonitoring::NTests {
 

--- a/ydb/core/quoter/quoter_service_bandwidth_test/server.h
+++ b/ydb/core/quoter/quoter_service_bandwidth_test/server.h
@@ -7,6 +7,7 @@
 #include <util/generic/maybe.h>
 
 #include <atomic>
+#include <library/cpp/testing/common/network.h>
 
 namespace NKikimr {
 
@@ -44,7 +45,7 @@ private:
 
 private:
     const TOptions &Opts;
-    TPortManager PortManager;
+    NTesting::TPortManager PortManager;
     const ui16 MsgBusPort;
     Tests::TServerSettings::TPtr ServerSettings;
 

--- a/ydb/core/quoter/quoter_service_bandwidth_test/ya.make
+++ b/ydb/core/quoter/quoter_service_bandwidth_test/ya.make
@@ -3,6 +3,7 @@ PROGRAM()
 PEERDIR(
     library/cpp/colorizer
     library/cpp/getopt
+    library/cpp/testing/common
     ydb/core/base
     ydb/core/kesus/tablet
     ydb/core/quoter

--- a/ydb/core/quoter/quoter_service_ut.cpp
+++ b/ydb/core/quoter/quoter_service_ut.cpp
@@ -13,6 +13,7 @@
 #include <ydb/library/ydb_issue/proto/issue_id.pb.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <util/system/compiler.h>
 #include <util/system/valgrind.h>

--- a/ydb/core/quoter/ut_helpers.h
+++ b/ydb/core/quoter/ut_helpers.h
@@ -15,6 +15,7 @@
 
 #include <library/cpp/testing/gmock_in_unittest/gmock.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <util/generic/hash_set.h>
 

--- a/ydb/core/security/secure_request_ut.cpp
+++ b/ydb/core/security/secure_request_ut.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/testlib/test_client.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace NKikimr {
 

--- a/ydb/core/security/ut_common.h
+++ b/ydb/core/security/ut_common.h
@@ -4,6 +4,7 @@
 
 #include <ydb/library/testlib/service_mocks/ldap_mock/ldap_defines.h>
 #include <ydb/library/testlib/service_mocks/ldap_mock/simple_server.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace NKikimr {
 

--- a/ydb/core/statistics/ut_common/ut_common.h
+++ b/ydb/core/statistics/ut_common/ut_common.h
@@ -13,6 +13,7 @@
 #include <ydb/core/testlib/test_client.h>
 #include <ydb/library/actors/testlib/test_runtime.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <cmath>
 

--- a/ydb/core/statistics/ut_common/ya.make
+++ b/ydb/core/statistics/ut_common/ya.make
@@ -7,6 +7,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/tx/columnshard/hooks/testing
+    library/cpp/testing/unittest
     ydb/core/testlib
     ydb/core/protos
     ydb/core/statistics

--- a/ydb/core/sys_view/ut_common.h
+++ b/ydb/core/sys_view/ut_common.h
@@ -7,6 +7,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace NKikimr {
 namespace NSysView {

--- a/ydb/core/testlib/actors/gtest/test_runtime_gtest.cpp
+++ b/ydb/core/testlib/actors/gtest/test_runtime_gtest.cpp
@@ -1,0 +1,77 @@
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/event_local.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/hfunc.h>
+
+#include <library/cpp/testing/gtest/gtest.h>
+
+// TTestActorRuntime must stay usable from gtest binaries: they cannot link
+// library/cpp/testing/unittest, because both test frameworks PROVIDES(test_framework).
+
+namespace NKikimr {
+namespace {
+
+    using namespace NActors;
+
+    struct TEvPing: TEventLocal<TEvPing, EventSpaceBegin(TEvents::ES_PRIVATE)> {
+    };
+
+    struct TEvPong: TEventLocal<TEvPong, EventSpaceBegin(TEvents::ES_PRIVATE) + 1> {
+        explicit TEvPong(ui64 value)
+            : Value(value)
+        {
+        }
+
+        const ui64 Value;
+    };
+
+    class TEchoActor: public TActorBootstrapped<TEchoActor> {
+    public:
+        void Bootstrap() {
+            Become(&TThis::StateWork);
+        }
+
+        void Handle(TEvPing::TPtr& ev) {
+            Send(ev->Sender, new TEvPong(ev->Cookie), 0, ev->Cookie);
+        }
+
+        STRICT_STFUNC(StateWork,
+            hFunc(TEvPing, Handle);
+        )
+    };
+
+    TEST(TTestActorRuntimeGTest, DispatchesEvents) {
+        TTestBasicRuntime runtime;
+        TAppPrepare app;
+        app.ClearDomainsAndHive();
+        runtime.Initialize(app.Unwrap());
+
+        const TActorId edge = runtime.AllocateEdgeActor();
+        const TActorId echo = runtime.Register(new TEchoActor);
+
+        constexpr ui64 cookie = 42;
+        // viaActorSystem, so that the event queues behind the Bootstrap one
+        runtime.Send(new IEventHandle(echo, edge, new TEvPing, 0, cookie), 0, true);
+
+        auto pong = runtime.GrabEdgeEvent<TEvPong>(edge);
+        ASSERT_TRUE(pong);
+        ASSERT_EQ(cookie, pong->Get()->Value);
+    }
+
+    TEST(TTestActorRuntimeGTest, ProvidesPortManager) {
+        TTestBasicRuntime runtime;
+        TAppPrepare app;
+        app.ClearDomainsAndHive();
+        runtime.Initialize(app.Unwrap());
+
+        NTesting::TPortManager& portManager = runtime.GetPortManager();
+        const ui16 port = portManager.GetPort();
+        ASSERT_NE(0u, port);
+        ASSERT_NE(port, portManager.GetPort());
+    }
+
+} // anonymous namespace
+} // namespace NKikimr

--- a/ydb/core/testlib/actors/gtest/ya.make
+++ b/ydb/core/testlib/actors/gtest/ya.make
@@ -1,0 +1,15 @@
+GTEST()
+
+SIZE(MEDIUM)
+
+PEERDIR(
+    ydb/core/testlib/basics/default
+)
+
+SRCS(
+    test_runtime_gtest.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/testlib/actors/test_runtime.cpp
+++ b/ydb/core/testlib/actors/test_runtime.cpp
@@ -61,8 +61,7 @@ namespace NActors {
     }
 
     TTestActorRuntime::TTestActorRuntime(THeSingleSystemEnv d)
-        : TPortManager(false)
-        , TTestActorRuntimeBase{d}
+        : TTestActorRuntimeBase{d}
     {
         /* How it is possible to do initilization without these components? */
         NKikimr::TAppData::RandomProvider = RandomProvider;
@@ -72,30 +71,26 @@ namespace NActors {
     }
 
     TTestActorRuntime::TTestActorRuntime(ui32 nodeCount, ui32 dataCenterCount, bool useRealThreads, bool useRdmaAllocator)
-        : TPortManager(false)
-        , TTestActorRuntimeBase{nodeCount, dataCenterCount, useRealThreads, useRdmaAllocator}
+        : TTestActorRuntimeBase{nodeCount, dataCenterCount, useRealThreads, useRdmaAllocator}
     {
         Initialize();
     }
 
     TTestActorRuntime::TTestActorRuntime(ui32 nodeCount, ui32 dataCenterCount, bool useRealThreads, NKikimr::NAudit::TAuditLogBackends&& auditLogBackends)
-        : TPortManager(false)
-        , TTestActorRuntimeBase{nodeCount, dataCenterCount, useRealThreads}
+        : TTestActorRuntimeBase{nodeCount, dataCenterCount, useRealThreads}
         , AuditLogBackends(std::move(auditLogBackends))
     {
         Initialize();
     }
 
     TTestActorRuntime::TTestActorRuntime(ui32 nodeCount, ui32 dataCenterCount)
-        : TPortManager(false)
-        , TTestActorRuntimeBase{nodeCount, dataCenterCount}
+        : TTestActorRuntimeBase{nodeCount, dataCenterCount}
     {
         Initialize();
     }
 
     TTestActorRuntime::TTestActorRuntime(ui32 nodeCount, bool useRealThreads)
-        : TPortManager(false)
-        , TTestActorRuntimeBase{nodeCount, useRealThreads}
+        : TTestActorRuntimeBase{nodeCount, useRealThreads}
     {
         Initialize();
     }

--- a/ydb/core/testlib/actors/test_runtime.h
+++ b/ydb/core/testlib/actors/test_runtime.h
@@ -9,7 +9,7 @@
 #include <ydb/core/protos/shared_cache.pb.h>
 
 #include <ydb/library/actors/testlib/test_runtime.h>
-#include <library/cpp/testing/unittest/tests_data.h>
+#include <library/cpp/testing/common/network.h>
 #include <library/cpp/threading/future/future.h>
 
 #include <ydb/core/protos/key.pb.h>
@@ -31,7 +31,7 @@ namespace NActors {
 
 
     class TTestActorRuntime
-        : private TPortManager
+        : private NTesting::TPortManager
         , public TTestActorRuntimeBase
     {
     private:
@@ -118,7 +118,7 @@ namespace NActors {
         NKikimr::TAppData& GetAppData(ui32 nodeIndex = 0);
         ui32 GetFirstNodeId();
 
-        TPortManager& GetPortManager() {
+        NTesting::TPortManager& GetPortManager() {
             return *this;
         }
 

--- a/ydb/core/testlib/actors/ya.make
+++ b/ydb/core/testlib/actors/ya.make
@@ -12,7 +12,7 @@ SRCS(
 PEERDIR(
     ydb/apps/version
     ydb/library/actors/testlib
-    library/cpp/testing/unittest
+    library/cpp/testing/common
     ydb/core/base
     ydb/core/mon
     ydb/core/mon_alloc
@@ -31,5 +31,6 @@ ENDIF()
 END()
 
 RECURSE_FOR_TESTS(
+    gtest
     ut
 )

--- a/ydb/core/testlib/basics/ya.make
+++ b/ydb/core/testlib/basics/ya.make
@@ -9,7 +9,6 @@ SRCS(
 
 PEERDIR(
     library/cpp/regex/pcre
-    library/cpp/testing/unittest
     ydb/core/base
     ydb/core/blobstorage
     ydb/core/blobstorage/crypto

--- a/ydb/core/tx/coordinator/coordinator_ut.cpp
+++ b/ydb/core/tx/coordinator/coordinator_ut.cpp
@@ -6,6 +6,7 @@
 #include <ydb/public/api/grpc/ydb_cms_v1.grpc.pb.h>
 #include <ydb/public/api/grpc/ydb_operation_v1.grpc.pb.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 #include <library/cpp/threading/future/async.h>
 
 // ad-hoc test parametrization support: only for single boolean flag

--- a/ydb/core/tx/coordinator/coordinator_volatile_ut.cpp
+++ b/ydb/core/tx/coordinator/coordinator_volatile_ut.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/core/testlib/test_client.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace NKikimr::NFlatTxCoordinator::NTest {
 

--- a/ydb/core/tx/mediator/mediator_ut.cpp
+++ b/ydb/core/tx/mediator/mediator_ut.cpp
@@ -10,6 +10,7 @@
 #include <ydb/core/testlib/test_client.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace NKikimr::NTxMediator {
 

--- a/ydb/core/tx/replication/service/s3_writer_ut.cpp
+++ b/ydb/core/tx/replication/service/s3_writer_ut.cpp
@@ -11,6 +11,7 @@
 
 #include <library/cpp/string_utils/base64/base64.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <util/string/printf.h>
 

--- a/ydb/core/tx/replication/ut_helpers/test_env.h
+++ b/ydb/core/tx/replication/ut_helpers/test_env.h
@@ -10,6 +10,7 @@
 #include <ydb/public/api/grpc/ydb_auth_v1.grpc.pb.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace NKikimr::NReplication::NTestHelpers {
 

--- a/ydb/core/tx/schemeshard/ut_backup/ut_backup.cpp
+++ b/ydb/core/tx/schemeshard/ut_backup/ut_backup.cpp
@@ -6,6 +6,7 @@
 #include <ydb/library/aws_init/aws.h>
 
 #include <library/cpp/testing/hook/hook.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <util/generic/hash_set.h>
 #include <util/string/cast.h>

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -24,6 +24,7 @@
 #include <ydb/public/lib/value/value.h>
 
 #include <library/cpp/testing/hook/hook.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <ydb/library/testlib/parquet_helpers/parquet_helpers.h>
 

--- a/ydb/core/tx/schemeshard/ut_export_reboots_s3/ut_export_reboots_s3.cpp
+++ b/ydb/core/tx/schemeshard/ut_export_reboots_s3/ut_export_reboots_s3.cpp
@@ -5,6 +5,7 @@
 #include <ydb/library/aws_init/aws.h>
 
 #include <library/cpp/testing/hook/hook.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <util/folder/path.h>
 #include <util/folder/tempdir.h>

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -14,6 +14,7 @@
 #include <ydb/public/api/protos/ydb_import.pb.h>
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 using namespace NKikimr;
 using namespace NSchemeShard;

--- a/ydb/core/tx/tiering/ut/ut_tiers.cpp
+++ b/ydb/core/tx/tiering/ut/ut_tiers.cpp
@@ -21,6 +21,7 @@
 
 #include <library/cpp/protobuf/json/proto2json.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 #include <util/system/hostname.h>
 
 namespace NKikimr {

--- a/ydb/core/tx/time_cast/time_cast_ut.cpp
+++ b/ydb/core/tx/time_cast/time_cast_ut.cpp
@@ -6,6 +6,7 @@
 #include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/core/testlib/test_client.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace NKikimr::NMediatorTimeCastTest {
 

--- a/ydb/core/tx/tx_proxy/schemereq_ut.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq_ut.cpp
@@ -1,4 +1,5 @@
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h>

--- a/ydb/core/wrappers/s3_wrapper_ut.cpp
+++ b/ydb/core/wrappers/s3_wrapper_ut.cpp
@@ -11,6 +11,7 @@
 #include <library/cpp/digest/md5/md5.h>
 #include <library/cpp/testing/hook/hook.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <util/string/printf.h>
 

--- a/ydb/core/ydb_convert/dictionary_feature_flag_ut.cpp
+++ b/ydb/core/ydb_convert/dictionary_feature_flag_ut.cpp
@@ -6,6 +6,7 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/event_local.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace NKikimr {
 

--- a/ydb/core/ymq/actor/cloud_events/cloud_events_ut/cloud_events_ut.cpp
+++ b/ydb/core/ymq/actor/cloud_events/cloud_events_ut/cloud_events_ut.cpp
@@ -2,6 +2,7 @@
 #include <ydb/core/ymq/actor/cloud_events/cloud_events.h>
 #include <ydb/core/testlib/test_client.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace NKikimr::NSQS {
 

--- a/ydb/core/ymq/actor/yc_search_ut/index_events_processor_ut.cpp
+++ b/ydb/core/ymq/actor/yc_search_ut/index_events_processor_ut.cpp
@@ -1,6 +1,7 @@
 #include <ydb/core/testlib/test_client.h>
 #include <ydb/core/ymq/actor/index_events_processor.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 #include <util/stream/file.h>
 #include <library/cpp/json/json_reader.h>
 #include "test_events_writer.h"

--- a/ydb/library/actors/http/http_cache_ut.cpp
+++ b/ydb/library/actors/http/http_cache_ut.cpp
@@ -8,6 +8,7 @@
 
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 namespace {
 

--- a/ydb/library/actors/testlib/test_runtime.h
+++ b/ydb/library/actors/testlib/test_runtime.h
@@ -13,7 +13,6 @@
 #include <ydb/library/actors/interconnect/mock/ic_mock.h>
 #include <library/cpp/random_provider/random_provider.h>
 #include <library/cpp/time_provider/time_provider.h>
-#include <library/cpp/testing/unittest/tests_data.h>
 #include <library/cpp/threading/future/future.h>
 
 #include <util/datetime/base.h>

--- a/ydb/library/ncloud/impl/access_service_ut.cpp
+++ b/ydb/library/ncloud/impl/access_service_ut.cpp
@@ -7,6 +7,7 @@
 #include <ydb/library/grpc/server/grpc_server.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <util/string/builder.h>
 

--- a/ydb/library/table_creator/table_creator_ut.cpp
+++ b/ydb/library/table_creator/table_creator_ut.cpp
@@ -1,6 +1,7 @@
 #include "table_creator.h"
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <ydb/core/testlib/test_client.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>

--- a/ydb/mvp/core/mvp_ut.cpp
+++ b/ydb/mvp/core/mvp_ut.cpp
@@ -8,6 +8,7 @@
 #include <ydb/library/testlib/service_mocks/session_service_mock.h>
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 #include <util/generic/map.h>
 
 using namespace NActors;

--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -16,6 +16,7 @@
 #include <library/cpp/json/json_writer.h>
 #include <library/cpp/string_utils/base64/base64.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 #include <util/generic/map.h>
 
 using namespace NMVP::NOIDC;

--- a/ydb/mvp/oidc_proxy/tokenator_integration_ut.cpp
+++ b/ydb/mvp/oidc_proxy/tokenator_integration_ut.cpp
@@ -6,6 +6,7 @@
 #include <ydb/public/api/client/nc_private/iam/v1/token_exchange_service.grpc.pb.h>
 #include <library/cpp/string_utils/base64/base64.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 using namespace NMVP::NOIDC;
 using namespace NActors;

--- a/ydb/services/metadata/initializer/ut/ut_init.cpp
+++ b/ydb/services/metadata/initializer/ut/ut_init.cpp
@@ -21,6 +21,7 @@
 #include <ydb/library/actors/core/av_bootstrapped.h>
 #include <library/cpp/protobuf/json/proto2json.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <util/system/hostname.h>
 #include <util/system/type_name.h>

--- a/ydb/services/metadata/secret/ut/ut_secret.cpp
+++ b/ydb/services/metadata/secret/ut/ut_secret.cpp
@@ -20,6 +20,7 @@
 #include <ydb/library/actors/core/av_bootstrapped.h>
 #include <library/cpp/protobuf/json/proto2json.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 
 #include <util/system/hostname.h>
 

--- a/ydb/services/workload_manager/ut/query_classifier_ut.cpp
+++ b/ydb/services/workload_manager/ut/query_classifier_ut.cpp
@@ -1,6 +1,7 @@
 #include <fmt/format.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
 #include <ydb/services/workload_manager/events.h>
 #include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/services/workload_manager/query_classifier.h>

--- a/ydb/tests/tools/kqprun/runlib/kikimr_setup.h
+++ b/ydb/tests/tools/kqprun/runlib/kikimr_setup.h
@@ -3,6 +3,7 @@
 #include "settings.h"
 
 #include <library/cpp/logger/backend.h>
+#include <library/cpp/testing/common/network.h>
 
 #include <ydb/core/protos/node_whiteboard.pb.h>
 #include <ydb/core/testlib/test_client.h>
@@ -35,7 +36,7 @@ private:
     void SetFunctionRegistry(const TServerSettings& settings, NKikimr::Tests::TServerSettings& serverSettings) const;
 
 protected:
-    TPortManager PortManager;
+    NTesting::TPortManager PortManager;
 };
 
 }  // namespace NKikimrRun

--- a/ydb/tests/tools/kqprun/runlib/ya.make
+++ b/ydb/tests/tools/kqprun/runlib/ya.make
@@ -11,6 +11,7 @@ PEERDIR(
     library/cpp/getopt
     library/cpp/json
     library/cpp/logger
+    library/cpp/testing/common
     library/cpp/threading/future
     ydb/core/base
     ydb/core/blob_depot

--- a/ydb/tests/tools/kqprun/src/ydb_setup.cpp
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.cpp
@@ -138,7 +138,7 @@ class TYdbSetup::TImpl : public TKikimrSetupBase {
 
     class TPortGenerator {
     public:
-        TPortGenerator(TPortManager& portManager, ui32 firstPort)
+        TPortGenerator(NTesting::TPortManager& portManager, ui32 firstPort)
             : PortManager_(portManager)
             , Port_(firstPort)
         {}
@@ -151,7 +151,7 @@ class TYdbSetup::TImpl : public TKikimrSetupBase {
         }
 
     private:
-        TPortManager& PortManager_;
+        NTesting::TPortManager& PortManager_;
         ui32 Port_;
     };
 


### PR DESCRIPTION
### Description for reviewers 

A gtest binary cannot link library/cpp/testing/unittest: both test frameworks declare PROVIDES(test_framework), so ymake rejects the dependency at configure time. TTestActorRuntime pulled unittest in only for TPortManager, which kept the actor test runtime out of gtest.

Add NTesting::TPortManager to library/cpp/testing/common. It owns every port it hands out until it is destroyed, and has no test framework dependencies. The legacy ::TPortManager stays in unittest: it also releases ports when the running unittest test case ends, which needs the unittest runtime. Semantics otherwise match the legacy one, including returning the requested port as is, unreserved, under NO_RANDOM_PORTS.

TTestActorRuntime used TPortManager(false), so switching it to the new class does not change its behaviour.

Both test_runtime.h headers stopped including tests_data.h, so the files that used to get ::TPortManager through them now include it explicitly. kqprun and quoter_service_bandwidth_test are not tests, so they use NTesting::TPortManager instead of linking a test framework.
