### PR TITLE
Backport shared and united pool fixes to 26-3-1

### DIFF
--- a/ydb/core/driver_lib/run/auto_config_initializer.cpp
+++ b/ydb/core/driver_lib/run/auto_config_initializer.cpp
@@ -281,6 +281,7 @@ namespace NKikimr::NAutoConfigInitializer {
                 executor->SetPriority(priority);
                 executor->SetSpinThreshold(0);
                 executor->SetHasSharedThread(hasSharedThread);
+                executor->SetAllThreadsAreShared(useUnitedPool);
             };
 
             assignPool(systemExecutor, "System", 30, cpuCount >= 3);

--- a/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
+++ b/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
@@ -120,4 +120,32 @@ Y_UNIT_TEST(GetServicePoolsWith4AndMoreCPUs) {
     }
 }
 
+Y_UNIT_TEST(SharedAndUnitedAutoConfigMatrix) {
+    for (ui32 cpuCount = 1; cpuCount <= 4; ++cpuCount) {
+        for (const bool useSharedThreads : {false, true}) {
+            for (const bool useUnitedPool : {false, true}) {
+                NKikimrConfig::TActorSystemConfig config;
+                config.SetCpuCount(cpuCount);
+                config.SetUseSharedThreads(useSharedThreads);
+                config.SetUseUnitedPool(useUnitedPool);
+
+                ApplyAutoConfig(&config, false, false);
+
+                bool hasBasicPool = false;
+                for (const auto& executor : config.GetExecutor()) {
+                    if (executor.GetType() != NKikimrConfig::TActorSystemConfig::TExecutor::BASIC) {
+                        continue;
+                    }
+                    hasBasicPool = true;
+                    UNIT_ASSERT_VALUES_EQUAL_C(
+                        executor.GetAllThreadsAreShared(), useUnitedPool,
+                        "cpu# " << cpuCount << " shared# " << useSharedThreads
+                        << " united# " << useUnitedPool << " pool# " << executor.GetName());
+                }
+                UNIT_ASSERT_C(hasBasicPool, "cpu# " << cpuCount << " produced no BASIC pools");
+            }
+        }
+    }
+}
+
 } // Y_UNIT_TEST_SUITE(AutoConfig)

--- a/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
+++ b/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
@@ -1,13 +1,153 @@
 #include "auto_config_initializer.h"
+#include "config_helpers.h"
 
 #include <ydb/core/protos/config.pb.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/scheduler_basic.h>
+#include <ydb/library/actors/core/subsystems/stats.h>
+#include <ydb/library/actors/core/thread_context.h>
+#include <ydb/library/yverify_stream/yverify_stream.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <util/system/event.h>
 
