### PR TITLE
Bound DQ task runner process pool across configuration changes

### DIFF
--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
@@ -1,4 +1,6 @@
 #include "tasks_runner_pipe.h"
+#include "tasks_runner_pipe_pool.h"
+#include "tasks_runner_pipe_process.h"
 
 #include <ydb/library/yql/dq/runtime/dq_input_channel.h>
 #include <ydb/library/yql/dq/runtime/dq_output_channel.h>
@@ -32,6 +34,8 @@
 #include <util/string/cast.h>
 #include <util/string/strip.h>
 #include <util/string/builder.h>
+
+#include <cerrno>
 
 namespace NYql::NTaskRunnerProxy {
 
@@ -199,38 +203,97 @@ public:
 #endif
     }
 
-    virtual void Kill() {
+    virtual void Kill()
+    {
 #ifndef _win_
+        if (Pid <= 0) {
+            return;
+        }
         // todo: investigate why ain't killed sometimes
         YQL_CLOG(DEBUG, ProviderDq) << "Kill child, pid: " << Pid;
         kill(Pid, 9);
 #endif
     }
 
-    bool IsAlive() {
+    virtual bool Cleanup(TDuration timeout)
+    {
 #ifdef _win_
+        Y_UNUSED(timeout);
         return true;
 #else
-        int status;
-        YQL_CLOG(TRACE, ProviderDq) << "Check Pid " << Pid;
-        return waitpid(Pid, &status, WNOHANG) <= 0;
+        return NPrivate::CleanupChildProcess(
+            &Pid,
+            timeout,
+            [] (int pid, int signal) {
+                return kill(pid, signal);
+            },
+            [] (int pid, int* status, int options) {
+                return waitpid(pid, status, options);
+            });
 #endif
     }
 
-    int Wait(TDuration timeout = TDuration::Seconds(5)) {
-        int status;
-        int ret;
+    bool IsAlive()
+    {
+#ifdef _win_
+        return true;
+#else
+        if (Pid <= 0) {
+            return false;
+        }
+
+        int status = 0;
+        YQL_CLOG(TRACE, ProviderDq) << "Check Pid " << Pid;
+        const int result = waitpid(Pid, &status, WNOHANG);
+        if (result == Pid || (result < 0 && errno == ECHILD)) {
+            Pid = -1;
+            return false;
+        }
+        return result <= 0;
+#endif
+    }
+
+    int Wait(TDuration timeout = TDuration::Seconds(5))
+    {
+        int status = 0;
 #ifndef _win_
-        TInstant start = TInstant::Now();
-        while ((ret = waitpid(Pid, &status, WNOHANG)) == 0 && TInstant::Now() - start < timeout) {
+        if (Pid <= 0) {
+            return status;
+        }
+
+        const int pid = Pid;
+        int result = 0;
+        const auto deadline = TInstant::Now() + timeout;
+        while (true) {
+            result = waitpid(pid, &status, WNOHANG);
+            if (result < 0 && errno == EINTR && TInstant::Now() < deadline) {
+                continue;
+            }
+            if (result != 0 || TInstant::Now() >= deadline) {
+                break;
+            }
             Sleep(TDuration::MilliSeconds(10));
         }
-        if (ret <= 0) {
-            kill(Pid, 9);
-            waitpid(Pid, &status, 0);
+        if (result == 0 || (result < 0 && errno != ECHILD)) {
+            kill(pid, 9);
+            do {
+                result = waitpid(pid, &status, 0);
+            } while (result < 0 && errno == EINTR);
+        }
+        if (result == pid || (result < 0 && errno == ECHILD)) {
+            Pid = -1;
         }
 #endif
         return status;
+    }
+
+    bool HasStarted() const
+    {
+#ifdef _win_
+        return true;
+#else
+        return Pid > 0;
+#endif
     }
 
     IOutputStream& GetStdin() {
@@ -292,77 +355,6 @@ protected:
 };
 
 /*______________________________________________________________________________________________*/
-
-struct TProcessHolder {
-    TProcessHolder()
-        : Watcher(MakeHolder<TThread>([this] () { Watch(); }))
-    {
-        Running.test_and_set();
-        Watcher->Start();
-    }
-
-    ~TProcessHolder()
-    {
-        Running.clear();
-        Watcher->Join();
-    }
-
-    i64 Size() {
-        TGuard<TMutex> lock(Mutex);
-        return Processes.size();
-    }
-
-    void Put(const TString& key, THolder<TChildProcess>process) {
-        TGuard<TMutex> lock(Mutex);
-        Processes.emplace_back(key, std::move(process));
-    }
-
-    THolder<TChildProcess> Acquire(const TString& key, TList<THolder<TChildProcess>>* stopList) {
-        TGuard<TMutex> lock(Mutex);
-        THolder<TChildProcess> result;
-        while (!Processes.empty()) {
-            auto first = std::move(Processes.front());
-            Processes.pop_front();
-            if (first.first == key) {
-                result = std::move(first.second);
-                break;
-            }
-            stopList->push_back(std::move(first.second));
-        }
-        return result;
-    }
-
-    void Watch() {
-        while (Running.test()) {
-            TList<THolder<TChildProcess>> stopList;
-            {
-                TGuard<TMutex> lock(Mutex);
-                auto it = Processes.begin();
-                while (it != Processes.end()) {
-                    if (!it->second->IsAlive()) {
-                        YQL_CLOG(DEBUG, ProviderDq) << "Remove dead process";
-                        stopList.emplace_back(std::move(it->second));
-                        it = Processes.erase(it);
-                    } else {
-                        ++it;
-                    }
-                }
-            }
-
-            for (const auto& job : stopList) {
-                job->Kill();
-                job->Wait(TDuration::Seconds(1));
-            }
-            Sleep(TDuration::MilliSeconds(1000));
-        }
-    }
-
-    THolder<TThread> Watcher;
-    std::atomic_flag Running;
-
-    TMutex Mutex;
-    TList<std::pair<TString, THolder<TChildProcess>>> Processes;
-};
 
 struct TPortoSettings {
     bool Enable;
@@ -437,7 +429,8 @@ private:
         cmd.Run().Wait();
     }
 
-    void Kill() override {
+    bool DestroyContainer()
+    {
         if (MemoryLimit) {
             try {
                 // see YQL-13760
@@ -464,10 +457,31 @@ private:
         try {
             TShellCommand cmd(PortoCtl, {"destroy", ContainerName});
             cmd.Run().Wait();
+            const auto exitCode = cmd.GetExitCode();
+            if (NPrivate::IsShellCommandSuccessful(cmd.GetStatus(), exitCode)) {
+                return true;
+            }
+            YQL_CLOG(DEBUG, ProviderDq) << "Cannot destroy container (Status: " << static_cast<int>(cmd.GetStatus())
+                                       << ", ExitCode: " << exitCode.GetOrElse(-1)
+                                       << ", Error: " << cmd.GetError() << ")";
+            return false;
         } catch (...) {
             YQL_CLOG(DEBUG, ProviderDq) << "Cannot destroy: " << CurrentExceptionMessage();
+            return false;
         }
+    }
+
+    void Kill() override
+    {
+        DestroyContainer();
         TChildProcess::Kill();
+    }
+
+    bool Cleanup(TDuration timeout) override
+    {
+        const bool containerDestroyed = DestroyContainer();
+        const bool childReaped = TChildProcess::Cleanup(timeout);
+        return containerDestroyed && childReaped;
     }
 
     void PrepareForExec() override {
@@ -1371,7 +1385,7 @@ public:
         std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
         const NDqProto::TDqTask& task,
         TFilesHolder::TPtr&& filesHolder,
-        THolder<TChildProcess>&& command,
+        std::shared_ptr<TChildProcess> command,
         ui64 stageId,
         const TString& traceId)
         : TraceId(traceId)
@@ -1711,7 +1725,7 @@ private:
     std::atomic<bool> Running;
     int Code = -1;
     TString Stderr;
-    THolder<TChildProcess> Command;
+    std::shared_ptr<TChildProcess> Command;
     THolder<TThread> StderrReader;
     IOutputStream& Output;
     IInputStream& Input;
@@ -1731,7 +1745,7 @@ public:
         std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
         const NDqProto::TDqTask& task,
         TFilesHolder::TPtr&& filesHolder,
-        THolder<TChildProcess>&& command,
+        std::shared_ptr<TChildProcess> command,
         ui64 stageId,
         const TString& traceId)
         : Delegate(new TTaskRunner(alloc, task, std::move(filesHolder), std::move(command), stageId, traceId))
@@ -1982,35 +1996,7 @@ private:
 /*______________________________________________________________________________________________*/
 
 class TPipeFactory: public IProxyFactory {
-    struct TJob: public TTaskScheduler::ITask {
-        TJob(NThreading::TPromise<void> p)
-            : Promise(std::move(p))
-        { }
-
-        TInstant Process() override {
-            Promise.SetValue();
-            return TInstant::Max();
-        }
-
-        NThreading::TPromise<void> Promise;
-    };
-
-    struct TStopJob: public TTaskScheduler::ITask {
-        TList<THolder<TChildProcess>> StopList;
-
-        TStopJob(TList<THolder<TChildProcess>>&& stopList)
-            : StopList(std::move(stopList))
-        { }
-
-        TInstant Process() override {
-            for (const auto& job : StopList) {
-                job->Kill();
-                job->Wait(TDuration::Seconds(1));
-            }
-
-            return TInstant::Max();
-        }
-    };
+    using TProcessPool = TPipeProcessPool<TChildProcess>;
 
 public:
     TPipeFactory(const TPipeFactoryOptions& options)
@@ -2029,11 +2015,49 @@ public:
             ? *options.Revision
             : GetProgramCommitId())
         , TaskScheduler(1)
-        , MaxProcesses(options.MaxProcesses)
+        , ProcessPool(
+            options.MaxProcesses,
+            [this] (std::function<void()> callback) {
+                return TaskScheduler.AddFunc(
+                    [callback = std::move(callback)] () mutable {
+                        callback();
+                        return TInstant::Max();
+                    },
+                    TInstant());
+            },
+            [] (const auto& process) {
+                try {
+                    const bool cleaned = process->Cleanup(TDuration::Seconds(1));
+                    if (!cleaned) {
+                        YQL_CLOG(ERROR, ProviderDq) << "Cannot confirm pooled child process cleanup";
+                    }
+                    return cleaned;
+                } catch (...) {
+                    YQL_CLOG(ERROR, ProviderDq) << "Cannot clean up child process: " << CurrentExceptionMessage();
+                    return false;
+                }
+            },
+            [] (const auto& process) {
+                return process->IsAlive();
+            })
         , PortoCtlPath(options.PortoCtlPath)
+        , Watcher(MakeHolder<TThread>([this] () { Watch(); }))
     {
-        Start(ExePath, PortoSettings);
         TaskScheduler.Start();
+        ProcessPool.Prewarm(MakeRequest(ExePath, PortoSettings));
+        Running.test_and_set();
+        Watcher->Start();
+    }
+
+    ~TPipeFactory()
+    {
+        Running.clear();
+        Watcher->Join();
+        ProcessPool.BeginShutdown();
+        TaskScheduler.Stop();
+        if (!ProcessPool.FinishShutdown()) {
+            YQL_CLOG(ERROR, ProviderDq) << "Cannot clean up all pooled child processes";
+        }
     }
 
     ITaskRunner::TPtr GetOld(std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc, const NDq::TDqTaskSettings& tmp, const TString& traceId) override {
@@ -2042,7 +2066,7 @@ public:
         tmp.GetMeta().UnpackTo(&taskMeta);
         ui64 stageId = taskMeta.GetStageId();
         auto result = GetExecutorForTask(taskMeta.GetFiles(), taskMeta.GetSettings());
-        auto [task, filesHolder] = PrepareTask(tmp, result.Get());
+        auto [task, filesHolder] = PrepareTask(tmp, result.get());
         return new TTaskRunner(alloc, task, std::move(filesHolder), std::move(result), stageId, traceId);
     }
 
@@ -2054,35 +2078,34 @@ public:
         tmp.GetMeta().UnpackTo(&taskMeta);
 
         auto result = GetExecutorForTask(taskMeta.GetFiles(), taskMeta.GetSettings());
-        auto [task, filesHolder] = PrepareTask(tmp, result.Get());
+        auto [task, filesHolder] = PrepareTask(tmp, result.get());
         return new TDqTaskRunner(alloc, task, std::move(filesHolder), std::move(result), taskMeta.GetStageId(), traceId);
     }
 
 private:
-    THolder<TChildProcess> StartOne(const TString& exePath, const TPortoSettings& portoSettings) {
-        return CreateChildProcess(PortoCtlPath, FileCache->GetDir(), exePath, Args, Env, ContainerId++, portoSettings);
+    TProcessPool::TRequest MakeRequest(const TString& exePath, const TPortoSettings& portoSettings)
+    {
+        return {
+            .Key = GetKey(exePath, portoSettings),
+            .Spawn = [this, exePath, portoSettings] {
+                return CreateChildProcess(
+                    PortoCtlPath,
+                    FileCache->GetDir(),
+                    exePath,
+                    Args,
+                    Env,
+                    ContainerId++,
+                    portoSettings);
+            },
+        };
     }
 
-    void Start(const TString& exePath, const TPortoSettings& portoSettings) {
-        const auto key = GetKey(exePath, portoSettings);
-        while (static_cast<int>(ProcessHolder.Size()) < MaxProcesses) {
-            auto process = StartOne(exePath, portoSettings);
-            ProcessHolder.Put(key, std::move(process));
+    void Watch()
+    {
+        while (Running.test()) {
+            ProcessPool.SweepDead();
+            Sleep(TDuration::MilliSeconds(1000));
         }
-    }
-
-    void ProcessJobs(const TString& exePath, const TPortoSettings& portoSettings) {
-        NThreading::TPromise<void> promise = NThreading::NewPromise();
-
-        promise.GetFuture().Apply([=, this](const NThreading::TFuture<void>&) mutable {
-            Start(exePath, portoSettings);
-        });
-
-        Y_ABORT_UNLESS(TaskScheduler.Add(MakeIntrusive<TJob>(promise), TInstant()));
-    }
-
-    void StopJobs(TList<THolder<TChildProcess>>&& stopList) {
-        Y_ABORT_UNLESS(TaskScheduler.Add(MakeIntrusive<TStopJob>(std::move(stopList)), TInstant()));
     }
 
     TString GetKey(const TString& exePath, const TPortoSettings& settings)
@@ -2150,7 +2173,7 @@ private:
     }
 
     template<typename T, typename S>
-    THolder<TChildProcess> GetExecutorForTask(const T& files, const S& settings) {
+    std::shared_ptr<TChildProcess> GetExecutorForTask(const T& files, const S& settings) {
         TString executorId;
         TPortoSettings portoSettings = PortoSettings;
 
@@ -2182,18 +2205,10 @@ private:
             exePath = *maybeExeFile;
         }
 
-        auto key = GetKey(exePath, portoSettings);
-        TList<THolder<TChildProcess>> stopList;
-        THolder<TChildProcess> result = ProcessHolder.Acquire(key, &stopList);
-        if (!result) {
-            result = StartOne(exePath, portoSettings);
-        }
-        ProcessJobs(exePath, portoSettings);
-        StopJobs(std::move(stopList));
-        return result;
+        return ProcessPool.Acquire(MakeRequest(exePath, portoSettings));
     }
 
-    static THolder<TChildProcess> CreateChildProcess(
+    static TProcessPool::TSpawnResult CreateChildProcess(
         const TString& portoCtlPath,
         const TString& cacheDir,
         const TString& exePath,
@@ -2202,18 +2217,41 @@ private:
         i64 containerId,
         const TPortoSettings& portoSettings)
     {
-        THolder<TChildProcess> command;
-        if (portoSettings.Enable) {
-            command = MakeHolder<TPortoProcess>(portoCtlPath, exePath, args, env, cacheDir + "/Slot-" + ToString(containerId), portoSettings);
-        } else {
-            command = MakeHolder<TChildProcess>(exePath, args, env, cacheDir + "/Slot-" + ToString(containerId));
+        std::shared_ptr<TChildProcess> command;
+        try {
+            if (portoSettings.Enable) {
+                command = std::make_shared<TPortoProcess>(
+                    portoCtlPath,
+                    exePath,
+                    args,
+                    env,
+                    cacheDir + "/Slot-" + ToString(containerId),
+                    portoSettings);
+            } else {
+                command = std::make_shared<TChildProcess>(
+                    exePath,
+                    args,
+                    env,
+                    cacheDir + "/Slot-" + ToString(containerId));
+            }
+            YQL_CLOG(DEBUG, ProviderDq) << "Executing " << exePath;
+            for (const auto& arg : args) {
+                YQL_CLOG(DEBUG, ProviderDq) << "Arg: " << arg;
+            }
+            command->Run();
+            return {
+                .Process = std::move(command),
+            };
+        } catch (...) {
+            YQL_CLOG(ERROR, ProviderDq) << "Cannot start child process (Executable: " << exePath
+                                       << ", Error: " << CurrentExceptionMessage() << ")";
+            return {
+                .Process = command && command->HasStarted()
+                    ? std::move(command)
+                    : nullptr,
+                .Error = std::current_exception(),
+            };
         }
-        YQL_CLOG(DEBUG, ProviderDq) << "Executing " << exePath;
-        for (const auto& arg: args) {
-            YQL_CLOG(DEBUG, ProviderDq) << "Arg: " << arg;
-        }
-        command->Run();
-        return command;
     }
 
     std::atomic<i64> ContainerId = 1;
@@ -2228,10 +2266,12 @@ private:
 
     const TString Revision;
 
-    TProcessHolder ProcessHolder;
     TTaskScheduler TaskScheduler;
-    const int MaxProcesses;
+    TProcessPool ProcessPool;
     const TString PortoCtlPath;
+
+    THolder<TThread> Watcher;
+    std::atomic_flag Running;
 };
 
 IProxyFactory::TPtr CreatePipeFactory(

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe_pool-inl.h
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe_pool-inl.h
@@ -1,0 +1,465 @@
+#ifndef TASKS_RUNNER_PIPE_POOL_INL_H_
+#error "Direct inclusion of this file is not allowed, include tasks_runner_pipe_pool.h"
+// For the sake of sane code completion.
+#include "tasks_runner_pipe_pool.h"
+#endif
+
+#include <util/generic/algorithm.h>
+#include <util/generic/yexception.h>
+
+#include <util/system/yassert.h>
+
+namespace NYql::NTaskRunnerProxy {
+
+template <class TProcess>
+TPipeProcessPool<TProcess>::TPipeProcessPool(
+    int maxProcesses,
+    TSchedule schedule,
+    TCleanup cleanup,
+    TIsAlive isAlive)
+    : MaxProcesses_(Max(0, maxProcesses))
+    , Schedule_(std::move(schedule))
+    , Cleanup_(std::move(cleanup))
+    , IsAlive_(std::move(isAlive))
+{ }
+
+template <class TProcess>
+void TPipeProcessPool<TProcess>::Prewarm(const TRequest& request)
+{
+    {
+        TGuard<TMutex> guard(Mutex_);
+        DesiredRequest_ = request;
+        RefillBlocked_ = false;
+    }
+
+    while (true) {
+        {
+            TGuard<TMutex> guard(Mutex_);
+            if (GetPoolOwnedCountUnsafe() >= MaxProcesses_) {
+                break;
+            }
+            ++Warming_;
+            VerifyBudgetUnsafe();
+        }
+
+        auto spawnResult = Spawn(request);
+        if (spawnResult.Error) {
+            {
+                TGuard<TMutex> guard(Mutex_);
+                --Warming_;
+                if (spawnResult.Process) {
+                    Retiring_.push_back(TEntry{
+                        .Id = NextEntryId_++,
+                        .Key = request.Key,
+                        .Process = std::move(spawnResult.Process),
+                    });
+                }
+                VerifyBudgetUnsafe();
+            }
+
+            auto error = spawnResult.Error;
+            BeginShutdown();
+            FinishShutdown();
+            std::rethrow_exception(error);
+        }
+
+        Y_ABORT_UNLESS(spawnResult.Process);
+        TGuard<TMutex> guard(Mutex_);
+        --Warming_;
+        Idle_.push_back(TEntry{
+            .Id = NextEntryId_++,
+            .Key = request.Key,
+            .Process = std::move(spawnResult.Process),
+        });
+        VerifyBudgetUnsafe();
+    }
+}
+
+template <class TProcess>
+typename TPipeProcessPool<TProcess>::TProcessPtr TPipeProcessPool<TProcess>::Acquire(const TRequest& request)
+{
+    TProcessPtr result;
+    std::exception_ptr quarantineError;
+    {
+        TGuard<TMutex> guard(Mutex_);
+        DesiredRequest_ = request;
+        RefillBlocked_ = false;
+
+        for (auto it = Idle_.begin(); it != Idle_.end();) {
+            if (it->Key == request.Key) {
+                if (!result) {
+                    result = std::move(it->Process);
+                    it = Idle_.erase(it);
+                } else {
+                    ++it;
+                }
+            } else {
+                Retiring_.push_back(std::move(*it));
+                it = Idle_.erase(it);
+            }
+        }
+
+        if (!Quarantined_.empty()) {
+            for (auto& entry : Quarantined_) {
+                entry.CleanupAttempted = false;
+            }
+            if (!result) {
+                quarantineError = Quarantined_.front().Error;
+            }
+        }
+        VerifyBudgetUnsafe();
+    }
+
+    RequestCleanup();
+    RequestRefill();
+
+    if (!result) {
+        if (quarantineError) {
+            std::rethrow_exception(quarantineError);
+        }
+
+        auto spawnResult = Spawn(request);
+        if (spawnResult.Error) {
+            if (spawnResult.Process) {
+                bool cleaned = false;
+                try {
+                    cleaned = Cleanup_(spawnResult.Process);
+                } catch (...) {
+                }
+
+                if (!cleaned) {
+                    TGuard<TMutex> guard(Mutex_);
+                    Quarantined_.push_back(TQuarantinedEntry{
+                        .Id = NextEntryId_++,
+                        .Process = std::move(spawnResult.Process),
+                        .Error = spawnResult.Error,
+                        .CleanupAttempted = true,
+                    });
+                }
+            }
+            std::rethrow_exception(spawnResult.Error);
+        }
+        Y_ABORT_UNLESS(spawnResult.Process);
+        result = std::move(spawnResult.Process);
+    }
+
+    return result;
+}
+
+template <class TProcess>
+void TPipeProcessPool<TProcess>::SweepDead()
+{
+    bool foundDeadProcess = false;
+    {
+        TGuard<TMutex> guard(Mutex_);
+        for (auto it = Idle_.begin(); it != Idle_.end();) {
+            bool alive = true;
+            try {
+                alive = IsAlive_(it->Process);
+            } catch (...) {
+            }
+
+            if (!alive) {
+                Retiring_.push_back(std::move(*it));
+                it = Idle_.erase(it);
+                foundDeadProcess = true;
+                RefillBlocked_ = true;
+            } else {
+                ++it;
+            }
+        }
+        VerifyBudgetUnsafe();
+    }
+
+    if (foundDeadProcess) {
+        RequestCleanup();
+    }
+}
+
+template <class TProcess>
+void TPipeProcessPool<TProcess>::BeginShutdown()
+{
+    TGuard<TMutex> guard(Mutex_);
+    ShuttingDown_ = true;
+    DesiredRequest_.Clear();
+    Retiring_.splice(Retiring_.end(), Idle_);
+    VerifyBudgetUnsafe();
+}
+
+template <class TProcess>
+bool TPipeProcessPool<TProcess>::FinishShutdown()
+{
+    {
+        TGuard<TMutex> guard(Mutex_);
+        for (auto& entry : Retiring_) {
+            entry.CleanupAttempted = false;
+        }
+        for (auto& entry : Quarantined_) {
+            entry.CleanupAttempted = false;
+        }
+    }
+    ProcessCleanup();
+
+    TGuard<TMutex> guard(Mutex_);
+    return Retiring_.empty() && Quarantined_.empty() && Warming_ == 0;
+}
+
+template <class TProcess>
+typename TPipeProcessPool<TProcess>::TSnapshot TPipeProcessPool<TProcess>::GetSnapshot() const
+{
+    TGuard<TMutex> guard(Mutex_);
+    return {
+        .Idle = static_cast<int>(Idle_.size()),
+        .Retiring = static_cast<int>(Retiring_.size()),
+        .Warming = Warming_,
+        .Quarantined = static_cast<int>(Quarantined_.size()),
+        .RefillQueued = RefillQueued_,
+        .RefillRunning = RefillRunning_,
+    };
+}
+
+template <class TProcess>
+void TPipeProcessPool<TProcess>::RequestCleanup()
+{
+    bool shouldSchedule = false;
+    {
+        TGuard<TMutex> guard(Mutex_);
+        const auto quarantinedIt = FindIf(Quarantined_, [] (const auto& entry) {
+            return !entry.CleanupAttempted;
+        });
+        const auto retiringIt = FindIf(Retiring_, [] (const auto& entry) {
+            return !entry.CleanupAttempted;
+        });
+        if (!ShuttingDown_ &&
+            (quarantinedIt != Quarantined_.end() || retiringIt != Retiring_.end()) &&
+            !CleanupQueued_ &&
+            !CleanupRunning_)
+        {
+            CleanupQueued_ = true;
+            shouldSchedule = true;
+        }
+    }
+
+    if (shouldSchedule && !Schedule([this] { ProcessCleanup(); })) {
+        TGuard<TMutex> guard(Mutex_);
+        CleanupQueued_ = false;
+    }
+}
+
+template <class TProcess>
+void TPipeProcessPool<TProcess>::ProcessCleanup()
+{
+    {
+        TGuard<TMutex> guard(Mutex_);
+        CleanupQueued_ = false;
+        CleanupRunning_ = true;
+    }
+
+    bool stateChanged = false;
+    while (true) {
+        TProcessPtr process;
+        i64 entryId = 0;
+        bool quarantined = false;
+        {
+            TGuard<TMutex> guard(Mutex_);
+            auto quarantinedIt = FindIf(Quarantined_, [] (const auto& entry) {
+                return !entry.CleanupAttempted;
+            });
+            if (quarantinedIt != Quarantined_.end()) {
+                entryId = quarantinedIt->Id;
+                process = quarantinedIt->Process;
+                quarantinedIt->CleanupAttempted = true;
+                quarantined = true;
+            } else {
+                auto retiringIt = FindIf(Retiring_, [] (const auto& entry) {
+                    return !entry.CleanupAttempted;
+                });
+                if (retiringIt != Retiring_.end()) {
+                    entryId = retiringIt->Id;
+                    process = retiringIt->Process;
+                    retiringIt->CleanupAttempted = true;
+                } else {
+                    CleanupRunning_ = false;
+                    break;
+                }
+            }
+        }
+
+        bool cleaned = false;
+        try {
+            cleaned = Cleanup_(process);
+        } catch (...) {
+        }
+
+        if (cleaned) {
+            TGuard<TMutex> guard(Mutex_);
+            if (quarantined) {
+                auto it = FindIf(Quarantined_, [entryId] (const auto& entry) {
+                    return entry.Id == entryId;
+                });
+                if (it != Quarantined_.end()) {
+                    Quarantined_.erase(it);
+                    stateChanged = true;
+                }
+            } else {
+                auto it = FindIf(Retiring_, [entryId] (const auto& entry) {
+                    return entry.Id == entryId;
+                });
+                if (it != Retiring_.end()) {
+                    Retiring_.erase(it);
+                    stateChanged = true;
+                }
+            }
+            if (stateChanged) {
+                VerifyBudgetUnsafe();
+            }
+        }
+    }
+
+    if (stateChanged) {
+        RequestRefill();
+    }
+}
+
+template <class TProcess>
+void TPipeProcessPool<TProcess>::RequestRefill()
+{
+    bool shouldSchedule = false;
+    {
+        TGuard<TMutex> guard(Mutex_);
+        if (!ShuttingDown_ &&
+            DesiredRequest_ &&
+            !RefillBlocked_ &&
+            Quarantined_.empty() &&
+            GetPoolOwnedCountUnsafe() < MaxProcesses_ &&
+            !RefillQueued_ &&
+            !RefillRunning_)
+        {
+            RefillQueued_ = true;
+            shouldSchedule = true;
+        }
+    }
+
+    if (shouldSchedule && !Schedule([this] { ProcessRefill(); })) {
+        TGuard<TMutex> guard(Mutex_);
+        RefillQueued_ = false;
+    }
+}
+
+template <class TProcess>
+void TPipeProcessPool<TProcess>::ProcessRefill()
+{
+    {
+        TGuard<TMutex> guard(Mutex_);
+        RefillQueued_ = false;
+        if (ShuttingDown_ || !DesiredRequest_ || RefillBlocked_ || !Quarantined_.empty()) {
+            return;
+        }
+        RefillRunning_ = true;
+    }
+
+    bool scheduleCleanup = false;
+    bool scheduleRefill = false;
+    while (true) {
+        TRequest request;
+        {
+            TGuard<TMutex> guard(Mutex_);
+            if (ShuttingDown_ ||
+                !DesiredRequest_ ||
+                RefillBlocked_ ||
+                !Quarantined_.empty() ||
+                GetPoolOwnedCountUnsafe() >= MaxProcesses_)
+            {
+                RefillRunning_ = false;
+                break;
+            }
+            request = *DesiredRequest_;
+            ++Warming_;
+            VerifyBudgetUnsafe();
+        }
+
+        auto spawnResult = Spawn(request);
+        if (spawnResult.Error) {
+            {
+                TGuard<TMutex> guard(Mutex_);
+                --Warming_;
+                const bool requestStillDesired =
+                    !ShuttingDown_ && DesiredRequest_ && DesiredRequest_->Key == request.Key;
+                RefillBlocked_ = requestStillDesired;
+                RefillRunning_ = false;
+                scheduleRefill = !requestStillDesired && !ShuttingDown_ && DesiredRequest_;
+                if (spawnResult.Process) {
+                    Retiring_.push_back(TEntry{
+                        .Id = NextEntryId_++,
+                        .Key = request.Key,
+                        .Process = std::move(spawnResult.Process),
+                    });
+                    scheduleCleanup = true;
+                }
+                VerifyBudgetUnsafe();
+            }
+            break;
+        }
+
+        Y_ABORT_UNLESS(spawnResult.Process);
+        {
+            TGuard<TMutex> guard(Mutex_);
+            --Warming_;
+            TEntry entry{
+                .Id = NextEntryId_++,
+                .Key = request.Key,
+                .Process = std::move(spawnResult.Process),
+            };
+            if (!ShuttingDown_ && DesiredRequest_ && DesiredRequest_->Key == request.Key) {
+                Idle_.push_back(std::move(entry));
+            } else {
+                Retiring_.push_back(std::move(entry));
+                scheduleCleanup = true;
+            }
+            VerifyBudgetUnsafe();
+        }
+    }
+
+    if (scheduleCleanup) {
+        RequestCleanup();
+    }
+    if (scheduleRefill) {
+        RequestRefill();
+    }
+}
+
+template <class TProcess>
+typename TPipeProcessPool<TProcess>::TSpawnResult TPipeProcessPool<TProcess>::Spawn(const TRequest& request) const
+{
+    try {
+        return request.Spawn();
+    } catch (...) {
+        return {
+            .Error = std::current_exception(),
+        };
+    }
+}
+
+template <class TProcess>
+bool TPipeProcessPool<TProcess>::Schedule(std::function<void()> callback)
+{
+    try {
+        return Schedule_(std::move(callback));
+    } catch (...) {
+        return false;
+    }
+}
+
+template <class TProcess>
+int TPipeProcessPool<TProcess>::GetPoolOwnedCountUnsafe() const
+{
+    return static_cast<int>(Idle_.size() + Retiring_.size()) + Warming_;
+}
+
+template <class TProcess>
+void TPipeProcessPool<TProcess>::VerifyBudgetUnsafe() const
+{
+    Y_ABORT_UNLESS(GetPoolOwnedCountUnsafe() <= MaxProcesses_);
+}
+
+} // namespace NYql::NTaskRunnerProxy

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe_pool.h
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe_pool.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <util/generic/function.h>
+#include <util/generic/list.h>
+#include <util/generic/maybe.h>
+#include <util/generic/string.h>
+
+#include <util/system/mutex.h>
+
+#include <exception>
+#include <memory>
+
+namespace NYql::NTaskRunnerProxy {
+
+template <class TProcess>
+class TPipeProcessPool
+{
+public:
+    using TProcessPtr = std::shared_ptr<TProcess>;
+
+    struct TSpawnResult
+    {
+        TProcessPtr Process;
+        std::exception_ptr Error;
+    };
+
+    struct TRequest
+    {
+        TString Key;
+        std::function<TSpawnResult()> Spawn;
+    };
+
+    struct TSnapshot
+    {
+        int Idle = 0;
+        int Retiring = 0;
+        int Warming = 0;
+        int Quarantined = 0;
+        bool RefillQueued = false;
+        bool RefillRunning = false;
+    };
+
+    // Scheduled callbacks must execute serially.
+    using TSchedule = std::function<bool(std::function<void()>)>;
+    using TCleanup = std::function<bool(const TProcessPtr&)>;
+    using TIsAlive = std::function<bool(const TProcessPtr&)>;
+
+    TPipeProcessPool(int maxProcesses, TSchedule schedule, TCleanup cleanup, TIsAlive isAlive);
+
+    // Only during initialization, before concurrent access.
+    void Prewarm(const TRequest& request);
+
+    TProcessPtr Acquire(const TRequest& request);
+    void SweepDead();
+
+    // Callers must stop acquiring processes before shutdown begins.
+    void BeginShutdown();
+
+    // No callbacks may be running or pending.
+    bool FinishShutdown();
+
+    TSnapshot GetSnapshot() const;
+
+private:
+    struct TEntry
+    {
+        i64 Id = 0;
+        TString Key;
+        TProcessPtr Process;
+        bool CleanupAttempted = false;
+    };
+
+    struct TQuarantinedEntry
+    {
+        i64 Id = 0;
+        TProcessPtr Process;
+        std::exception_ptr Error;
+        bool CleanupAttempted = false;
+    };
+
+    const int MaxProcesses_;
+    const TSchedule Schedule_;
+    const TCleanup Cleanup_;
+    const TIsAlive IsAlive_;
+
+    mutable TMutex Mutex_;
+    TList<TEntry> Idle_;
+    TList<TEntry> Retiring_;
+    TList<TQuarantinedEntry> Quarantined_;
+    int Warming_ = 0;
+    i64 NextEntryId_ = 1;
+
+    TMaybe<TRequest> DesiredRequest_;
+    bool CleanupQueued_ = false;
+    bool CleanupRunning_ = false;
+    bool RefillQueued_ = false;
+    bool RefillRunning_ = false;
+    bool RefillBlocked_ = false;
+    bool ShuttingDown_ = false;
+
+    void RequestCleanup();
+    void ProcessCleanup();
+
+    void RequestRefill();
+    void ProcessRefill();
+
+    TSpawnResult Spawn(const TRequest& request) const;
+    bool Schedule(std::function<void()> callback);
+    int GetPoolOwnedCountUnsafe() const;
+    void VerifyBudgetUnsafe() const;
+};
+
+} // namespace NYql::NTaskRunnerProxy
+
+#define TASKS_RUNNER_PIPE_POOL_INL_H_
+#include "tasks_runner_pipe_pool-inl.h"
+#undef TASKS_RUNNER_PIPE_POOL_INL_H_

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe_process.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe_process.cpp
@@ -1,0 +1,72 @@
+#include "tasks_runner_pipe_process.h"
+
+#include <util/system/thread.h>
+
+#include <cerrno>
+#include <csignal>
+
+#ifndef _win_
+#include <sys/wait.h>
+#endif
+
+namespace NYql::NTaskRunnerProxy::NPrivate {
+
+bool CleanupChildProcess(
+    int* pid,
+    TDuration timeout,
+    const TKillFunction& killFunction,
+    const TWaitPidFunction& waitPidFunction)
+{
+#ifdef _win_
+    Y_UNUSED(pid);
+    Y_UNUSED(timeout);
+    Y_UNUSED(killFunction);
+    Y_UNUSED(waitPidFunction);
+    return true;
+#else
+    if (*pid <= 0) {
+        return true;
+    }
+
+    const int childPid = *pid;
+    if (killFunction(childPid, SIGKILL) != 0 && errno != ESRCH) {
+        return false;
+    }
+
+    int status = 0;
+    const auto deadline = TInstant::Now() + timeout;
+    while (true) {
+        const int result = waitPidFunction(childPid, &status, WNOHANG);
+        if (result == childPid) {
+            *pid = -1;
+            return true;
+        }
+        if (result < 0) {
+            if (errno == EINTR) {
+                if (TInstant::Now() >= deadline) {
+                    return false;
+                }
+                continue;
+            }
+            if (errno == ECHILD) {
+                *pid = -1;
+                return true;
+            }
+            return false;
+        }
+        if (TInstant::Now() >= deadline) {
+            return false;
+        }
+        Sleep(TDuration::MilliSeconds(10));
+    }
+#endif
+}
+
+bool IsShellCommandSuccessful(
+    TShellCommand::ECommandStatus status,
+    const TMaybe<int>& exitCode)
+{
+    return status == TShellCommand::SHELL_FINISHED && exitCode && *exitCode == 0;
+}
+
+} // namespace NYql::NTaskRunnerProxy::NPrivate

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe_process.h
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe_process.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <util/datetime/base.h>
+
+#include <util/generic/function.h>
+#include <util/generic/maybe.h>
+
+#include <util/system/shellcommand.h>
+
+namespace NYql::NTaskRunnerProxy::NPrivate {
+
+using TKillFunction = std::function<int(int, int)>;
+using TWaitPidFunction = std::function<int(int, int*, int)>;
+
+bool CleanupChildProcess(
+    int* pid,
+    TDuration timeout,
+    const TKillFunction& killFunction,
+    const TWaitPidFunction& waitPidFunction);
+
+bool IsShellCommandSuccessful(
+    TShellCommand::ECommandStatus status,
+    const TMaybe<int>& exitCode);
+
+} // namespace NYql::NTaskRunnerProxy::NPrivate

--- a/ydb/library/yql/providers/dq/task_runner/ut/tasks_runner_pipe_pool_ut.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/ut/tasks_runner_pipe_pool_ut.cpp
@@ -1,0 +1,923 @@
+#include <ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe_pool.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/scope.h>
+
+#include <util/system/event.h>
+#include <util/system/thread.h>
+
+#include <deque>
+#include <exception>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace NYql::NTaskRunnerProxy {
+namespace {
+
+struct TFakeProcess
+{
+    int Id = 0;
+    TString Key;
+    bool Alive = true;
+};
+
+class TManualScheduler
+{
+public:
+    bool AcceptCallbacks = true;
+
+    bool Schedule(std::function<void()> callback)
+    {
+        TGuard<TMutex> guard(Mutex_);
+        if (!AcceptCallbacks) {
+            return false;
+        }
+        Callbacks_.push_back(std::move(callback));
+        return true;
+    }
+
+    void RunNext()
+    {
+        std::function<void()> callback;
+        {
+            TGuard<TMutex> guard(Mutex_);
+            UNIT_ASSERT(!Callbacks_.empty());
+            callback = std::move(Callbacks_.front());
+            Callbacks_.pop_front();
+        }
+        callback();
+    }
+
+    void RunAll()
+    {
+        int callbackCount = 0;
+        while (Size() > 0) {
+            UNIT_ASSERT_C(++callbackCount < 100, "Scheduler callback backlog does not converge");
+            RunNext();
+        }
+    }
+
+    void Clear()
+    {
+        TGuard<TMutex> guard(Mutex_);
+        Callbacks_.clear();
+    }
+
+    int Size() const
+    {
+        TGuard<TMutex> guard(Mutex_);
+        return static_cast<int>(Callbacks_.size());
+    }
+
+private:
+    mutable TMutex Mutex_;
+    std::deque<std::function<void()>> Callbacks_;
+};
+
+class TFixture
+{
+public:
+    using TPool = TPipeProcessPool<TFakeProcess>;
+
+    TManualScheduler Scheduler;
+    TPool Pool;
+
+    int NextProcessId = 1;
+    bool CleanupSucceeds = true;
+    bool FailNextSpawn = false;
+    int FailSpawnCount = 0;
+    bool ThrowNextSpawn = false;
+    bool ProcessOnSpawnError = false;
+    std::function<void(const TString&)> OnSpawn;
+    std::function<void()> OnCleanup;
+    std::vector<std::shared_ptr<TFakeProcess>> Processes;
+    std::vector<std::shared_ptr<TFakeProcess>> ActiveProcesses;
+    std::vector<int> CleanedProcessIds;
+
+    explicit TFixture(int maxProcesses)
+        : Pool(
+            maxProcesses,
+            [&] (auto callback) { return Scheduler.Schedule(std::move(callback)); },
+            [&] (const auto& process) {
+                if (OnCleanup) {
+                    OnCleanup();
+                }
+                TGuard<TMutex> guard(Mutex_);
+                CleanedProcessIds.push_back(process->Id);
+                if (!CleanupSucceeds) {
+                    return false;
+                }
+                process->Alive = false;
+                return true;
+            },
+            [] (const auto& process) { return process->Alive; })
+    { }
+
+    TPool::TRequest MakeRequest(const TString& key)
+    {
+        return {
+            .Key = key,
+            .Spawn = [&, key] {
+                bool throwSpawn = false;
+                bool failSpawn = false;
+                bool processOnSpawnError = false;
+                std::shared_ptr<TFakeProcess> process;
+                std::function<void(const TString&)> onSpawn;
+                {
+                    TGuard<TMutex> guard(Mutex_);
+                    throwSpawn = std::exchange(ThrowNextSpawn, false);
+                    failSpawn = std::exchange(FailNextSpawn, false);
+                    if (FailSpawnCount > 0) {
+                        --FailSpawnCount;
+                        failSpawn = true;
+                    }
+                    processOnSpawnError = ProcessOnSpawnError;
+                    if (!throwSpawn) {
+                        process = std::make_shared<TFakeProcess>(TFakeProcess{
+                            .Id = NextProcessId++,
+                            .Key = key,
+                            .Alive = !failSpawn || processOnSpawnError,
+                        });
+                        Processes.push_back(process);
+                        onSpawn = std::exchange(OnSpawn, {});
+                    }
+                }
+
+                if (throwSpawn) {
+                    throw std::runtime_error("Spawn threw");
+                }
+
+                if (onSpawn) {
+                    onSpawn(key);
+                }
+
+                if (failSpawn) {
+                    return TPool::TSpawnResult{
+                        .Process = processOnSpawnError ? process : nullptr,
+                        .Error = std::make_exception_ptr(std::runtime_error("Spawn failed")),
+                    };
+                }
+
+                return TPool::TSpawnResult{.Process = std::move(process)};
+            },
+        };
+    }
+
+    void MarkActive(const std::shared_ptr<TFakeProcess>& process)
+    {
+        TGuard<TMutex> guard(Mutex_);
+        ActiveProcesses.push_back(process);
+    }
+
+    int CountAliveUnreturned() const
+    {
+        TGuard<TMutex> guard(Mutex_);
+        int result = 0;
+        for (const auto& process : Processes) {
+            if (process->Alive && Find(ActiveProcesses, process) == ActiveProcesses.end()) {
+                ++result;
+            }
+        }
+        return result;
+    }
+
+private:
+    mutable TMutex Mutex_;
+};
+
+void AssertWithinBudget(const TFixture::TPool::TSnapshot& snapshot, int maxProcesses)
+{
+    UNIT_ASSERT_C(
+        snapshot.Idle + snapshot.Retiring + snapshot.Warming <= maxProcesses,
+        TStringBuilder()
+            << "Pool-owned process limit exceeded: "
+            << snapshot.Idle << " idle + "
+            << snapshot.Retiring << " retiring + "
+            << snapshot.Warming << " warming");
+}
+
+Y_UNIT_TEST_SUITE(TPipeProcessPoolTest) {
+
+    Y_UNIT_TEST(DoesNotRefillOverRetiringProcesses)
+    {
+        TFixture fixture(2);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        fixture.CleanupSucceeds = false;
+
+        auto activeProcess = fixture.Pool.Acquire(fixture.MakeRequest("B"));
+        fixture.MarkActive(activeProcess);
+        UNIT_ASSERT_VALUES_EQUAL(activeProcess->Key, "B");
+
+        fixture.Scheduler.RunNext();
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        AssertWithinBudget(snapshot, 2);
+        UNIT_ASSERT_LE(fixture.CountAliveUnreturned(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Retiring, 2);
+        fixture.Scheduler.RunAll();
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 2);
+    }
+
+    Y_UNIT_TEST(QueuedRefillCannotBypassBudgetAfterKeyChange)
+    {
+        TFixture fixture(2);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+
+        auto activeA = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+        auto activeB = fixture.Pool.Acquire(fixture.MakeRequest("B"));
+        fixture.MarkActive(activeA);
+        fixture.MarkActive(activeB);
+        fixture.OnSpawn = [&] (const TString&) {
+            UNIT_ASSERT_LE(fixture.CountAliveUnreturned(), 2);
+        };
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Scheduler.Size(), 2);
+
+        fixture.Scheduler.RunNext();
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        AssertWithinBudget(snapshot, 2);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Idle, 1);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Retiring, 1);
+        UNIT_ASSERT_LE(fixture.CountAliveUnreturned(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(activeA->Key, "A");
+        UNIT_ASSERT_VALUES_EQUAL(activeB->Key, "B");
+    }
+
+    Y_UNIT_TEST(InFlightSpawnUsesReservationAcrossKeyChange)
+    {
+        TFixture fixture(2);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        auto activeA = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+
+        std::shared_ptr<TFakeProcess> activeB;
+        fixture.OnSpawn = [&] (const TString& key) {
+            UNIT_ASSERT_VALUES_EQUAL(key, "A");
+            activeB = fixture.Pool.Acquire(fixture.MakeRequest("B"));
+            AssertWithinBudget(fixture.Pool.GetSnapshot(), 2);
+        };
+        fixture.Scheduler.RunNext();
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        AssertWithinBudget(snapshot, 2);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Idle, 0);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Retiring, 2);
+        UNIT_ASSERT_VALUES_EQUAL(activeA->Key, "A");
+        UNIT_ASSERT_VALUES_EQUAL(activeB->Key, "B");
+    }
+
+    Y_UNIT_TEST(CleanupRestartsRefillForLatestKey)
+    {
+        TFixture fixture(2);
+        fixture.Pool.Prewarm(fixture.MakeRequest("exeA,mem0"));
+        auto activeB = fixture.Pool.Acquire(fixture.MakeRequest("exeB,mem1"));
+
+        fixture.Scheduler.RunAll();
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        AssertWithinBudget(snapshot, 2);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Idle, 2);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Retiring, 0);
+        UNIT_ASSERT_VALUES_EQUAL(activeB->Key, "exeB,mem1");
+        for (const auto& process : fixture.Processes) {
+            if (process->Alive && process != activeB) {
+                UNIT_ASSERT_VALUES_EQUAL(process->Key, "exeB,mem1");
+            }
+        }
+    }
+
+    Y_UNIT_TEST(LatestKeyWinsAcrossAtoBtoA)
+    {
+        TFixture fixture(2);
+        fixture.Pool.Prewarm(fixture.MakeRequest("exeA,mem0"));
+        auto activeB = fixture.Pool.Acquire(fixture.MakeRequest("exeB,mem1"));
+        auto activeA = fixture.Pool.Acquire(fixture.MakeRequest("exeA,mem2"));
+
+        fixture.Scheduler.RunAll();
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        AssertWithinBudget(snapshot, 2);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Idle, 2);
+        UNIT_ASSERT_VALUES_EQUAL(activeB->Key, "exeB,mem1");
+        UNIT_ASSERT_VALUES_EQUAL(activeA->Key, "exeA,mem2");
+        for (const auto& process : fixture.Processes) {
+            if (process->Alive && process != activeA && process != activeB) {
+                UNIT_ASSERT_VALUES_EQUAL(process->Key, "exeA,mem2");
+            }
+        }
+    }
+
+    Y_UNIT_TEST(ActiveProcessIsOutsidePoolBudgetAndIsNotCleaned)
+    {
+        TFixture fixture(1);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        auto activeA = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+        const int activeId = activeA->Id;
+
+        auto activeB = fixture.Pool.Acquire(fixture.MakeRequest("B"));
+        fixture.Scheduler.RunAll();
+
+        UNIT_ASSERT(activeA->Alive);
+        UNIT_ASSERT(activeB->Alive);
+        UNIT_ASSERT(Find(fixture.CleanedProcessIds, activeId) == fixture.CleanedProcessIds.end());
+        AssertWithinBudget(fixture.Pool.GetSnapshot(), 1);
+    }
+
+    Y_UNIT_TEST(SpawnErrorReleasesReservationWithoutRetryLoop)
+    {
+        TFixture fixture(1);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        auto active = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+        fixture.FailNextSpawn = true;
+
+        fixture.Scheduler.RunAll();
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        AssertWithinBudget(snapshot, 1);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Warming, 0);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Idle, 0);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Scheduler.Size(), 0);
+        UNIT_ASSERT(active->Alive);
+    }
+
+    Y_UNIT_TEST(SpawnExceptionReleasesReservationWithoutRetryLoop)
+    {
+        TFixture fixture(1);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        auto active = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+        fixture.ThrowNextSpawn = true;
+
+        fixture.Scheduler.RunAll();
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        AssertWithinBudget(snapshot, 1);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Warming, 0);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Idle, 0);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Scheduler.Size(), 0);
+        UNIT_ASSERT(active->Alive);
+    }
+
+    Y_UNIT_TEST(StaleRefillFailureDoesNotBlockLatestKey)
+    {
+        TFixture fixture(1);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        auto activeA = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+        fixture.FailNextSpawn = true;
+        fixture.OnSpawn = [&] (const TString& key) {
+            UNIT_ASSERT_VALUES_EQUAL(key, "A");
+            fixture.MarkActive(fixture.Pool.Acquire(fixture.MakeRequest("B")));
+        };
+
+        fixture.Scheduler.RunAll();
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Idle, 1);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Retiring, 0);
+        UNIT_ASSERT(activeA->Alive);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Processes.back()->Key, "B");
+    }
+
+    Y_UNIT_TEST(FailedDemandCleanupQuarantinesAndBlocksFurtherSpawns)
+    {
+        for (int maxProcesses : {0, 1}) {
+            TFixture fixture(maxProcesses);
+            fixture.CleanupSucceeds = false;
+            fixture.FailNextSpawn = true;
+            fixture.ProcessOnSpawnError = true;
+
+            UNIT_ASSERT_EXCEPTION_CONTAINS(
+                fixture.Pool.Acquire(fixture.MakeRequest("A")),
+                std::runtime_error,
+                "Spawn failed");
+            UNIT_ASSERT_VALUES_EQUAL(fixture.Processes.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Quarantined, 1);
+
+            UNIT_ASSERT_EXCEPTION_CONTAINS(
+                fixture.Pool.Acquire(fixture.MakeRequest("B")),
+                std::runtime_error,
+                "Spawn failed");
+            fixture.Scheduler.RunAll();
+            UNIT_ASSERT_VALUES_EQUAL(fixture.Processes.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(fixture.CleanedProcessIds.size(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Quarantined, 1);
+            UNIT_ASSERT_VALUES_EQUAL(fixture.Scheduler.Size(), 0);
+
+            fixture.Scheduler.RunAll();
+            UNIT_ASSERT_VALUES_EQUAL(fixture.CleanedProcessIds.size(), 2);
+        }
+    }
+
+    Y_UNIT_TEST(MatchingIdleCanBeAcquiredWhileDemandProcessIsQuarantined)
+    {
+        TFixture fixture(1);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        auto active = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+        fixture.MarkActive(active);
+
+        TManualEvent spawnEntered;
+        TManualEvent allowSpawn;
+        fixture.OnSpawn = [&] (const TString& key) {
+            UNIT_ASSERT_VALUES_EQUAL(key, "A");
+            spawnEntered.Signal();
+            allowSpawn.WaitI();
+        };
+        TThread refillThread([&] {
+            fixture.Scheduler.RunNext();
+        });
+        refillThread.Start();
+        bool joined = false;
+        Y_DEFER {
+            if (!joined) {
+                allowSpawn.Signal();
+                refillThread.Join();
+            }
+        };
+
+        UNIT_ASSERT(spawnEntered.WaitT(TDuration::Seconds(5)));
+        fixture.CleanupSucceeds = false;
+        fixture.FailNextSpawn = true;
+        fixture.ProcessOnSpawnError = true;
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            fixture.Pool.Acquire(fixture.MakeRequest("A")),
+            std::runtime_error,
+            "Spawn failed");
+
+        allowSpawn.Signal();
+        refillThread.Join();
+        joined = true;
+
+        auto idle = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+        fixture.MarkActive(idle);
+        UNIT_ASSERT(idle->Alive);
+        UNIT_ASSERT_VALUES_EQUAL(idle->Key, "A");
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Quarantined, 1);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Processes.size(), 3);
+
+        fixture.Scheduler.RunAll();
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Processes.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Quarantined, 1);
+    }
+
+    Y_UNIT_TEST(SuccessfulAcquireTriggeredCleanupResumesRefill)
+    {
+        TFixture fixture(1);
+        fixture.CleanupSucceeds = false;
+        fixture.FailNextSpawn = true;
+        fixture.ProcessOnSpawnError = true;
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            fixture.Pool.Acquire(fixture.MakeRequest("A")),
+            std::runtime_error,
+            "Spawn failed");
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Quarantined, 1);
+
+        fixture.CleanupSucceeds = true;
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            fixture.Pool.Acquire(fixture.MakeRequest("B")),
+            std::runtime_error,
+            "Spawn failed");
+        fixture.Scheduler.RunAll();
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Quarantined, 0);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Idle, 1);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Processes.size(), 2);
+
+        auto active = fixture.Pool.Acquire(fixture.MakeRequest("B"));
+        UNIT_ASSERT_VALUES_EQUAL(active->Key, "B");
+    }
+
+    Y_UNIT_TEST(SuccessfulInitialDemandCleanupDoesNotQuarantine)
+    {
+        TFixture fixture(0);
+        fixture.FailNextSpawn = true;
+        fixture.ProcessOnSpawnError = true;
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            fixture.Pool.Acquire(fixture.MakeRequest("A")),
+            std::runtime_error,
+            "Spawn failed");
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Quarantined, 0);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 0);
+
+        auto active = fixture.Pool.Acquire(fixture.MakeRequest("B"));
+        UNIT_ASSERT_VALUES_EQUAL(active->Key, "B");
+    }
+
+    Y_UNIT_TEST(ConcurrentPartialDemandFailuresRemainOwned)
+    {
+        TFixture fixture(0);
+        fixture.CleanupSucceeds = false;
+        fixture.FailSpawnCount = 2;
+        fixture.ProcessOnSpawnError = true;
+
+        TManualEvent firstSpawnEntered;
+        TManualEvent allowFirstSpawn;
+        fixture.OnSpawn = [&] (const TString&) {
+            firstSpawnEntered.Signal();
+            allowFirstSpawn.WaitI();
+        };
+
+        std::exception_ptr firstError;
+        TThread firstThread([&] {
+            try {
+                fixture.Pool.Acquire(fixture.MakeRequest("A"));
+            } catch (...) {
+                firstError = std::current_exception();
+            }
+        });
+        firstThread.Start();
+        bool joined = false;
+        Y_DEFER {
+            if (!joined) {
+                allowFirstSpawn.Signal();
+                firstThread.Join();
+            }
+        };
+
+        UNIT_ASSERT(firstSpawnEntered.WaitT(TDuration::Seconds(5)));
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            fixture.Pool.Acquire(fixture.MakeRequest("B")),
+            std::runtime_error,
+            "Spawn failed");
+        allowFirstSpawn.Signal();
+        firstThread.Join();
+        joined = true;
+
+        UNIT_ASSERT(firstError);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Quarantined, 2);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 2);
+
+        fixture.CleanupSucceeds = true;
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            fixture.Pool.Acquire(fixture.MakeRequest("C")),
+            std::runtime_error,
+            "Spawn failed");
+        fixture.Scheduler.RunAll();
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Quarantined, 0);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 0);
+    }
+
+    Y_UNIT_TEST(ShutdownRetriesQuarantinedCleanup)
+    {
+        TFixture fixture(0);
+        fixture.CleanupSucceeds = false;
+        fixture.FailNextSpawn = true;
+        fixture.ProcessOnSpawnError = true;
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            fixture.Pool.Acquire(fixture.MakeRequest("A")),
+            std::runtime_error,
+            "Spawn failed");
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Quarantined, 1);
+
+        fixture.Pool.BeginShutdown();
+        UNIT_ASSERT(!fixture.Pool.FinishShutdown());
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Quarantined, 1);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 1);
+
+        fixture.CleanupSucceeds = true;
+        UNIT_ASSERT(fixture.Pool.FinishShutdown());
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Quarantined, 0);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CleanedProcessIds.size(), 3);
+    }
+
+    Y_UNIT_TEST(RejectedQuarantineCleanupIsRetriedOnNextAcquire)
+    {
+        TFixture fixture(0);
+        fixture.CleanupSucceeds = false;
+        fixture.FailNextSpawn = true;
+        fixture.ProcessOnSpawnError = true;
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            fixture.Pool.Acquire(fixture.MakeRequest("A")),
+            std::runtime_error,
+            "Spawn failed");
+
+        fixture.Scheduler.AcceptCallbacks = false;
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            fixture.Pool.Acquire(fixture.MakeRequest("B")),
+            std::runtime_error,
+            "Spawn failed");
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Scheduler.Size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CleanedProcessIds.size(), 1);
+
+        fixture.Scheduler.AcceptCallbacks = true;
+        fixture.CleanupSucceeds = true;
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            fixture.Pool.Acquire(fixture.MakeRequest("C")),
+            std::runtime_error,
+            "Spawn failed");
+        fixture.Scheduler.RunAll();
+
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Quarantined, 0);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CleanedProcessIds.size(), 2);
+    }
+
+    Y_UNIT_TEST(InFlightSpawnAcrossKeyChangeUsesIndependentBound)
+    {
+        TFixture fixture(2);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        auto activeA = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+        fixture.MarkActive(activeA);
+
+        TManualEvent spawnEntered;
+        TManualEvent allowSpawn;
+        fixture.OnSpawn = [&] (const TString& key) {
+            UNIT_ASSERT_VALUES_EQUAL(key, "A");
+            spawnEntered.Signal();
+            allowSpawn.WaitI();
+        };
+        TThread refillThread([&] {
+            fixture.Scheduler.RunNext();
+        });
+        refillThread.Start();
+        bool joined = false;
+        Y_DEFER {
+            if (!joined) {
+                allowSpawn.Signal();
+                refillThread.Join();
+            }
+        };
+
+        const bool entered = spawnEntered.WaitT(TDuration::Seconds(5));
+        if (entered) {
+            auto activeB = fixture.Pool.Acquire(fixture.MakeRequest("B"));
+            fixture.MarkActive(activeB);
+            AssertWithinBudget(fixture.Pool.GetSnapshot(), 2);
+            UNIT_ASSERT_LE(fixture.CountAliveUnreturned(), 2);
+        }
+        allowSpawn.Signal();
+        refillThread.Join();
+        joined = true;
+        UNIT_ASSERT(entered);
+
+        fixture.Scheduler.RunAll();
+        AssertWithinBudget(fixture.Pool.GetSnapshot(), 2);
+        UNIT_ASSERT_LE(fixture.CountAliveUnreturned(), 2);
+    }
+
+    Y_UNIT_TEST(ShutdownWaitsForInFlightSpawnLifecycle)
+    {
+        TFixture fixture(1);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        auto activeA = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+        fixture.MarkActive(activeA);
+
+        TManualEvent spawnEntered;
+        TManualEvent allowSpawn;
+        fixture.OnSpawn = [&] (const TString&) {
+            spawnEntered.Signal();
+            allowSpawn.WaitI();
+        };
+        TThread refillThread([&] {
+            fixture.Scheduler.RunNext();
+        });
+        refillThread.Start();
+        bool joined = false;
+        Y_DEFER {
+            if (!joined) {
+                allowSpawn.Signal();
+                refillThread.Join();
+            }
+        };
+
+        const bool entered = spawnEntered.WaitT(TDuration::Seconds(5));
+        if (entered) {
+            fixture.Pool.BeginShutdown();
+            UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Warming, 1);
+        }
+        allowSpawn.Signal();
+        refillThread.Join();
+        joined = true;
+        UNIT_ASSERT(entered);
+
+        UNIT_ASSERT(fixture.Pool.FinishShutdown());
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 0);
+        UNIT_ASSERT(activeA->Alive);
+    }
+
+    Y_UNIT_TEST(BeginShutdownDoesNotRetryRunningCleanup)
+    {
+        TFixture fixture(1);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        fixture.CleanupSucceeds = false;
+        auto active = fixture.Pool.Acquire(fixture.MakeRequest("B"));
+        fixture.MarkActive(active);
+        fixture.OnCleanup = [&] {
+            fixture.Pool.BeginShutdown();
+            UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 1);
+        };
+
+        fixture.Scheduler.RunAll();
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CleanedProcessIds.size(), 1);
+        fixture.OnCleanup = {};
+        fixture.CleanupSucceeds = true;
+        UNIT_ASSERT(fixture.Pool.FinishShutdown());
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CleanedProcessIds.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 0);
+        UNIT_ASSERT(active->Alive);
+    }
+
+    Y_UNIT_TEST(PartiallySpawnedProcessRetiresBeforeReservationIsReleased)
+    {
+        TFixture fixture(1);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        auto active = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+        fixture.FailNextSpawn = true;
+        fixture.ProcessOnSpawnError = true;
+
+        fixture.Scheduler.RunNext();
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        AssertWithinBudget(snapshot, 1);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Retiring, 1);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Warming, 0);
+
+        fixture.Scheduler.RunAll();
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Idle, 0);
+    }
+
+    Y_UNIT_TEST(CleanupErrorKeepsRetiringBudget)
+    {
+        TFixture fixture(1);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        fixture.CleanupSucceeds = false;
+        auto activeB = fixture.Pool.Acquire(fixture.MakeRequest("B"));
+
+        fixture.Scheduler.RunAll();
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        AssertWithinBudget(snapshot, 1);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Retiring, 1);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Idle, 0);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Scheduler.Size(), 0);
+        UNIT_ASSERT(activeB->Alive);
+        fixture.MarkActive(activeB);
+        auto activeC = fixture.Pool.Acquire(fixture.MakeRequest("C"));
+        fixture.MarkActive(activeC);
+        fixture.Scheduler.RunAll();
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CleanedProcessIds.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 1);
+        UNIT_ASSERT(activeB->Alive);
+        UNIT_ASSERT(activeC->Alive);
+    }
+
+    Y_UNIT_TEST(PrewarmFailureCleansStartedProcessesAndPreservesError)
+    {
+        for (bool partialSpawn : {false, true}) {
+            for (bool cleanupSucceeds : {false, true}) {
+                TFixture fixture(3);
+                fixture.ProcessOnSpawnError = partialSpawn;
+                fixture.CleanupSucceeds = cleanupSucceeds;
+                fixture.OnSpawn = [&] (const TString&) {
+                    fixture.FailNextSpawn = true;
+                };
+
+                UNIT_ASSERT_EXCEPTION_CONTAINS(
+                    fixture.Pool.Prewarm(fixture.MakeRequest("A")),
+                    std::runtime_error,
+                    "Spawn failed");
+
+                const int startedCount = partialSpawn ? 2 : 1;
+                UNIT_ASSERT_VALUES_EQUAL(fixture.Processes.size(), 2);
+                UNIT_ASSERT_VALUES_EQUAL(fixture.CleanedProcessIds.size(), startedCount);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    fixture.CountAliveUnreturned(), cleanupSucceeds ? 0 : startedCount);
+                const auto snapshot = fixture.Pool.GetSnapshot();
+                UNIT_ASSERT_VALUES_EQUAL(snapshot.Idle, 0);
+                UNIT_ASSERT_VALUES_EQUAL(snapshot.Warming, 0);
+                UNIT_ASSERT_VALUES_EQUAL(snapshot.Retiring, cleanupSucceeds ? 0 : startedCount);
+                UNIT_ASSERT_VALUES_EQUAL(fixture.Scheduler.Size(), 0);
+            }
+        }
+    }
+
+    Y_UNIT_TEST(WatcherCleansDeadIdleWithoutRestartUntilDemand)
+    {
+        TFixture fixture(2);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        fixture.Processes.front()->Alive = false;
+
+        fixture.Pool.SweepDead();
+        AssertWithinBudget(fixture.Pool.GetSnapshot(), 2);
+        fixture.Scheduler.RunAll();
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        AssertWithinBudget(snapshot, 2);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Idle, 1);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Retiring, 0);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Processes.size(), 2);
+
+        auto active = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+        fixture.MarkActive(active);
+        fixture.Scheduler.RunAll();
+        UNIT_ASSERT(active->Alive);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Idle, 2);
+        UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 2);
+    }
+
+    Y_UNIT_TEST(DeadIdleDoesNotCauseRepeatedOrQueuedRefill)
+    {
+        for (bool queueRefill : {false, true}) {
+            TFixture fixture(2);
+            fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+            std::shared_ptr<TFakeProcess> active;
+            if (queueRefill) {
+                active = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+                fixture.MarkActive(active);
+            }
+            for (const auto& process : fixture.Processes) {
+                if (process != active) {
+                    process->Alive = false;
+                }
+            }
+
+            for (int iteration = 0; iteration < 3; ++iteration) {
+                fixture.Pool.SweepDead();
+                fixture.Scheduler.RunAll();
+                UNIT_ASSERT_VALUES_EQUAL(fixture.Processes.size(), 2);
+                UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Idle, 0);
+                UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Retiring, 0);
+                UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 0);
+            }
+
+            auto nextActive = fixture.Pool.Acquire(fixture.MakeRequest("B"));
+            fixture.MarkActive(nextActive);
+            fixture.Scheduler.RunAll();
+            UNIT_ASSERT(nextActive->Alive);
+            UNIT_ASSERT_VALUES_EQUAL(nextActive->Key, "B");
+            UNIT_ASSERT_VALUES_EQUAL(fixture.Pool.GetSnapshot().Idle, 2);
+            UNIT_ASSERT_VALUES_EQUAL(fixture.CountAliveUnreturned(), 2);
+            if (active) {
+                UNIT_ASSERT(active->Alive);
+            }
+        }
+    }
+
+    Y_UNIT_TEST(ZeroDisablesOnlyBackgroundPool)
+    {
+        TFixture fixture(0);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+
+        auto active = fixture.Pool.Acquire(fixture.MakeRequest("B"));
+
+        UNIT_ASSERT_VALUES_EQUAL(active->Key, "B");
+        UNIT_ASSERT_VALUES_EQUAL(fixture.Scheduler.Size(), 0);
+        AssertWithinBudget(fixture.Pool.GetSnapshot(), 0);
+    }
+
+    Y_UNIT_TEST(SchedulerRejectionDoesNotLeakPendingRefill)
+    {
+        TFixture fixture(1);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        fixture.Scheduler.AcceptCallbacks = false;
+
+        auto active = fixture.Pool.Acquire(fixture.MakeRequest("A"));
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        UNIT_ASSERT(!snapshot.RefillQueued);
+        UNIT_ASSERT(!snapshot.RefillRunning);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Warming, 0);
+        UNIT_ASSERT(active->Alive);
+    }
+
+    Y_UNIT_TEST(SmallPoolOfThreeObeysSameBudget)
+    {
+        TFixture fixture(3);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        auto active = fixture.Pool.Acquire(fixture.MakeRequest("B"));
+
+        fixture.Scheduler.RunAll();
+
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        AssertWithinBudget(snapshot, 3);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Idle, 3);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Retiring, 0);
+        UNIT_ASSERT(active->Alive);
+    }
+
+    Y_UNIT_TEST(ShutdownCleansOnlyPoolOwnedProcesses)
+    {
+        TFixture fixture(2);
+        fixture.Pool.Prewarm(fixture.MakeRequest("A"));
+        auto activeB = fixture.Pool.Acquire(fixture.MakeRequest("B"));
+
+        fixture.Pool.BeginShutdown();
+        fixture.Scheduler.Clear();
+        UNIT_ASSERT(fixture.Pool.FinishShutdown());
+
+        UNIT_ASSERT(activeB->Alive);
+        const auto snapshot = fixture.Pool.GetSnapshot();
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Idle, 0);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Retiring, 0);
+    }
+}
+
+} // namespace
+} // namespace NYql::NTaskRunnerProxy

