### PR TITLE
Preserve PersistentBuffer fast erase metadata across recovery

### DIFF
--- a/ydb/core/blobstorage/ddisk/persistent_buffer_barriers_manager.cpp
+++ b/ydb/core/blobstorage/ddisk/persistent_buffer_barriers_manager.cpp
@@ -419,14 +419,17 @@ namespace NKikimr::NDDisk {
             auto itErase = std::upper_bound(erase.Lsns.begin(), erase.Lsns.end(), barrier.Lsn);
             erase.Lsns = std::vector<ui64>(itErase, erase.Lsns.end());
 
-            auto pbIt = persistentBuffers.find({tid, erase.Generation, dbg});
-            if (pbIt == persistentBuffers.end()) {
-                it = Erases.erase(it);
-                continue;
-            }
-
+            // Preserve the version and its on-disk sector even without live records.
+            // Otherwise subsequent erases restart HeaderLsn, and an older header
+            // still present on disk can win during the next recovery.
             const TPersistentBufferSectorInfo eraseSector{.ChunkIdx = erase.ChunkIdx, .SectorIdx = erase.SectorIdx};
             allocator.MarkOccupied(std::span<const TPersistentBufferSectorInfo>(&eraseSector, 1));
+
+            auto pbIt = persistentBuffers.find({tid, erase.Generation, dbg});
+            if (pbIt == persistentBuffers.end()) {
+                ++it;
+                continue;
+            }
 
             TPersistentBuffer& buffer = pbIt->second;
             for (ui64 lsn : erase.Lsns) {

--- a/ydb/core/blobstorage/ddisk/ut/persistent_buffer_barriers_manager_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/persistent_buffer_barriers_manager_ut.cpp
@@ -32,6 +32,40 @@ static constexpr ui32 MaxRawLsns = TPersistentBufferFastErases::ErasesBufferSize
 
 Y_UNIT_TEST_SUITE(TPersistentBufferBarriersManagerTest) {
 
+    Y_UNIT_TEST(RestoreKeepsFastEraseVersionWithoutRecords) {
+        auto mgr = MakeManager();
+        auto alloc = MakeAllocator();
+        TPersistentBufferFastErases oldHeader{};
+        oldHeader.Header.Flags = TPersistentBufferHeader::IS_ERASE;
+        oldHeader.Header.RecordLsn = 100;
+        oldHeader.TabletId = 100;
+        oldHeader.Generation = 1;
+        const ui64 oldLsns[] = {1, 2};
+        memcpy(oldHeader.CompactLsns, oldLsns, sizeof(oldLsns));
+        UNIT_ASSERT(mgr.AddErase(&oldHeader.Header, 0, 10));
+        std::map<TPersistentBufferId, TPersistentBuffer> buffers;
+        mgr.RestoreErases(buffers, alloc);
+        UNIT_ASSERT_VALUES_EQUAL(alloc.GetFreeSpace(), 1023);
+
+        std::vector<ui64> newLsns = {564, 565};
+        auto update = mgr.Erase(100, 1, newLsns, alloc);
+        UNIT_ASSERT(update);
+        UNIT_ASSERT_VALUES_EQUAL(update->Header.Header.RecordLsn, 101);
+        UNIT_ASSERT_VALUES_EQUAL(update->OldChunkIdx, 0);
+        UNIT_ASSERT_VALUES_EQUAL(update->OldSectorIdx, 10);
+
+        // Freed sectors retain valid old headers until overwritten. Recovery must
+        // choose the newer erase even when it encounters the stale header last.
+        auto recovered = MakeManager();
+        auto recoveredAlloc = MakeAllocator();
+        UNIT_ASSERT(recovered.AddErase(&update->Header.Header, update->ChunkIdx, update->SectorIdx));
+        UNIT_ASSERT(!recovered.AddErase(&oldHeader.Header, 0, 10));
+        buffers[{100, 1}].Records[564] = {};
+        buffers[{100, 1}].Records[565] = {};
+        recovered.RestoreErases(buffers, recoveredAlloc);
+        UNIT_ASSERT(buffers.empty());
+    }
+
     Y_UNIT_TEST(RestoreKeepsBarriersWithoutRecords) {
         auto mgr = MakeManager();
         auto alloc = MakeAllocator();
@@ -771,9 +805,9 @@ Y_UNIT_TEST_SUITE(TPersistentBufferBarriersManagerTest) {
             "Erase must reset accumulated LSNs when generation increases");
     }
 
-    // RestoreErases must discard erase records whose generation does not match
-    // any entry in persistentBuffers (old-generation records already cleaned up).
-    Y_UNIT_TEST(RestoreErasesDropsRecordForMissingGeneration) {
+    // RestoreErases must preserve metadata for a generation without live records
+    // without applying its erases to another generation.
+    Y_UNIT_TEST(RestoreErasesKeepsMetadataForMissingGeneration) {
         auto mgr = MakeManager();
         auto alloc = MakeAllocator(1024, 0);
 
@@ -808,9 +842,10 @@ Y_UNIT_TEST_SUITE(TPersistentBufferBarriersManagerTest) {
 
         mgr.RestoreErases(pbs, alloc);
 
-        // The erase record for generation 1 must be dropped because there is no
-        // {tabletId, 1} entry in persistentBuffers.
+        // Keep the generation-1 erase metadata even without live records.
+        // Its version must survive until a replacement is persisted.
         // The generation-2 record must remain untouched.
+        UNIT_ASSERT_VALUES_EQUAL(mgr.GetErasesCount(tabletId), 3u);
         auto pbIt = pbs.find({tabletId, 2});
         UNIT_ASSERT_C(pbIt != pbs.end(), "Generation-2 record must survive");
         UNIT_ASSERT_C(pbIt->second.Records.count(5), "LSN 5 in generation 2 must not be erased");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Prevent erased PersistentBuffer records from reappearing after restarts.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fast erase persists a replacement header containing the erased LSNs and an increasing `Header.RecordLsn`. Recovery uses that version to select the newest header; freeing a sector does not erase its old contents.

When recovery found no live records for the erased generation (for example, after applying a cutoff barrier), `RestoreErases()` dropped the entire erase entry and left its sector unreserved. This also discarded `HeaderLsn`. Subsequent fast erases restarted the version at 1. On another restart, a still-valid old header with a larger version could win over the newer header, so the latest erased records were recovered as live. For example, forgetting version 100 allows a new erase at version 1 to lose to the old version 100.

Keep the erase metadata and mark its sector occupied even when there are no live records. The next erase therefore advances version 100 to 101 and releases the previous sector only after the replacement write completes. Old headers cannot outrank the new erase. The regression covers recovery without live records, sector reservation, version continuity, and replay with a stale header; the missing-generation case also retains metadata without erasing another generation's records.

This mechanism is consistent with #51089: the archived failure returned previously erased LSNs 564 and 565 after the second restart, following an empty-buffer first restart. The specific CI failure has not yet been reproduced, so its attribution to this mechanism remains unconfirmed.