+#include <atomic>
 
 Y_UNIT_TEST_SUITE(AutoConfig) {
 
 using namespace NKikimr;
 using namespace NAutoConfigInitializer;
+
+namespace {
+
+class TDelayedSignalActor : public NActors::TActorBootstrapped<TDelayedSignalActor> {
+public:
+    TDelayedSignalActor(
+            TManualEvent* ready,
+            TManualEvent* done,
+            NActors::TActorId* actorId,
+            std::atomic<ui32>* executionOwnerPoolId)
+        : Ready(ready)
+        , Done(done)
+        , ActorId(actorId)
+        , ExecutionOwnerPoolId(executionOwnerPoolId)
+    {}
+
+    void Bootstrap() {
+        Become(&TDelayedSignalActor::StateFunc);
+        *ActorId = SelfId();
+        Ready->Signal();
+    }
+
+    STFUNC(StateFunc) {
+        Y_VERIFY_S(
+            ev->GetTypeRewrite() == NActors::TEvents::TEvWakeup::EventType,
+            "unexpected event type# " << ev->GetTypeRewrite());
+        ExecutionOwnerPoolId->store(NActors::TlsThreadContext->OwnerPoolId(), std::memory_order_release);
+        Done->Signal();
+        PassAway();
+    }
+
+private:
+    TManualEvent* const Ready;
+    TManualEvent* const Done;
+    NActors::TActorId* const ActorId;
+    std::atomic<ui32>* const ExecutionOwnerPoolId;
+};
+
+class TStartAdjacentActor : public NActors::TActorBootstrapped<TStartAdjacentActor> {
+public:
+    TStartAdjacentActor(
+            ui32 adjacentPoolId,
+            TManualEvent* ready,
+            TManualEvent* done,
+            NActors::TActorId* actorId,
+            std::atomic<ui32>* executionOwnerPoolId)
+        : AdjacentPoolId(adjacentPoolId)
+        , Ready(ready)
+        , Done(done)
+        , ActorId(actorId)
+        , ExecutionOwnerPoolId(executionOwnerPoolId)
+    {}
+
+    void Bootstrap() {
+        Register(
+            new TDelayedSignalActor(Ready, Done, ActorId, ExecutionOwnerPoolId),
+            NActors::TMailboxType::HTSwap,
+            AdjacentPoolId);
+        PassAway();
+    }
+
+private:
+    const ui32 AdjacentPoolId;
+    TManualEvent* const Ready;
+    TManualEvent* const Done;
+    NActors::TActorId* const ActorId;
+    std::atomic<ui32>* const ExecutionOwnerPoolId;
+};
+
+THolder<NActors::TActorSystemSetup> CreateActorSystemSetup(
+        const NKikimrConfig::TActorSystemConfig& config)
+{
+    auto setup = MakeHolder<NActors::TActorSystemSetup>();
+    setup->NodeId = 1;
+    setup->CpuManager.Shared.United = config.GetUseUnitedPool();
+    NActorSystemConfigHelpers::AddExecutorPools(setup->CpuManager, config, nullptr);
+    setup->Scheduler.Reset(NActors::CreateSchedulerThread(
+        NActorSystemConfigHelpers::CreateSchedulerConfig(config.GetScheduler())));
+    return setup;
+}
+
+const NActors::TBasicExecutorPoolConfig& FindBasicPool(
+        const NActors::TCpuManagerConfig& config,
+        ui32 poolId)
+{
+    const NActors::TBasicExecutorPoolConfig* result = nullptr;
+    for (const auto& pool : config.Basic) {
+        if (pool.PoolId == poolId) {
+            result = &pool;
+            break;
+        }
+    }
+    UNIT_ASSERT_C(result, "BASIC executor pool " << poolId << " was not configured");
+    return *result;
+}
+
+ui64 GetSharedParkedTicks(const NActors::TActorSystem& actorSystem, ui32 poolId) {
+    NActors::TExecutorPoolStats poolStats;
+    TVector<NActors::TExecutorThreadStats> threadStats;
+    TVector<NActors::TExecutorThreadStats> sharedThreadStats;
+    NActors::GetActorSystemStats(actorSystem).GetPoolStats(
+        poolId,
+        poolStats,
+        threadStats,
+        sharedThreadStats);
+
+    ui64 parkedTicks = 0;
+    for (const auto& stats : sharedThreadStats) {
+        parkedTicks += stats.SafeParkedTicks;
+    }
+    return parkedTicks;
+}
+
+bool WaitForSharedThreadToPark(
+        const NActors::TActorSystem& actorSystem,
+        ui32 poolId,
+        TDuration timeout)
+{
+    const ui64 initialParkedTicks = GetSharedParkedTicks(actorSystem, poolId);
+    const TInstant deadline = TInstant::Now() + timeout;
+    while (TInstant::Now() < deadline) {
+        Sleep(TDuration::MilliSeconds(1));
+        if (GetSharedParkedTicks(actorSystem, poolId) > initialParkedTicks) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // anonymous namespace
 
 #define ASSERT_POOLS(pools, sys, user, batch, io, ic) \
     do { \
@@ -146,6 +286,127 @@ Y_UNIT_TEST(SharedAndUnitedAutoConfigMatrix) {
             }
         }
     }
+}
+
+Y_UNIT_TEST(GetManualPoolsUseExecutorIndicesDirectly) {
+    NKikimrConfig::TActorSystemConfig config;
+
+    auto* placement = config.AddExecutor();
+    placement->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::BASIC);
+    placement->SetThreads(1);
+    placement->SetPlacement(0);
+
+    auto* system = config.AddExecutor();
+    system->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::BASIC);
+    system->SetName("System");
+
+    auto* user = config.AddExecutor();
+    user->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::BASIC);
+    user->SetName("User");
+
+    auto* io = config.AddExecutor();
+    io->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::IO);
+    io->SetName("IO");
+
+    auto* batch = config.AddExecutor();
+    batch->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::BASIC);
+    batch->SetName("Batch");
+
+    config.SetSysExecutor(1);
+    config.SetUserExecutor(2);
+    config.SetIoExecutor(3);
+    config.SetBatchExecutor(4);
+
+    auto* interconnect = config.AddServiceExecutor();
+    interconnect->SetServiceName("Interconnect");
+    interconnect->SetExecutorId(3);
+
+    auto* background = config.AddServiceExecutor();
+    background->SetServiceName("Background");
+    background->SetExecutorId(4);
+
+    const TASPools pools = GetASPools(config, false);
+    ASSERT_POOLS(pools, 1, 2, 4, 3, 3);
+
+    TMap<TString, ui32> services = GetServicePools(config, false);
+    UNIT_ASSERT_VALUES_EQUAL(services, (TMap<TString, ui32>{{"Background", 4}, {"Interconnect", 3}}));
+}
+
+Y_UNIT_TEST(AutoConfiguredAdjacentPoolWakesAfterIdle) {
+    NKikimrConfig::TActorSystemConfig config;
+    config.SetCpuCount(2);
+    config.SetUseSharedThreads(true);
+    config.SetUseUnitedPool(true);
+
+    ApplyAutoConfig(&config, false, false);
+
+    const ui32 ownerPoolId = config.GetSysExecutor();
+    const ui32 adjacentPoolId = config.GetBatchExecutor();
+    auto setup = CreateActorSystemSetup(config);
+
+    UNIT_ASSERT(setup->CpuManager.Shared.United);
+    UNIT_ASSERT_VALUES_EQUAL(setup->CpuManager.Basic.size(), 4);
+    UNIT_ASSERT_VALUES_EQUAL(setup->CpuManager.IO.size(), 1);
+
+    const auto& ownerPool = FindBasicPool(setup->CpuManager, ownerPoolId);
+    UNIT_ASSERT_VALUES_EQUAL(ownerPool.PoolName, "User");
+    UNIT_ASSERT_VALUES_EQUAL(ownerPool.Threads, 1);
+    UNIT_ASSERT_VALUES_EQUAL(ownerPool.DefaultThreadCount, 1);
+    UNIT_ASSERT_VALUES_EQUAL(ownerPool.MaxThreadCount, 1);
+    UNIT_ASSERT(ownerPool.HasSharedThread);
+    UNIT_ASSERT(ownerPool.AllThreadsAreShared);
+    UNIT_ASSERT_VALUES_EQUAL(ownerPool.ForcedForeignSlotCount, 1);
+    UNIT_ASSERT_VALUES_EQUAL(ownerPool.AdjacentPools, (std::vector<i16>{static_cast<i16>(adjacentPoolId)}));
+
+    const auto& adjacentPool = FindBasicPool(setup->CpuManager, adjacentPoolId);
+    UNIT_ASSERT_VALUES_EQUAL(adjacentPool.PoolName, "Batch");
+    UNIT_ASSERT_VALUES_EQUAL(adjacentPool.Threads, 0);
+    UNIT_ASSERT_VALUES_EQUAL(adjacentPool.DefaultThreadCount, 0);
+    UNIT_ASSERT_VALUES_EQUAL(adjacentPool.MaxThreadCount, 0);
+    UNIT_ASSERT(!adjacentPool.HasSharedThread);
+    UNIT_ASSERT(adjacentPool.AllThreadsAreShared);
+    UNIT_ASSERT_VALUES_EQUAL(adjacentPool.ForcedForeignSlotCount, 0);
+    UNIT_ASSERT(adjacentPool.AdjacentPools.empty());
+
+    NActors::TActorSystem actorSystem(setup);
+    actorSystem.Start();
+
+    TManualEvent ready;
+    TManualEvent done;
+    NActors::TActorId adjacentActorId;
+    std::atomic<ui32> executionOwnerPoolId = Max<ui32>();
+    actorSystem.Register(
+        new TStartAdjacentActor(
+            adjacentPoolId,
+            &ready,
+            &done,
+            &adjacentActorId,
+            &executionOwnerPoolId),
+        NActors::TMailboxType::HTSwap,
+        ownerPoolId);
+
+    const bool actorIsReady = ready.WaitT(TDuration::Seconds(5));
+    const bool ownerIsParked = actorIsReady
+        && WaitForSharedThreadToPark(actorSystem, ownerPoolId, TDuration::Seconds(5));
+    if (ownerIsParked) {
+        actorSystem.Schedule(
+            TDuration::MilliSeconds(100),
+            new NActors::IEventHandle(
+                adjacentActorId,
+                NActors::TActorId(),
+                new NActors::TEvents::TEvWakeup()));
+    }
+    const bool completed = ownerIsParked && done.WaitT(TDuration::Seconds(5));
+
+    actorSystem.Stop();
+    UNIT_ASSERT_C(actorIsReady, "auto-configured Batch actor did not initialize");
+    UNIT_ASSERT_C(ownerIsParked, "auto-configured adjacent User thread did not become idle");
+    UNIT_ASSERT_C(completed,
+        "auto-configured Batch pool did not execute a delayed event after its adjacent User owner became idle");
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        executionOwnerPoolId.load(std::memory_order_acquire),
+        ownerPoolId,
+        "Batch activation was not executed by its adjacent User owner");
 }
 
 } // Y_UNIT_TEST_SUITE(AutoConfig)

