### PR TITLE
[sqs_topic] Fix SendMessageBatch DelaySeconds receive flake

### DIFF
--- a/ydb/tests/functional/sqs_topic/test_send_message_batch.py
+++ b/ydb/tests/functional/sqs_topic/test_send_message_batch.py
@@ -48,20 +48,11 @@ class TestSqsTopicSendMessageBatch(KikimrSqsTopicTestBase):
             ],
         )
 
-        # TODO: Per-message DelaySeconds does not delay delivery on receive. Fix it.
         assert_that(response['Successful'], has_length(len(message_bodies)))
         for entry in response['Successful']:
             assert_that(entry['MessageId'], not_none())
 
-        receive_response = self._boto_client.receive_message(
-            QueueUrl=self._queue_url,
-            WaitTimeSeconds=20,
-            MaxNumberOfMessages=len(message_bodies),
-        )
-
-        messages = receive_response.get('Messages')
-        assert_that(messages, not_none())
-        assert_that(messages, has_length(len(message_bodies)))
+        messages = self._receive_messages(len(message_bodies), wait_time_seconds=20)
         received_bodies = sorted(message['Body'] for message in messages)
         assert_that(received_bodies, equal_to(sorted(message_bodies)))
 

--- a/ydb/tests/library/sqs_topic/test_base.py
+++ b/ydb/tests/library/sqs_topic/test_base.py
@@ -362,3 +362,22 @@ class KikimrSqsTopicTestBase(object):
         assert_that(messages, not_none())
         assert_that(messages, has_length(1))
         return messages[0]['MessageAttributes'][attribute_name]
+
+    def _receive_messages(self, expected_count, wait_time_seconds=20):
+        # ReceiveMessage may return fewer than MaxNumberOfMessages as soon as
+        # any message is visible (including after DelaySeconds). Keep polling
+        # until the expected count is collected or the wait budget expires.
+        messages = []
+        deadline = time.time() + wait_time_seconds
+        while len(messages) < expected_count:
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                break
+            response = self._boto_client.receive_message(
+                QueueUrl=self._queue_url,
+                WaitTimeSeconds=min(20, max(1, int(remaining))),
+                MaxNumberOfMessages=min(10, expected_count - len(messages)),
+            )
+            messages.extend(response.get('Messages') or [])
+        assert_that(messages, has_length(expected_count))
+        return messages


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

`test_send_message_batch.py.TestSqsTopicSendMessageBatch.test_send_message_batch_with_delay_seconds` flaked because it expected both delayed messages from a single `ReceiveMessage`.

Per-message `DelaySeconds` is applied. Long poll returns as soon as the first message becomes visible and is not required to fill `MaxNumberOfMessages`. In CI that showed up as one of two messages after ~5s.

The test now polls `ReceiveMessage` until both bodies arrive (or the wait budget expires). Helper: `_receive_messages` in `ydb/tests/library/sqs_topic/test_base.py`.