### PR TITLE
Preserve arrival order of ready PDisk YardInit requests

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -3041,7 +3041,7 @@ void TPDisk::ProcessFastOperationsQueue() {
             case ERequestType::RequestYardInit: {
                 std::unique_ptr<TYardInit> init{static_cast<TYardInit*>(req.release())};
                 if (YardInitStart(*init)) {
-                    PendingYardInits.emplace(std::move(init));
+                    PendingYardInits.emplace_back(std::move(init));
                 }
                 break;
             }
@@ -4161,7 +4161,7 @@ void TPDisk::ProcessPausedQueue() {
     }
 }
 
-void TPDisk::ProcessYardInitSet() {
+void TPDisk::ProcessPendingYardInits() {
     for (ui32 owner = 0; owner < OwnerData.size(); ++owner) {
         TOwnerData &data = OwnerData[owner];
         if (data.LogReader) {
@@ -4174,7 +4174,7 @@ void TPDisk::ProcessYardInitSet() {
 
     if (!PendingYardInits.empty()) {
         TGuard<TMutex> guard(StateMutex);
-        // Process pending queue
+        // Finish ready owners in arrival order without blocking them on busy owners.
         for (auto it = PendingYardInits.begin(); it != PendingYardInits.end();) {
             if (!OwnerData[(*it)->Owner].HaveRequestsInFlight()) {
                 YardInitFinish(**it);
@@ -4487,7 +4487,7 @@ void TPDisk::Update() {
     ProcessChunkForgetQueue();
     LastTact = tact;
 
-    ProcessYardInitSet();
+    ProcessPendingYardInits();
 
     Mon.UpdateDurationTracker.WaitingStart(isNothingToDo);
     LWTRACK(PDiskStartWaiting, UpdateCycleOrbit, PCtx->PDiskId);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
@@ -36,6 +36,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <list>
 #include <queue>
 
 #if defined(__linux__)
@@ -101,7 +102,8 @@ public:
     TVector<std::unique_ptr<TChunkForget>> JointChunkForgets;
     TVector<std::unique_ptr<TRequestBase>> FastOperationsQueue;
     TDeque<TRequestBase*> PausedQueue;
-    std::set<std::unique_ptr<TYardInit>> PendingYardInits;
+    // Preserve arrival order among ready owners; busy owners may still be skipped.
+    std::list<std::unique_ptr<TYardInit>> PendingYardInits;
     ui64 LastFlushId = 0;
     bool IsQueuePaused = false;
     bool IsQueueStep = false;
@@ -454,7 +456,7 @@ public:
     void ProcessChunkWriteQueue();
     void ProcessChunkReadQueue();
     void ProcessLogReadQueue();
-    void ProcessYardInitSet();
+    void ProcessPendingYardInits();
     void TrimAllUntrimmedChunks();
     void ProcessChunkTrimQueue();
     void ClearQuarantineChunks();

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_races.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_races.cpp
@@ -13,6 +13,60 @@
 namespace NKikimr {
 
 Y_UNIT_TEST_SUITE(TPDiskRaces) {
+    void TestYardInitOrder(bool firstOwnerBusy) {
+        TActorTestContext testCtx({});
+        const TVDiskID firstVDisk(1, 1, 0, 0, 0);
+        const TVDiskID secondVDisk(2, 1, 0, 0, 0);
+        for (const auto& vdisk : {firstVDisk, secondVDisk}) {
+            testCtx.TestResponse<NPDisk::TEvYardInitResult>(
+                new NPDisk::TEvYardInit(2, vdisk, testCtx.TestCtx.PDiskGuid), NKikimrProto::OK);
+        }
+
+        auto* pdisk = testCtx.GetPDisk();
+        pdisk->PDiskThread.StopSync();
+        const NPDisk::TEvYardInit firstEvent(3, firstVDisk, testCtx.TestCtx.PDiskGuid);
+        const NPDisk::TEvYardInit secondEvent(3, secondVDisk, testCtx.TestCtx.PDiskGuid);
+        std::unique_ptr<NPDisk::TYardInit> first(
+            pdisk->ReqCreator.CreateFromEv<NPDisk::TYardInit>(firstEvent, testCtx.Sender));
+        std::unique_ptr<NPDisk::TYardInit> second(
+            pdisk->ReqCreator.CreateFromEv<NPDisk::TYardInit>(secondEvent, testCtx.Sender));
+        // Submit in descending pointer order to expose pointer-sorted pending requests.
+        if (std::less<NPDisk::TYardInit*>()(first.get(), second.get())) {
+            first.swap(second);
+        }
+        const auto firstOwner = pdisk->VDiskOwners.at(first->VDiskIdWOGeneration());
+        const auto secondOwner = pdisk->VDiskOwners.at(second->VDiskIdWOGeneration());
+        pdisk->InputRequest(first.release());
+        pdisk->InputRequest(second.release());
+        pdisk->EnqueueAll();
+        pdisk->ProcessFastOperationsQueue();
+
+        auto& inFlight = pdisk->OwnerData[firstOwner].InFlight->ChunkWrites;
+        if (firstOwnerBusy) {
+            ++inFlight;
+        }
+        pdisk->ProcessPendingYardInits();
+        auto result = testCtx.Recv<NPDisk::TEvYardInitResult>();
+        UNIT_ASSERT_VALUES_EQUAL(result->Status, NKikimrProto::OK);
+        UNIT_ASSERT_VALUES_EQUAL(result->PDiskParams->Owner, firstOwnerBusy ? secondOwner : firstOwner);
+        if (firstOwnerBusy) {
+            --inFlight;
+            pdisk->ProcessPendingYardInits();
+        }
+        result = testCtx.Recv<NPDisk::TEvYardInitResult>();
+        UNIT_ASSERT_VALUES_EQUAL(result->Status, NKikimrProto::OK);
+        UNIT_ASSERT_VALUES_EQUAL(result->PDiskParams->Owner, firstOwnerBusy ? firstOwner : secondOwner);
+        UNIT_ASSERT(pdisk->PendingYardInits.empty());
+    }
+
+    Y_UNIT_TEST(YardInitReadyOwnersPreserveOrder) {
+        TestYardInitOrder(false);
+    }
+
+    Y_UNIT_TEST(YardInitBusyOwnerDoesNotBlockReadyOwner) {
+        TestYardInitOrder(true);
+    }
+
     void TestKillOwnerWhileDeletingChunk(bool usePDiskMock, ui32 timeLimit, ui32 inflight, ui32 reservedChunks, ui32 vdisksNum) {
         THPTimer timer;
         while (timer.Passed() < timeLimit) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Preserve request arrival order when PDisk processes ready owner initializations.

### Description for reviewers <!-- (optional) description for those who read this PR -->

PendingYardInits currently stores requests in std::set<std::unique_ptr<TYardInit>>, so its traversal follows pointer order rather than arrival order. Two ready YardInit requests received as A, B can therefore reach YardInitFinish as B, A without any actor-system delivery reordering. This is one mechanism behind the response-ordering problem addressed defensively in #52611.

Use a list populated with emplace_back and traverse ready requests in arrival order. Preserve the existing behavior of skipping owners with operations still in flight so they do not block unrelated ready owners. This change removes pointer-based reordering; it does not promise strict FIFO response delivery across busy owners or asynchronous completion paths. Rename ProcessYardInitSet to ProcessPendingYardInits to reflect the new container.

Regression tests use the real PDisk with controlled processing: they submit known-owner requests in descending pointer order and check response owner IDs, then verify that a busy owner is skipped and completed once its outstanding operation clears. The branch is independent of the load-actor changes in #52611.

Related mute issue: [#50117](https://github.com/ydb-platform/ydb/issues/50117) (PDiskTestLogWrite).
