### PR TITLE
Keep the memory controller alive when /proc/self/maps is unreadable

### DIFF
--- a/ydb/core/memory_controller/memory_controller.cpp
+++ b/ydb/core/memory_controller/memory_controller.cpp
@@ -53,6 +53,14 @@ ui64 SafeDiff(ui64 a, ui64 b) {
     return a - Min(a, b);
 }
 
+ui64 GetMemoryMapsCountOrZero() {
+    try {
+        return GetMemoryMapsCount();
+    } catch (const yexception&) {
+        return 0;
+    }
+}
+
 class TMemoryConsumer : public IMemoryConsumer {
 public:
     TMemoryConsumer(EMemoryConsumerKind kind, TActorId actorId)
@@ -251,7 +259,7 @@ private:
         Counters->GetCounter("Stats/CGroupLimit")->Set(processMemoryInfo.CGroupLimit.value_or(0));
         Counters->GetCounter("Stats/MemTotal")->Set(processMemoryInfo.MemTotal.value_or(0));
         Counters->GetCounter("Stats/MemAvailable")->Set(processMemoryInfo.MemAvailable.value_or(0));
-        Counters->GetCounter("Stats/MemMapsCount")->Set(GetMemoryMapsCount());
+        Counters->GetCounter("Stats/MemMapsCount")->Set(GetMemoryMapsCountOrZero());
         Counters->GetCounter("Stats/AllocatedMemory")->Set(processMemoryInfo.AllocatedMemory);
         Counters->GetCounter("Stats/AllocatorCachesMemory")->Set(processMemoryInfo.AllocatorCachesMemory);
         Counters->GetCounter("Stats/HardLimit")->Set(hardLimitBytes);

--- a/ydb/core/memory_controller/memory_controller_ut.cpp
+++ b/ydb/core/memory_controller/memory_controller_ut.cpp
@@ -9,6 +9,11 @@
 #include <ydb/core/tx/columnshard/engines/storage/optimizer/abstract/optimizer.h>
 #include <ydb/core/tx/limiter/grouped_memory/usage/service.h>
 #include <ydb/library/actors/testlib/test_runtime.h>
+#include <util/generic/scope.h>
+
+#ifdef _linux_
+#include <sys/resource.h>
+#endif
 
 namespace NKikimr::NMemory {
 
@@ -140,6 +145,31 @@ Y_UNIT_TEST(Counters) {
     UNIT_ASSERT_VALUES_EQUAL(server->MemoryControllerCounters->GetCounter("Stats/CGroupLimit")->Val(), 100_MB);
     UNIT_ASSERT_VALUES_EQUAL(server->MemoryControllerCounters->GetCounter("Stats/HardLimit")->Val(), 100_MB);
 }
+
+#ifdef _linux_
+Y_UNIT_TEST(Counters_MemMapsUnavailable) {
+    TPortManager pm;
+    TServerSettings serverSettings(pm.GetPort(2134));
+    serverSettings.SetDomainName("Root")
+        .SetUseRealThreads(false);
+
+    auto server = MakeIntrusive<TWithMemoryControllerServer>(serverSettings);
+    auto& runtime = *server->GetRuntime();
+
+    runtime.SimulateSleep(TDuration::Seconds(2));
+    UNIT_ASSERT_GT(server->MemoryControllerCounters->GetCounter("Stats/MemMapsCount")->Val(), 0);
+
+    rlimit saved;
+    UNIT_ASSERT_VALUES_EQUAL(getrlimit(RLIMIT_NOFILE, &saved), 0);
+    rlimit noFiles = saved;
+    noFiles.rlim_cur = 0;
+    UNIT_ASSERT_VALUES_EQUAL(setrlimit(RLIMIT_NOFILE, &noFiles), 0);
+    Y_DEFER { setrlimit(RLIMIT_NOFILE, &saved); };
+
+    runtime.SimulateSleep(TDuration::Seconds(2));
+    UNIT_ASSERT_VALUES_EQUAL(server->MemoryControllerCounters->GetCounter("Stats/MemMapsCount")->Val(), 0);
+}
+#endif
 
 Y_UNIT_TEST(Counters_HardLimit) {
     TPortManager pm;


### PR DESCRIPTION
Issue YDBBUGS-791

### Changelog category

* Bugfix

### Description for reviewers

Stops the node from terminating when the memory controller cannot read `/proc/self/maps`: nodes died once per second under EMFILE with `Terminating due to uncaught exception ... (Error 24: Too many open files) ... can't open "/proc/self/maps" ... of type TFileError`.

- **Root cause.** `TMemoryController::HandleWakeup` is `noexcept` and feeds the `Stats/MemMapsCount` sensor from `GetMemoryMapsCount()`, which reads `/proc/self/maps` through a plain `TFileInput` and throws `TFileError` on any `open`/`read` failure. It is the only unguarded I/O on the wakeup path: `TProcStat::Fill` wraps every `/proc` read in `try/catch`, and tcmalloc crashes on OOM instead of throwing `bad_alloc`. Dropping `noexcept` would not help, `IActor::Receive` rethrows for actors that are not `IActorExceptionHandler`.
- **Fix.** The controller wraps the call in `GetMemoryMapsCountOrZero()` and reports 0 while the maps file is unreadable; everything else in the wakeup keeps working. The helper in `yql/essentials` is not touched.
- **Verified on a slice.** With `prlimit --nofile=64` a dynamic slot on the old binary died within 1 s with the stack from the ticket; with the catch in place the same starvation left the slot alive on the same pid, and the sensors resumed once the limit was restored.

Test in `memory_controller/memory_controller_ut.cpp`: `Counters_MemMapsUnavailable` (sets the `RLIMIT_NOFILE` soft limit to 0 and expects `Stats/MemMapsCount` to drop to 0; on the old code the forked test dies in `std::terminate`).
