### PR TITLE
Hive scatter movable sources

### DIFF
--- a/ydb/core/mind/hive/balancer.cpp
+++ b/ydb/core/mind/hive/balancer.cpp
@@ -128,6 +128,7 @@ protected:
     std::vector<TNodeId>::iterator NextNode;
     std::vector<TFullTabletId> Tablets;
     std::vector<TFullTabletId>::iterator NextTablet;
+    std::unordered_map<TFullTabletId, TNodeId> ScatterSourcesInFlight;
 
     static constexpr ui64 MAX_TABLETS_PROCESSED = 10;
 
@@ -188,20 +189,33 @@ protected:
         Stats.CurrentMovements = Movements;
     }
 
+    bool IsNodeSuitableForBalancing(const TNodeInfo& node) const {
+        if (!Settings.MinNodeUsage) {
+            return true;
+        }
+        // Wait for a source's previous restart to update its resource totals.
+        // Other sources can still make progress up to MaxInFlight.
+        return !node.Down && !node.Freeze
+            && node.GetTabletUsage(Settings.ResourceToBalance) > *Settings.MinNodeUsage
+            && std::none_of(ScatterSourcesInFlight.begin(), ScatterSourcesInFlight.end(), [&](const auto& entry) {
+                return entry.second == node.Id;
+            });
+    }
+
     void BalanceNodes() {
         std::vector<TNodeInfo*> nodes;
         if (!Settings.FilterNodeIds.empty()) {
             nodes.reserve(Settings.FilterNodeIds.size());
             for (TNodeId nodeId : Settings.FilterNodeIds) {
                 TNodeInfo* node = Hive->FindNode(nodeId);
-                if (node != nullptr && node->IsAlive()) {
+                if (node != nullptr && node->IsAlive() && IsNodeSuitableForBalancing(*node)) {
                     nodes.emplace_back(node);
                 }
             }
         } else {
             nodes.reserve(Hive->Nodes.size());
             for (auto& [nodeId, nodeInfo] : Hive->Nodes) {
-                if (nodeInfo.IsAlive()) {
+                if (nodeInfo.IsAlive() && IsNodeSuitableForBalancing(nodeInfo)) {
                     nodes.emplace_back(&nodeInfo);
                 }
             }
@@ -222,6 +236,7 @@ protected:
             break;
         }
 
+        Nodes.clear();
         Nodes.reserve(nodes.size());
         for (auto node : nodes) {
             Nodes.push_back(node->Id);
@@ -232,21 +247,8 @@ protected:
     }
 
     bool IsTabletSuitableForBalancing(const TTabletInfo* tablet, TInstant now) const {
-        if (!tablet->IsGoodForBalancer(now)) {
-            return false;
-        }
-        if (Settings.FilterObjectId && tablet->GetObjectId() != *Settings.FilterObjectId) {
-            return false;
-        }
-        if (!tablet->HasMetric(Settings.ResourceToBalance)) {
-            return false;
-        }
-        if (tablet->IsPinnedToNode()) {
-            // The tablet accounts for most of its node's usage, so moving it would only relocate the
-            // load. Leave it where it is and let the balancer drain the rest of the node instead.
-            return false;
-        }
-        return true;
+        return tablet->IsGoodForBalancer(now, Settings.ResourceToBalance)
+            && (!Settings.FilterObjectId || tablet->GetObjectId() == *Settings.FilterObjectId);
     }
 
     // Tablets we would rather not move are ordered last: system tablets because restarting them is
@@ -286,7 +288,7 @@ protected:
             }
             Tablets.clear();
             TNodeInfo* node = Hive->FindNode(*NextNode);
-            if (node == nullptr) {
+            if (node == nullptr || !node->IsAlive() || !IsNodeSuitableForBalancing(*node)) {
                 continue;
             }
             YDB_LOG_TRACE("Balancer selected node",
@@ -355,8 +357,11 @@ protected:
             if (!tabletId) {
                 break;
             }
+            ++tabletsProcessed;
             TTabletInfo* tablet = Hive->FindTablet(*tabletId);
-            if (tablet == nullptr || !tablet->IsRunning()) {
+            if (tablet == nullptr || !tablet->IsRunning()
+                || !IsTabletSuitableForBalancing(tablet, now)
+                || !IsNodeSuitableForBalancing(*tablet->Node)) {
                 continue;
             }
             YDB_LOG_TRACE("Balancer selected tablet",
@@ -370,6 +375,9 @@ protected:
                     tablet->ActorsToNotifyOnRestart.emplace_back(SelfId()); // volatile settings, will not persist upon restart
                     ++KickInFlight;
                     ++Movements;
+                    if (Settings.MinNodeUsage) {
+                        ScatterSourcesInFlight.emplace(tablet->GetFullTabletId(), tablet->Node->Id);
+                    }
                     YDB_LOG_DEBUG("Balancer moving tablet",
                         {"logPrefix", GetLogPrefix()},
                         {"tablet", tablet->ToString()},
@@ -380,7 +388,6 @@ protected:
                     UpdateProgress();
                 }
             }
-            ++tabletsProcessed;
         }
 
         if (KickInFlight == 0) {
@@ -395,6 +402,7 @@ protected:
             {"status", ev->Get()->Status},
             {"tabletId", ev->Get()->TabletId});
         --KickInFlight;
+        ScatterSourcesInFlight.erase(ev->Get()->TabletId);
         BalanceNodes();
         KickNextTablet();
     }

--- a/ydb/core/mind/hive/balancer.cpp
+++ b/ydb/core/mind/hive/balancer.cpp
@@ -128,8 +128,10 @@ protected:
     std::vector<TNodeId>::iterator NextNode;
     std::vector<TFullTabletId> Tablets;
     std::vector<TFullTabletId>::iterator NextTablet;
+    TNodeId TabletsNodeId = 0;
     std::unordered_set<TNodeId> ScatterSourceNodeIds;
     std::unordered_map<TFullTabletId, TNodeId> ScatterSourcesInFlight;
+    std::unordered_set<TNodeId> ScatterNodesInFlight;
 
     static constexpr ui64 MAX_TABLETS_PROCESSED = 10;
 
@@ -199,9 +201,7 @@ protected:
         return ScatterSourceNodeIds.contains(node.Id)
             && !node.Down && !node.Freeze
             && node.GetTabletUsage(Settings.ResourceToBalance) > *Settings.MinNodeUsage
-            && std::none_of(ScatterSourcesInFlight.begin(), ScatterSourcesInFlight.end(), [&](const auto& entry) {
-                return entry.second == node.Id;
-            });
+            && !ScatterNodesInFlight.contains(node.Id);
     }
 
     void BalanceNodes() {
@@ -284,6 +284,14 @@ protected:
     }
 
     std::optional<TFullTabletId> GetNextTablet(TInstant now) {
+        if (Settings.MinNodeUsage && !Tablets.empty() && NextTablet != Tablets.end()) {
+            TNodeInfo* node = Hive->FindNode(TabletsNodeId);
+            if (node == nullptr || !node->IsAlive() || !IsNodeSuitableForBalancing(*node)) {
+                // NextNode already points to the next source. Skip this source's
+                // remaining tablets without spending the per-event tablet budget.
+                Tablets.clear();
+            }
+        }
         for (; Tablets.empty() || NextTablet == Tablets.end(); ++NextNode) {
             if (NextNode == Nodes.end()) {
                 return std::nullopt;
@@ -332,6 +340,7 @@ protected:
                 Tablets.push_back(tablet->GetFullTabletId());
             }
             NextTablet = Tablets.begin();
+            TabletsNodeId = node->Id;
         }
         return *(NextTablet++);
     }
@@ -379,6 +388,7 @@ protected:
                     ++Movements;
                     if (Settings.MinNodeUsage) {
                         ScatterSourcesInFlight.emplace(tablet->GetFullTabletId(), tablet->Node->Id);
+                        ScatterNodesInFlight.insert(tablet->Node->Id);
                     }
                     YDB_LOG_DEBUG("Balancer moving tablet",
                         {"logPrefix", GetLogPrefix()},
@@ -404,7 +414,11 @@ protected:
             {"status", ev->Get()->Status},
             {"tabletId", ev->Get()->TabletId});
         --KickInFlight;
-        ScatterSourcesInFlight.erase(ev->Get()->TabletId);
+        auto source = ScatterSourcesInFlight.find(ev->Get()->TabletId);
+        if (source != ScatterSourcesInFlight.end()) {
+            ScatterNodesInFlight.erase(source->second);
+            ScatterSourcesInFlight.erase(source);
+        }
         BalanceNodes();
         KickNextTablet();
     }

--- a/ydb/core/mind/hive/balancer.cpp
+++ b/ydb/core/mind/hive/balancer.cpp
@@ -128,6 +128,7 @@ protected:
     std::vector<TNodeId>::iterator NextNode;
     std::vector<TFullTabletId> Tablets;
     std::vector<TFullTabletId>::iterator NextTablet;
+    std::unordered_set<TNodeId> ScatterSourceNodeIds;
     std::unordered_map<TFullTabletId, TNodeId> ScatterSourcesInFlight;
 
     static constexpr ui64 MAX_TABLETS_PROCESSED = 10;
@@ -195,7 +196,8 @@ protected:
         }
         // Wait for a source's previous restart to update its resource totals.
         // Other sources can still make progress up to MaxInFlight.
