### PR TITLE
ydb-bench: decouple actor-system vCPUs from CPU affinity

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -432,3 +432,17 @@ Generic configurable summary charts remain available below the baseline table.
 Run manifests use schema version 4. Earlier manifests are intentionally not
 read as resumable results because they lack the immutable step plan and durable
 per-step artifact contract.
+# Actor-system capacity and CPU placement
+
+For local YDB, `actor-system.static-nodes.cpu-count` and `actor-system.dynamic-nodes.cpu-count` independently set the vCPU count used by YDB automatic actor-system configuration **per node**. They do not set an OS affinity mask or an exact executor thread count. These positive integers remain unchanged when dynamic nodes are added. `affinity` only controls eligible logical CPUs; its mask can be larger or smaller than the configured actor-system capacity. For example:
+
+```yaml
+actor-system:
+  static-nodes: {cpu-count: 8}
+  dynamic-nodes: {cpu-count: 8}
+affinity:
+  static-nodes: {mode: pack-numa-pack-chiplet, cpus: 16}
+  dynamic-nodes: {mode: pack-numa-pack-chiplet, cpus: 32}
+```
+
+An explicit actor-system count also works with `mode: none`. Omitting it preserves YDB's automatic detection from the process affinity (or available host CPUs). Linux CPU usage remains relative to the assigned CPUs, not this actor-system setting.

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -126,6 +126,15 @@ def _profile_schema(benchmark):
                     "properties": {
                         "use-shared-threads": {"type": "boolean", "default": False},
                         "use-united-pool": {"type": "boolean", "default": False},
+                        **{
+                            role: {
+                                "type": "object",
+                                "additionalProperties": False,
+                                "required": ["cpu-count"],
+                                "properties": {"cpu-count": {"type": "integer", "minimum": 1, "maximum": 32767}},
+                            }
+                            for role in ("static-nodes", "dynamic-nodes")
+                        },
                     },
                 },
                 "geometry": {
@@ -554,12 +563,22 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
     workload_metadata = workload_definition(workload["type"])
 
     actor_system = _mapping(
-        value.get("actor-system"), location + ".actor-system", ("use-shared-threads", "use-united-pool")
+        value.get("actor-system"),
+        location + ".actor-system",
+        ("use-shared-threads", "use-united-pool", "static-nodes", "dynamic-nodes"),
     )
     actor_system_config = {
         name.replace("-", "_"): _boolean(actor_system.get(name, False), location + ".actor-system." + name)
         for name in ("use-shared-threads", "use-united-pool")
     }
+    for role in ("static-nodes", "dynamic-nodes"):
+        if role in actor_system:
+            role_location = location + ".actor-system." + role
+            role_config = _mapping(actor_system[role], role_location, ("cpu-count",))
+            cpu_count = _positive_integer(role_config.get("cpu-count"), role_location + ".cpu-count")
+            if cpu_count > 32767:
+                _config_error(role_location + ".cpu-count", "must be at most 32767")
+            actor_system_config[role.replace("-", "_")] = {"cpu_count": cpu_count}
 
     geometry = _mapping(
         value.get("geometry"),

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -600,6 +600,16 @@ class LocalYdbCluster:
     def _node_ports(self):
         return {name: _next_available_port(candidates, name) for name, candidates in self.port_candidates.items()}
 
+    def _node_config(self, role, directory):
+        cpu_count = self.actor_system.get(role, {}).get("cpu_count")
+        if cpu_count is None:
+            return self.config_path
+        config = yaml.safe_load(self.config_path.read_text(encoding="utf-8"))
+        config["config"]["actor_system_config"]["cpu_count"] = cpu_count
+        path = directory / "cluster.yaml"
+        atomic_write_text(path, yaml.safe_dump(config, sort_keys=False))
+        return path
+
     def start(self):
         self._progress("preparing-cluster")
         self.directory.mkdir(parents=True, exist_ok=True)
@@ -618,7 +628,7 @@ class LocalYdbCluster:
                 self.ydbd,
                 "server",
                 "--yaml-config",
-                self.config_path,
+                self._node_config("static_nodes", node_directory),
                 "--node",
                 "static",
                 "--grpc-port",
@@ -722,7 +732,7 @@ class LocalYdbCluster:
                 self.ydbd,
                 "server",
                 "--yaml-config",
-                self.config_path,
+                self._node_config("dynamic_nodes", node_directory),
                 "--tenant",
                 self.database,
                 "--node-broker-port",

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -415,6 +415,8 @@ function localYdbLoadForWorkload(load,parameters,definition=null,workload=null){
     "onfig.geometry[key]);lines.push('    actor-system:');"
     "for(const [key,yamlKey] of Object.entries(localYdbActorSystemKeys))"
     "lines.push('      '+yamlKey+': '+Boolean(config.actor_system?.[key]));"
+    "for(const role of ['static_nodes','dynamic_nodes']){const count=config.actor_system?.[role]?.cpu_count;"
+    "if(count!==undefined)lines.push('      '+role.replaceAll('_','-')+':','        cpu-count: '+count);}"
     "lines.push('    client:','      threads: '+config.client.threads,'    load:','      parameter: '"
     "+config.load.parameter,'      allow-errors: '+Boolean(config.load.allow_errors));if(config.load.values)lines.push('      values: '+yamlArray(config.load.values));else{lines."
     "push('      search:','        start: '+config.load.search.start,'        maximum: '+config.load.search.maximum);if("
@@ -565,6 +567,12 @@ function localYdbProfileEditor(profile){
     .map(([key,label])=>localField('local-geometry-'+key,label,geometry[key],'','type=number min=1')).join('');
   const actorSystemFields=Object.keys(localYdbActorSystemKeys)
     .map(key=>actorSystemFlag(key,Boolean(config.actor_system?.[key]))).join('');
+  const actorCpuFields=['static_nodes','dynamic_nodes'].map(role=>localField(
+    'local-actor-cpu-'+role,(role==='static_nodes'?'Static':'Dynamic')+' node vCPUs',
+    config.actor_system?.[role]?.cpu_count??'',
+    'Per-node actor-system capacity; independent of CPU placement. Empty: automatic.',
+    'type=number min=1 max=32767'
+  )).join('');
   const loadCommon=
     localSelect('local-load-mode','Objective',loadMode,objectiveChoices)+
     localSelect('local-load-parameter','Parameter',load.parameter,definition.load_parameters)+
@@ -629,6 +637,7 @@ function localYdbProfileEditor(profile){
     )+options+'</div><h3>Cluster geometry</h3><div class=form-grid>'+
     localSelect('local-geometry-preset','Preset',geometry.preset,['single','storage','custom'])+geometryFields+
     '</div><h3>Actor system (static and dynamic nodes)</h3><div class=actor-flags>'+actorSystemFields+
+    '</div><div class=form-grid>'+actorCpuFields+
     '</div><h3>Client and load</h3><div class=form-grid>'+
     localField('local-client-threads','YDB CLI threads',config.client.threads,clientThreadsHelp,'type=number min=1')+
     loadCommon+loadFields+'</div>'+slo+'<h3>Measurement</h3><div class=form-grid>'+
@@ -779,6 +788,14 @@ function bindLocalYdbEditor(profile){
     config.actor_system=Object.fromEntries(Object.keys(localYdbActorSystemKeys).map(key=>[
       key,Boolean(document.querySelector('#local-actor-system-'+key)?.checked)
     ]));
+    for(const role of ['static_nodes','dynamic_nodes']){
+      const id='local-actor-cpu-'+role;
+      if(document.querySelector('#'+id)?.value){
+        const count=localInteger(id);
+        if(count>32767)throw Error('Actor-system vCPUs must not exceed 32767.');
+        config.actor_system[role]={cpu_count:count};
+      }
+    }
     const loadMode=document.querySelector('#local-load-mode').value;
     const parameter=document.querySelector('#local-load-parameter').value;
     const allow_errors=Boolean(document.querySelector('#local-load-allow-errors')?.checked);
@@ -1402,6 +1419,8 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     "    'Duration seconds':measurement.duration??'—','Repetitions':measurement.repetitions??'—',\n"
     "    'Verification repetitions':measurement.verification_repetitions??0,\n"
     "    'use_shared_threads':parameters.actor_system?.use_shared_threads??false,\n"
+    "    'Static node vCPUs':parameters.actor_system?.static_nodes?.cpu_count??'automatic',\n"
+    "    'Dynamic node vCPUs':parameters.actor_system?.dynamic_nodes?.cpu_count??'automatic',\n"
     "    'use_united_pool':parameters.actor_system?.use_united_pool??false,\n"
     "    'Geometry preset':geometry.preset??'—','Static nodes':geometry.static_nodes??'—',\n"
     "    'Initial dynamic nodes':geometry.dynamic_nodes??'—','Maximum dynamic nodes':geometry.max_dynamic_nodes??'—',\n"
@@ -2071,7 +2090,11 @@ function localReportConfiguration(data){
     ])+'</div>'+localReportTable('CPU placement',affinity,['Role','Logical CPU IDs'])+
     localReportTable('Workload',[
       ['Type',p.workload?.type],['Operation',p.workload?.operation],...rows(p.workload?.options)
-    ])+localReportTable('Actor system',rows(p.actor_system))+
+    ])+localReportTable('Actor system',[
+      ['Static node vCPUs',p.actor_system?.static_nodes?.cpu_count??'Automatic'],
+      ['Dynamic node vCPUs',p.actor_system?.dynamic_nodes?.cpu_count??'Automatic'],
+      ...rows(Object.fromEntries(Object.entries(p.actor_system||{}).filter(([key])=>!['static_nodes','dynamic_nodes'].includes(key))))
+    ])+
     localReportTable('Binaries',Object.entries(data.binaries||{}).map(([role,binary])=>[
       role.replaceAll('_',' '),String(binary.name||'—').split('/').pop(),binary.sha256||'—'
     ]),['Role','Name','SHA-256'])+'</details>'
@@ -4426,7 +4449,9 @@ class RunService:
                 ),
             )
             client = project(value.get("client"), ("threads",))