--- a/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
+++ b/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
@@ -93,7 +93,15 @@ THolder<NActors::TActorSystemSetup> CreateActorSystemSetup(
     auto setup = MakeHolder<NActors::TActorSystemSetup>();
     setup->NodeId = 1;
     setup->CpuManager.Shared.United = config.GetUseUnitedPool();
-    NActorSystemConfigHelpers::AddExecutorPools(setup->CpuManager, config, nullptr);
+    setup->CpuManager.PingInfoByPool.resize(config.GetExecutor().size());
+    for (int poolId = 0; poolId < config.GetExecutor().size(); ++poolId) {
+        NActorSystemConfigHelpers::AddExecutorPool(
+            setup->CpuManager,
+            config.GetExecutor(poolId),
+            config,
+            poolId,
+            nullptr);
+    }
     setup->Scheduler.Reset(NActors::CreateSchedulerThread(
         NActorSystemConfigHelpers::CreateSchedulerConfig(config.GetScheduler())));
     return setup;
@@ -288,48 +296,43 @@ Y_UNIT_TEST(SharedAndUnitedAutoConfigMatrix) {
     }
 }
 
-Y_UNIT_TEST(GetManualPoolsUseExecutorIndicesDirectly) {
+Y_UNIT_TEST(UnitedPoolPreservesAutoConfiguredUserSlotLimit) {
     NKikimrConfig::TActorSystemConfig config;
+    config.SetCpuCount(8);
+    config.SetUseSharedThreads(true);
+    config.SetUseUnitedPool(true);
 
-    auto* placement = config.AddExecutor();
-    placement->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::BASIC);
-    placement->SetThreads(1);
-    placement->SetPlacement(0);
+    ApplyAutoConfig(&config, true, false);
 
-    auto* system = config.AddExecutor();
-    system->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::BASIC);
-    system->SetName("System");
+    const ui32 userPoolId = config.GetSysExecutor();
+    auto setup = CreateActorSystemSetup(config);
+    const auto& userPool = FindBasicPool(setup->CpuManager, userPoolId);
+    UNIT_ASSERT_VALUES_EQUAL(userPool.PoolName, "User");
+    UNIT_ASSERT_VALUES_EQUAL(userPool.DefaultThreadCount, 4);
+    UNIT_ASSERT_VALUES_EQUAL(userPool.MaxThreadCount, 8);
+    UNIT_ASSERT(userPool.AllThreadsAreShared);
 
