### PR TITLE
Fix TEvBlock version handling for compatibility

### DIFF
--- a/ydb/core/base/blobstorage.cpp
+++ b/ydb/core/base/blobstorage.cpp
@@ -121,8 +121,10 @@ std::unique_ptr<TEvBlobStorage::TEvCheckIntegrityResult> TEvBlobStorage::TEvChec
 void TEvBlobStorage::TEvBlock::ToSpan(NWilson::TSpan& span) const {
     span
         .Attribute("TabletId", ::ToString(TabletId))
-        .Attribute("Generation", Generation)
-        .Attribute("Version", Version);
+        .Attribute("Generation", Generation);
+    if (Version) {
+        span.Attribute("Version", *Version);
+    }
 }
 
 std::unique_ptr<TEvBlobStorage::TEvBlockResult> TEvBlobStorage::TEvBlock::MakeErrorResponse(

--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -1486,7 +1486,7 @@ struct TEvBlobStorage {
         const TInstant Deadline;
         const ui64 IssuerGuid = RandomNumber<ui64>() | 1;
         const TWriteSource WriteSource;
-        const ui32 Version;
+        const std::optional<ui32> Version;
         bool IsMonitored = true;
 
         TEvBlock(TCloneEventPolicy, const TEvBlock& origin)
@@ -1501,7 +1501,7 @@ struct TEvBlobStorage {
         {}
 
         TEvBlock(ui64 tabletId, ui32 generation, TInstant deadline,
-                TWriteSource writeSource = UnknownWriteSource(), ui32 version = 0)
+                TWriteSource writeSource = UnknownWriteSource(), std::optional<ui32> version = std::nullopt)
             : TabletId(tabletId)
             , Generation(generation)
             , Deadline(deadline)
@@ -1510,7 +1510,7 @@ struct TEvBlobStorage {
         {}
 
         TEvBlock(ui64 tabletId, ui32 generation, TInstant deadline, ui64 issuerGuid,
-                TWriteSource writeSource = UnknownWriteSource(), ui32 version = 0)
+                TWriteSource writeSource = UnknownWriteSource(), std::optional<ui32> version = std::nullopt)
             : TabletId(tabletId)
             , Generation(generation)
             , Deadline(deadline)
@@ -1523,9 +1523,11 @@ struct TEvBlobStorage {
             Y_UNUSED(isFull);
             TStringStream str;
             str << "TEvBlock {TabletId# " << TabletId
-                << " Generation# " << Generation
-                << " Version# " << Version
-                << " Deadline# " << Deadline.MilliSeconds()
+                << " Generation# " << Generation;
+            if (Version) {
+                str << " Version# " << *Version;
+            }
+            str << " Deadline# " << Deadline.MilliSeconds()
                 << " IsMonitored# " << IsMonitored
                 << "}";
             return str.Str();

--- a/ydb/core/blob_depot/agent/storage_block.cpp
+++ b/ydb/core/blob_depot/agent/storage_block.cpp
@@ -24,7 +24,9 @@ namespace NKikimr::NBlobDepot {
                 block.SetTabletId(Request.TabletId);
                 block.SetBlockedGeneration(Request.Generation);
                 block.SetIssuerGuid(Request.IssuerGuid);
-                block.SetVersion(Request.Version);
+                if (Request.Version) {
+                    block.SetVersion(*Request.Version);
+                }
                 block.SetWriteSourceOp(WriteSourceToProto(Request.WriteSource));
                 Agent.Issue(std::move(block), this, std::make_shared<TBlockContext>(TActivationContext::Monotonic()));
             }

--- a/ydb/core/blob_depot/blocks.cpp
+++ b/ydb/core/blob_depot/blocks.cpp
@@ -10,7 +10,7 @@ namespace NKikimr::NBlobDepot {
         const ui32 BlockedGeneration;
         const ui32 NodeId;
         const ui64 IssuerGuid;
-        const ui32 Version;
+        const std::optional<ui32> Version;
         const TWriteSource WriteSource;
         const TInstant Timestamp;
         std::unique_ptr<IEventHandle> Response;
@@ -20,7 +20,7 @@ namespace NKikimr::NBlobDepot {
         TTxType GetTxType() const override { return NKikimrBlobDepot::TXTYPE_UPDATE_BLOCK; }
 
         TTxUpdateBlock(TBlobDepot *self, ui64 tabletId, ui32 blockedGeneration, ui32 nodeId, ui64 issuerGuid,
-                ui32 version, TWriteSource writeSource, TInstant timestamp, std::unique_ptr<IEventHandle> response)
+                std::optional<ui32> version, TWriteSource writeSource, TInstant timestamp, std::unique_ptr<IEventHandle> response)
             : TTransactionBase(self)
             , TabletId(tabletId)
             , BlockedGeneration(blockedGeneration)
@@ -62,29 +62,32 @@ namespace NKikimr::NBlobDepot {
                         NIceDb::TUpdate<Schema::Blocks::IssuedByNode>(NodeId),
                         NIceDb::TUpdate<Schema::Blocks::IssueTimestamp>(Timestamp));
                 }
-            } else if (Version < block.Version) {
+            } else if (Version && *Version < block.Version) {
                 response.SetStatus(NKikimrProto::ERROR);
                 response.SetErrorReason("obsolete tablet storage info version");
                 response.SetIsTabletStorageInfoVersionObsolete(true);
                 response.SetActualGeneration(block.BlockedGeneration);
             } else if (hasBlock && !block.CanSetNewBlock(BlockedGeneration, IssuerGuid)) {
-                response.SetStatus(Version == block.Version ? NKikimrProto::ALREADY : NKikimrProto::ERROR);
+                response.SetStatus(!Version || *Version == block.Version ? NKikimrProto::ALREADY : NKikimrProto::ERROR);
                 response.SetActualGeneration(block.BlockedGeneration);
-                if (Version > block.Version) {
+                if (Version && *Version > block.Version) {
                     response.SetErrorReason("generation check failed while increasing tablet storage info version");
                 }
             } else {
                 block.BlockedGeneration = BlockedGeneration;
                 block.IssuerGuid = IssuerGuid;
-                block.Version = Version;
                 ProcessBlock = true;
                 db.Table<Schema::Blocks>().Key(tabletId).Update(
                     NIceDb::TUpdate<Schema::Blocks::BlockedGeneration>(BlockedGeneration),
                     NIceDb::TUpdate<Schema::Blocks::IssuerGuid>(IssuerGuid),
                     NIceDb::TUpdate<Schema::Blocks::IssuedByNode>(NodeId),
-                    NIceDb::TUpdate<Schema::Blocks::IssueTimestamp>(Timestamp),
-                    NIceDb::TUpdate<Schema::Blocks::Version>(Version)
+                    NIceDb::TUpdate<Schema::Blocks::IssueTimestamp>(Timestamp)
                 );
+                if (Version) {
+                    block.Version = *Version;
+                    db.Table<Schema::Blocks>().Key(tabletId).Update(
+                        NIceDb::TUpdate<Schema::Blocks::Version>(*Version));
+                }
             }
             return true;
         }
@@ -113,7 +116,7 @@ namespace NKikimr::NBlobDepot {
         const ui32 BlockedGeneration;
         const ui32 NodeId;
         const ui64 IssuerGuid;
-        const ui32 Version;
+        const std::optional<ui32> Version;
         std::unique_ptr<IEventHandle> Response;
         ui32 BlocksPending = 0;
         ui32 RetryCount = 0;
@@ -127,7 +130,7 @@ namespace NKikimr::NBlobDepot {
         }
 
         TBlockProcessorActor(TBlobDepot *self, ui64 tabletId, ui32 blockedGeneration, ui32 nodeId, ui64 issuerGuid,
-                ui32 version, std::unique_ptr<IEventHandle> response)
+                std::optional<ui32> version, std::unique_ptr<IEventHandle> response)
             : Self(self)
             , TabletId(tabletId)
             , BlockedGeneration(blockedGeneration)
@@ -144,7 +147,7 @@ namespace NKikimr::NBlobDepot {
             }
             auto& block = Self->BlocksManager->Blocks[TabletId];
             if (block.BlockedGeneration == BlockedGeneration && block.IssuerGuid == IssuerGuid
-                    && block.Version == Version) {
+                    && (!Version || block.Version == *Version)) {
                 return false;
             } else {
                 auto& r = Response->Get<TEvBlobDepot::TEvBlockResult>()->Record;
@@ -367,7 +370,7 @@ namespace NKikimr::NBlobDepot {
     }
 
     void TBlobDepot::TBlocksManager::OnBlockCommitted(ui64 tabletId, ui32 blockedGeneration, ui32 nodeId,
-            ui64 issuerGuid, ui32 version, std::unique_ptr<IEventHandle> response) {
+            ui64 issuerGuid, std::optional<ui32> version, std::unique_ptr<IEventHandle> response) {
         Self->RegisterWithSameMailbox(new TBlockProcessorActor(Self, tabletId, blockedGeneration, nodeId, issuerGuid,
             version, std::move(response)));
     }
@@ -387,7 +390,8 @@ namespace NKikimr::NBlobDepot {
             const ui64 tabletId = record.GetTabletId();
             TAgent& agent = Self->GetAgent(ev->Recipient);
             Self->Execute(std::make_unique<TTxUpdateBlock>(Self, tabletId, record.GetBlockedGeneration(),
-                agent.Connection->NodeId, record.GetIssuerGuid(), record.GetVersion(), writeSource,
+                agent.Connection->NodeId, record.GetIssuerGuid(),
+                record.HasVersion() ? std::optional<ui32>(record.GetVersion()) : std::nullopt, writeSource,
                 TActivationContext::Now(), std::move(response)));
         }
 

--- a/ydb/core/blob_depot/blocks.h
+++ b/ydb/core/blob_depot/blocks.h
@@ -42,8 +42,8 @@ namespace NKikimr::NBlobDepot {
 
         void AddBlockOnLoad(ui64 tabletId, ui32 blockedGeneration, ui64 issuerGuid, ui32 version);
         void AddBlockOnDecommit(const TEvBlobStorage::TEvAssimilateResult::TBlock& block, NTabletFlatExecutor::TTransactionContext& txc);
-        void OnBlockCommitted(ui64 tabletId, ui32 blockedGeneration, ui32 nodeId, ui64 issuerGuid, ui32 version,
-            std::unique_ptr<IEventHandle> response);
+        void OnBlockCommitted(ui64 tabletId, ui32 blockedGeneration, ui32 nodeId, ui64 issuerGuid,
+            std::optional<ui32> version, std::unique_ptr<IEventHandle> response);
         void Handle(TEvBlobDepot::TEvBlock::TPtr ev);
         void Handle(TEvBlobDepot::TEvQueryBlocks::TPtr ev);
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_block.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_block.cpp
@@ -14,7 +14,7 @@ namespace NKikimr {
 class TBlobStorageGroupBlockRequest : public TBlobStorageGroupRequestActor {
     const ui64 TabletId;
     const ui32 Generation;
-    const ui32 Version;
+    const std::optional<ui32> Version;
     const TInstant Deadline;
     const ui64 IssuerGuid;
     const TWriteSource WriteSource;

--- a/ydb/core/blobstorage/dsproxy/mock/model.h
+++ b/ydb/core/blobstorage/dsproxy/mock/model.h
@@ -242,18 +242,20 @@ namespace NFake {
                     return result.release();
                 }
                 ui32& version = BlockVersions[msg->TabletId];
-                if (msg->Version < version) {
-                    result->Status = NKikimrProto::ERROR;
-                    result->IsTabletStorageInfoVersionObsolete = true;
-                    return result.release();
-                }
-                if (msg->Version > version) {
-                    if (const auto it = Blocks.find(msg->TabletId);
-                            it != Blocks.end() && msg->Generation <= it->second) {
+                if (msg->Version) {
+                    if (*msg->Version < version) {
                         result->Status = NKikimrProto::ERROR;
+                        result->IsTabletStorageInfoVersionObsolete = true;
                         return result.release();
                     }
-                    version = msg->Version;
+                    if (*msg->Version > version) {
+                        if (const auto it = Blocks.find(msg->TabletId);
+                                it != Blocks.end() && msg->Generation <= it->second) {
+                            result->Status = NKikimrProto::ERROR;
+                            return result.release();
+                        }
+                        version = *msg->Version;
+                    }
                 }
             }
 

--- a/ydb/core/blobstorage/ut_blobstorage/blob_depot.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/blob_depot.cpp
@@ -205,6 +205,17 @@ Y_UNIT_TEST_SUITE(BlobDepot) {
         result = block(14, 3);
         UNIT_ASSERT_VALUES_EQUAL(result->Get()->Status, NKikimrProto::ERROR);
         UNIT_ASSERT(result->Get()->IsTabletStorageInfoVersionObsolete);
+
+        env.Runtime->WrapInActorContext(sender, [&] {
+            SendToBSProxy(sender, tenv.BlobDepot, new TEvBlobStorage::TEvBlock(tabletId, 16,
+                TInstant::Max(), issuerGuid));
+        });
+        result = CaptureTEvBlockResult(env, sender, false);
+        UNIT_ASSERT_VALUES_EQUAL(result->Get()->Status, NKikimrProto::OK);
+
+        result = block(17, 3);
+        UNIT_ASSERT_VALUES_EQUAL(result->Get()->Status, NKikimrProto::ERROR);
+        UNIT_ASSERT(result->Get()->IsTabletStorageInfoVersionObsolete);
     }
 
     Y_UNIT_TEST(BasicCollectGarbage) {

--- a/ydb/core/blobstorage/ut_blobstorage/extra_block_checks.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/extra_block_checks.cpp
@@ -60,6 +60,19 @@ Y_UNIT_TEST_SUITE(ExtraBlockChecks) {
         result = block(15, 3);
         UNIT_ASSERT_VALUES_EQUAL(result->Get()->Status, NKikimrProto::ERROR);
         UNIT_ASSERT(result->Get()->IsTabletStorageInfoVersionObsolete);
+
+        // A client that omits Version (an old binary) must still be able to raise the block,
+        // and must not clobber the stored version with 0.
+        runtime->WrapInActorContext(edge, [&] {
+            SendToBSProxy(edge, info->GroupID, new TEvBlobStorage::TEvBlock(tabletId, 16,
+                TInstant::Max(), issuerGuid));
+        });
+        result = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvBlockResult>(edge, false);
+        UNIT_ASSERT_VALUES_EQUAL(result->Get()->Status, NKikimrProto::OK);
+
+        result = block(17, 3);
+        UNIT_ASSERT_VALUES_EQUAL(result->Get()->Status, NKikimrProto::ERROR);
+        UNIT_ASSERT(result->Get()->IsTabletStorageInfoVersionObsolete);
     }
 
     Y_UNIT_TEST(Basic) {

--- a/ydb/core/blobstorage/ut_vdisk/lib/vdisk_mock.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/vdisk_mock.cpp
@@ -348,7 +348,7 @@ public:
         if (!raw) {
             if (!tabletId || tabletId >> 63) {
                 status = NKikimrProto::ERROR;
-            } else {
+            } else if (record.HasVersion()) {
                 const auto versionIt = Blocks.find(~tabletId);
                 const ui32 version = versionIt != Blocks.end() ? versionIt->second : 0;
                 if (record.GetVersion() < version) {

--- a/ydb/core/blobstorage/vdisk/common/vdisk_events.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_events.h
@@ -28,6 +28,7 @@
 
 #include <util/digest/multi.h>
 #include <util/generic/maybe.h>
+#include <optional>
 #include <util/stream/str.h>
 #include <util/string/escape.h>
 #include <util/generic/overloaded.h>
@@ -1913,7 +1914,8 @@ namespace NKikimr {
         {}
 
         TEvVBlock(ui64 tabletId, ui32 generation, const TVDiskID &vdisk, TInstant deadline,
-                TWriteSource writeSource = UnknownWriteSource(), ui64 issuerGuid = 0, ui32 version = 0)
+                TWriteSource writeSource = UnknownWriteSource(), ui64 issuerGuid = 0,
+                std::optional<ui32> version = std::nullopt)
         {
             Record.SetTabletId(tabletId);
             Record.SetGeneration(generation);
@@ -1921,7 +1923,7 @@ namespace NKikimr {
                 Record.SetIssuerGuid(issuerGuid);
             }
             if (version) {
-                Record.SetVersion(version);
+                Record.SetVersion(*version);
             }
             VDiskIDFromVDiskID(vdisk, Record.MutableVDiskID());
             if (deadline != TInstant::Max()) {

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hull.cpp
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hull.cpp
@@ -269,16 +269,19 @@ namespace NKikimr {
             && writeSource != TWriteSource::SkeletonForceBlock;
     }
 
-    THullCheckStatus THull::CheckBlockCmdAndAllocLsn(ui64 tabletID, ui32 gen, ui64 issuerGuid, ui32 version,
+    THullCheckStatus THull::CheckBlockCmdAndAllocLsn(ui64 tabletID, ui32 gen, ui64 issuerGuid, std::optional<ui32> version,
             TWriteSource writeSource, ui32 *actGen, TLsnSeg *seg, bool *versionChanged) {
         const TBlocksCache::TBlockedGen g(gen, issuerGuid);
         auto res = BlocksCache.IsBlocked(tabletID, g, actGen);
 
-        if (ShouldCheckVersion(tabletID, writeSource)) {
+        // A missing Version field is a legacy client that predates TTabletStorageInfo::Version;
+        // those must still be able to boot against a VDisk that already stores a version. An
+        // explicit Version (including 0) is always checked.
+        if (ShouldCheckVersion(tabletID, writeSource) && version) {
             const auto [actualVersion, lsn] = BlocksCache.FindMax(~tabletID);
-            if (version < actualVersion) {
+            if (*version < actualVersion) {
                 return {NKikimrProto::ERROR, "obsolete tablet storage info version", lsn, lsn != 0, true};
-            } else if (actualVersion < version) {
+            } else if (actualVersion < *version) {
                 if (res.Status != TBlocksCache::EStatus::OK) {
                     // the version may only advance along with the block, so reject the whole command
                     return {NKikimrProto::ERROR, "generation check failed while increasing tablet storage info version",
@@ -294,7 +297,7 @@ namespace NKikimr {
                 ? Fields->LsnMngr->AllocDiscreteLsnBatchForHullAndSyncLog(2)
                 : Fields->LsnMngr->AllocLsnForHullAndSyncLog();
             if (*versionChanged) {
-                BlocksCache.UpdateInFlight(~tabletID, {version, 0}, seg->First);
+                BlocksCache.UpdateInFlight(~tabletID, {*version, 0}, seg->First);
             }
             BlocksCache.UpdateInFlight(tabletID, g, seg->Last);
             return {NKikimrProto::OK, "", false};

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hull.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hull.h
@@ -8,6 +8,8 @@
 #include <ydb/core/blobstorage/vdisk/hulldb/bulksst_add/hulldb_bulksst_add.h>
 #include <ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_context.h>
 
+#include <optional>
+
 namespace NKikimr {
 
     class TLsnMngr;
@@ -157,7 +159,7 @@ namespace NKikimr {
                 ui64 tabletID,
                 ui32 gen,
                 ui64 issuerGuid,
-                ui32 version,
+                std::optional<ui32> version,
                 TWriteSource writeSource,
                 ui32 *actGen,
                 TLsnSeg *seg,

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -1225,18 +1225,21 @@ namespace NKikimr {
                 return;
             }
 
+            const std::optional<ui32> version = record.HasVersion()
+                ? std::optional<ui32>(record.GetVersion()) : std::nullopt;
+
             YDB_LOG_DEBUG_CTX_COMP(ctx, BS_VDISK_BLOCK, "TEvVBlock",
                 {"VDiskLogPrefix", VCtx->VDiskLogPrefix},
                 {"tabletId", tabletId},
                 {"gen", gen},
-                {"version", record.GetVersion()},
+                {"version", version},
                 {"marker", "BSVS00"});
 
             TLsnSeg seg;
             ui32 actGen = 0;
             bool versionChanged = false;
             const auto writeSource = WriteSourceFromProto(record.GetWriteSourceOp());
-            auto checkStatus = Hull->CheckBlockCmdAndAllocLsn(tabletId, gen, issuerGuid, record.GetVersion(),
+            auto checkStatus = Hull->CheckBlockCmdAndAllocLsn(tabletId, gen, issuerGuid, version,
                 writeSource, &actGen, &seg, &versionChanged);
             TEvBlobStorage::TEvVBlockResult::TTabletActGen act(tabletId, actGen);
             std::unique_ptr<TEvBlobStorage::TEvVBlockResult> result(CreateResult(VCtx, checkStatus.Status,

--- a/ydb/core/tablet/tablet_req_blockbs_ut.cpp
+++ b/ydb/core/tablet/tablet_req_blockbs_ut.cpp
@@ -27,7 +27,9 @@ Y_UNIT_TEST_SUITE(TBlockBlobStorageTest) {
         auto blockErrors = [&](TAutoPtr<IEventHandle>& ev) {
             switch (ev->GetTypeRewrite()) {
                 case TEvBlobStorage::TEvBlock::EventType: {
-                    UNIT_ASSERT_VALUES_EQUAL(ev->Get<TEvBlobStorage::TEvBlock>()->Version, info->Version);
+                    const auto& version = ev->Get<TEvBlobStorage::TEvBlock>()->Version;
+                    UNIT_ASSERT(version);
+                    UNIT_ASSERT_VALUES_EQUAL(*version, info->Version);
                     break;
                 }
                 case TEvBlobStorage::TEvBlockResult::EventType: {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix TEvBlock version handling for compatibility

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch fixes incorrect behaviour when old clients issue zero Version and it gets misprocessed.