-            actor_system = project(value.get("actor_system"), ("use_shared_threads", "use_united_pool"))
+            actor_system = project(
+                value.get("actor_system"), ("use_shared_threads", "use_united_pool", "static_nodes", "dynamic_nodes")
+            )
             load = project(value.get("load"), ("parameter", "allow_errors", "values", "search", "objective"))
             measurement = project(
                 value.get("measurement"),

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -2173,6 +2173,19 @@ class YdbBenchTest(unittest.TestCase):
                     )
                 )
 
+    def test_local_ydb_actor_cpu_count_is_independent_of_affinity(self):
+        profile = {"workload": {"type": "kv", "operation": "upsert"}, "load": {"parameter": "threads", "values": [1]}}
+        profile["actor-system"] = {"static-nodes": {"cpu-count": 8}, "dynamic-nodes": {"cpu-count": 4}}
+        loaded = load_config(self._config(yaml.safe_dump({"local-ydb": {"cpu": profile}}))).runs[0]
+        actor_system = loaded.parameters["local_ydb"]["actor_system"]
+        self.assertEqual(actor_system["static_nodes"], {"cpu_count": 8})
+        self.assertEqual(actor_system["dynamic_nodes"], {"cpu_count": 4})
+        for value in (True, 0, -1, 1.5, "8", None, 32768):
+            with self.subTest(value=value):
+                profile["actor-system"]["static-nodes"]["cpu-count"] = value
+                with self.assertRaisesRegex(BenchmarkError, "cpu-count"):
+                    load_config(self._config(yaml.safe_dump({"local-ydb": {"cpu": profile}})))
+
     def test_local_ydb_actor_system_flags_default_and_validate(self):
         profile = {"workload": {"type": "kv", "operation": "upsert"}, "load": {"parameter": "threads", "values": [1]}}
 