-        return !node.Down && !node.Freeze
+        return ScatterSourceNodeIds.contains(node.Id)
+            && !node.Down && !node.Freeze
             && node.GetTabletUsage(Settings.ResourceToBalance) > *Settings.MinNodeUsage
             && std::none_of(ScatterSourcesInFlight.begin(), ScatterSourcesInFlight.end(), [&](const auto& entry) {
                 return entry.second == node.Id;
@@ -420,6 +422,9 @@ public:
         , Settings(std::move(settings))
         , Stats(Hive->BalancerStats[static_cast<std::size_t>(Settings.Type)])
     {
+        if (Settings.MinNodeUsage) {
+            ScatterSourceNodeIds.insert(Settings.FilterNodeIds.begin(), Settings.FilterNodeIds.end());
+        }
         Stats.IsRunningNow = true;
         Stats.CurrentMaxMovements = Settings.MaxMovements ? Settings.MaxMovements : Hive->TabletsTotal;
         Stats.CurrentMovements = 0;

--- a/ydb/core/mind/hive/hive.h
+++ b/ydb/core/mind/hive/hive.h
@@ -375,6 +375,8 @@ struct TBalancerSettings {
     const std::vector<TNodeId> FilterNodeIds = {};
     EResourceToBalance ResourceToBalance = EResourceToBalance::ComputeResources;
     std::optional<TFullObjectId> FilterObjectId;
+    // Scatter sources must stay above this bound throughout the run.
+    std::optional<double> MinNodeUsage;
 };
 
 struct TStorageBalancerSettings {

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -2801,27 +2801,47 @@ std::optional<TBalancerSettings> THive::GetScatterBalancerSettings(TConstArrayRe
     const auto minScatter = GetMinScatterToBalance();
     const auto minUsage = GetMinNodeUsageToBalance();
     for (const auto& [resource, type] : resources) {
-        // The cohort is resource-specific: a node with no movable CPU tablets
-        // must not keep CPU balancing active or lower its minimum.
-        std::vector<const TNodeInfo*> eligibleNodes;
-        eligibleNodes.reserve(nodes.size());
+        // Loaded nodes without movable tablets must not affect the thresholds.
+        // Keep resource-idle receivers as comparison points, including new nodes
+        // and nodes whose movable tablets consume a different resource.
+        std::vector<const TNodeInfo*> sourceCandidates;
+        std::vector<const TNodeInfo*> comparisonNodes;
+        sourceCandidates.reserve(nodes.size());
+        comparisonNodes.reserve(nodes.size());
         for (const auto* node : nodes) {
+            if (!node->IsAlive() || node->Down || node->Freeze) {
+                continue;
+            }
             if (node->HasTabletsForBalancer(resource, now)) {
-                eligibleNodes.push_back(node);
+                sourceCandidates.push_back(node);
+                comparisonNodes.push_back(node);
+            } else if (node->GetNodeUsage(resource) == 0
+                       && (resource == EResourceToBalance::Counter
+                           || node->GetNodeUsage() == 0
+                           || node->HasTabletsForBalancer(EResourceToBalance::ComputeResources, now))) {
+                // Counter scatter compares tablet counts independently of compute load.
+                // An empty node with only external load is not a compute receiver.
+                comparisonNodes.push_back(node);
             }
         }
-        auto eligibleRange = eligibleNodes
+        auto comparisonRange = comparisonNodes
             | std::views::transform([](const TNodeInfo* node) -> const TNodeInfo& { return *node; });
-        const auto stats = GetStats(eligibleRange.begin(), eligibleRange.end());
+        const auto stats = GetStats(comparisonRange.begin(), comparisonRange.end());
         const double scatterLimit = TTabletInfo::ExtractResourceUsage(minScatter, resource);
         if (!(TTabletInfo::ExtractResourceUsage(stats.ScatterByResource, resource) > scatterLimit)) {
             continue;
         }
-        // scatter = (maximum - max(minimum, floor)) / maximum. Only sources
-        // strictly above floor / (1 - scatterLimit) can cause this trigger.
-        const double sourceThreshold = TTabletInfo::ExtractResourceUsage(minUsage, resource) / (1 - scatterLimit);
+        double minimumUsage = std::numeric_limits<double>::max();
+        for (const auto& node : stats.Values) {
+            minimumUsage = std::min(minimumUsage, TTabletInfo::ExtractResourceUsage(node.ResourceNormValues, resource));
+        }
+        // scatter = (maximum - max(minimum, floor)) / maximum. Hold the initial
+        // effective minimum fixed for this pass and only shed load from sources
+        // strictly above max(minimum, floor) / (1 - scatterLimit).
+        const double effectiveMinimum = std::max(minimumUsage, TTabletInfo::ExtractResourceUsage(minUsage, resource));
+        const double sourceThreshold = effectiveMinimum / (1 - scatterLimit);
         std::vector<TNodeId> sourceNodeIds;
-        for (const auto* node : eligibleNodes) {
+        for (const auto* node : sourceCandidates) {
             if (node->GetTabletUsage(resource) > sourceThreshold) {
                 sourceNodeIds.push_back(node->Id);
             }

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -2791,7 +2791,12 @@ THive::THiveStats THive::GetStats(TIter begin, TIter end) const {
     return stats;
 }
 
-std::optional<TBalancerSettings> THive::GetScatterBalancerSettings(TConstArrayRef<const TNodeInfo*> nodes, TInstant now) const {
+std::optional<TBalancerSettings> THive::GetScatterBalancerSettings(TConstArrayRef<const TNodeInfo*> nodes, TInstant now,
+        std::optional<TResourceNormalizedValues> scatterByResource) const {
+    if (!scatterByResource) {
+        auto range = nodes | std::views::transform([](const TNodeInfo* node) -> const TNodeInfo& { return *node; });
+        scatterByResource = GetStats(range.begin(), range.end()).ScatterByResource;
+    }
     static constexpr std::pair<EResourceToBalance, EBalancerType> resources[] = {
         {EResourceToBalance::Counter, EBalancerType::ScatterCounter},
         {EResourceToBalance::CPU, EBalancerType::ScatterCPU},
@@ -2800,50 +2805,92 @@ std::optional<TBalancerSettings> THive::GetScatterBalancerSettings(TConstArrayRe
     };
     const auto minScatter = GetMinScatterToBalance();
     const auto minUsage = GetMinNodeUsageToBalance();
+    TNodeInfo::TBalancerResourceMask requestedResources;
     for (const auto& [resource, type] : resources) {
-        // Loaded nodes without movable tablets must not affect the thresholds.
-        // Keep resource-idle receivers as comparison points, including new nodes
-        // and nodes whose movable tablets consume a different resource.
-        std::vector<const TNodeInfo*> sourceCandidates;
-        std::vector<const TNodeInfo*> comparisonNodes;
-        sourceCandidates.reserve(nodes.size());
-        comparisonNodes.reserve(nodes.size());
-        for (const auto* node : nodes) {
-            if (!node->IsAlive() || node->Down || node->Freeze) {
-                continue;
-            }
-            if (node->HasTabletsForBalancer(resource, now)) {
-                sourceCandidates.push_back(node);
-                comparisonNodes.push_back(node);
-            } else if (node->GetNodeUsage(resource) == 0
-                       && (resource == EResourceToBalance::Counter
-                           || node->GetNodeUsage() == 0
-                           || node->HasTabletsForBalancer(EResourceToBalance::ComputeResources, now))) {
-                // Counter scatter compares tablet counts independently of compute load.
-                // An empty node with only external load is not a compute receiver.
-                comparisonNodes.push_back(node);
+        Y_UNUSED(type);
+        const double limit = TTabletInfo::ExtractResourceUsage(minScatter, resource);
+        // Removing nodes cannot increase scatter with the same resource floor.
+        // Reuse the segment statistics before looking at any tablets.
+        if (TTabletInfo::ExtractResourceUsage(*scatterByResource, resource) > limit) {
+            requestedResources.set(static_cast<size_t>(resource));
+            if (resource != EResourceToBalance::Counter) {
+                requestedResources.set(static_cast<size_t>(EResourceToBalance::ComputeResources));
             }
         }
-        auto comparisonRange = comparisonNodes
-            | std::views::transform([](const TNodeInfo* node) -> const TNodeInfo& { return *node; });
-        const auto stats = GetStats(comparisonRange.begin(), comparisonRange.end());
-        const double scatterLimit = TTabletInfo::ExtractResourceUsage(minScatter, resource);
-        if (!(TTabletInfo::ExtractResourceUsage(stats.ScatterByResource, resource) > scatterLimit)) {
+    }
+    if (requestedResources.none()) {
+        return std::nullopt;
+    }
+    struct TNodeState {
+        const TNodeInfo* Node;
+        TNodeInfo::TBalancerResourceScanner Scanner;
+
+        TNodeState(const TNodeInfo* node, TNodeInfo::TBalancerResourceMask resources, TInstant now)
+            : Node(node)
+            , Scanner(*node, resources, now)
+        {}
+    };
+    std::vector<TNodeState> nodeStates;
+    nodeStates.reserve(nodes.size());
+    for (const auto* node : nodes) {
+        if (node->IsAlive() && !node->Down && !node->Freeze) {
+            nodeStates.emplace_back(node, requestedResources, now);
+        }
+    }
+    std::vector<std::pair<TNodeId, double>> sources;
+    sources.reserve(nodeStates.size());
+    for (const auto& [resource, type] : resources) {
+        if (!requestedResources.test(static_cast<size_t>(resource))) {
             continue;
         }
-        double minimumUsage = std::numeric_limits<double>::max();
-        for (const auto& node : stats.Values) {
-            minimumUsage = std::min(minimumUsage, TTabletInfo::ExtractResourceUsage(node.ResourceNormValues, resource));
+        sources.clear();
+        double minimum = std::numeric_limits<double>::max();
+        double maximum = 0;
+        for (auto& state : nodeStates) {
+            const auto* node = state.Node;
+            const bool source = state.Scanner.HasResource(resource);
+            if (!source) {
+                if (node->GetNodeUsage(resource) != 0) {
+                    continue;
+                }
+                // Keep idle receivers, including nodes with movable tablets
+                // consuming another resource. Counter ignores compute load.
+                if (resource != EResourceToBalance::Counter && node->GetNodeUsage() != 0
+                    && !state.Scanner.HasResource(EResourceToBalance::ComputeResources)) {
+                    continue;
+                }
+            }
+            const double usage = node->GetTabletUsage(resource);
+            minimum = std::min(minimum, usage);
+            maximum = std::max(maximum, usage);
+            if (source) {
+                sources.emplace_back(node->Id, usage);
+            }
         }
-        // scatter = (maximum - max(minimum, floor)) / maximum. Hold the initial
-        // effective minimum fixed for this pass and only shed load from sources
-        // strictly above max(minimum, floor) / (1 - scatterLimit).
-        const double effectiveMinimum = std::max(minimumUsage, TTabletInfo::ExtractResourceUsage(minUsage, resource));
+        if (sources.empty()) {
+            continue;
+        }
+        const double floor = TTabletInfo::ExtractResourceUsage(minUsage, resource);
+        const double effectiveMinimum = std::max(minimum, floor);
+        maximum = std::max(maximum, floor);
+        double discrepancy = maximum - effectiveMinimum;
+        if (resource == EResourceToBalance::Counter
+            && discrepancy * CurrentConfig.GetMaxResourceCounter() <= 1.5) {
+            discrepancy = 0;
+        }
+        const double scatter = maximum == 0 ? 0 : discrepancy / maximum;
+        const double scatterLimit = TTabletInfo::ExtractResourceUsage(minScatter, resource);
+        if (!(scatter > scatterLimit)) {
+            continue;
+        }
+        // Hold the initial effective minimum fixed for this pass. Only sources
+        // strictly above this bound may continue shedding tablet load.
         const double sourceThreshold = effectiveMinimum / (1 - scatterLimit);
         std::vector<TNodeId> sourceNodeIds;
-        for (const auto* node : sourceCandidates) {
-            if (node->GetTabletUsage(resource) > sourceThreshold) {
-                sourceNodeIds.push_back(node->Id);
+        sourceNodeIds.reserve(sources.size());
+        for (const auto& [nodeId, usage] : sources) {
+            if (usage > sourceThreshold) {
+                sourceNodeIds.push_back(nodeId);
             }
         }
         // An empty FilterNodeIds means unrestricted balancing, not no donors.
@@ -3029,12 +3076,15 @@ void THive::Handle(TEvPrivate::TEvProcessTabletBalancer::TPtr&) {
             continue;
         }
 
+        if (!CheckScatter(stats.ScatterByResource)) {
+            continue;
+        }
         std::vector<const TNodeInfo*> segmentNodes;
         segmentNodes.reserve(stats.Values.size());
         for (const auto& node : nodes) {
             segmentNodes.push_back(&node);
         }
-        if (auto scatterSettings = GetScatterBalancerSettings(segmentNodes, TActivationContext::Now())) {
+        if (auto scatterSettings = GetScatterBalancerSettings(segmentNodes, TActivationContext::Now(), stats.ScatterByResource)) {
             YDB_LOG_TRACE("ProcessTabletBalancer: movable nodes triggered scatter balancer",
                 {"logPrefix", GetLogPrefix()},
                 {"balancerTypeName", EBalancerTypeName(scatterSettings->Type)},

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -2791,6 +2791,58 @@ THive::THiveStats THive::GetStats(TIter begin, TIter end) const {
     return stats;
 }
 
+std::optional<TBalancerSettings> THive::GetScatterBalancerSettings(TConstArrayRef<const TNodeInfo*> nodes, TInstant now) const {
+    static constexpr std::pair<EResourceToBalance, EBalancerType> resources[] = {
+        {EResourceToBalance::Counter, EBalancerType::ScatterCounter},
+        {EResourceToBalance::CPU, EBalancerType::ScatterCPU},
+        {EResourceToBalance::Memory, EBalancerType::ScatterMemory},
+        {EResourceToBalance::Network, EBalancerType::ScatterNetwork},
+    };
+    const auto minScatter = GetMinScatterToBalance();
+    const auto minUsage = GetMinNodeUsageToBalance();
+    for (const auto& [resource, type] : resources) {
+        // The cohort is resource-specific: a node with no movable CPU tablets
+        // must not keep CPU balancing active or lower its minimum.
+        std::vector<const TNodeInfo*> eligibleNodes;
+        eligibleNodes.reserve(nodes.size());
+        for (const auto* node : nodes) {
+            if (node->HasTabletsForBalancer(resource, now)) {
+                eligibleNodes.push_back(node);
+            }
+        }
+        auto eligibleRange = eligibleNodes
+            | std::views::transform([](const TNodeInfo* node) -> const TNodeInfo& { return *node; });
+        const auto stats = GetStats(eligibleRange.begin(), eligibleRange.end());
+        const double scatterLimit = TTabletInfo::ExtractResourceUsage(minScatter, resource);
+        if (!(TTabletInfo::ExtractResourceUsage(stats.ScatterByResource, resource) > scatterLimit)) {
+            continue;
+        }
+        // scatter = (maximum - max(minimum, floor)) / maximum. Only sources
+        // strictly above floor / (1 - scatterLimit) can cause this trigger.
+        const double sourceThreshold = TTabletInfo::ExtractResourceUsage(minUsage, resource) / (1 - scatterLimit);
+        std::vector<TNodeId> sourceNodeIds;
+        for (const auto* node : eligibleNodes) {
+            if (node->GetTabletUsage(resource) > sourceThreshold) {
+                sourceNodeIds.push_back(node->Id);
+            }
+        }
+        // An empty FilterNodeIds means unrestricted balancing, not no donors.
+        if (sourceNodeIds.empty()) {
+            continue;
+        }
+        return TBalancerSettings{
+            .Type = type,
+            .MaxMovements = (int)CurrentConfig.GetMaxMovementsOnAutoBalancer(),
+            .RecheckOnFinish = CurrentConfig.GetContinueAutoBalancer(),
+            .MaxInFlight = GetBalancerInflight(),
+            .FilterNodeIds = std::move(sourceNodeIds),
+            .ResourceToBalance = resource,
+            .MinNodeUsage = sourceThreshold,
+        };
+    }
+    return std::nullopt;
+}
+
 THive::THiveStats THive::GetStats() const {
     auto getNode = [](const decltype(Nodes)::value_type& p) -> const TNodeInfo& { return p.second; };
     auto nodesRange = Nodes | std::views::transform(getNode);
@@ -2957,42 +3009,18 @@ void THive::Handle(TEvPrivate::TEvProcessTabletBalancer::TPtr&) {
             continue;
         }
 
-        auto scatteredResource = CheckScatter(stats.ScatterByResource);
-        if (scatteredResource) {
-            EBalancerType balancerType = EBalancerType::Scatter;
-            switch (*scatteredResource) {
-                case EResourceToBalance::Counter:
-                    balancerType = EBalancerType::ScatterCounter;
-                    break;
-                case EResourceToBalance::CPU:
-                    balancerType = EBalancerType::ScatterCPU;
-                    break;
-                case EResourceToBalance::Memory:
-                    balancerType = EBalancerType::ScatterMemory;
-                    break;
-                case EResourceToBalance::Network:
-                    balancerType = EBalancerType::ScatterNetwork;
-                    break;
-                case EResourceToBalance::ComputeResources:
-                    balancerType = EBalancerType::Scatter;
-                    break;
-            }
-            std::vector<TNodeId> nodeIds;
-            nodeIds.reserve(stats.Values.size());
-            std::transform(nodes.begin(), nodes.end(), std::back_inserter(nodeIds), [](const TNodeInfo& node) { return node.Id; });
-            YDB_LOG_TRACE("ProcessTabletBalancer: scatter over limit triggered balancer",
+        std::vector<const TNodeInfo*> segmentNodes;
+        segmentNodes.reserve(stats.Values.size());
+        for (const auto& node : nodes) {
+            segmentNodes.push_back(&node);
+        }
+        if (auto scatterSettings = GetScatterBalancerSettings(segmentNodes, TActivationContext::Now())) {
+            YDB_LOG_TRACE("ProcessTabletBalancer: movable nodes triggered scatter balancer",
                 {"logPrefix", GetLogPrefix()},
-                {"scatterByResource", stats.ScatterByResource},
-                {"minScatterToBalance", GetMinScatterToBalance()},
-                {"balancerTypeName", EBalancerTypeName(balancerType)});
-            settings.emplace(TBalancerSettings{
-                .Type = balancerType,
-                .MaxMovements = (int)CurrentConfig.GetMaxMovementsOnAutoBalancer(),
-                .RecheckOnFinish = CurrentConfig.GetContinueAutoBalancer(),
-                .MaxInFlight = GetBalancerInflight(),
-                .FilterNodeIds = std::move(nodeIds),
-                .ResourceToBalance = *scatteredResource,
-            });
+                {"balancerTypeName", EBalancerTypeName(scatterSettings->Type)},
+                {"sourceNodeIds", scatterSettings->FilterNodeIds},
+                {"minNodeUsage", *scatterSettings->MinNodeUsage});
+            settings.emplace(std::move(*scatterSettings));
             if (maybeStartBalancer()) {
                 continue;
             }

--- a/ydb/core/mind/hive/hive_impl.h
+++ b/ydb/core/mind/hive/hive_impl.h
@@ -34,6 +34,7 @@
 #include <ydb/library/actors/core/hfunc.h>
 #include <library/cpp/containers/ring_buffer/ring_buffer.h>
 
+#include <util/generic/array_ref.h>
 #include <util/generic/queue.h>
 #include <util/random/random.h>
 
@@ -1128,6 +1129,7 @@ protected:
     };
 
     THiveStats GetStats() const;
+    std::optional<TBalancerSettings> GetScatterBalancerSettings(TConstArrayRef<const TNodeInfo*> nodes, TInstant now) const;
     template<std::forward_iterator TIter>
     THiveStats GetStats(TIter begin, TIter end) const;
     void RemoveNodeFromSegments(TNodeInfo* node);

--- a/ydb/core/mind/hive/hive_impl.h
+++ b/ydb/core/mind/hive/hive_impl.h
@@ -1129,7 +1129,8 @@ protected:
     };
 
     THiveStats GetStats() const;
-    std::optional<TBalancerSettings> GetScatterBalancerSettings(TConstArrayRef<const TNodeInfo*> nodes, TInstant now) const;
+    std::optional<TBalancerSettings> GetScatterBalancerSettings(TConstArrayRef<const TNodeInfo*> nodes, TInstant now,
+        std::optional<TResourceNormalizedValues> scatterByResource = {}) const;
     template<std::forward_iterator TIter>
     THiveStats GetStats(TIter begin, TIter end) const;
     void RemoveNodeFromSegments(TNodeInfo* node);

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -5486,13 +5486,19 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         auto limitsObserver = runtime.AddObserver<TEvLocal::TEvStatus>([](auto&& ev) {
             ev->Get()->Record.ClearResourceMaximum();
         });
-        TBlockEvents<NHive::TEvPrivate::TEvProcessTabletBalancer> blockBalancer(runtime);
         CreateTestBootstrapper(runtime, CreateTestTabletInfo(hiveTablet, TTabletTypes::Hive), &CreateDefaultHive);
         {
             TDispatchOptions options;
             options.FinalEvents.emplace_back(TEvLocal::EvStatus, NUM_NODES);
             runtime.DispatchEvents(options);
         }
+        const TActorId hiveActor = ResolveTablet(runtime, hiveTablet);
+        auto blockBalancer = runtime.AddObserver<NHive::TEvPrivate::TEvProcessTabletBalancer>([hiveActor](auto& ev) {
+            // Private event IDs may be shared by unrelated actors, including BSC.
+            if (ev->Recipient == hiveActor) {
+                ev.Reset();
+            }
+        });
         const TActorId sender = runtime.AllocateEdgeActor();
         using TDistribution = std::array<std::vector<ui64>, NUM_NODES>;
         TDistribution initial;
@@ -5592,7 +5598,7 @@ Y_UNIT_TEST_SUITE(THiveTest) {
                 it->second = target;
             }
         });
-        blockBalancer.Stop();
+        blockBalancer.Remove();
         BalanceTablets(runtime, hiveTablet, sender);
         {
             TDispatchOptions options;
@@ -5961,6 +5967,9 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         Setup(runtime, true, 1, [](TAppPrepare& app) {
             app.HiveConfig.SetTabletKickCooldownPeriod(0);
             app.HiveConfig.SetResourceChangeReactionPeriod(0);
+            // The second node's two CPU tablets contribute 30%. A 20% source
+            // threshold permits one 15% tablet move before this donor stops.
+            app.HiveConfig.SetMinNodeUsageToBalance(0.1);
         });
         const int nodeBase = runtime.GetNodeId(0);
         TActorId senderA = runtime.AllocateEdgeActor();

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -5457,10 +5457,12 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         }
     }
 
-    void TestHiveScatterStopsAtSourceThreshold(ui32 inflight) {
+    void TestHiveScatterStopsAtSourceThreshold(ui32 inflight, bool checkParallelDispatch = false) {
         constexpr ui32 NUM_NODES = 6;
-        constexpr ui64 CPU_PER_TABLET = 10'000;
+        constexpr ui64 CPU_PER_PERCENT = 10'000;
         constexpr ui64 MAX_CPU = 1'000'000;
+        const ui32 tabletsPerPercent = checkParallelDispatch ? 4 : 1;
+        const ui64 cpuPerTablet = CPU_PER_PERCENT / tabletsPerPercent;
         const ui64 hiveTablet = MakeDefaultHiveID();
         const ui64 owner = MakeTabletID(false, 1);
         TTestBasicRuntime runtime(NUM_NODES, false);
@@ -5505,7 +5507,7 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         THashMap<ui64, ui32> tabletNodes;
         ui64 ownerIdx = 100500;
         for (ui32 node = 0; node < NUM_NODES; ++node) {
-            for (ui32 tablet = 0; tablet <= node; ++tablet, ++ownerIdx) {
+            for (ui32 tablet = 0; tablet < (node + 1) * tabletsPerPercent; ++tablet, ++ownerIdx) {
                 auto create = MakeHolder<TEvHive::TEvCreateTablet>(owner, ownerIdx, TTabletTypes::Dummy, BINDED_CHANNELS);
                 create->Record.SetObjectId(ownerIdx);
                 create->Record.AddAllowedNodeIDs(runtime.GetNodeId(node));
@@ -5555,11 +5557,11 @@ Y_UNIT_TEST_SUITE(THiveTest) {
             const ui32 node = ev->Sender.NodeId() - runtime.GetNodeId(0);
             if (node < NUM_NODES) {
                 record.MutableTotalResourceUsage()->Clear();
-                record.MutableTotalResourceUsage()->SetCPU((node + 1) * CPU_PER_TABLET);
+                record.MutableTotalResourceUsage()->SetCPU((node + 1) * CPU_PER_PERCENT);
             }
             for (auto& metric : *record.MutableTabletMetrics()) {
                 if (tabletNodes.contains(metric.GetTabletID())) {
-                    metric.MutableResourceUsage()->SetCPU(CPU_PER_TABLET);
+                    metric.MutableResourceUsage()->SetCPU(cpuPerTablet);
                 }
             }
         });
@@ -5570,11 +5572,11 @@ Y_UNIT_TEST_SUITE(THiveTest) {
             const TActorId localSender = runtime.AllocateEdgeActor(node);
             for (ui32 sample = 0; sample < 20; ++sample) {
                 auto metrics = MakeHolder<TEvHive::TEvTabletMetrics>();
-                metrics->Record.MutableTotalResourceUsage()->SetCPU((node + 1) * CPU_PER_TABLET);
+                metrics->Record.MutableTotalResourceUsage()->SetCPU((node + 1) * CPU_PER_PERCENT);
                 for (ui64 tabletId : initial[node]) {
                     auto* metric = metrics->Record.AddTabletMetrics();
                     metric->SetTabletID(tabletId);
-                    metric->MutableResourceUsage()->SetCPU(CPU_PER_TABLET);
+                    metric->MutableResourceUsage()->SetCPU(cpuPerTablet);
                 }
                 runtime.SendToPipe(hiveTablet, localSender, metrics.Release(), node, GetPipeConfigWithRetries());
                 TAutoPtr<IEventHandle> handle;
@@ -5598,6 +5600,52 @@ Y_UNIT_TEST_SUITE(THiveTest) {
                 it->second = target;
             }
         });
+        if (checkParallelDispatch) {
+            TBlockEvents<NHive::TEvPrivate::TEvRestartComplete> completions(runtime, [&](const auto& ev) {
+                const IActor* actor = runtime.FindActor(ev->GetRecipientRewrite());
+                return actor && actor->GetActivityType() == NKikimrServices::TActivity::HIVE_BALANCER_ACTOR
+                    && tabletNodes.contains(ev->Get()->TabletId.first);
+            });
+            TBlockEvents<TEvents::TEvWakeup> wakeups(runtime, [&](const auto& ev) {
+                const IActor* actor = runtime.FindActor(ev->GetRecipientRewrite());
+                return actor && actor->GetActivityType() == NKikimrServices::TActivity::HIVE_BALANCER_ACTOR;
+            });
+            blockBalancer.Remove();
+            BalanceTablets(runtime, hiveTablet, sender);
+            runtime.WaitFor("both scatter sources to restart tablets", [&] {
+                return completions.size() == 2 || !wakeups.empty();
+            }, TDuration::Seconds(10));
+            // Each source has more than one event's worth of cached tablets.
+            // A busy source must not consume the budget before the next donor.
+            UNIT_ASSERT_C(wakeups.empty(), "busy source delayed another donor with a wakeup");
+            UNIT_ASSERT_VALUES_EQUAL(movements, 2);
+            UNIT_ASSERT_VALUES_EQUAL(departures[3], 1);
+            UNIT_ASSERT_VALUES_EQUAL(departures[4], 1);
+
+            // Release only one source: it must be able to donate again while
+            // the other source still has an unfinished restart.
+            completions.Unblock(1);
+            runtime.WaitFor("completed source to restart another tablet", [&] {
+                return completions.size() == 2 || !wakeups.empty();
+            }, TDuration::Seconds(10));
+            UNIT_ASSERT_C(wakeups.empty(), "completed source did not resume immediately");
+            UNIT_ASSERT_VALUES_EQUAL(movements, 3);
+            UNIT_ASSERT_VALUES_EQUAL(departures[3] + departures[4], 3);
+
+            completions.Stop().Unblock();
+            wakeups.Stop().Unblock();
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(NHive::TEvPrivate::EvBalancerOut);
+            runtime.DispatchEvents(options, TDuration::Seconds(10));
+            const auto finalDistribution = getDistribution();
+            UNIT_ASSERT_VALUES_EQUAL(departures[3], 2);
+            UNIT_ASSERT_VALUES_EQUAL(departures[4], 6);
+            UNIT_ASSERT_VALUES_EQUAL(movements, 8);
+            UNIT_ASSERT_VALUES_EQUAL(finalDistribution[3].size(), 14);
+            UNIT_ASSERT_VALUES_EQUAL(finalDistribution[4].size(), 14);
+            UNIT_ASSERT_EQUAL(finalDistribution.back(), initial.back());
+            return;
+        }
         blockBalancer.Remove();
         BalanceTablets(runtime, hiveTablet, sender);
         {
@@ -5631,6 +5679,10 @@ Y_UNIT_TEST_SUITE(THiveTest) {
 
     Y_UNIT_TEST(TestHiveScatterStopsAtSourceThresholdConcurrent) {
         TestHiveScatterStopsAtSourceThreshold(4);
+    }
+
+    Y_UNIT_TEST(TestHiveScatterBusySourceDoesNotDelayOtherSources) {
+        TestHiveScatterStopsAtSourceThreshold(4, true);
     }
 
     Y_UNIT_TEST(TestHiveBalancerDifferentResources) {

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -5457,6 +5457,176 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         }
     }
 
+    void TestHiveScatterStopsAtSourceThreshold(ui32 inflight) {
+        constexpr ui32 NUM_NODES = 6;
+        constexpr ui64 CPU_PER_TABLET = 10'000;
+        constexpr ui64 MAX_CPU = 1'000'000;
+        const ui64 hiveTablet = MakeDefaultHiveID();
+        const ui64 owner = MakeTabletID(false, 1);
+        TTestBasicRuntime runtime(NUM_NODES, false);
+        Setup(runtime, true, 1, [inflight](TAppPrepare& app) {
+            app.HiveConfig.SetMaxResourceCPU(MAX_CPU);
+            app.HiveConfig.SetMinNodeUsageToBalance(0.0175);
+            app.HiveConfig.SetMinCPUScatterToBalance(0.5);
+            app.HiveConfig.SetMinCounterScatterToBalance(1);
+            app.HiveConfig.SetMinMemoryScatterToBalance(1);
+            app.HiveConfig.SetMinNetworkScatterToBalance(1);
+            app.HiveConfig.SetMaxNodeUsageToKick(1);
+            app.HiveConfig.SetSpreadNeighbours(false);
+            app.HiveConfig.SetWarmUpEnabled(false);
+            app.HiveConfig.SetTabletKickCooldownPeriod(0);
+            app.HiveConfig.SetResourceChangeReactionPeriod(86'400);
+            app.HiveConfig.SetMetricsWindowSize(3'600'000);
+            app.HiveConfig.SetMaxMovementsOnAutoBalancer(100);
+            app.HiveConfig.SetBalancerInflight(inflight);
+            app.HiveConfig.SetNodeBalanceStrategy(NKikimrConfig::THiveConfig::HIVE_NODE_BALANCE_STRATEGY_HEAVIEST);
+            app.HiveConfig.SetNodeSelectStrategy(NKikimrConfig::THiveConfig::HIVE_NODE_SELECT_STRATEGY_RANDOM_MIN_7P);
+        });
+        // Use identical limits independently of the machine running this test.
+        auto limitsObserver = runtime.AddObserver<TEvLocal::TEvStatus>([](auto&& ev) {
+            ev->Get()->Record.ClearResourceMaximum();
+        });
+        TBlockEvents<NHive::TEvPrivate::TEvProcessTabletBalancer> blockBalancer(runtime);
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(hiveTablet, TTabletTypes::Hive), &CreateDefaultHive);
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvLocal::EvStatus, NUM_NODES);
+            runtime.DispatchEvents(options);
+        }
+        const TActorId sender = runtime.AllocateEdgeActor();
+        using TDistribution = std::array<std::vector<ui64>, NUM_NODES>;
+        TDistribution initial;
+        THashMap<ui64, ui32> tabletNodes;
+        ui64 ownerIdx = 100500;
+        for (ui32 node = 0; node < NUM_NODES; ++node) {
+            for (ui32 tablet = 0; tablet <= node; ++tablet, ++ownerIdx) {
+                auto create = MakeHolder<TEvHive::TEvCreateTablet>(owner, ownerIdx, TTabletTypes::Dummy, BINDED_CHANNELS);
+                create->Record.SetObjectId(ownerIdx);
+                create->Record.AddAllowedNodeIDs(runtime.GetNodeId(node));
+                if (node == NUM_NODES - 1) {
+                    // Six percent of background load that the balancer cannot move.
+                    create->Record.SetBalancerPolicy(NKikimrHive::POLICY_IGNORE);
+                }
+                const ui64 tabletId = SendCreateTestTablet(runtime, hiveTablet, owner, std::move(create), 0, true);
+                MakeSureTabletIsUp(runtime, tabletId, 0);
+                initial[node].push_back(tabletId);
+                tabletNodes.emplace(tabletId, node);
+                if (node != NUM_NODES - 1) {
+                    // The placement restriction is only for constructing the fixture.
+                    auto update = MakeHolder<TEvHive::TEvCreateTablet>(owner, ownerIdx, TTabletTypes::Dummy, BINDED_CHANNELS);
+                    update->Record.SetObjectId(ownerIdx);
+                    UNIT_ASSERT_VALUES_EQUAL(SendCreateTestTablet(runtime, hiveTablet, owner, std::move(update), 0, false), tabletId);
+                }
+            }
+        }
+        auto getDistribution = [&]() {
+            runtime.SendToPipe(hiveTablet, sender, new TEvHive::TEvRequestHiveInfo());
+            TAutoPtr<IEventHandle> handle;
+            auto* response = runtime.GrabEdgeEventRethrow<TEvHive::TEvResponseHiveInfo>(handle);
+            TDistribution result;
+            for (const auto& tablet : response->Record.GetTablets()) {
+                if (!tabletNodes.contains(tablet.GetTabletID())) {
+                    continue;
+                }
+                const ui32 node = tablet.GetNodeID() - runtime.GetNodeId(0);
+                UNIT_ASSERT_LT(node, NUM_NODES);
+                result[node].push_back(tablet.GetTabletID());
+            }
+            for (auto& tablets : result) {
+                std::sort(tablets.begin(), tablets.end());
+            }
+            return result;
+        };
+        for (auto& tablets : initial) {
+            std::sort(tablets.begin(), tablets.end());
+        }
+        UNIT_ASSERT_EQUAL(getDistribution(), initial);
+
+        auto metricsObserver = runtime.AddObserver<TEvHive::TEvTabletMetrics>([&](auto&& ev) {
+            auto& record = ev->Get()->Record;
+            record.MutableResourceMaximum()->Clear();
+            record.MutableResourceMaximum()->SetCPU(MAX_CPU);
+            const ui32 node = ev->Sender.NodeId() - runtime.GetNodeId(0);
+            if (node < NUM_NODES) {
+                record.MutableTotalResourceUsage()->Clear();
+                record.MutableTotalResourceUsage()->SetCPU((node + 1) * CPU_PER_TABLET);
+            }
+            for (auto& metric : *record.MutableTabletMetrics()) {
+                if (tabletNodes.contains(metric.GetTabletID())) {
+                    metric.MutableResourceUsage()->SetCPU(CPU_PER_TABLET);
+                }
+            }
+        });
+        // Repeated node totals become stable and deliberately stay at their initial
+        // values throughout the moves. In particular node 5 still reports 5% after
+        // its tablet aggregate reaches 3%; this must not permit a third evacuation.
+        for (ui32 node = 0; node < NUM_NODES; ++node) {
+            const TActorId localSender = runtime.AllocateEdgeActor(node);
+            for (ui32 sample = 0; sample < 20; ++sample) {
+                auto metrics = MakeHolder<TEvHive::TEvTabletMetrics>();
+                metrics->Record.MutableTotalResourceUsage()->SetCPU((node + 1) * CPU_PER_TABLET);
+                for (ui64 tabletId : initial[node]) {
+                    auto* metric = metrics->Record.AddTabletMetrics();
+                    metric->SetTabletID(tabletId);
+                    metric->MutableResourceUsage()->SetCPU(CPU_PER_TABLET);
+                }
+                runtime.SendToPipe(hiveTablet, localSender, metrics.Release(), node, GetPipeConfigWithRetries());
+                TAutoPtr<IEventHandle> handle;
+                runtime.GrabEdgeEventRethrow<TEvLocal::TEvTabletMetricsAck>(handle);
+            }
+        }
+        ui32 movements = 0;
+        std::array<ui32, NUM_NODES> departures = {};
+        auto moveObserver = runtime.AddObserver<TEvLocal::TEvBootTablet>([&](auto&& ev) {
+            const ui64 tabletId = ev->Get()->Record.GetInfo().GetTabletID();
+            auto it = tabletNodes.find(tabletId);
+            if (it == tabletNodes.end()) {
+                return;
+            }
+            const ui32 target = ev->Recipient.NodeId() - runtime.GetNodeId(0);
+            if (it->second != target) {
+                // Nodes 1--3 never donate, including after receiving a tablet.
+                UNIT_ASSERT_C(it->second == 3 || it->second == 4, "unexpected source " << it->second + 1);
+                ++departures[it->second];
+                ++movements;
+                it->second = target;
+            }
+        });
+        blockBalancer.Stop();
+        BalanceTablets(runtime, hiveTablet, sender);
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(NHive::TEvPrivate::EvBalancerOut);
+            runtime.DispatchEvents(options, TDuration::Seconds(10));
+        }
+        const auto finalDistribution = getDistribution();
+        UNIT_ASSERT_VALUES_EQUAL(movements, 3);
+        UNIT_ASSERT_VALUES_EQUAL(departures[3], 1);
+        UNIT_ASSERT_VALUES_EQUAL(departures[4], 2);
+        for (ui32 node = 0; node < NUM_NODES - 1; ++node) {
+            UNIT_ASSERT_VALUES_EQUAL_C(finalDistribution[node].size(), 3, "node " << node + 1);
+        }
+        UNIT_ASSERT_EQUAL(finalDistribution.back(), initial.back());
+        // The immovable sixth node must not trigger another CPU pass after the
+        // five participating nodes reach equal 3% loads.
+        BalanceTablets(runtime, hiveTablet, sender);
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(NHive::TEvPrivate::EvBalancerOut);
+            runtime.DispatchEvents(options, TDuration::Seconds(10));
+        }
+        UNIT_ASSERT_VALUES_EQUAL(movements, 3);
+        UNIT_ASSERT_EQUAL(getDistribution(), finalDistribution);
+    }
+
+    Y_UNIT_TEST(TestHiveScatterStopsAtSourceThresholdSerial) {
+        TestHiveScatterStopsAtSourceThreshold(1);
+    }
+
+    Y_UNIT_TEST(TestHiveScatterStopsAtSourceThresholdConcurrent) {
+        TestHiveScatterStopsAtSourceThreshold(4);
+    }
+
     Y_UNIT_TEST(TestHiveBalancerDifferentResources) {
         static constexpr ui64 TABLETS_PER_NODE = 4;
         TTestBasicRuntime runtime(2, false);

--- a/ydb/core/mind/hive/node_info.cpp
+++ b/ydb/core/mind/hive/node_info.cpp
@@ -485,14 +485,66 @@ void TNodeInfo::UpdateResourceMaximum(const NKikimrTabletBase::TMetrics& metrics
     Hive.UpdateTotalResourceValues(nullptr, nullptr, {}, {}, {}, normalizedValues - oldNormalizedValues);
 }
 
-bool TNodeInfo::HasTabletsForBalancer(EResourceToBalance resource, TInstant now) const {
-    if (!IsAlive() || Down || Freeze) {
+TNodeInfo::TBalancerResourceScanner::TBalancerResourceScanner(
+        const TNodeInfo& node, TBalancerResourceMask resources, TInstant now)
+    : Now(now)
+    , Pending(resources)
+{
+    if (resources.none() || !node.IsAlive() || node.Down || node.Freeze) {
+        return;
+    }
+    auto it = node.Tablets.find(TTabletInfo::EVolatileState::TABLET_VOLATILE_STATE_RUNNING);
+    if (it != node.Tablets.end()) {
+        Tablets = &it->second;
+        Next = Tablets->begin();
+    }
+}
+
+bool TNodeInfo::TBalancerResourceScanner::HasResource(EResourceToBalance resource) {
+    const auto requested = static_cast<size_t>(resource);
+    if (Found.test(requested)) {
+        return true;
+    }
+    if (!Tablets || !Pending.test(requested)) {
         return false;
     }
-    auto it = Tablets.find(TTabletInfo::EVolatileState::TABLET_VOLATILE_STATE_RUNNING);
-    return it != Tablets.end() && std::any_of(it->second.begin(), it->second.end(), [&](const TTabletInfo* tablet) {
-        return tablet->IsRunning() && tablet->IsGoodForBalancer(now, resource);
-    });
+    while (Next != Tablets->end()) {
+        const auto* tablet = *Next++;
+        if (!tablet->IsRunning() || !tablet->IsGoodForBalancer(Now) || tablet->IsPinnedToNode()) {
+            continue;
+        }
+        for (size_t index = 0; index < Pending.size(); ++index) {
+            // ComputeResources has its own HasMetric semantics; it is not the
+            // union of the three individual compute-resource checks.
+            if (Pending.test(index) && tablet->HasMetric(static_cast<EResourceToBalance>(index))) {
+                Found.set(index);
+                Pending.reset(index);
+            }
+        }
+        if (Found.test(requested)) {
+            return true;
+        }
+    }
+    Tablets = nullptr;
+    return false;
+}
+
+TNodeInfo::TBalancerResourceMask TNodeInfo::GetBalancerResourceMask(TBalancerResourceMask resources, TInstant now) const {
+    TBalancerResourceScanner scanner(*this, resources, now);
+    TBalancerResourceMask result;
+    for (size_t index = 0; index < resources.size(); ++index) {
+        if (resources.test(index) && scanner.HasResource(static_cast<EResourceToBalance>(index))) {
+            result.set(index);
+        }
+    }
+    return result;
+}
+
+bool TNodeInfo::HasTabletsForBalancer(EResourceToBalance resource, TInstant now) const {
+    TBalancerResourceMask resources;
+    resources.set(static_cast<size_t>(resource));
+    TBalancerResourceScanner scanner(*this, resources, now);
+    return scanner.HasResource(resource);
 }
 
 double TNodeInfo::GetNodeUsageForTablet(const TTabletInfo& tablet, bool neighbourPenalty) const {

--- a/ydb/core/mind/hive/node_info.cpp
+++ b/ydb/core/mind/hive/node_info.cpp
@@ -491,7 +491,7 @@ bool TNodeInfo::HasTabletsForBalancer(EResourceToBalance resource, TInstant now)
     }
     auto it = Tablets.find(TTabletInfo::EVolatileState::TABLET_VOLATILE_STATE_RUNNING);
     return it != Tablets.end() && std::any_of(it->second.begin(), it->second.end(), [&](const TTabletInfo* tablet) {
-        return tablet->IsGoodForBalancer(now, resource);
+        return tablet->IsRunning() && tablet->IsGoodForBalancer(now, resource);
     });
 }
 
@@ -537,7 +537,7 @@ double TNodeInfo::GetNodeUsage(const TResourceNormalizedValues& normValues, ERes
 }
 
 double TNodeInfo::GetTabletUsage(EResourceToBalance resource) const {
-    return GetNodeUsage(NormalizeRawValues(ResourceValues, GetResourceMaximumValues()), resource);
+    return TTabletInfo::ExtractResourceUsage(NormalizeRawValues(ResourceValues, GetResourceMaximumValues()), resource);
 }
 
 double TNodeInfo::GetNodeUsage(EResourceToBalance resource) const {

--- a/ydb/core/mind/hive/node_info.cpp
+++ b/ydb/core/mind/hive/node_info.cpp
@@ -485,6 +485,16 @@ void TNodeInfo::UpdateResourceMaximum(const NKikimrTabletBase::TMetrics& metrics
     Hive.UpdateTotalResourceValues(nullptr, nullptr, {}, {}, {}, normalizedValues - oldNormalizedValues);
 }
 
+bool TNodeInfo::HasTabletsForBalancer(EResourceToBalance resource, TInstant now) const {
+    if (!IsAlive() || Down || Freeze) {
+        return false;
+    }
+    auto it = Tablets.find(TTabletInfo::EVolatileState::TABLET_VOLATILE_STATE_RUNNING);
+    return it != Tablets.end() && std::any_of(it->second.begin(), it->second.end(), [&](const TTabletInfo* tablet) {
+        return tablet->IsGoodForBalancer(now, resource);
+    });
+}
+
 double TNodeInfo::GetNodeUsageForTablet(const TTabletInfo& tablet, bool neighbourPenalty) const {
     // what it would like when tablet will run on this node?
     auto maximum = GetResourceMaximumValues();
@@ -524,6 +534,10 @@ double TNodeInfo::GetNodeUsage(const TResourceNormalizedValues& normValues, ERes
         usage = std::max(usage, AveragedNodeTotalUsage.GetValue());
     }
     return usage;
+}
+
+double TNodeInfo::GetTabletUsage(EResourceToBalance resource) const {
+    return GetNodeUsage(NormalizeRawValues(ResourceValues, GetResourceMaximumValues()), resource);
 }
 
 double TNodeInfo::GetNodeUsage(EResourceToBalance resource) const {

--- a/ydb/core/mind/hive/node_info.h
+++ b/ydb/core/mind/hive/node_info.h
@@ -277,7 +277,11 @@ public:
         return ResourceMaximumValues;
     }
 
+    bool HasTabletsForBalancer(EResourceToBalance resource, TInstant now) const;
+
     double GetNodeUsageForTablet(const TTabletInfo& tablet, bool neighbourPenalty = true) const;
+    // Aggregate used by scatter; excludes delayed node-wide resource totals.
+    double GetTabletUsage(EResourceToBalance resource) const;
     double GetNodeUsage(EResourceToBalance resource = EResourceToBalance::ComputeResources) const;
     double GetNodeUsage(const TResourceNormalizedValues& normValues,
                         EResourceToBalance resource = EResourceToBalance::ComputeResources) const;

--- a/ydb/core/mind/hive/node_info.h
+++ b/ydb/core/mind/hive/node_info.h
@@ -277,6 +277,22 @@ public:
         return ResourceMaximumValues;
     }
 
+    using TBalancerResourceMask = std::bitset<static_cast<size_t>(EResourceToBalance::Network) + 1>;
+    // Only valid within one synchronous decision: the RUNNING bucket must not
+    // change, and cooldowns are checked at the same instant for every resource.
+    class TBalancerResourceScanner {
+        TInstant Now;
+        TBalancerResourceMask Pending;
+        TBalancerResourceMask Found;
+        const std::unordered_set<TTabletInfo*>* Tablets = nullptr;
+        std::unordered_set<TTabletInfo*>::const_iterator Next;
+
+    public:
+        TBalancerResourceScanner(const TNodeInfo& node, TBalancerResourceMask resources, TInstant now);
+        bool HasResource(EResourceToBalance resource);
+    };
+
+    TBalancerResourceMask GetBalancerResourceMask(TBalancerResourceMask resources, TInstant now) const;
     bool HasTabletsForBalancer(EResourceToBalance resource, TInstant now) const;
 
     double GetNodeUsageForTablet(const TTabletInfo& tablet, bool neighbourPenalty = true) const;

--- a/ydb/core/mind/hive/scatter_balancer_ut.cpp
+++ b/ydb/core/mind/hive/scatter_balancer_ut.cpp
@@ -135,6 +135,90 @@ void AssertSources(const std::optional<TBalancerSettings>& settings, std::initia
 } // anonymous namespace
 
 Y_UNIT_TEST_SUITE(THiveScatterBalancerTest) {
+    Y_UNIT_TEST(ResourceMaskCombinesTabletsAndOnlyReturnsRequestedResources) {
+        TScatterFixture fixture;
+        auto& node = fixture.AddNode(EResourceToBalance::CPU, 50'000);
+        fixture.AddTablet(node, EResourceToBalance::Memory);
+        fixture.AddTablet(node, EResourceToBalance::Network);
+        fixture.AddTablet(node, EResourceToBalance::Counter);
+        TNodeInfo::TBalancerResourceMask requested;
+        UNIT_ASSERT(node.GetBalancerResourceMask(requested, fixture.Now).none());
+        requested.set();
+        UNIT_ASSERT(node.GetBalancerResourceMask(requested, fixture.Now).all());
+        requested.reset();
+        requested.set(static_cast<size_t>(EResourceToBalance::CPU));
+        UNIT_ASSERT(node.GetBalancerResourceMask(requested, fixture.Now) == requested);
+        fixture.Tablets.front()->BalancerPolicy = TTabletInfo::EBalancerPolicy::POLICY_IGNORE;
+        UNIT_ASSERT(node.GetBalancerResourceMask(requested, fixture.Now).none());
+    }
+
+    Y_UNIT_TEST(ResourceMaskIsRefreshedAfterCooldownAndMetricChanges) {
+        TScatterFixture fixture;
+        auto& node = fixture.AddNode(EResourceToBalance::CPU, 50'000);
+        auto& tablet = *fixture.Tablets.back();
+        TNodeInfo::TBalancerResourceMask requested;
+        requested.set(static_cast<size_t>(EResourceToBalance::CPU));
+        UNIT_ASSERT(node.GetBalancerResourceMask(requested, fixture.Now).any());
+        tablet.MakeBalancerDecision(fixture.Now);
+        UNIT_ASSERT(node.GetBalancerResourceMask(requested, fixture.Now).none());
+        const auto later = fixture.Now + TDuration::Seconds(601);
+        UNIT_ASSERT(node.GetBalancerResourceMask(requested, later).any());
+        SetResource(tablet.GetMutableResourceValues(), EResourceToBalance::CPU, 0);
+        UNIT_ASSERT(node.GetBalancerResourceMask(requested, later).none());
+    }
+
+    Y_UNIT_TEST(ComputeResourceMaskPreservesCounterBasedEligibility) {
+        TScatterFixture fixture;
+        auto& receiver = fixture.AddNode(EResourceToBalance::Counter, 1);
+        fixture.AddNode(EResourceToBalance::CPU, 50'000);
+        TNodeInfo::TBalancerResourceMask requested;
+        requested.set(static_cast<size_t>(EResourceToBalance::CPU));
+        requested.set(static_cast<size_t>(EResourceToBalance::ComputeResources));
+        const auto mask = receiver.GetBalancerResourceMask(requested, fixture.Now);
+        UNIT_ASSERT(!mask.test(static_cast<size_t>(EResourceToBalance::CPU)));
+        UNIT_ASSERT(mask.test(static_cast<size_t>(EResourceToBalance::ComputeResources)));
+        // A permitted compute metric with value zero and a nonzero counter is
+        // still a ComputeResources match. Keep this node as a CPU receiver.
+        AssertSources(fixture.Settings(), {2});
+    }
+
+    Y_UNIT_TEST(NextResourceCanTriggerAfterFirstCohortIsBalanced) {
+        TScatterFixture fixture;
+        auto& first = fixture.AddNode(EResourceToBalance::CPU, 30'000);
+        fixture.AddTablet(first, EResourceToBalance::Memory);
+        SetResource(first.ResourceValues, EResourceToBalance::Memory, 10'000);
+        auto& second = fixture.AddNode(EResourceToBalance::CPU, 30'000);
+        fixture.AddTablet(second, EResourceToBalance::Memory);
+        SetResource(second.ResourceValues, EResourceToBalance::Memory, 50'000);
+        fixture.AddNode(EResourceToBalance::CPU, 900'000);
+        fixture.Tablets.back()->BalancerPolicy = TTabletInfo::EBalancerPolicy::POLICY_IGNORE;
+        const auto settings = fixture.Settings();
+        AssertSources(settings, {2});
+        UNIT_ASSERT(settings->ResourceToBalance == EResourceToBalance::Memory);
+    }
+
+    Y_UNIT_TEST(CounterDifferenceOfOneIsIgnoredAfterRemovingUnmovableNodes) {
+        TScatterFixture fixture;
+        fixture.AddNode(EResourceToBalance::Counter, 1);
+        fixture.AddNode(EResourceToBalance::Counter, 2);
+        fixture.AddNode(EResourceToBalance::Counter, 10);
+        fixture.Tablets.back()->BalancerPolicy = TTabletInfo::EBalancerPolicy::POLICY_IGNORE;
+        UNIT_ASSERT(!fixture.Settings());
+    }
+
+    Y_UNIT_TEST(CPUKeepsPriorityWhenMemoryAlsoExceedsScatterLimit) {
+        TScatterFixture fixture;
+        auto& first = fixture.AddNode(EResourceToBalance::CPU, 10'000);
+        fixture.AddTablet(first, EResourceToBalance::Memory);
+        SetResource(first.ResourceValues, EResourceToBalance::Memory, 50'000);
+        auto& second = fixture.AddNode(EResourceToBalance::CPU, 50'000);
+        fixture.AddTablet(second, EResourceToBalance::Memory);
+        SetResource(second.ResourceValues, EResourceToBalance::Memory, 10'000);
+        const auto settings = fixture.Settings();
+        AssertSources(settings, {2});
+        UNIT_ASSERT(settings->ResourceToBalance == EResourceToBalance::CPU);
+    }
+
     Y_UNIT_TEST(SelectsOnlySourcesAboveThresholdFromMovableCohort) {
         TScatterFixture fixture;
         for (i64 percent = 1; percent <= 6; ++percent) {

--- a/ydb/core/mind/hive/scatter_balancer_ut.cpp
+++ b/ydb/core/mind/hive/scatter_balancer_ut.cpp
@@ -1,0 +1,324 @@
+#include "hive_impl.h"
+#include "ut_common.h"
+
+#include <ydb/core/testlib/actor_helpers.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NHive {
+namespace {
+
+class TScatterHive : public TTestHive {
+public:
+    using TTestHive::TTestHive;
+    using THive::GetScatterBalancerSettings;
+};
+
+class TScatterNode : public TNodeInfo {
+public:
+    TScatterNode(TNodeId id, THive& hive)
+        : TNodeInfo(id, hive)
+    {
+        Local = TActorId(id, "LOCAL");
+        ResourceMaximumValues = {1'000'000, 1'000'000, 1'000'000, 1'000'000};
+        std::get<NMetrics::EResource::Memory>(ResourceMaximumValues) = 1'000'000'000;
+        SetAlive(true);
+    }
+
+    void SetAlive(bool alive) {
+        VolatileState = alive ? EVolatileState::Connected : EVolatileState::Disconnected;
+    }
+};
+
+class TScatterTablet : public TLeaderTabletInfo {
+public:
+    TScatterTablet(TTabletId id, THive& hive, TNodeInfo& node)
+        : TLeaderTabletInfo(id, hive)
+    {
+        Type = TTabletTypes::Dummy;
+        State = ETabletState::ReadyToWork;
+        Node = &node;
+        NodeId = node.Id;
+        VolatileState = EVolatileState::TABLET_VOLATILE_STATE_RUNNING;
+    }
+};
+
+void SetResource(TResourceRawValues& values, EResourceToBalance resource, i64 value) {
+    switch (resource) {
+        case EResourceToBalance::Counter: std::get<NMetrics::EResource::Counter>(values) = value; break;
+        case EResourceToBalance::CPU: std::get<NMetrics::EResource::CPU>(values) = value; break;
+        case EResourceToBalance::Memory: std::get<NMetrics::EResource::Memory>(values) = value * 1'000; break;
+        case EResourceToBalance::Network: std::get<NMetrics::EResource::Network>(values) = value; break;
+        case EResourceToBalance::ComputeResources: Y_ABORT("A concrete resource is required");
+    }
+}
+
+void SetResource(TMetrics& values, EResourceToBalance resource, i64 value) {
+    switch (resource) {
+        case EResourceToBalance::Counter: values.Counter = value; break;
+        case EResourceToBalance::CPU: values.CPU = value; break;
+        case EResourceToBalance::Memory: values.Memory = value * 1'000; break;
+        case EResourceToBalance::Network: values.Network = value; break;
+        case EResourceToBalance::ComputeResources: Y_ABORT("A concrete resource is required");
+    }
+}
+
+struct TScatterFixture {
+    static TIntrusivePtr<TTabletStorageInfo> MakeStorage() {
+        auto storage = MakeIntrusive<TTabletStorageInfo>();
+        storage->TabletType = TTabletTypes::Hive;
+        return storage;
+    }
+
+    TActorSystemStub ActorSystem;
+    TIntrusivePtr<TTabletStorageInfo> Storage = MakeStorage();
+    TScatterHive Hive;
+    std::vector<std::unique_ptr<TScatterNode>> Nodes;
+    std::vector<std::unique_ptr<TScatterTablet>> Tablets;
+    const TInstant Now = TInstant::Seconds(10'000);
+
+    TScatterFixture()
+        : Hive(Storage.Get(), TActorId())
+    {
+        Hive.CurrentConfig.SetMinNodeUsageToBalance(.0175);
+        Hive.CurrentConfig.SetMinCPUScatterToBalance(.5);
+        Hive.CurrentConfig.SetMinMemoryScatterToBalance(.5);
+        Hive.CurrentConfig.SetMinNetworkScatterToBalance(.5);
+        Hive.CurrentConfig.SetMinCounterScatterToBalance(.5);
+        Hive.CurrentConfig.SetMaxResourceCounter(1'000'000);
+        Hive.CurrentConfig.SetTabletKickCooldownPeriod(600);
+        Hive.CurrentConfig.SetUseTabletUsageEstimate(false);
+        Hive.CurrentConfig.SetMaxMovementsOnAutoBalancer(100);
+        Hive.CurrentConfig.SetBalancerInflight(4);
+        Hive.CurrentConfig.SetContinueAutoBalancer(true);
+    }
+
+    TScatterNode& AddNode(EResourceToBalance resource, i64 usage, bool hasTablet = true) {
+        Nodes.push_back(std::make_unique<TScatterNode>(Nodes.size() + 1, Hive));
+        auto& node = *Nodes.back();
+        SetResource(node.ResourceValues, resource, usage);
+        if (hasTablet) {
+            AddTablet(node, resource);
+        }
+        return node;
+    }
+
+    TScatterTablet& AddTablet(TScatterNode& node, EResourceToBalance resource) {
+        Tablets.push_back(std::make_unique<TScatterTablet>(Tablets.size() + 1, Hive, node));
+        auto& tablet = *Tablets.back();
+        // A compute tablet consumes 1% of capacity, above the metric noise floors.
+        // Memory uses a larger capacity so that the same percentages are meaningful.
+        SetResource(tablet.GetMutableResourceValues(), resource,
+            resource == EResourceToBalance::Counter ? 1 : 10'000);
+        auto values = tablet.GetResourceCurrentValues();
+        tablet.FilterRawValues(values);
+        UNIT_ASSERT(TTabletInfo::ExtractResourceUsage(values, resource) > 0);
+        node.Tablets[TTabletInfo::EVolatileState::TABLET_VOLATILE_STATE_RUNNING].insert(&tablet);
+        return tablet;
+    }
+
+    std::optional<TBalancerSettings> Settings() const {
+        std::vector<const TNodeInfo*> nodes;
+        for (const auto& node : Nodes) {
+            nodes.push_back(node.get());
+        }
+        return Hive.GetScatterBalancerSettings(nodes, Now);
+    }
+};
+
+void AssertSources(const std::optional<TBalancerSettings>& settings, std::initializer_list<TNodeId> expected) {
+    UNIT_ASSERT(settings);
+    auto actual = settings->FilterNodeIds;
+    std::sort(actual.begin(), actual.end());
+    UNIT_ASSERT(actual == std::vector<TNodeId>(expected));
+}
+
+} // anonymous namespace
+
+Y_UNIT_TEST_SUITE(THiveScatterBalancerTest) {
+    Y_UNIT_TEST(SelectsOnlySourcesAboveThresholdFromMovableCohort) {
+        TScatterFixture fixture;
+        for (i64 percent = 1; percent <= 6; ++percent) {
+            fixture.AddNode(EResourceToBalance::CPU, percent * 10'000);
+        }
+        fixture.Tablets.back()->BalancerPolicy = TTabletInfo::EBalancerPolicy::POLICY_IGNORE;
+        auto settings = fixture.Settings();
+        AssertSources(settings, {4, 5});
+        UNIT_ASSERT(settings->Type == EBalancerType::ScatterCPU);
+        UNIT_ASSERT(settings->ResourceToBalance == EResourceToBalance::CPU);
+        UNIT_ASSERT(settings->MinNodeUsage);
+        UNIT_ASSERT_DOUBLES_EQUAL(*settings->MinNodeUsage, .035, 1e-12);
+        UNIT_ASSERT_VALUES_EQUAL(settings->MaxMovements, 100);
+        UNIT_ASSERT_VALUES_EQUAL(settings->MaxInFlight, 4);
+        UNIT_ASSERT(settings->RecheckOnFinish);
+    }
+
+    Y_UNIT_TEST(UnmovableMaximumCannotTriggerBalancing) {
+        TScatterFixture fixture;
+        fixture.AddNode(EResourceToBalance::CPU, 30'000);
+        fixture.AddNode(EResourceToBalance::CPU, 30'000);
+        fixture.AddNode(EResourceToBalance::CPU, 900'000);
+        fixture.Tablets.back()->BalancerPolicy = TTabletInfo::EBalancerPolicy::POLICY_IGNORE;
+        UNIT_ASSERT(!fixture.Settings());
+    }
+
+    Y_UNIT_TEST(BackgroundLoadWithoutTabletsIsNotAScatterSource) {
+        TScatterFixture fixture;
+        for (i64 percent = 1; percent <= 5; ++percent) {
+            fixture.AddNode(EResourceToBalance::CPU, percent * 10'000);
+        }
+        auto& background = fixture.AddNode(EResourceToBalance::CPU, 0, false);
+        TResourceRawValues total{};
+        SetResource(total, EResourceToBalance::CPU, 60'000);
+        for (int i = 0; i < 20; ++i) {
+            background.AveragedResourceTotalValues.Push(total);
+        }
+        background.ResourceTotalValues = background.AveragedResourceTotalValues.GetValue();
+        UNIT_ASSERT(background.AveragedResourceTotalValues.IsValueStable());
+        UNIT_ASSERT_DOUBLES_EQUAL(background.GetNodeUsage(EResourceToBalance::CPU), .06, 1e-12);
+        UNIT_ASSERT(!background.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now));
+        AssertSources(fixture.Settings(), {4, 5});
+    }
+
+    Y_UNIT_TEST(UnmovableMinimumCannotTriggerBalancing) {
+        TScatterFixture fixture;
+        fixture.AddNode(EResourceToBalance::CPU, 10'000);
+        fixture.Tablets.back()->BalancerPolicy = TTabletInfo::EBalancerPolicy::POLICY_IGNORE;
+        fixture.AddNode(EResourceToBalance::CPU, 50'000);
+        fixture.AddNode(EResourceToBalance::CPU, 50'000);
+        UNIT_ASSERT(!fixture.Settings());
+    }
+
+    Y_UNIT_TEST(EmptyAndSingleEligibleCohortsDoNotStartUnrestrictedBalancer) {
+        TScatterFixture fixture;
+        UNIT_ASSERT(!fixture.Settings());
+        fixture.AddNode(EResourceToBalance::CPU, 0, false);
+        fixture.AddNode(EResourceToBalance::CPU, 500'000, false);
+        UNIT_ASSERT(!fixture.Settings());
+        fixture.AddNode(EResourceToBalance::CPU, 900'000);
+        // Empty recipients remain possible destinations, but are not scatter cohort members.
+        UNIT_ASSERT(!fixture.Settings());
+    }
+
+    Y_UNIT_TEST(NodeEligibilityChecksLivenessAdministrativeStateAndRunningTablets) {
+        TScatterFixture fixture;
+        auto& node = fixture.AddNode(EResourceToBalance::CPU, 50'000, false);
+        UNIT_ASSERT(!node.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now));
+        auto& tablet = fixture.AddTablet(node, EResourceToBalance::CPU);
+        UNIT_ASSERT(node.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now));
+        node.SetAlive(false);
+        UNIT_ASSERT(!node.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now));
+        node.SetAlive(true);
+        node.Down = true;
+        UNIT_ASSERT(!node.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now));
+        node.Down = false;
+        node.Freeze = true;
+        UNIT_ASSERT(!node.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now));
+        node.Freeze = false;
+        node.Tablets[TTabletInfo::EVolatileState::TABLET_VOLATILE_STATE_RUNNING].erase(&tablet);
+        node.Tablets[TTabletInfo::EVolatileState::TABLET_VOLATILE_STATE_STARTING].insert(&tablet);
+        UNIT_ASSERT(!node.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now));
+    }
+
+    Y_UNIT_TEST(TabletEligibilityChecksPolicyMetricCooldownAndPinning) {
+        TScatterFixture fixture;
+        auto& node = fixture.AddNode(EResourceToBalance::CPU, 50'000);
+        auto& tablet = *fixture.Tablets.back();
+        UNIT_ASSERT(tablet.IsGoodForBalancer(fixture.Now, EResourceToBalance::CPU));
+        UNIT_ASSERT(!tablet.IsGoodForBalancer(fixture.Now, EResourceToBalance::Memory));
+        tablet.BalancerPolicy = TTabletInfo::EBalancerPolicy::POLICY_IGNORE;
+        UNIT_ASSERT(!tablet.IsGoodForBalancer(fixture.Now, EResourceToBalance::CPU));
+        tablet.BalancerPolicy = TTabletInfo::EBalancerPolicy::POLICY_BALANCE;
+        tablet.MakeBalancerDecision(fixture.Now);
+        UNIT_ASSERT(!tablet.IsGoodForBalancer(fixture.Now + TDuration::Seconds(600), EResourceToBalance::CPU));
+        UNIT_ASSERT(tablet.IsGoodForBalancer(fixture.Now + TDuration::Seconds(601), EResourceToBalance::CPU));
+        fixture.Hive.CurrentConfig.SetUseTabletUsageEstimate(true);
+        fixture.Hive.CurrentConfig.SetTabletImpactToPin(.01);
+        fixture.Hive.CurrentConfig.SetTabletImpactShareToPin(.5);
+        tablet.SetUsageImpact(.05);
+        UNIT_ASSERT(tablet.IsPinnedToNode());
+        UNIT_ASSERT(!node.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now + TDuration::Seconds(601)));
+    }
+
+    Y_UNIT_TEST(IgnoredTabletTypeIsNotEligible) {
+        TScatterFixture fixture;
+        auto& node = fixture.AddNode(EResourceToBalance::CPU, 50'000);
+        fixture.Hive.UpdateConfig([](auto& config) {
+            config.AddBalancerIgnoreTabletTypes(TTabletTypes::Dummy);
+        });
+        UNIT_ASSERT(!node.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now));
+    }
+
+    Y_UNIT_TEST(ResourceCohortsAreIndependent) {
+        for (auto resource : {EResourceToBalance::CPU, EResourceToBalance::Memory, EResourceToBalance::Network}) {
+            TScatterFixture fixture;
+            fixture.AddNode(resource, 10'000);
+            fixture.AddNode(resource, 50'000);
+            auto other = resource == EResourceToBalance::CPU ? EResourceToBalance::Memory : EResourceToBalance::CPU;
+            auto& irrelevant = fixture.AddNode(other, 900'000);
+            SetResource(irrelevant.ResourceValues, resource, 900'000);
+            auto settings = fixture.Settings();
+            AssertSources(settings, {2});
+            UNIT_ASSERT(settings->ResourceToBalance == resource);
+        }
+    }
+
+    Y_UNIT_TEST(CounterHasZeroFloorAndIgnoresDifferenceOfOne) {
+        TScatterFixture fixture;
+        fixture.Hive.CurrentConfig.SetMinCounterScatterToBalance(.2);
+        fixture.AddNode(EResourceToBalance::Counter, 1);
+        auto& second = fixture.AddNode(EResourceToBalance::Counter, 2);
+        fixture.AddTablet(second, EResourceToBalance::Counter);
+        UNIT_ASSERT(!fixture.Settings());
+        fixture.AddTablet(second, EResourceToBalance::Counter);
+        SetResource(second.ResourceValues, EResourceToBalance::Counter, 3);
+        auto settings = fixture.Settings();
+        AssertSources(settings, {1, 2});
+        UNIT_ASSERT(settings->Type == EBalancerType::ScatterCounter);
+        UNIT_ASSERT_DOUBLES_EQUAL(*settings->MinNodeUsage, 0., 1e-12);
+    }
+
+    Y_UNIT_TEST(SourceThresholdUsesOneMinusScatterAndStrictComparison) {
+        for (double scatter : {0., .2, .5, .75}) {
+            TScatterFixture fixture;
+            fixture.Hive.CurrentConfig.SetMinCPUScatterToBalance(scatter);
+            // Every configuration has the same 4% source threshold.
+            fixture.Hive.CurrentConfig.SetMinNodeUsageToBalance(.04 * (1. - scatter));
+            fixture.AddNode(EResourceToBalance::CPU, 5'000);
+            fixture.AddNode(EResourceToBalance::CPU, 30'000);
+            fixture.AddNode(EResourceToBalance::CPU, 40'000);
+            fixture.AddNode(EResourceToBalance::CPU, 60'000);
+            auto settings = fixture.Settings();
+            AssertSources(settings, {4});
+            UNIT_ASSERT_DOUBLES_EQUAL(*settings->MinNodeUsage, .04, 1e-12);
+        }
+    }
+
+    Y_UNIT_TEST(ScatterLimitOfOneAndEqualityDoNotTrigger) {
+        TScatterFixture fixture;
+        fixture.Hive.CurrentConfig.SetMinNodeUsageToBalance(.02);
+        fixture.AddNode(EResourceToBalance::CPU, 10'000);
+        fixture.AddNode(EResourceToBalance::CPU, 40'000);
+        UNIT_ASSERT(!fixture.Settings()); // scatter == .5
+        fixture.Hive.CurrentConfig.SetMinCPUScatterToBalance(1.);
+        fixture.Hive.CurrentConfig.SetMinNodeUsageToBalance(0.);
+        UNIT_ASSERT(!fixture.Settings());
+    }
+
+    Y_UNIT_TEST(StaleNodeTotalsDoNotKeepSourcesAboveThreshold) {
+        TScatterFixture fixture;
+        fixture.AddNode(EResourceToBalance::CPU, 10'000);
+        auto& source = fixture.AddNode(EResourceToBalance::CPU, 50'000);
+        for (int i = 0; i < 20; ++i) {
+            source.AveragedResourceTotalValues.Push(source.ResourceValues);
+        }
+        source.ResourceTotalValues = source.AveragedResourceTotalValues.GetValue();
+        UNIT_ASSERT(source.AveragedResourceTotalValues.IsValueStable());
+        AssertSources(fixture.Settings(), {2});
+        SetResource(source.ResourceValues, EResourceToBalance::CPU, 30'000);
+        UNIT_ASSERT_DOUBLES_EQUAL(source.GetNodeUsage(EResourceToBalance::CPU), .05, 1e-12);
+        UNIT_ASSERT_DOUBLES_EQUAL(source.GetTabletUsage(EResourceToBalance::CPU), .03, 1e-12);
+        UNIT_ASSERT(!fixture.Settings());
+    }
+}
+
+} // namespace NKikimr::NHive

--- a/ydb/core/mind/hive/scatter_balancer_ut.cpp
+++ b/ydb/core/mind/hive/scatter_balancer_ut.cpp
@@ -188,15 +188,96 @@ Y_UNIT_TEST_SUITE(THiveScatterBalancerTest) {
         UNIT_ASSERT(!fixture.Settings());
     }
 
-    Y_UNIT_TEST(EmptyAndSingleEligibleCohortsDoNotStartUnrestrictedBalancer) {
+    Y_UNIT_TEST(UnmovableMinimumDoesNotLowerSourceThreshold) {
+        TScatterFixture fixture;
+        fixture.AddNode(EResourceToBalance::CPU, 10'000);
+        fixture.Tablets.back()->BalancerPolicy = TTabletInfo::EBalancerPolicy::POLICY_IGNORE;
+        fixture.AddNode(EResourceToBalance::CPU, 40'000);
+        fixture.AddNode(EResourceToBalance::CPU, 50'000);
+        fixture.AddNode(EResourceToBalance::CPU, 90'000);
+        auto settings = fixture.Settings();
+        AssertSources(settings, {4});
+        UNIT_ASSERT(settings->ResourceToBalance == EResourceToBalance::CPU);
+        UNIT_ASSERT_DOUBLES_EQUAL(*settings->MinNodeUsage, .08, 1e-12);
+    }
+
+    Y_UNIT_TEST(IdleReceiverAllowsSingleSourceWithoutBecomingASource) {
         TScatterFixture fixture;
         UNIT_ASSERT(!fixture.Settings());
         fixture.AddNode(EResourceToBalance::CPU, 0, false);
         fixture.AddNode(EResourceToBalance::CPU, 500'000, false);
         UNIT_ASSERT(!fixture.Settings());
         fixture.AddNode(EResourceToBalance::CPU, 900'000);
-        // Empty recipients remain possible destinations, but are not scatter cohort members.
+        AssertSources(fixture.Settings(), {3});
+    }
+
+    Y_UNIT_TEST(SingleSourceWithoutIdleReceiversDoesNotTrigger) {
+        TScatterFixture fixture;
+        fixture.AddNode(EResourceToBalance::CPU, 900'000);
         UNIT_ASSERT(!fixture.Settings());
+    }
+
+    Y_UNIT_TEST(BackgroundOnlyScalarUsageIsNotAnIdleComputeReceiver) {
+        TScatterFixture fixture;
+        fixture.Hive.CurrentConfig.SetMinCounterScatterToBalance(1.);
+        for (int i = 0; i < 5; ++i) {
+            fixture.AddNode(EResourceToBalance::CPU, 50'000);
+        }
+        auto& background = fixture.AddNode(EResourceToBalance::CPU, 0, false);
+        AssertSources(fixture.Settings(), {1, 2, 3, 4, 5});
+
+        for (int i = 0; i < 20; ++i) {
+            background.AveragedNodeTotalUsage.Push(.06);
+        }
+        background.NodeTotalUsage = background.AveragedNodeTotalUsage.GetValue();
+        UNIT_ASSERT(background.AveragedNodeTotalUsage.IsValueStable());
+        UNIT_ASSERT_DOUBLES_EQUAL(background.GetNodeUsage(), .06, 1e-12);
+        UNIT_ASSERT_DOUBLES_EQUAL(background.GetNodeUsage(EResourceToBalance::CPU), 0., 1e-12);
+        UNIT_ASSERT(!background.HasTabletsForBalancer(EResourceToBalance::ComputeResources, fixture.Now));
+        // The equal 5% sources must not be compared with external load masquerading as zero CPU.
+        UNIT_ASSERT(!fixture.Settings());
+    }
+
+    Y_UNIT_TEST(ResourceIdleNodeWithOtherMovableResourceCanReceive) {
+        TScatterFixture fixture;
+        auto& receiver = fixture.AddNode(EResourceToBalance::Memory, 10'000);
+        fixture.AddNode(EResourceToBalance::CPU, 50'000);
+        UNIT_ASSERT_DOUBLES_EQUAL(receiver.GetNodeUsage(EResourceToBalance::CPU), 0., 1e-12);
+        UNIT_ASSERT(receiver.GetNodeUsage() > 0.);
+        UNIT_ASSERT(receiver.HasTabletsForBalancer(EResourceToBalance::ComputeResources, fixture.Now));
+        auto settings = fixture.Settings();
+        AssertSources(settings, {2});
+        UNIT_ASSERT(settings->ResourceToBalance == EResourceToBalance::CPU);
+    }
+
+    Y_UNIT_TEST(CounterIdleReceiverMayHaveBackgroundComputeLoad) {
+        TScatterFixture fixture;
+        auto& receiver = fixture.AddNode(EResourceToBalance::CPU, 800'000, false);
+        auto& source = fixture.AddNode(EResourceToBalance::Counter, 3);
+        fixture.AddTablet(source, EResourceToBalance::Counter);
+        fixture.AddTablet(source, EResourceToBalance::Counter);
+        UNIT_ASSERT(receiver.GetNodeUsage() > 0.);
+        UNIT_ASSERT(!receiver.HasTabletsForBalancer(EResourceToBalance::ComputeResources, fixture.Now));
+        auto settings = fixture.Settings();
+        AssertSources(settings, {2});
+        UNIT_ASSERT(settings->ResourceToBalance == EResourceToBalance::Counter);
+    }
+
+    Y_UNIT_TEST(IdleReceiversMustBeAliveUpAndUnfrozen) {
+        for (int unavailableState = 0; unavailableState < 3; ++unavailableState) {
+            TScatterFixture fixture;
+            fixture.AddNode(EResourceToBalance::CPU, 50'000);
+            auto& receiver = fixture.AddNode(EResourceToBalance::CPU, 0, false);
+            AssertSources(fixture.Settings(), {1});
+            if (unavailableState == 0) {
+                receiver.SetAlive(false);
+            } else if (unavailableState == 1) {
+                receiver.Down = true;
+            } else {
+                receiver.Freeze = true;
+            }
+            UNIT_ASSERT(!fixture.Settings());
+        }
     }
 
     Y_UNIT_TEST(NodeEligibilityChecksLivenessAdministrativeStateAndRunningTablets) {
@@ -204,6 +285,12 @@ Y_UNIT_TEST_SUITE(THiveScatterBalancerTest) {
         auto& node = fixture.AddNode(EResourceToBalance::CPU, 50'000, false);
         UNIT_ASSERT(!node.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now));
         auto& tablet = fixture.AddTablet(node, EResourceToBalance::CPU);
+        UNIT_ASSERT(node.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now));
+        // Group reassignment can retain the RUNNING bucket while the leader is
+        // not ready for a restart. Use the same readiness check as the balancer.
+        tablet.State = ETabletState::GroupAssignment;
+        UNIT_ASSERT(!node.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now));
+        tablet.State = ETabletState::ReadyToWork;
         UNIT_ASSERT(node.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now));
         node.SetAlive(false);
         UNIT_ASSERT(!node.HasTabletsForBalancer(EResourceToBalance::CPU, fixture.Now));
@@ -251,6 +338,9 @@ Y_UNIT_TEST_SUITE(THiveScatterBalancerTest) {
     Y_UNIT_TEST(ResourceCohortsAreIndependent) {
         for (auto resource : {EResourceToBalance::CPU, EResourceToBalance::Memory, EResourceToBalance::Network}) {
             TScatterFixture fixture;
+            fixture.Hive.CurrentConfig.SetMinCPUScatterToBalance(resource == EResourceToBalance::CPU ? .5 : 1.);
+            fixture.Hive.CurrentConfig.SetMinMemoryScatterToBalance(resource == EResourceToBalance::Memory ? .5 : 1.);
+            fixture.Hive.CurrentConfig.SetMinNetworkScatterToBalance(resource == EResourceToBalance::Network ? .5 : 1.);
             fixture.AddNode(resource, 10'000);
             fixture.AddNode(resource, 50'000);
             auto other = resource == EResourceToBalance::CPU ? EResourceToBalance::Memory : EResourceToBalance::CPU;
@@ -272,9 +362,29 @@ Y_UNIT_TEST_SUITE(THiveScatterBalancerTest) {
         fixture.AddTablet(second, EResourceToBalance::Counter);
         SetResource(second.ResourceValues, EResourceToBalance::Counter, 3);
         auto settings = fixture.Settings();
-        AssertSources(settings, {1, 2});
+        AssertSources(settings, {2});
         UNIT_ASSERT(settings->Type == EBalancerType::ScatterCounter);
-        UNIT_ASSERT_DOUBLES_EQUAL(*settings->MinNodeUsage, 0., 1e-12);
+        UNIT_ASSERT_DOUBLES_EQUAL(*settings->MinNodeUsage, 1.25e-6, 1e-12);
+    }
+
+    Y_UNIT_TEST(SourceThresholdUsesResourceMinimumAboveFloor) {
+        for (auto resource : {EResourceToBalance::CPU, EResourceToBalance::Memory, EResourceToBalance::Network}) {
+            TScatterFixture fixture;
+            fixture.Hive.CurrentConfig.SetMinCounterScatterToBalance(1.);
+            fixture.Hive.CurrentConfig.SetMinCPUScatterToBalance(resource == EResourceToBalance::CPU ? .5 : 1.);
+            fixture.Hive.CurrentConfig.SetMinMemoryScatterToBalance(resource == EResourceToBalance::Memory ? .5 : 1.);
+            fixture.Hive.CurrentConfig.SetMinNetworkScatterToBalance(resource == EResourceToBalance::Network ? .5 : 1.);
+            auto& minimum = fixture.AddNode(resource, 40'000);
+            fixture.AddNode(resource, 50'000);
+            fixture.AddNode(resource, 90'000);
+            // Composite node usage must not replace the selected resource minimum.
+            const auto other = resource == EResourceToBalance::CPU ? EResourceToBalance::Memory : EResourceToBalance::CPU;
+            SetResource(minimum.ResourceValues, other, 500'000);
+            auto settings = fixture.Settings();
+            AssertSources(settings, {3});
+            UNIT_ASSERT(settings->ResourceToBalance == resource);
+            UNIT_ASSERT_DOUBLES_EQUAL(*settings->MinNodeUsage, .08, 1e-12);
+        }
     }
 
     Y_UNIT_TEST(SourceThresholdUsesOneMinusScatterAndStrictComparison) {
@@ -310,13 +420,18 @@ Y_UNIT_TEST_SUITE(THiveScatterBalancerTest) {
         auto& source = fixture.AddNode(EResourceToBalance::CPU, 50'000);
         for (int i = 0; i < 20; ++i) {
             source.AveragedResourceTotalValues.Push(source.ResourceValues);
+            source.AveragedNodeTotalUsage.Push(.05);
         }
         source.ResourceTotalValues = source.AveragedResourceTotalValues.GetValue();
+        source.NodeTotalUsage = source.AveragedNodeTotalUsage.GetValue();
         UNIT_ASSERT(source.AveragedResourceTotalValues.IsValueStable());
+        UNIT_ASSERT(source.AveragedNodeTotalUsage.IsValueStable());
         AssertSources(fixture.Settings(), {2});
         SetResource(source.ResourceValues, EResourceToBalance::CPU, 30'000);
         UNIT_ASSERT_DOUBLES_EQUAL(source.GetNodeUsage(EResourceToBalance::CPU), .05, 1e-12);
+        UNIT_ASSERT_DOUBLES_EQUAL(source.GetNodeUsage(), .05, 1e-12);
         UNIT_ASSERT_DOUBLES_EQUAL(source.GetTabletUsage(EResourceToBalance::CPU), .03, 1e-12);
+        UNIT_ASSERT_DOUBLES_EQUAL(source.GetTabletUsage(EResourceToBalance::ComputeResources), .03, 1e-12);
         UNIT_ASSERT(!fixture.Settings());
     }
 }

--- a/ydb/core/mind/hive/tablet_info.cpp
+++ b/ydb/core/mind/hive/tablet_info.cpp
@@ -220,6 +220,10 @@ bool TTabletInfo::IsGoodForBalancer(TInstant now) const {
             && (now - LastBalancerDecisionTime > Hive.GetTabletKickCooldownPeriod());
 }
 
+bool TTabletInfo::IsGoodForBalancer(TInstant now, EResourceToBalance resource) const {
+    return IsGoodForBalancer(now) && HasMetric(resource) && !IsPinnedToNode();
+}
+
 void TTabletInfo::SetUsageImpact(double usageImpact) {
     UsageImpact = usageImpact;
     if (Node != nullptr && IsResourceDrainingState(VolatileState)) {

--- a/ydb/core/mind/hive/tablet_info.h
+++ b/ydb/core/mind/hive/tablet_info.h
@@ -134,6 +134,7 @@ public:
     }
 
     bool IsGoodForBalancer(TInstant now) const;
+    bool IsGoodForBalancer(TInstant now, EResourceToBalance resource) const;
 
     void MakeBalancerDecision(TInstant now) {
         LastBalancerDecisionTime = now;

--- a/ydb/core/mind/hive/ut/ya.make
+++ b/ydb/core/mind/hive/ut/ya.make
@@ -20,6 +20,7 @@ PEERDIR(
 YQL_LAST_ABI_VERSION()
 
 SRCS(
+    scatter_balancer_ut.cpp
     object_distribution_ut.cpp
     scale_recommender_policy_ut.cpp
     sequencer_ut.cpp


### PR DESCRIPTION
### Изменения

Балансировщик Hive исключает из расчёта порогов загруженные ноды, с которых нельзя переместить таблетки, сохраняет свободные ноды в качестве получателей и прекращает своз с донора, когда суммарная нагрузка его таблеток становится не выше порога.

Ранее в статистику разброса нагрузки (scatter) попадали ноды, с которых балансировщик не мог ничего переместить. Кроме того, после запуска балансировки своз с выбранных нод мог продолжаться до исчерпания лимита переносов.

Теперь множество нод для расчёта scatter формируется отдельно для каждого ресурса. При выборе доноров используются те же проверки доступности таблеток, что и перед переносом: рабочее состояние, политика балансировки, список исключённых типов, интервал после предыдущего решения балансировщика, наличие метрики выбранного ресурса и закрепление таблетки из-за её высокого вклада в нагрузку. Отключённые, замороженные и недоступные ноды исключаются.

Порог донора рассчитывается по формуле:

```text
порог_донора = max(u_min, m) / (1 - s)
```

Здесь `u_min` — минимальная нагрузка выбранного ресурса среди участвующих в расчёте нод на момент запуска; `m` — настроенная нижняя граница нагрузки для этого ресурса; `s` — порог scatter.

Донором может быть только нода с нагрузкой **строго выше** полученного порога. Порог фиксируется на весь запуск, а соответствие ему проверяется перед каждым переносом. Для проверки используется сумма ресурсных метрик таблеток: запаздывающие общие метрики ноды не должны разрешать лишний своз.

С одной ноды допускается не более одного незавершённого переноса. Переносы с разных нод могут выполняться параллельно. Лимит числа переносов остаётся верхней границей, которую балансировщик не обязан исчерпать.

Фактический минимум важен, если все участвующие ноды загружены выше настроенной нижней границы. Например, при нагрузках **4%, 5%, 9%**, нижней границе **1,75%** и пороге scatter **0,5** граница донора составляет `4 / (1 - 0,5) = 8%`. Своз разрешён только с ноды, загруженной на 9%.

#### Пример с шестью нодами

Есть шесть нод с нагрузками **1%, 2%, 3%, 4%, 5%, 6%**. На нодах 1–5 каждая таблетка создаёт нагрузку в **один процентный пункт**. Нагрузка ноды 6 полностью создаётся другими источниками, неподвластными балансировщику; таблеток для переноса на ней нет.

Для примера используются настройки CPU-балансировки:

- `MinNodeUsageToBalance = 0.0175`;
- `MinCPUScatterToBalance = 0.5`;
- `MaxMovementsOnAutoBalancer = 100`.

Балансировка соседних таблеток отключена, остальные ресурсные триггеры не срабатывают. У нод одинаковые ресурсные ёмкости и приоритеты размещения, получатели выбираются по минимальной загрузке. Переносы успешны, параллельных изменений нагрузки и условий размещения нет.

| Нода | Начальная нагрузка | Участвует в расчёте CPU scatter | Донор в начале запуска | Ожидаемая нагрузка после запуска |
| --- | ---: | --- | --- | ---: |
| 1 | 1% | Да | Нет | 3% |
| 2 | 2% | Да | Нет | 3% |
| 3 | 3% | Да | Нет | 3% |
| 4 | 4% | Да | Да | 3% |
| 5 | 5% | Да | Да | 3% |
| 6 | 6%, неперемещаемая нагрузка | Нет | Нет | 6% |

В расчёте участвуют только ноды 1–5. Их фактический минимум — 1%, но для расчёта применяется нижняя граница 1,75%. Максимум — 5%. Поэтому scatter равен `(5 - 1,75) / 5 = 0,65`, что выше настроенного порога 0,5.

Граница донора равна `1,75 / (1 - 0,5) = 3,5%`. Её проходят только ноды 4 и 5:

- с ноды 4 переносится одна таблетка: нагрузка снижается с 4% до 3%;
- с ноды 5 переносятся две таблетки: нагрузка снижается с 5% до 3%;
- с нод 1–3 и ноды 6 таблетки не свозятся.

Возможная последовательность: **5→1, 4→2, 5→1**. Итоговое распределение — **3% / 3% / 3% / 3% / 3% / 6%**. Обе ноды-донора оказываются ниже границы 3,5%, и балансировка заканчивается после **трёх переносов**, хотя лимит допускает 100.

То же ограничение доноров действует при параллельных переносах: с одной ноды одновременно выполняется не более одного переноса. При указанных условиях итоговое распределение сохраняется, хотя порядок переносов может отличаться. Нода 6 не влияет на расчёт порогов и не поддерживает повторные запуски CPU-балансировки.

#### Границы изменения

Изменение затрагивает выбор доноров при балансировке по scatter. Выбор получателя по-прежнему использует существующие проверки допустимости размещения и доступных ресурсов. Исключение ноды из расчёта scatter само по себе не запрещает ей принимать таблетки. Ручная, аварийная и соседская балансировки не получают нового ограничения доноров. Наличие подходящей для переноса таблетки не гарантирует, что для неё найдётся допустимый получатель.

Свободные ноды сохраняются в множестве сравнения, чтобы новые или вернувшиеся пустые ноды могли принимать таблетки. Нода с нулевой нагрузкой выбранного вычислительного ресурса включается в это множество, если она полностью свободна либо содержит перемещаемые таблетки, потребляющие другой вычислительный ресурс. Пустая нода, имеющая только внешнюю нагрузку, исключается.

Для Counter сравнивается число таблеток независимо от вычислительной нагрузки: ноды с нулевым счётчиком остаются в множестве сравнения. Ноды, включённые только как получатели для сравнения, не становятся донорами в рамках этого запуска.

### Оптимизация для большого числа нод

Перед поиском перемещаемых таблеток проверяется уже рассчитанный scatter сегмента. Удаление нод из множества сравнения при той же нижней границе не увеличивает scatter, поэтому при допустимом исходном разбросе обход таблеток не нужен.

Если разброс превышен, ленивый сканер сохраняет позицию и найденные ресурсные признаки каждой ноды. Общие проверки доступности таблетки выполняются один раз за её посещение; при переходе к другому ресурсу обход продолжается с сохранённой позиции. Сохраняются приоритет Counter → CPU → Memory → Network и раннее завершение на первом подходящем ресурсе. Сканер живёт только в рамках синхронного решения и не требует инвалидировать постоянный кеш при изменении метрик или окончании cooldown.

Участие ноды в незавершённом переносе проверяется через отдельное хеш-множество. Остаток списка таблеток занятого донора пропускается сразу, чтобы другой донор мог начать перенос, не ожидая дополнительного wakeup.

### Тесты и покрытие

На окончательных исходниках прошли **29 новых тестов** и **26 существующих регрессионных тестов** (`relwithdebinfo`, Clang coverage, Linux; код возврата обоих прогонов — 0).

Новые тесты проверяют пример с шестью нодами при последовательных и параллельных переносах, исключение неперемещаемых максимумов и минимумов, свободных получателей, независимость ресурсов, строгую границу донора, cooldown, политику/тип/закрепление таблеток, запаздывающие метрики, приоритет ресурсов и продолжение переноса с другого донора без дополнительного wakeup. Последний сценарий использует по 0,25 процентного пункта на таблетку, чтобы у занятых доноров оставалось больше таблеток, чем бюджет обработки одного события.

Регрессионный прогон охватывает существующие тесты балансировщика, запрет балансировки при малой нагрузке, SpreadNeighbours, BridgeBalance и Drain.

| Область diff | Покрыто изменённых исполняемых строк | Покрытие |
| --- | ---: | ---: |
| Весь PR относительно `2b00aac42ef83f545551b395b8539c126b6eb270` | 216 / 221 | **97,74%** |
| Оптимизация относительно `5cd6a55a4a578b72c70da8f4e72cc48aa2b0a1b0` | 144 / 144 | **100%** |

| Production-файл, весь PR | Покрыто / изменено исполняемых строк |
| --- | ---: |
| `balancer.cpp` | 35 / 38 |
| `hive_impl.cpp` | 121 / 123 |
| `node_info.cpp` | 57 / 57 |
| `tablet_info.cpp` | 3 / 3 |

Покрытие измерено только новыми функциональными тестами, до регрессионного прогона и микротеста производительности. Метрика — добавленные/изменённые production-строки с положительным LCOV `DA` / добавленные/изменённые production-строки, имеющие запись `DA`. Строки без `DA` перечислены отдельно в полном отчёте; это покрытие строк, а не ветвей и не всего Hive. Требование не менее 80% выполнено для обеих областей diff. Совпадение 11 проверяемых исходных файлов локально и на удалённом хосте проверено по SHA-256.


### Сложность алгоритмов относительно 26-2

База сравнения — `stable-26-2`, commit `c1b646a4c39b97284f536d9104a00735585da3f0`; новая версия — PR `866bc4f0021a996b5a607d29631105f90fd267c6`. `N` — число нод сегмента, `T` — число таблеток в их RUNNING-наборах, `R = 4` — Counter/CPU/Memory/Network, `K ≤ N` — число отобранных доноров, `I` — число незавершённых переносов.

| Фаза обычной scatter-балансировки | 26-2 | PR |
| --- | --- | --- |
| Проверка при допустимом исходном scatter | `O(N)`, без обхода таблеток | `O(N)`, без обхода таблеток |
| Решение при превышении исходного scatter | `O(N)`: агрегаты и список всех нод сегмента | В худшем случае `O(RN + (R + 1)T) = O(N + T)`: проверка перемещаемости и выбор доноров |
| Временная память решения | `O(N)` | `O(N + K) = O(N)`, без копирования всех таблеток |

В 26-2 пригодность таблеток проверяется после запуска актора. PR переносит эту проверку в решение о запуске. Ленивый сканер сохраняет позицию и найденные ресурсные признаки: каждая таблетка посещается не более одного раза за вызов helper. Общая проверка доступности выполняется один раз за посещение, затем проверяются ресурсные признаки, включая `ComputeResources`. Если пригодная таблетка находится сразу, обход может завершиться раньше; при cooldown или запрете балансировки всех таблеток потребуется прочитать весь `T`. Ресурсы сохраняют порядок Counter → CPU → Memory → Network и раннее завершение на первом подходящем результате.

После решения актор PR перебирает `K` исходных доноров вместо всех `N` нод сегмента; при `HEAVIEST` сортировка ограничена `O(K log K)`. Для нового ограничения «не более одного незавершённого переноса с источника» используются хеш-множества и map: ожидаемое `O(1)` на проверку и обновление, дополнительная память `O(K + I)`. В 26-2 есть только общий счётчик незавершённых переносов за `O(1)`; утверждение об устранении сканирования `O(I)` относится к промежуточному варианту PR, а не к 26-2.

В проверенном снимке 26-2 повторный `BalanceNodes` дописывает идентификаторы нод в прежний список. После `M` завершений его размер может вырасти до `O((M + 1)N)`, что увеличивает память и возможный последующий перебор. Сортируется каждый раз новый локальный набор до `N` нод за `O(N log N)`. В PR список идентификаторов очищается перед заполнением; для scatter его размер ограничен `O(K)`.

Сохраняются существующие затраты на перебор таблеток выбранной ноды, их упорядочивание и `FindBestNode`, который может проверять все ноды Hive для каждого кандидата. Они не входят в измеряемую фазу решения. При 100 тысячах нод и 10 таблетках на ноду новый активный проход в худшем случае читает миллион таблеток синхронно. `MAX_TABLETS_PROCESSED` не ограничивает этот проход, сортировки или поиск получателя. Линейность всего балансировщика и гарантированно короткая пауза не заявляются.

### Сравнение производительности с 26-2 на одном ядре

Сравниваются реальные реализации **stable-26-2 `c1b646a4c39b97284f536d9104a00735585da3f0`** и **PR `866bc4f0021a996b5a607d29631105f90fd267c6`**. В обеих версиях явно установлены **одинаковые параметры балансировки** из профиля на скриншотах:

| Параметр | Обе версии |
| --- | --- |
| `MinNodeUsageToBalance` | `0.1` |
| `MinScatterToBalance`; scatter CPU / Memory / Network | `0.5`; `0.5 / 0.5 / 0.5` |
| `MinCounterScatterToBalance` | `0.02` |
| `MaxNodeUsageToKick`; `NodeUsageRangeToKick` | `0.9`; `0.2` |
| `MaxResourceCPU / Memory / Network / Counter` | `10000000 / 512000000000 / 1000000000 / 100000000` |
| `TabletKickCooldownPeriod`; `ResourceChangeReactionPeriod`; `MetricsWindowSize` | `600`; `10`; `60000` |
| `ResourceOvercommitment`; `MaxMovementsOnAutoBalancer`; `BalancerInflight` | `3`; `100`; `1` |
| `ContinueAutoBalancer`; `MinPeriodBetweenBalance` | `true`; `0.2` |
| `NodeSelectStrategy / NodeBalanceStrategy / TabletBalanceStrategy` | `RANDOM_MIN_7P / HEAVIEST / WEIGHTED_RANDOM` |
| `SpreadNeighbours`; `ObjectImbalanceToBalance` | `true`; `0.02` |
| `CheckMoveExpediency`; `WarmUpEnabled`; `UseTabletUsageEstimate` | `true`; `true`; `true` |

Явное значение `MinNodeUsageToBalance` существенно: default в 26-2 равен `0.1`, а в базе PR — `0.3`. В замере обеим версиям задано `0.1`. Совпали текст конфигурации и hash её сериализации `705871298052869097` (FNV-1a 64); дополнительно проверены defaults и AllowedMetrics, используемые выбранным путём. Dummy-таблетки имеют заданные CPU/Network и нулевые Memory/Counter. Новые параметры pinning не влияют на fixture с `UsageImpact=0`.

**Измеряемый участок:** настоящий `THive::Handle(TEvProcessTabletBalancer)` со сбором статистики и выбором настроек, до регистрации актора. Одинаковый временный перехват в начале `StartHiveBalancer`, перед проверкой возможности запуска, записывает выбранный ресурс и размер `FilterNodeIds`. Актор не регистрируется; сообщение в ветке без решения также не отправляется. Создание fixture, установка метрик и cooldown находятся вне таймера. **Это время решения, а не полного цикла балансировки:** подбор получателей, сортировки внутри актора, переносы и перезапуски здесь не измерены. Переданный список нод не равен числу переносов или реально запущенных акторов.

Linux, Intel Xeon (Cascadelake, VM), поток закреплён за CPU 0. Обе сборки: `relwithdebinfo`, `-O3`, C++20, без LTO, с Clang coverage; используется один бинарник Clang 20.1.8 из ресурса 26-2 `10492077879`. Логирование отключено, часы actor system зафиксированы для одинакового cooldown. Два прогрева и девять измерений на сценарий; ниже медианы. Итоговые прогоны выполнены последовательно с `--split-factor=1 --test-threads=1 --retest`, без другой сборки и параллельных тестовых chunks. Каждый имеет статус **GOOD**, один chunk и код возврата **0**. Проверены **33 пары сценариев**, одинаковая конфигурация и ожидаемые результаты отбора.

Во всех строках следующей таблицы **100 000 нод**. Проценты CPU здесь — доля заданной ёмкости `MaxResourceCPU`, а не показание столбца CPU в интерфейсе. При ёмкости 10 ядер уровень 50% означает пять ядер.

| Сценарий | Таблеток | 26-2, мс | PR, мс | PR / 26-2 |
| --- | ---: | ---: | ---: | ---| 
| Равномерно 50%, таблеток нет | 0 | 10,278 | 9,026 | 0,88× | 
| Равномерно 50%, одна таблетка на ноду | 100 000 | 10,197 | 9,292 | 0,91× | 
| Равномерно 10%, десять таблеток на ноду | 1 000 000 | 9,864 | 10,376 | 1,05× | 
| Равномерно 50%, десять таблеток на ноду | 1 000 000 | 10,723 | 9,178 | 0,86× | 
| Равномерно 50%, все таблетки в cooldown | 1 000 000 | 10,247 | 9,140 | 0,89× | 
| CPU-источник и исключённый максимум Network | 1 000 000 | 15,100 | 68,724 | 4,55× | 
| Тот же дисбаланс, все таблетки в cooldown | 1 000 000 | 12,877 | 166,865 | 12,96× | 
| Пустая нода с фоновой нагрузкой | 999 990 | 12,518 | 69,354 | 5,54× | 
| Пустая нода с фоновой нагрузкой, все таблетки в cooldown | 999 990 | 12,496 | 156,260 | 12,50× | 

В сценарии с CPU-источником остальные ноды имеют CPU 10%; нода 1 дополнительно имеет Network 80% и запрещённые к балансировке таблетки, а нода 2 — CPU 80%. PR исключает ноду 1 из расчёта и выбирает только ноду 2. В сценарии с фоновой нагрузкой нода 1 не имеет таблеток и сообщает CPU 80%, остальные имеют по десять таблеток и CPU 50%; PR исключает фоновую ноду и не формирует решение. Варианты cooldown меняют только состояние доступности таблеток, конфигурация остаётся прежней.

При 10 000 нод и 100 000 таблеток медианы для равномерных 50% составили `0,597 → 0,594 мс`, для CPU-источника — `0,778 → 3,249 мс`, для дисбаланса с cooldown всех таблеток — `0,771 → 13,083 мс`. В отдельном сценарии с шестью нодами на уровнях 1–6% обе версии не формируют решение: весь диапазон ниже общего порога 10%. Функциональный пример выше намеренно использует другой порог, `0.0175`, и проверяется отдельными тестами.

Спокойный проход сохранил сопоставимую стоимость. При превышении исходного scatter решение PR существенно дороже 26-2, поскольку теперь до запуска проверяется перемещаемость таблеток. Наибольшая медиана среди проверенных сценариев — **166,865 мс синхронной работы на одном ядре**, диапазон девяти измерений в этом сценарии — `165,782–167,765 мс`. Это наблюдение конкретного стенда, а не верхняя граница времени работы алгоритма. В 26-2 часть этих проверок выполняется уже внутри актора; сокращение списка источников и отказ от бесполезного запуска могут уменьшить последующую работу, но данный замер этого не измеряет. Ускорение всей балансировки относительно 26-2 не заявляется.

### Совместимость с production 26-2
Проверен снимок `stable-26-2` на commit `c1b646a4c39b97284f536d9104a00735585da3f0`. Сам патч, включая оптимизации, не меняет Hive DB schema, protobuf, конфигурационные поля и пути сохранения/восстановления. Пороги, сканеры и множества незавершённых переносов существуют только в памяти. Переносы используют прежние транзакции и обычные сохранённые поля размещения.

Поэтому возврат с **адаптированного backport на ту же 26-2** на исходный бинарник ожидаемо совместим по формату данных. Завершённые переносы сохранятся; старая логика балансировки возобновится и сможет снова менять распределение.
