### PR TITLE
Fix scrub restoration of metadata-only blob parts

### DIFF
--- a/ydb/core/blobstorage/vdisk/scrub/restore_corrupted_blob_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/scrub/restore_corrupted_blob_actor.cpp
@@ -62,6 +62,13 @@ namespace NKikimr {
                 if ((local & Item->Needed).Empty()) {
                     return; // no useful parts here
                 }
+                // Metadata-only parts have no payload to read from PDisk.
+                for (ui32 i = local.FirstPosition(); i != local.GetSize(); i = local.NextPosition(i)) {
+                    const TLogoBlobID partId(key.LogoBlobID(), i + 1);
+                    if (Item->Needed.Get(i) && !GType.PartSize(partId)) {
+                        Item->SetPartData(partId, TRope());
+                    }
+                }
                 TDiskDataExtractor extr;
                 memRec.GetDiskData(&extr, outbound);
                 switch (extr.BlobType) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix restoration of metadata-only blob parts during scrubbing in mirror-3-of-4 groups.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Mirror-3-of-4 part 3 has zero payload size. During restoration, the segment data extractor queued its empty TDiskPart as a physical read, producing TEvChunkRead with chunk, offset and size all zero and triggering the PDisk mock invariant in BlobScrubbing::mirror3of4.

Mark needed zero-sized parts recorded in the local part mask as available empty data. The existing read-queue filter then skips their disk reads while normal recovery and write-back continue. Parts absent from the local mask are not synthesized.

Fixes #52168.