-    auto* user = config.AddExecutor();
-    user->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::BASIC);
-    user->SetName("User");
+    NActors::TActorSystem actorSystem(setup);
+    actorSystem.Start();
 
-    auto* io = config.AddExecutor();
-    io->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::IO);
-    io->SetName("IO");
+    NActors::TExecutorPoolState state;
+    bool sharedQuotaObserved = false;
+    const TInstant deadline = TInstant::Now() + TDuration::Seconds(5);
+    while (TInstant::Now() < deadline) {
+        NActors::GetActorSystemStats(actorSystem).GetExecutorPoolState(userPoolId, state);
+        if (state.SharedCpuQuota > 1.0) {
+            sharedQuotaObserved = true;
+            break;
+        }
+        Sleep(TDuration::MilliSeconds(10));
+    }
 
-    auto* batch = config.AddExecutor();
-    batch->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::BASIC);
-    batch->SetName("Batch");
-
-    config.SetSysExecutor(1);
-    config.SetUserExecutor(2);
-    config.SetIoExecutor(3);
-    config.SetBatchExecutor(4);
-
-    auto* interconnect = config.AddServiceExecutor();
-    interconnect->SetServiceName("Interconnect");
-    interconnect->SetExecutorId(3);
-
-    auto* background = config.AddServiceExecutor();
-    background->SetServiceName("Background");
-    background->SetExecutorId(4);
-
-    const TASPools pools = GetASPools(config, false);
-    ASSERT_POOLS(pools, 1, 2, 4, 3, 3);
-
-    TMap<TString, ui32> services = GetServicePools(config, false);
-    UNIT_ASSERT_VALUES_EQUAL(services, (TMap<TString, ui32>{{"Background", 4}, {"Interconnect", 3}}));
+    actorSystem.Stop();
+    UNIT_ASSERT_C(sharedQuotaObserved,
+        "User pool did not report its owned shared slots");
+    UNIT_ASSERT_VALUES_EQUAL(state.MaxLimit, 8);
+    UNIT_ASSERT_LE(state.CurrentLimit, state.MaxLimit);
+    UNIT_ASSERT_LE(state.PossibleMaxLimit, state.MaxLimit);
 }
 
 Y_UNIT_TEST(AutoConfiguredAdjacentPoolWakesAfterIdle) {

--- a/ydb/library/actors/core/cpu_manager.cpp
+++ b/ydb/library/actors/core/cpu_manager.cpp
@@ -27,14 +27,14 @@ namespace NActors {
 
     void TCpuManager::SetupShared() {
         ACTORLIB_DEBUG(EDebugLevel::ActorSystem, "TCpuManager::SetupShared");
-        bool hasSharedThread = false;
+        bool needsSharedPool = false;
         for (TBasicExecutorPoolConfig& cfg : Config.Basic) {
-            if (cfg.HasSharedThread) {
-                hasSharedThread = true;
+            if (cfg.HasSharedThread || cfg.AllThreadsAreShared) {
+                needsSharedPool = true;
                 break;
             }
         }
-        if (!hasSharedThread) {
+        if (!needsSharedPool) {
             ACTORLIB_DEBUG(EDebugLevel::ActorSystem, "TCpuManager::SetupShared: no shared threads, skipping");
             return;
         }

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -195,12 +195,17 @@ namespace NActors {
         semaphore.CurrentThreadCount = ThreadCount;
         Semaphore = semaphore.ConvertToI64();
 
-        DefaultThreadCount = DefaultFullThreadCount + HasOwnSharedThread;
-        MinThreadCount = MinFullThreadCount + HasOwnSharedThread;
-        MaxThreadCount = MaxFullThreadCount + HasOwnSharedThread;
+        const i16 ownSharedThreadCount = cfg.AllThreadsAreShared
+            ? cfg.DefaultThreadCount
+            : HasOwnSharedThread;
+        DefaultThreadCount = DefaultFullThreadCount + ownSharedThreadCount;
+        MinThreadCount = MinFullThreadCount + ownSharedThreadCount;
+        MaxThreadCount = cfg.AllThreadsAreShared
+            ? Max(cfg.MaxThreadCount, cfg.DefaultThreadCount)
+            : MaxFullThreadCount + ownSharedThreadCount;
 
         if (SharedOnly) {
-            MaxThreadCount = cfg.ForcedForeignSlotCount + 1;
+            MaxThreadCount = cfg.ForcedForeignSlotCount + ownSharedThreadCount;
         }
 
         Threads.Reset(new NThreading::TPadded<TExecutorThreadCtx>[MaxFullThreadCount]);

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -472,8 +472,12 @@ namespace NActors {
             EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "need to wake up");
             WakeUpLoop(semaphore.CurrentThreadCount);
         } else if (SharedPool) {
-            EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "shared pool wake up global threads");
-            SharedPool->WakeUpGlobalThreads(PoolId);
+            if (SharedPool->WakeUpAdjacentOwner(PoolId)) {
+                EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "shared pool wake up adjacent owner");
+            } else {
+                EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "shared pool wake up global threads");
+                SharedPool->WakeUpGlobalThreads(PoolId);
+            }
         }
     }
 

--- a/ydb/library/actors/core/executor_pool_shared.cpp
+++ b/ydb/library/actors/core/executor_pool_shared.cpp
@@ -102,6 +102,7 @@ namespace NActors {
         , DefaultSpinThresholdCycles(cfg.SpinThreshold * NHPTimer::GetCyclesPerSecond() * 0.000001) // convert microseconds to cycles
         , PoolName("Shared")
         , SoftProcessingDurationTs(cfg.SoftProcessingDurationTs)
+        , United(cfg.United)
         , Threads(new NThreading::TPadded<TSharedExecutorThreadCtx>[PoolThreads])
         , ForeignThreadsAllowedByPool(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])
         , ForeignThreadSlots(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])

