### PR TITLE
YQL: collect DQ worker memory and process metrics

### DIFF
--- a/ydb/library/yql/providers/dq/api/protos/service.proto
+++ b/ydb/library/yql/providers/dq/api/protos/service.proto
@@ -194,6 +194,8 @@ message RegisterNodeRequest {
         int64 CpuSystem = 7;
         int64 CpuUser = 8;
         int64 CpuTotal = 9;
+        int64 MaxRss = 10; // bytes
+        int64 CurrentRss = 11; // bytes
     }
 
     TRusage Rusage = 21;

--- a/ydb/library/yql/providers/dq/runtime/runtime_data.cpp
+++ b/ydb/library/yql/providers/dq/runtime/runtime_data.cpp
@@ -21,6 +21,7 @@ void TWorkerRuntimeData::AddRusageDelta(const TRusage& delta) {
         }
         Rusages[Index].Stime += delta.Stime;
         Rusages[Index].Utime += delta.Utime;
+        Rusages[Index].MaxRss = Max(Rusages[Index].MaxRss, delta.MaxRss);
         Rusages[Index].MajorPageFaults += delta.MajorPageFaults;
     }
     LastUpdate = TInstant::Seconds(now.Seconds());

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
@@ -55,6 +55,30 @@ extern "C" int waitpid(int pid, int* status, int options);
 
 namespace {
 
+struct TPipeFactoryCounters {
+    explicit TPipeFactoryCounters(const NMonitoring::TDynamicCounterPtr& root)
+        : ProcessesInPool(root->GetCounter("ProcessesInPool"))
+        , ProcessesPendingStop(root->GetCounter("ProcessesPendingStop"))
+        , PortoContainersAlive(root->GetCounter("PortoContainersAlive"))
+        , PortoContainersStarted(root->GetCounter("PortoContainersStarted", /*derivative=*/true))
+        , PortoContainersDestroyed(root->GetCounter("PortoContainersDestroyed", /*derivative=*/true))
+        , PortoContainerDestroyErrors(root->GetCounter("PortoContainerDestroyErrors", /*derivative=*/true))
+    {
+    }
+
+    const NMonitoring::TDynamicCounters::TCounterPtr ProcessesInPool;
+    const NMonitoring::TDynamicCounters::TCounterPtr ProcessesPendingStop;
+
+    // Best-effort count of Porto containers owned by live TPortoProcess objects.
+    // It intentionally does not query Porto and therefore cannot detect orphaned containers.
+    const NMonitoring::TDynamicCounters::TCounterPtr PortoContainersAlive;
+    const NMonitoring::TDynamicCounters::TCounterPtr PortoContainersStarted;
+    const NMonitoring::TDynamicCounters::TCounterPtr PortoContainersDestroyed;
+    const NMonitoring::TDynamicCounters::TCounterPtr PortoContainerDestroyErrors;
+};
+
+using TPipeFactoryCountersPtr = std::shared_ptr<TPipeFactoryCounters>;
+
 void Load(IInputStream& input, void* buf, size_t size) {
     char* p = (char*)buf;
     while (size) {
@@ -196,6 +220,7 @@ public:
         Stdout = MakeHolder<TPipedInput>(output[0]);
         Stderr = MakeHolder<TPipedInput>(error[0]);
         YQL_CLOG(DEBUG, ProviderDq) << "Forked child, pid: " << Pid;
+        OnStarted();
 #endif
     }
 
@@ -275,6 +300,9 @@ protected:
         }
     }
 