--- a/ydb/library/yql/providers/dq/task_runner/ut/tasks_runner_pipe_process_ut.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/ut/tasks_runner_pipe_process_ut.cpp
@@ -1,0 +1,101 @@
+#include <ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe_process.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <cerrno>
+
+namespace NYql::NTaskRunnerProxy::NPrivate {
+namespace {
+
+Y_UNIT_TEST_SUITE(TPipeChildProcessTest) {
+
+#ifndef _win_
+    Y_UNIT_TEST(InvalidPidDoesNotReachSyscalls)
+    {
+        int pid = -1;
+        int killCallCount = 0;
+        int waitPidCallCount = 0;
+
+        UNIT_ASSERT(CleanupChildProcess(
+            &pid,
+            TDuration::Zero(),
+            [&] (int, int) {
+                ++killCallCount;
+                return 0;
+            },
+            [&] (int, int*, int) {
+                ++waitPidCallCount;
+                return 0;
+            }));
+        UNIT_ASSERT_VALUES_EQUAL(killCallCount, 0);
+        UNIT_ASSERT_VALUES_EQUAL(waitPidCallCount, 0);
+    }
+
+    Y_UNIT_TEST(InterruptedWaitIsRetried)
+    {
+        int pid = 42;
+        int waitPidCallCount = 0;
+
+        UNIT_ASSERT(CleanupChildProcess(
+            &pid,
+            TDuration::Seconds(1),
+            [] (int, int) {
+                return 0;
+            },
+            [&] (int childPid, int*, int) {
+                if (++waitPidCallCount == 1) {
+                    errno = EINTR;
+                    return -1;
+                }
+                return childPid;
+            }));
+        UNIT_ASSERT_VALUES_EQUAL(waitPidCallCount, 2);
+        UNIT_ASSERT_VALUES_EQUAL(pid, -1);
+    }
+
+    Y_UNIT_TEST(InterruptedWaitRespectsDeadline)
+    {
+        int pid = 42;
+        int waitPidCallCount = 0;
+        UNIT_ASSERT(!CleanupChildProcess(
+            &pid,
+            TDuration::Zero(),
+            [] (int, int) { return 0; },
+            [&] (int childPid, int*, int) {
+                if (++waitPidCallCount <= 3) {
+                    errno = EINTR;
+                    return -1;
+                }
+                return childPid;
+            }));
+        UNIT_ASSERT_VALUES_EQUAL(waitPidCallCount, 1);
+        UNIT_ASSERT_VALUES_EQUAL(pid, 42);
+    }
+
+    Y_UNIT_TEST(TimeoutDoesNotConfirmCleanup)
+    {
+        int pid = 42;
+
+        UNIT_ASSERT(!CleanupChildProcess(
+            &pid,
+            TDuration::Zero(),
+            [] (int, int) {
+                return 0;
+            },
+            [] (int, int*, int) {
+                return 0;
+            }));
+        UNIT_ASSERT_VALUES_EQUAL(pid, 42);
+    }
+#endif
+
+    Y_UNIT_TEST(ShellCommandRequiresSuccessfulExit)
+    {
+        UNIT_ASSERT(IsShellCommandSuccessful(TShellCommand::SHELL_FINISHED, 0));
+        UNIT_ASSERT(!IsShellCommandSuccessful(TShellCommand::SHELL_ERROR, 1));
+        UNIT_ASSERT(!IsShellCommandSuccessful(TShellCommand::SHELL_FINISHED, Nothing()));
+    }
+}
+
+} // namespace
+} // namespace NYql::NTaskRunnerProxy::NPrivate

