### PR TITLE
Make StageId in TaskGraph unique across transactions

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -659,7 +659,7 @@ private:
             const auto& tx = Request.Transactions[txIdx];
             for (ui32 stageIdx = 0; stageIdx < tx.Body->StagesSize(); ++stageIdx) {
                 const auto& stage = tx.Body->GetStages(stageIdx);
-                auto& stageInfo = TasksGraph.GetStageInfo(TStageId(txIdx, stageIdx));
+                auto& stageInfo = TasksGraph.GetStageInfo(TasksGraph.MakeStageId(txIdx, stageIdx));
 
                 if (stageInfo.Meta.ShardKind == NSchemeCache::ETableKind::KindAsyncIndexTable) {
                     TMaybe<TString> error;

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -573,7 +573,7 @@ protected:
             for (ui32 i = 0; i < tx->ResultsSize(); ++i) {
                 const auto& result = tx->GetResults(i);
                 const auto& connection = result.GetConnection();
-                const auto& inputStageInfo = TasksGraph.GetStageInfo(NYql::NDq::TStageId(txIdx, connection.GetStageIndex()));
+                const auto& inputStageInfo = TasksGraph.GetStageInfo(TasksGraph.MakeStageId(txIdx, connection.GetStageIndex()));
                 if (inputStageInfo.Tasks.size() >= 1) {
                     continue;
                 }

--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
@@ -924,7 +924,7 @@ NDqProto::TDqStageStats* GetOrCreateStageStats(const NYql::NDq::TStageId& stageI
     const TKqpTasksGraph& tasksGraph, NDqProto::TDqExecutionStats& execStats)
 {
     auto& stageInfo = tasksGraph.GetStageInfo(stageId);
-    auto& stageProto = stageInfo.Meta.Tx.Body->GetStages(stageId.StageId);
+    auto& stageProto = stageInfo.Meta.GetStage(stageId);
 
     for (auto& stage : *execStats.MutableStages()) {
         if (stage.GetStageGuid() == stageProto.GetStageGuid()) {
@@ -1014,7 +1014,7 @@ void TQueryExecutionStats::Prepare() {
                 auto& info = TasksGraph->GetStageInfo(stageStats.StageId);
                 auto& stage = info.Meta.GetStage(info.Id);
                 for (const auto& input : stage.GetInputs()) {
-                    auto& peerStageStats = StageStats[NYql::NDq::TStageId(stageStats.StageId.TxId, input.GetStageIndex())];
+                    auto& peerStageStats = StageStats[TasksGraph->MakeStageId(stageStats.StageId.TxId, input.GetStageIndex())];
                     stageStats.InputStages.push_back(&peerStageStats);
                     stageStats.Input.emplace(peerStageStats.StageId.StageId, 0);
                     peerStageStats.OutputStages.push_back(&stageStats);
@@ -1571,15 +1571,10 @@ void TQueryExecutionStats::ExportExecStats(NYql::NDqProto::TDqExecutionStats& st
             THashMap<ui32, NDqProto::TDqStageStats*> protoStages;
 
             for (auto& [stageId, stagetype] : TasksGraph->GetStagesInfo()) {
-                if (stageId.TxId == 0) {
-                    protoStages.emplace(stageId.StageId, GetOrCreateStageStats(stageId, *TasksGraph, stats));
-                }
+                protoStages.emplace(stageId.StageId, GetOrCreateStageStats(stageId, *TasksGraph, stats));
             }
 
             for (auto& [stageId, stageStat] : StageStats) {
-                if (stageStat.StageId.TxId != 0) {
-                    continue;
-                }
                 auto it = protoStages.find(stageStat.StageId.StageId);
                 YQL_ENSURE(it != protoStages.end());
                 auto& stageStats = *it->second;

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -617,14 +617,21 @@ void AddQueryPathParam(TKqpTasksGraph::TTaskType& task, const TIntrusivePtr<NKik
 } // anonymous namespace
 
 void TKqpTasksGraph::FillStages() {
+    // StageIds are numbered continuously across all transactions, so that a stage is identified by its StageId
+    // alone - unlike the tx-local stage indexes used inside the physical plan protobuf.
+    StageIdBases.resize(Transactions.size());
+    ui64 stageIdBase = 0;
+
     for (size_t txIdx = 0; txIdx < Transactions.size(); ++txIdx) {
         const auto& tx = Transactions.at(txIdx);
+        StageIdBases[txIdx] = stageIdBase;
 
         for (ui32 stageIdx = 0; stageIdx < tx.Body->StagesSize(); ++stageIdx) {
             const auto& stage = tx.Body->GetStages(stageIdx);
-            NYql::NDq::TStageId stageId(txIdx, stageIdx);
+            NYql::NDq::TStageId stageId(txIdx, stageIdBase + stageIdx);
 
             TStageInfoMeta meta(tx);
+            meta.StageIdBase = stageIdBase;
 
             ui64 stageSourcesCount = 0;
             for (const auto& source : stage.GetSources()) {
@@ -826,6 +833,8 @@ void TKqpTasksGraph::FillStages() {
 
             YQL_ENSURE(tables.empty() || tables.size() == 1);
         }
+
+        stageIdBase += tx.Body->StagesSize();
     }
 }
 
@@ -833,7 +842,7 @@ void TKqpTasksGraph::BuildResultChannels(const TKqpPhyTxHolder::TConstPtr& tx, u
     for (ui32 i = 0; i < tx->ResultsSize(); ++i) {
         const auto& result = tx->GetResults(i);
         const auto& connection = result.GetConnection();
-        const auto& inputStageInfo = GetStageInfo(TStageId(txIdx, connection.GetStageIndex()));
+        const auto& inputStageInfo = GetStageInfo(MakeStageId(txIdx, connection.GetStageIndex()));
         const auto& outputIdx = connection.GetOutputIndex();
 
         if (inputStageInfo.Tasks.size() < 1) {
@@ -1340,7 +1349,7 @@ void TKqpTasksGraph::BuildKqpStageChannels(TStageInfo& stageInfo, ui64 txId, boo
     if (enableShuffleElimination && !isFusedWithScanStage) { // taskIdHash can be already set if it is a fused stage, so hashpartition will derive columnv1 parameters from there
         for (ui32 inputIndex = 0; inputIndex < stage.InputsSize(); ++inputIndex) {
             const auto& input = stage.GetInputs(inputIndex);
-            auto& originStageInfo = GetStageInfo(NYql::NDq::TStageId(stageInfo.Id.TxId, input.GetStageIndex()));
+            auto& originStageInfo = GetStageInfo(MakeStageId(stageInfo.Id.TxId, input.GetStageIndex()));
             ui32 outputIdx = input.GetOutputIndex();
             columnShardHashV1Params = originStageInfo.Meta.GetColumnShardHashV1Params(outputIdx);
             if (input.GetTypeCase() == NKqpProto::TKqpPhyConnection::kMap || inputIndex == stage.InputsSize() - 1) { // this branch is only for logging purposes
@@ -1399,7 +1408,7 @@ void TKqpTasksGraph::BuildKqpStageChannels(TStageInfo& stageInfo, ui64 txId, boo
     ui64 nextOriginTaskId = 0;
     for (const auto& input : stage.GetInputs()) {
         ui32 inputIdx = input.GetInputIndex();
-        auto& inputStageInfo = GetStageInfo(TStageId(stageInfo.Id.TxId, input.GetStageIndex()));
+        auto& inputStageInfo = GetStageInfo(MakeStageId(stageInfo.Id.TxId, input.GetStageIndex()));
         const auto& outputIdx = input.GetOutputIndex();
 
         switch (input.GetTypeCase()) {
@@ -2380,7 +2389,7 @@ std::pair<ui32, TKqpTasksGraph::TTaskType::ECreateReason> TKqpTasksGraph::GetMax
             result = threads;
         }
     } else if (nodesCount) {
-        const TStagePredictor& predictor = stageInfo.Meta.Tx.Body->GetCalculationPredictor(stageInfo.Id.StageId);
+        const TStagePredictor& predictor = stageInfo.Meta.Tx.Body->GetCalculationPredictor(stageInfo.Meta.GetStageIdx(stageInfo.Id));
         taskReason = TTaskType::LEVEL_PREDICTED; // TODO: need to store also params for predictor
         result = predictor.CalcTasksOptimalCount(TStagePredictor::GetUsableThreads(), previousTasksCount / nodesCount) * nodesCount;
     }
@@ -2412,7 +2421,7 @@ std::pair<ui32, TKqpTasksGraph::TTaskType::ECreateReason> TKqpTasksGraph::GetSca
             taskReason = TTaskType::OLAP_AGGREGATION_SCAN;
             result = AggregationSettings.GetCSScanThreadsPerNode();
         } else {
-            const TStagePredictor& predictor = stageInfo.Meta.Tx.Body->GetCalculationPredictor(stageInfo.Id.StageId);
+            const TStagePredictor& predictor = stageInfo.Meta.Tx.Body->GetCalculationPredictor(stageInfo.Meta.GetStageIdx(stageInfo.Id));
             taskReason = TTaskType::LEVEL_PREDICTED; // TODO: need to store also params for predictor
             result = predictor.CalcTasksOptimalCount(TStagePredictor::GetUsableThreads(), {});
         }
@@ -3484,7 +3493,7 @@ size_t TKqpTasksGraph::BuildAllTasks(std::optional<TLlvmSettings> llvmSettings,
         auto scheduledTaskCount = ScheduleByCost(tx, resourcesSnapshot); // TODO: move inside ReadFromSource()
         for (ui32 stageIdx = 0; stageIdx < tx.Body->StagesSize(); ++stageIdx) {
             const auto& stage = tx.Body->GetStages(stageIdx);
-            auto& stageInfo = GetStageInfo(NYql::NDq::TStageId(txIdx, stageIdx));
+            auto& stageInfo = GetStageInfo(MakeStageId(txIdx, stageIdx));
 
             // TODO: move this check to FillStages() - after all necessary params are set in KqpTasksGraph ctor.
 
@@ -3569,7 +3578,7 @@ size_t TKqpTasksGraph::BuildAllTasks(std::optional<TLlvmSettings> llvmSettings,
         const auto& tx = Transactions.at(txIdx);
         for (ui32 stageIdx = 0; stageIdx < tx.Body->StagesSize(); ++stageIdx) {
             const auto& stage = tx.Body->GetStages(stageIdx);
-            auto& stageInfo = GetStageInfo(NYql::NDq::TStageId(txIdx, stageIdx));
+            auto& stageInfo = GetStageInfo(MakeStageId(txIdx, stageIdx));
 
             switch(stageInfo.Meta.TasksType) {
                 case TStageInfoMeta::SOURCE_TASKS: {
@@ -3648,7 +3657,7 @@ void TKqpTasksGraph::BuildLiteralTasks() {
         const auto& tx = Transactions.at(txIdx);
 
         for (ui32 stageIdx = 0; stageIdx < tx.Body->StagesSize(); ++stageIdx) {
-            auto& stageInfo = GetStageInfo(TStageId(txIdx, stageIdx));
+            auto& stageInfo = GetStageInfo(MakeStageId(txIdx, stageIdx));
 
             YQL_ENSURE(stageInfo.Meta.ShardOperations.empty());
             YQL_ENSURE(stageInfo.InputsCount == 0);
@@ -3754,7 +3763,7 @@ std::vector<std::pair<ui64, i64>> TKqpTasksGraph::BuildInternalSinksPriorityOrde
         const auto& tx = Transactions.at(txIdx);
         for (ui32 stageIdx = 0; stageIdx < tx.Body->StagesSize(); ++stageIdx) {
             const auto& stage = tx.Body->GetStages(stageIdx);
-            const auto& stageInfo = GetStageInfo(NYql::NDq::TStageId(txIdx, stageIdx));
+            const auto& stageInfo = GetStageInfo(MakeStageId(txIdx, stageIdx));
 
             auto addSink = [&stageInfo, &order, txIdx](const NKqpProto::TKqpInternalSink& intSink) {
                 AFL_ENSURE(intSink.GetSettings().Is<NKikimrKqp::TKqpTableSinkSettings>());
@@ -3921,7 +3930,7 @@ void TKqpTasksGraph::CountScanTasksFromSource(TStageInfo& stageInfo, bool limitT
 
     std::list<TStageId> inputs;
     for (const auto& input : stage.GetInputs()) {
-        inputs.emplace_back(stageId.TxId, input.GetStageIndex());
+        inputs.push_back(MakeStageId(stageId.TxId, input.GetStageIndex()));
     }
 
     const auto stageType = stage.GetTaskCount() ? TMaxTasksGraph::FIXED : TMaxTasksGraph::ANY;
@@ -3985,7 +3994,7 @@ void TKqpTasksGraph::CountFullTextScanTasksFromSource(TStageInfo& stageInfo) {
     // TODO: can it have any inputs at all?
     std::list<TStageId> inputs;
     for (const auto& input : stage.GetInputs()) {
-        inputs.emplace_back(stageId.TxId, input.GetStageIndex());
+        inputs.push_back(MakeStageId(stageId.TxId, input.GetStageIndex()));
     }
     MaxTasksGraph->AddStage(stageInfo, TMaxTasksGraph::ANY, inputs);
 
@@ -3999,7 +4008,7 @@ void TKqpTasksGraph::CountSysViewTasksFromSource(TStageInfo& stageInfo) {
     // TODO: can it have any inputs at all?
     std::list<TStageId> inputs;
     for (const auto& input : stage.GetInputs()) {
-        inputs.emplace_back(stageId.TxId, input.GetStageIndex());
+        inputs.push_back(MakeStageId(stageId.TxId, input.GetStageIndex()));
     }
     MaxTasksGraph->AddStage(stageInfo, TMaxTasksGraph::ANY, inputs);
 
@@ -4014,7 +4023,7 @@ void TKqpTasksGraph::CountReadTasksFromSource(TStageInfo& stageInfo, size_t reso
     // TODO: can it have any inputs at all?
     std::list<TStageId> inputs;
     for (const auto& input : stage.GetInputs()) {
-        inputs.emplace_back(stageId.TxId, input.GetStageIndex());
+        inputs.push_back(MakeStageId(stageId.TxId, input.GetStageIndex()));
     }
     MaxTasksGraph->AddStage(stageInfo, TMaxTasksGraph::ANY, inputs);
 
@@ -4047,7 +4056,7 @@ void TKqpTasksGraph::CountSysViewScanTasks(TStageInfo& stageInfo) {
     // TODO: can it have any inputs at all?
     std::list<TStageId> inputs;
     for (const auto& input : stage.GetInputs()) {
-        inputs.emplace_back(stageId.TxId, input.GetStageIndex());
+        inputs.push_back(MakeStageId(stageId.TxId, input.GetStageIndex()));
     }
     MaxTasksGraph->AddStage(stageInfo, TMaxTasksGraph::FIXED, inputs);
 
@@ -4092,7 +4101,7 @@ void TKqpTasksGraph::CountComputeTasks(TStageInfo& stageInfo, const ui32 nodesCo
             }
         }
 
-        const auto& inputStageId = NYql::NDq::TStageId(stageId.TxId, input.GetStageIndex());
+        const auto& inputStageId = MakeStageId(stageId.TxId, input.GetStageIndex());
         inputs.push_back(inputStageId);
 
         auto inputTypeCase = input.GetTypeCase();
@@ -4191,7 +4200,7 @@ void TKqpTasksGraph::CountScanTasksFromShards(TStageInfo& stageInfo, bool enable
     // TODO: can it have any inputs at all?
     std::list<TStageId> inputs;
     for (const auto& input : stage.GetInputs()) {
-        inputs.emplace_back(stageId.TxId, input.GetStageIndex());
+        inputs.push_back(MakeStageId(stageId.TxId, input.GetStageIndex()));
     }
 
     THashMap<ui64 /* nodeId */, ui64> nodeShards;

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -2304,7 +2304,7 @@ void TKqpTasksGraph::RestoreTasksGraphInfo(const TVector<NKikimrKqp::TKqpNodeRes
 
         for (ui64 stageIdx = 0; stageIdx < tx.Body->StagesSize(); ++stageIdx) {
             const auto& stage = tx.Body->GetStages(stageIdx);
-            auto& stageInfo = GetStageInfo({txIdx, stageIdx});
+            auto& stageInfo = GetStageInfo(MakeStageId(txIdx, stageIdx));
 
             if (const auto& sources = stage.GetSources(); !sources.empty() && sources[0].GetTypeCase() == NKqpProto::TKqpSource::kExternalSource) {
                 RestoreReadTasksFromSource(stageInfo, resourcesSnapshot);

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
@@ -77,6 +77,11 @@ struct TColumnShardHashV1Params {
 struct TStageInfoMeta {
     const IKqpGateway::TPhysicalTxData& Tx;
 
+    // The physical plan protobuf numbers stages within each transaction independently, while TStageId::StageId is
+    // unique across the whole tasks graph. This is the StageId of the first stage of this stage's transaction, so
+    // `StageId - StageIdBase` is the index of the stage in Tx.Body.
+    ui64 StageIdBase = 0;
+
     enum ETasksType : ui8 {
         UNKNOWN_TASKS = 0,
         SOURCE_TASKS,
@@ -154,9 +159,16 @@ struct TStageInfoMeta {
         return txBody->GetStages(idx);
     }
 
+    // Index of the stage in Tx.Body, see StageIdBase.
+    template <class TStageIdExt>
+    size_t GetStageIdx(const TStageIdExt& stageId) const {
+        YQL_ENSURE(stageId.StageId >= StageIdBase);
+        return stageId.StageId - StageIdBase;
+    }
+
     template <class TStageIdExt>
     const NKqpProto::TKqpPhyStage& GetStage(const TStageIdExt& stageId) const {
-        return GetStage(stageId.StageId);
+        return GetStage(GetStageIdx(stageId));
     }
 
     bool HasReads() const {
@@ -417,6 +429,18 @@ public:
     TVector<TString> GetStageIntrospection(const NYql::NDq::TStageId& stageId) const;
     TString DumpToString() const;
 
+    // The physical plan protobuf numbers stages within each transaction independently, while TStageId::StageId is
+    // unique across the whole graph (see TStageInfoMeta::StageIdBase). Converts a transaction-local stage index
+    // (NKqpProto::TKqpPhyConnection::StageIndex and the like) into the graph-wide stage id.
+    NYql::NDq::TStageId MakeStageId(ui64 txIdx, ui64 stageIdx) const {
+        return NYql::NDq::TStageId(txIdx, StageIdBases.at(txIdx) + stageIdx);
+    }
+
+    // StageId of the first stage of each transaction, indexed by transaction index.
+    const TVector<ui64>& GetStageIdBases() const {
+        return StageIdBases;
+    }
+
     void FillExternalSourceSecureParams(THashMap<TString, TString>& secureParams, const NKqpProto::TKqpPhyStage& stage) const;
 
 private:
@@ -497,6 +521,7 @@ private:
 
 private:
     const TVector<IKqpGateway::TPhysicalTxData>& Transactions;
+    TVector<ui64> StageIdBases; // filled by FillStages()
     NKikimr::NKqp::TTxAllocatorState::TPtr TxAlloc;
     const NKikimrConfig::TTableServiceConfig::TAggregationConfig AggregationSettings;
     TKqpRequestCounters::TPtr Counters;

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph_ut.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph_ut.cpp
@@ -95,20 +95,28 @@ struct TTaskDistribution {
     // test that means to cover the mapping must require this to be non-zero.
     ui32 ShuffleEliminationOrderSensitiveMappings = 0;
 
+    // StageId of the first stage of each transaction, see TKqpTasksGraph::GetStageIdBases(). The tests address a
+    // stage by its transaction-local index, while the graph keys stages by a graph-wide unique StageId.
+    TVector<ui64> StageIdBases;
+
+    TStageId Key(ui32 txIdx, ui32 stageIdx) const {
+        return TStageId(txIdx, StageIdBases.at(txIdx) + stageIdx);
+    }
+
     ui32 Count(ui32 txIdx = 0, ui32 stageIdx = 0) const {
-        auto it = TasksPerStage.find(TStageId(txIdx, stageIdx));
+        auto it = TasksPerStage.find(Key(txIdx, stageIdx));
         return it != TasksPerStage.end() ? it->second : 0;
     }
 
     // Number of distinct nodes the stage's tasks landed on.
     ui32 NodesUsed(ui32 txIdx = 0, ui32 stageIdx = 0) const {
-        auto it = TasksPerStageNode.find(TStageId(txIdx, stageIdx));
+        auto it = TasksPerStageNode.find(Key(txIdx, stageIdx));
         return it != TasksPerStageNode.end() ? static_cast<ui32>(it->second.size()) : 0;
     }
 
     // Tasks of the stage placed on a given node.
     ui32 OnNode(ui64 nodeId, ui32 txIdx = 0, ui32 stageIdx = 0) const {
-        auto it = TasksPerStageNode.find(TStageId(txIdx, stageIdx));
+        auto it = TasksPerStageNode.find(Key(txIdx, stageIdx));
         if (it == TasksPerStageNode.end()) {
             return 0;
         }
@@ -131,7 +139,7 @@ struct TTaskDistribution {
     // Node-count agnostic, so it stays compact and stable regardless of how many cluster nodes there are.
     THashMap<ui32, ui32> NodeHistogram(ui32 txIdx = 0, ui32 stageIdx = 0) const {
         THashMap<ui32, ui32> histogram;
-        auto it = TasksPerStageNode.find(TStageId(txIdx, stageIdx));
+        auto it = TasksPerStageNode.find(Key(txIdx, stageIdx));
         if (it != TasksPerStageNode.end()) {
             for (const auto& [_, tasks] : it->second) {
                 histogram[tasks]++;
@@ -367,6 +375,7 @@ public:
             {"tasksGraphDump", Graph->DumpToString()});
 
         auto reply = MakeHolder<TEvBuildTasksDone>();
+        reply->Result.StageIdBases = Graph->GetStageIdBases();
         for (const auto& [stageId, stageInfo] : Graph->GetStagesInfo()) {
             reply->Result.TasksPerStage[stageId] = static_cast<ui32>(stageInfo.Tasks.size());
             for (ui64 taskId : stageInfo.Tasks) {


### PR DESCRIPTION
KqpExecuter may execute several computation graphs, placed into separate "transactions" whose stages were enumerated independently, both starting from 0. NYql.NDqProto.TDqStageStats has room only for a flat StageId, so stages of different transactions clashed and ExportExecStats() worked around it by exporting stages of TxId = 0 only.

Number StageIds continuously across all transactions of the graph, so that a stage is identified by its StageId alone - matching the already unique TaskId numbering - and export the stats of every stage.

TKqpTasksGraph::MakeStageId() converts a transaction-local stage index (as stored in the physical plan protobuf) into the graph-wide stage id; TStageInfoMeta::StageIdBase / GetStageIdx() go the other way for the places that index back into the transaction body.

Fixes #52600