@@ -2211,7 +2224,11 @@ class YdbBenchTest(unittest.TestCase):
               flags:
                 workload: {type: stock, operation: put-rand-order}
                 load: {parameter: threads, values: [1]}
-                actor-system: {use-shared-threads: true, use-united-pool: false}
+                actor-system:
+                  use-shared-threads: true
+                  use-united-pool: false
+                  static-nodes: {cpu-count: 8}
+                  dynamic-nodes: {cpu-count: 4}
         """))
         model = web.editor_model(loaded, self.root / "results")
         script = "const editor={model:" + json.dumps(model) + "};\n"
@@ -2246,6 +2263,8 @@ class YdbBenchTest(unittest.TestCase):
         self.assertFalse(result["old"]["use_shared_threads"])
         self.assertTrue(result["current"]["use_shared_threads"])
         self.assertFalse(result["current"]["use_united_pool"])
+        self.assertEqual(result["current"]["Static node vCPUs"], 8)
+        self.assertEqual(result["current"]["Dynamic node vCPUs"], 4)
 
     def test_local_ydb_profile_is_editable_by_web_builder(self):
         loaded = load_config(self._config("""
@@ -4528,6 +4547,19 @@ class YdbBenchTest(unittest.TestCase):
             self.assertEqual(command[command.index("--yaml-config") + 1], cluster.config_path)
         config = yaml.safe_load(cluster.config_path.read_text(encoding="utf-8"))
         self.assertEqual(config["config"]["actor_system_config"], {"use_auto_config": True, **flags})
+
+        cluster.actor_system.update(static_nodes={"cpu_count": 8}, dynamic_nodes={"cpu_count": 4})
+        for role, expected in (("static_nodes", 8), ("dynamic_nodes", 4)):
+            with self.subTest(role=role):
+                directory = cluster.directory / role
+                directory.mkdir()
+                path = cluster._node_config(role, directory)
+                effective = yaml.safe_load(path.read_text(encoding="utf-8"))
+                self.assertEqual(
+                    effective["config"]["actor_system_config"],
+                    {"use_auto_config": True, **flags, "cpu_count": expected},
+                )
+        self.assertNotIn("cpu_count", yaml.safe_load(cluster.config_path.read_text())["config"]["actor_system_config"])
 
     def test_local_ydb_scaling_waits_for_database_and_every_new_node(self):
         cluster_directory = self.root / "scaling-cluster"


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Allow local YDB benchmarks to configure static and dynamic node actor-system vCPUs independently of CPU affinity.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Whole-chiplet affinity can expand the requested CPU mask, causing YDB automatic pool sizing to use more CPUs than intended. Add per-role cpu-count settings to YAML and the builder, pass them to node configurations, and display them separately in reports and comparisons. Omitted settings preserve automatic CPU detection.