--- a/ydb/library/yql/providers/dq/task_runner/ut/ya.make
+++ b/ydb/library/yql/providers/dq/task_runner/ut/ya.make
@@ -1,0 +1,14 @@
+UNITTEST_FOR(ydb/library/yql/providers/dq/task_runner)
+
+SRCS(
+    tasks_runner_pipe_process_ut.cpp
+    tasks_runner_pipe_pool_ut.cpp
+)
+
+PEERDIR(
+    library/cpp/testing/unittest
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/library/yql/providers/dq/task_runner/ya.make
+++ b/ydb/library/yql/providers/dq/task_runner/ya.make
@@ -23,8 +23,13 @@ YQL_LAST_ABI_VERSION()
 SRCS(
     file_cache.cpp
     tasks_runner_local.cpp
+    tasks_runner_pipe_process.cpp
     tasks_runner_proxy.cpp
     tasks_runner_pipe.cpp
 )
 
 END()
+
+RECURSE_FOR_TESTS(
+    ut
+)


### PR DESCRIPTION
## What changed

- Keep idle, retiring, and in-flight warm spawns within MaxProcesses during executable or settings changes.
- Retain a partially started demand process when cleanup cannot be confirmed.
- While such a process is quarantined, block new demand and background spawns but keep matching idle runners available.
- Retry quarantined cleanup only from a later Acquire or during shutdown.

## Why

The old refill path could keep the previous warm pool while creating a full replacement pool. A partial demand spawn also lost ownership when best-effort cleanup failed. Both cases could accumulate service processes and contribute to OOM during hybrid revisions.

Unconfirmed demand cleanup now fails closed: capacity may be temporarily unavailable, but later acquires cannot start more processes until cleanup is confirmed. This addresses one mechanism found while investigating DQ-147 and DQ-150; it does not claim to cover every OOM cause.

Tracker: https://st.yandex-team.ru/DQ-147, https://st.yandex-team.ru/DQ-150

## Tests

- task runner unit tests: 33 passed in relwithdebinfo
- upstream task_runner_actor, worker_manager, and actors builds
- Arcadia dq_vanilla_job and worker_node consumer builds