--- a/ydb/library/actors/core/executor_pool_shared.cpp
+++ b/ydb/library/actors/core/executor_pool_shared.cpp
@@ -35,6 +35,7 @@ namespace NActors {
         : PoolInfos(poolInfos)
     {
         PoolThreadRanges.resize(poolInfos.size());
+        AdjacentOwnerByPool.resize(poolInfos.size(), -1);
         ui64 totalThreads = 0;
         for (const auto& poolInfo : poolInfos) {
             PoolThreadRanges[poolInfo.PoolId].Begin = totalThreads;
@@ -42,6 +43,19 @@ namespace NActors {
             totalThreads += poolInfo.SharedThreadCount;
             if (poolInfo.InPriorityOrder) {
                 PriorityOrder.push_back(poolInfo.PoolId);
+            }
+            Y_ABORT_UNLESS(poolInfo.AdjacentPools.empty() || poolInfo.SharedThreadCount > 0,
+                "pool %d has adjacent pools but owns no shared threads", poolInfo.PoolId);
+            for (i16 adjacentPoolId : poolInfo.AdjacentPools) {
+                Y_ABORT_UNLESS(adjacentPoolId >= 0 && static_cast<size_t>(adjacentPoolId) < poolInfos.size(),
+                    "invalid adjacent pool %d for owner pool %d", adjacentPoolId, poolInfo.PoolId);
+                Y_ABORT_UNLESS(poolInfo.PoolId != adjacentPoolId,
+                    "pool %d cannot be adjacent to itself", poolInfo.PoolId);
+                i16& adjacentOwner = AdjacentOwnerByPool[adjacentPoolId];
+                Y_ABORT_UNLESS(adjacentOwner == -1,
+                    "adjacent pool %d has multiple owner pools: %d and %d",
+                    adjacentPoolId, adjacentOwner, poolInfo.PoolId);
+                adjacentOwner = poolInfo.PoolId;
             }
         }
         Sort(PoolInfos.begin(), PoolInfos.end(), [](const TPoolShortInfo& a, const TPoolShortInfo& b) {
@@ -494,6 +508,19 @@ namespace NActors {
             }
         }
         return true;
+    }
+
+    bool TSharedExecutorPool::WakeUpAdjacentOwner(i16 poolId) {
+        Y_ABORT_UNLESS(poolId >= 0 && static_cast<size_t>(poolId) < PoolManager.AdjacentOwnerByPool.size());
+        const i16 adjacentOwnerPoolId = PoolManager.AdjacentOwnerByPool[poolId];
+        if (adjacentOwnerPoolId == -1) {
+            return false;
+        }
+        if (WakeUpLocalThreads(adjacentOwnerPoolId)) {
+            EXECUTOR_POOL_SHARED_DEBUG(EDebugLevel::Executor, "wakeup from adjacent pool owner; poolId == ", poolId, " adjacentOwnerPoolId == ", adjacentOwnerPoolId);
+            return true;
+        }
+        return false;
     }
 
     bool TSharedExecutorPool::WakeUpGlobalThreads(i16 ownerPoolId) {

--- a/ydb/library/actors/core/executor_pool_shared.h
+++ b/ydb/library/actors/core/executor_pool_shared.h
@@ -45,6 +45,7 @@ namespace NActors {
         std::vector<TPoolShortInfo> PoolInfos;
         TStackVec<TPoolThreadRange, 8> PoolThreadRanges;
         TStackVec<i16, 8> PriorityOrder;
+        std::vector<i16> AdjacentOwnerByPool;
 
         TPoolManager(const std::vector<TPoolShortInfo> &poolInfos);
     };
@@ -164,6 +165,7 @@ namespace NActors {
         i16 GetSharedThreadCount() const override;
 
         bool WakeUpLocalThreads(i16 poolId);
+        bool WakeUpAdjacentOwner(i16 poolId);
         bool WakeUpGlobalThreads(i16 poolId);
 
         void FillForeignThreadsAllowed(std::vector<i16>& foreignThreadsAllowed) const override;

--- a/ydb/library/actors/core/harmonizer/cpu_consumption.cpp
+++ b/ydb/library/actors/core/harmonizer/cpu_consumption.cpp
@@ -124,8 +124,8 @@ void THarmonizerCpuConsumption::Pull(const std::vector<std::unique_ptr<TPoolInfo
             IsStarvedPresent = true;
         }
 
-        bool hasSharedThread = sharedInfo.OwnedThreads[poolIdx] != -1;
-        float expectedThreadCount = pool.GetFullThreadCount() + (hasSharedThread ? 1 : 0) + 0.5;
+        i16 ownSharedThreadCount = Max<i16>(sharedInfo.OwnedThreads[poolIdx], 0);
+        float expectedThreadCount = pool.GetFullThreadCount() + ownSharedThreadCount + 0.5;
         bool isMoreThanExpected = (PoolConsumption[poolIdx].LastSecondCpu >= expectedThreadCount) && (PoolFullThreadConsumption[poolIdx].LastSecondCpu >= currentFullThreadCount - 1);
         bool isNeedy = (pool.IsAvgPingGood() || pool.NewNotEnoughCpuExecutions);
         if (isNeedy && !pool.IsSharedOnly) {
@@ -138,7 +138,7 @@ void THarmonizerCpuConsumption::Pull(const std::vector<std::unique_ptr<TPoolInfo
             NeedyPools.push_back(poolIdx);
         }
 
-        bool isHoggish = !isNeedy && IsHoggish(PoolConsumption[poolIdx].Elapsed, currentFullThreadCount + hasSharedThread) && IsHoggish(PoolConsumption[poolIdx].LastSecondElapsed, currentFullThreadCount + hasSharedThread);
+        bool isHoggish = !isNeedy && IsHoggish(PoolConsumption[poolIdx].Elapsed, currentFullThreadCount + ownSharedThreadCount) && IsHoggish(PoolConsumption[poolIdx].LastSecondElapsed, currentFullThreadCount + ownSharedThreadCount);
         if (isHoggish) {
             float freeCpu = std::min(currentFullThreadCount - PoolFullThreadConsumption[poolIdx].Elapsed, currentFullThreadCount - PoolFullThreadConsumption[poolIdx].LastSecondElapsed);
             HoggishPools.push_back({poolIdx, freeCpu});

--- a/ydb/library/actors/core/harmonizer/harmonizer.cpp
+++ b/ydb/library/actors/core/harmonizer/harmonizer.cpp
@@ -136,10 +136,10 @@ void THarmonizer::ProcessWaitingStats() {
 
 void THarmonizer::SetForeignThreadSlotsForCurrentFullThreadCount(ui16 poolIdx) {
     if (Shared) {
-        bool hasOwnSharedThread = SharedInfo.OwnedThreads[poolIdx] != -1;
+        i16 ownSharedThreadCount = Max<i16>(SharedInfo.OwnedThreads[poolIdx], 0);
         i16 currentFullThreadCount = Pools[poolIdx]->GetFullThreadCount();
-        i16 slots = Pools[poolIdx]->MaxThreadCount - currentFullThreadCount - hasOwnSharedThread;
-        i16 maxSlots = Shared->GetSharedThreadCount() - hasOwnSharedThread;
+        i16 slots = Pools[poolIdx]->MaxThreadCount - currentFullThreadCount - ownSharedThreadCount;
+        i16 maxSlots = Shared->GetSharedThreadCount() - ownSharedThreadCount;
         Shared->SetForeignThreadSlots(poolIdx, Min<i16>(slots, maxSlots));
     }
 }
@@ -157,7 +157,8 @@ void THarmonizer::ProcessStarvedState() {
         if (CpuConsumption.PoolConsumption[poolIdx].Elapsed > pool.GetThreadCount()) {
             continue;
         }
-        i16 maxSharedCpuQuota = i16(SharedInfo.OwnedThreads[poolIdx] != -1) + SharedInfo.ForeignThreadsAllowed[poolIdx];
+        i16 maxSharedCpuQuota = Max<i16>(SharedInfo.OwnedThreads[poolIdx], 0)
+            + SharedInfo.ForeignThreadsAllowed[poolIdx];
         if (SharedInfo.CpuConsumption[poolIdx].CpuQuota > maxSharedCpuQuota) {
             continue;
         }
@@ -360,8 +361,8 @@ void THarmonizer::HarmonizeImpl(ui64 ts) {
 
         float possibleMaxSharedQuota = 0.0f;
         if (Shared) {
-            bool hasOwnSharedThread = SharedInfo.OwnedThreads[poolIdx] != -1;
-            i16 sharedThreads = std::min<i16>(SharedInfo.ForeignThreadsAllowed[poolIdx] + hasOwnSharedThread, SharedInfo.ThreadCount);
+            i16 ownSharedThreadCount = Max<i16>(SharedInfo.OwnedThreads[poolIdx], 0);
+            i16 sharedThreads = std::min<i16>(SharedInfo.ForeignThreadsAllowed[poolIdx] + ownSharedThreadCount, SharedInfo.ThreadCount);
             float poolSharedElapsedCpu = SharedInfo.CpuConsumption[poolIdx].Elapsed;
             possibleMaxSharedQuota = std::min<float>(poolSharedElapsedCpu + freeSharedCpu, sharedThreads);
         }
@@ -478,8 +479,8 @@ void THarmonizer::AddPool(IExecutorPool* pool, TSelfPingInfo *pingInfo, bool ign
     if (Shared) {
         TVector<i16> ownedThreads(Pools.size(), -1);
         Shared->FillOwnedThreads(ownedThreads);
-        bool hasOwnSharedThread = ownedThreads[pool->PoolId] != -1;
-        Shared->SetForeignThreadSlots(pool->PoolId, Min<i16>(poolInfo.MaxThreadCount, Shared->GetSharedThreadCount()) - hasOwnSharedThread);
+        i16 ownSharedThreadCount = Max<i16>(ownedThreads[pool->PoolId], 0);
+        Shared->SetForeignThreadSlots(pool->PoolId, Min<i16>(poolInfo.MaxThreadCount, Shared->GetSharedThreadCount()) - ownSharedThreadCount);
     }
     if (pingInfo) {
         poolInfo.AvgPingCounter = pingInfo->AvgPingCounter;

--- a/ydb/library/actors/core/ut/actor_shared_threads.cpp
+++ b/ydb/library/actors/core/ut/actor_shared_threads.cpp
@@ -13,6 +13,7 @@
 
 #include <util/generic/algorithm.h>
 #include <library/cpp/deprecated/atomic/atomic.h>
+#include <util/system/event.h>
 #include <util/system/rwlock.h>
 #include <util/system/hp_timer.h>
 
@@ -24,6 +25,21 @@ Y_UNIT_TEST_SUITE(SharedThreads) {
     using TActorBenchmark = ::NActors::NTests::TActorBenchmark<>;
     using TSettings = TActorBenchmark::TSettings;
     using TSendReceiveActorParams = TActorBenchmark::TSendReceiveActorParams;
+
+    class TSignalActor : public TActorBootstrapped<TSignalActor> {
+    public:
+        explicit TSignalActor(TManualEvent* done)
+            : Done(done)
+        {}
+
+        void Bootstrap() {
+            Done->Signal();
+            PassAway();
+        }
+
+    private:
+        TManualEvent* const Done;
+    };
 
     class TAliveCounterDecorator : public TDecorator {
     public:
@@ -227,6 +243,31 @@ Y_UNIT_TEST_SUITE(SharedThreads) {
 
     Y_UNIT_TEST(RegistrationAndPassingAwayActorsLazyStrictPool) {
         RunRegistrationAndPassingAwayActors<ESendingType::Lazy>(true);
+    }
+
+    Y_UNIT_TEST(AllThreadsSharedRunWithoutLegacySharedFlag) {
+        THolder<TActorSystemSetup> setup = TActorBenchmark::GetActorSystemSetup();
+        setup->CpuManager.Shared.United = true;
+        setup->CpuManager.Basic.emplace_back(TBasicExecutorPoolConfig{
+            .PoolId = 0,
+            .PoolName = "UnitedPool",
+            .Threads = 2,
+            .SpinThreshold = 0,
+            .MaxThreadCount = 2,
+            .DefaultThreadCount = 2,
+            .AllThreadsAreShared = true,
+        });
+
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TManualEvent done;
+        actorSystem.Register(new TSignalActor(&done), TMailboxType::HTSwap, 0);
+        const bool completed = done.WaitT(TDuration::Seconds(5));
+
+        actorSystem.Stop();
+        UNIT_ASSERT_C(completed,
+            "AllThreadsAreShared pool did not execute an actor without the legacy HasSharedThread flag");
     }
 
 } // Y_UNIT_TEST_SUITE(ActorBenchmark)

--- a/ydb/library/actors/core/ut/executor_pools_ut.cpp
+++ b/ydb/library/actors/core/ut/executor_pools_ut.cpp
@@ -2,6 +2,7 @@
 #include "debug.h"
 #include "executor_pool_basic.h"
 #include "executor_pool_shared.h"
+#include "harmonizer/harmonizer.h"
 #include "hfunc.h"
 #include "scheduler_basic.h"
 #include "thread_context.h"
@@ -219,6 +220,59 @@ void TieBasicPoolsAndSharedPool(const std::vector<std::unique_ptr<TBasicExecutor
 ////////////////////////////////////////////////////////////////////////////////
 
 Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
+
+    Y_UNIT_TEST(UnitedPoolSlotLimitIncludesOwnedAndForeignSlots) {
+        auto harmonizer = MakeHarmonizer(0);
+        auto sharedPool = std::make_unique<TSharedExecutorPool>(TSharedExecutorPoolConfig{
+            .United = true,
+        }, std::vector<TPoolShortInfo>{
+            TPoolShortInfo{
+                .PoolId = 0,
+                .SharedThreadCount = 4,
+                .InPriorityOrder = true,
+                .PoolName = "User",
+            },
+            TPoolShortInfo{
+                .PoolId = 1,
+                .SharedThreadCount = 4,
+                .InPriorityOrder = true,
+                .PoolName = "Other",
+            },
+        });
+        harmonizer->SetSharedPool(sharedPool.get());
+
+        TBasicExecutorPool pool(TBasicExecutorPoolConfig{
+            .PoolId = 0,
+            .PoolName = "User",
+            .Threads = 8,
+            .MaxThreadCount = 8,
+            .DefaultThreadCount = 4,
+            .HasSharedThread = true,
+            .AllThreadsAreShared = true,
+        }, harmonizer.get());
+        harmonizer->AddPool(&pool);
+
+        std::vector<i16> ownedThreads;
+        std::vector<i16> foreignThreadsAllowed;
+        sharedPool->FillOwnedThreads(ownedThreads);
+        sharedPool->FillForeignThreadsAllowed(foreignThreadsAllowed);
+
+        UNIT_ASSERT_VALUES_EQUAL(pool.GetFullThreadCount(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(pool.GetDefaultThreadCount(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(pool.GetMinThreadCount(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(pool.GetMaxThreadCount(), 8);
+        UNIT_ASSERT_VALUES_EQUAL(ownedThreads[0], 4);
+        UNIT_ASSERT_VALUES_EQUAL(foreignThreadsAllowed[0], 4);
+
+        pool.SetSharedCpuQuota(4);
+        TExecutorPoolState state;
+        pool.GetExecutorPoolState(state);
+        UNIT_ASSERT_VALUES_EQUAL(state.CurrentLimit, 4);
+        UNIT_ASSERT_VALUES_EQUAL(state.MaxLimit, 8);
+        UNIT_ASSERT_VALUES_EQUAL(state.PossibleMaxLimit, 8);
+        UNIT_ASSERT_LE(state.CurrentLimit, state.MaxLimit);
+        UNIT_ASSERT_LE(state.PossibleMaxLimit, state.MaxLimit);
+    }
 
     Y_UNIT_TEST(SharedPoolReportsUnitedMode) {
         for (const bool united : {false, true}) {

--- a/ydb/library/actors/core/ut/executor_pools_ut.cpp
+++ b/ydb/library/actors/core/ut/executor_pools_ut.cpp
@@ -220,6 +220,17 @@ void TieBasicPoolsAndSharedPool(const std::vector<std::unique_ptr<TBasicExecutor
 
 Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
 
+    Y_UNIT_TEST(SharedPoolReportsUnitedMode) {
+        for (const bool united : {false, true}) {
+            TSharedExecutorPoolConfig config;
+            config.United = united;
+
+            const TSharedExecutorPool sharedPool(config, {});
+
+            UNIT_ASSERT_VALUES_EQUAL(sharedPool.IsUnited(), united);
+        }
+    }
+
     Y_UNIT_TEST(ReceiveActivationForEachRevolvingCounter) {
         std::unique_ptr<IExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
             .Threads = 1,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed shared and united executor pool configuration, wakeups, and slot-limit accounting.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Backports the shared/united pool fixes from main. United executors could report the wrong mode, fail to create a shared pool or propagate tiny auto-configuration, leave adjacent-pool work sleeping after its owner parked, and interpret owned shared slots as a single slot when calculating maximum and foreign capacity. The changes restore shared-pool startup and owner wakeup routing and keep owned, foreign, and maximum slot counts in consistent units.