+    virtual void OnStarted() {
+    }
+
     virtual void Exec() {
         for (int i = 3; i < 32768; ++i) {
             close(i);
@@ -294,8 +322,9 @@ protected:
 /*______________________________________________________________________________________________*/
 
 struct TProcessHolder {
-    TProcessHolder()
-        : Watcher(MakeHolder<TThread>([this] () { Watch(); }))
+    explicit TProcessHolder(TPipeFactoryCountersPtr counters)
+        : Counters(std::move(counters))
+        , Watcher(MakeHolder<TThread>([this] () { Watch(); }))
     {
         Running.test_and_set();
         Watcher->Start();
@@ -315,6 +344,7 @@ struct TProcessHolder {
     void Put(const TString& key, THolder<TChildProcess>process) {
         TGuard<TMutex> lock(Mutex);
         Processes.emplace_back(key, std::move(process));
+        UpdatePoolSize();
     }
 
     THolder<TChildProcess> Acquire(const TString& key, TList<THolder<TChildProcess>>* stopList) {
@@ -329,6 +359,7 @@ struct TProcessHolder {
             }
             stopList->push_back(std::move(first.second));
         }
+        UpdatePoolSize();
         return result;
     }
 
@@ -347,6 +378,7 @@ struct TProcessHolder {
                         ++it;
                     }
                 }
+                UpdatePoolSize();
             }
 
             for (const auto& job : stopList) {
@@ -357,6 +389,11 @@ struct TProcessHolder {
         }
     }
 
+    void UpdatePoolSize() {
+        *Counters->ProcessesInPool = Processes.size();
+    }
+
+    const TPipeFactoryCountersPtr Counters;
     THolder<TThread> Watcher;
     std::atomic_flag Running;
 
@@ -386,11 +423,12 @@ struct TPortoSettings {
 class TPortoProcess: public TChildProcess
 {
 public:
-    TPortoProcess(const TString& portoCtl, const TString& exeName, const TVector<TString>& args, const THashMap<TString, TString>& env, const TString& workDir, const TPortoSettings& portoSettings)
+    TPortoProcess(const TString& portoCtl, const TString& exeName, const TVector<TString>& args, const THashMap<TString, TString>& env, const TString& workDir, const TPortoSettings& portoSettings, TPipeFactoryCountersPtr counters)
         : TChildProcess(exeName, args, env, workDir)
         , PortoCtl(portoCtl)
         , PortoLayer(portoSettings.Layer)
         , MemoryLimit(portoSettings.MemoryLimit)
+        , Counters(std::move(counters))
         , ContainerName(WorkDir.substr(WorkDir.rfind("/") + 1))
         , InternalWorkDir_("mnt/work")
         , InternalExeDir("usr/local/bin")
@@ -417,6 +455,9 @@ public:
     }
 
     ~TPortoProcess() {
+        if (Started) {
+            --*Counters->PortoContainersAlive;
+        }
         try {
             NFs::RemoveRecursive(TmpDir);
         } catch (...) {
@@ -425,6 +466,12 @@ public:
     }
 
 private:
+
+    void OnStarted() override {
+        Started = true;
+        ++*Counters->PortoContainersStarted;
+        ++*Counters->PortoContainersAlive;
+    }
 
     TString GetPortoSetting(const TString& name) const {
         TShellCommand cmd(PortoCtl, {"get", ContainerName, name});
@@ -461,11 +508,25 @@ private:
             }
         }
 
+        bool destroyed = false;
         try {
             TShellCommand cmd(PortoCtl, {"destroy", ContainerName});
             cmd.Run().Wait();
+            const auto exitCode = cmd.GetExitCode();
+            destroyed = exitCode.GetOrElse(-1) == 0;
+            if (!destroyed) {
+                YQL_CLOG(DEBUG, ProviderDq) << "Cannot destroy container " << ContainerName
+                    << ", exit code: " << exitCode.GetOrElse(-1)
+                    << ", stderr: " << cmd.GetError();
+            }
         } catch (...) {
             YQL_CLOG(DEBUG, ProviderDq) << "Cannot destroy: " << CurrentExceptionMessage();
+        }
+        if (destroyed && !DestroyReported) {
+            ++*Counters->PortoContainersDestroyed;
+            DestroyReported = true;
+        } else if (!destroyed && !DestroyReported) {
+            ++*Counters->PortoContainerDestroyErrors;
         }
         TChildProcess::Kill();
     }
@@ -530,6 +591,9 @@ private:
     const TString PortoCtl;
     const TString PortoLayer;
     const TMaybe<ui64> MemoryLimit;
+    const TPipeFactoryCountersPtr Counters;
+    bool Started = false;
+    bool DestroyReported = false;
     TString ContainerName;
 
     const TString InternalWorkDir_;
@@ -1997,15 +2061,18 @@ class TPipeFactory: public IProxyFactory {
 
     struct TStopJob: public TTaskScheduler::ITask {
         TList<THolder<TChildProcess>> StopList;
+        const TPipeFactoryCountersPtr Counters;
 
-        TStopJob(TList<THolder<TChildProcess>>&& stopList)
+        TStopJob(TList<THolder<TChildProcess>>&& stopList, TPipeFactoryCountersPtr counters)
             : StopList(std::move(stopList))
+            , Counters(std::move(counters))
         { }
 
         TInstant Process() override {
             for (const auto& job : StopList) {
                 job->Kill();
                 job->Wait(TDuration::Seconds(1));
+                --*Counters->ProcessesPendingStop;
             }
 
             return TInstant::Max();
@@ -2028,6 +2095,9 @@ public:
         , Revision(options.Revision
             ? *options.Revision
             : GetProgramCommitId())
+        , Counters(std::make_shared<TPipeFactoryCounters>(
+              options.Counters ? options.Counters : MakeIntrusive<NMonitoring::TDynamicCounters>()))
+        , ProcessHolder(Counters)
         , TaskScheduler(1)
         , MaxProcesses(options.MaxProcesses)
         , PortoCtlPath(options.PortoCtlPath)
@@ -2060,7 +2130,7 @@ public:
 
 private:
     THolder<TChildProcess> StartOne(const TString& exePath, const TPortoSettings& portoSettings) {
-        return CreateChildProcess(PortoCtlPath, FileCache->GetDir(), exePath, Args, Env, ContainerId++, portoSettings);
+        return CreateChildProcess(PortoCtlPath, FileCache->GetDir(), exePath, Args, Env, ContainerId++, portoSettings, Counters);
     }
 
     void Start(const TString& exePath, const TPortoSettings& portoSettings) {
@@ -2082,7 +2152,8 @@ private:
     }
 
     void StopJobs(TList<THolder<TChildProcess>>&& stopList) {
-        Y_ABORT_UNLESS(TaskScheduler.Add(MakeIntrusive<TStopJob>(std::move(stopList)), TInstant()));
+        *Counters->ProcessesPendingStop += stopList.size();
+        Y_ABORT_UNLESS(TaskScheduler.Add(MakeIntrusive<TStopJob>(std::move(stopList), Counters), TInstant()));
     }
 
     TString GetKey(const TString& exePath, const TPortoSettings& settings)
@@ -2200,11 +2271,12 @@ private:
         const TVector<TString>& args,
         const THashMap<TString, TString>& env,
         i64 containerId,
-        const TPortoSettings& portoSettings)
+        const TPortoSettings& portoSettings,
+        const TPipeFactoryCountersPtr& counters)
     {
         THolder<TChildProcess> command;
         if (portoSettings.Enable) {
-            command = MakeHolder<TPortoProcess>(portoCtlPath, exePath, args, env, cacheDir + "/Slot-" + ToString(containerId), portoSettings);
+            command = MakeHolder<TPortoProcess>(portoCtlPath, exePath, args, env, cacheDir + "/Slot-" + ToString(containerId), portoSettings, counters);
         } else {
             command = MakeHolder<TChildProcess>(exePath, args, env, cacheDir + "/Slot-" + ToString(containerId));
         }
@@ -2228,6 +2300,7 @@ private:
 
     const TString Revision;
 
+    const TPipeFactoryCountersPtr Counters;
     TProcessHolder ProcessHolder;
     TTaskScheduler TaskScheduler;
     const int MaxProcesses;

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.h
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.h
@@ -3,6 +3,8 @@
 #include "tasks_runner_proxy.h"
 #include "file_cache.h"
 
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+
 #include <util/generic/hash.h>
 #include <util/generic/string.h>
 
@@ -18,6 +20,7 @@ struct TPipeFactoryOptions {
     TString ContainerName;
     TString PortoCtlPath = "/usr/bin/porto";
     TMaybe<TString> Revision; // revision override for tests
+    NMonitoring::TDynamicCounterPtr Counters;
 };
 
 IProxyFactory::TPtr CreatePipeFactory(const TPipeFactoryOptions& options);

--- a/ydb/library/yql/providers/dq/worker_manager/interface/worker_info.cpp
+++ b/ydb/library/yql/providers/dq/worker_manager/interface/worker_info.cpp
@@ -138,6 +138,8 @@ namespace NYql::NDqs {
 
         CpuSystem = cpuSystemCur;
         CpuUser = cpuUserCur;
+        MaxRss = request.GetRusage().GetMaxRss();
+        CurrentRss = request.GetRusage().GetCurrentRss();
 
         auto pageFaultsDelta = (request.GetRusage().GetMajorPageFaults() - MajorPageFaults);
         MajorPageFaults = request.GetRusage().GetMajorPageFaults();

--- a/ydb/library/yql/providers/dq/worker_manager/interface/worker_info.h
+++ b/ydb/library/yql/providers/dq/worker_manager/interface/worker_info.h
@@ -127,6 +127,8 @@ struct TWorkerInfo: public TThrRefBase {
     i64 CpuSystem = 0;
     i64 CpuUser = 0;
     i64 CpuTotal = 0;
+    i64 MaxRss = 0;
+    i64 CurrentRss = 0;
     i64 MajorPageFaults = 0;
 
     int RunningRequests = 0;

--- a/ydb/library/yql/providers/dq/worker_manager/local_worker_manager.cpp
+++ b/ydb/library/yql/providers/dq/worker_manager/local_worker_manager.cpp
@@ -200,6 +200,8 @@ private:
     void WakeUp() {
         auto currentRusage = TRusage::Get();
         TRusage delta;
+        // MaxRss is a peak, not a delta; AddRusageDelta merges it with Max.
+        delta.MaxRss = currentRusage.MaxRss;
         delta.Utime = currentRusage.Utime - Rusage.Utime;
         delta.Stime = currentRusage.Stime - Rusage.Stime;
         delta.MajorPageFaults = currentRusage.MajorPageFaults - Rusage.MajorPageFaults;


### PR DESCRIPTION
## Summary

- expose worker peak and current RSS through the DQ worker registration data;
- preserve peak RSS while aggregating runtime usage;
- add task runner gauges for pooled processes and processes pending stop;
- add Porto container lifecycle and destroy-error counters.

The process metrics are registered under `component=task_runner_pipe`. Generic pool metrics are independent of the child-process launch mechanism, while Porto lifecycle metrics remain specific to `TPortoProcess`.

## Testing

```text
/home/uzhas/ydb/ya make worker_manager task_runner -j4
```

Run from `ydb/library/yql/providers/dq`; all 92 targets completed successfully.
