### PR TITLE
Reserve address space of freed MKQL pages instead of leaking it

### DIFF
--- a/yql/essentials/minikql/aligned_page_pool.cpp
+++ b/yql/essentials/minikql/aligned_page_pool.cpp
@@ -71,30 +71,61 @@ TString GetMemoryMapsString() {
 template <typename T, bool SysAlign>
 class TGlobalPools;
 
+template <typename T>
+concept TMadviseProvider = requires(T& provider, void* addr, size_t size, bool needed) {
+    provider.Madvise(addr, size, needed);
+};
+
 template <typename T, bool SysAlign>
 class TGlobalPagePool {
     friend class TGlobalPools<T, SysAlign>;
 
+    /**
+        Whenever the provider is able to drop the content of a region without unmapping it, the pages
+        evicted from the cache are not returned to the OS by `Munmap()` but only advised away and kept
+        in the reserved list. Their memory is released, while their address space is reused by the
+        following allocations.
+
+        Constantly mapping and unmapping page-sized regions fragments the address space of a long running
+        process: both the number of memory maps and the size of the page table (VmPTE) grow without bound,
+        the latter also being accounted in RSS.
+     */
+    static constexpr bool ReserveFreedPages = TMadviseProvider<T>;
+
 public:
-    TGlobalPagePool(T& provider, size_t pageSize)
+    TGlobalPagePool(T& provider, size_t pageSize, std::atomic<i64>& totalMmappedBytes)
         : Provider_(provider)
         , PageSize_(pageSize)
+        , TotalMmappedBytes_(totalMmappedBytes)
     {
     }
 
     ~TGlobalPagePool() {
         void* addr = nullptr;
         while (Pages_.Dequeue(&addr)) {
-            FreePage(addr);
+            UnmapPage(addr);
+        }
+        while (ReservedPages_.Dequeue(&addr)) {
+            UnmapPage(addr);
         }
     }
 
     void* GetPage() {
-        void* page = nullptr;
-        if (Pages_.Dequeue(&page)) {
-            --Count_;
-            NYql::NUdf::SanitizerMakeRegionInaccessible(page, PageSize_);
+        // The cached pages are still backed by the memory, so prefer them to the reserved ones,
+        // which have to be brought back by an extra syscall and the following page faults.
+        if (void* page = PopPage()) {
             return page;
+        }
+
+        if constexpr (ReserveFreedPages) {
+            void* page = nullptr;
+            if (ReservedPages_.Dequeue(&page)) {
+                auto res = Provider_.Madvise(page, PageSize_, /*needed=*/true);
+                Y_DEBUG_ABORT_UNLESS(0 == res, "Madvise failed: %s", LastSystemErrorText());
+                TotalMmappedBytes_ += PageSize_;
+                NYql::NUdf::SanitizerMakeRegionInaccessible(page, PageSize_);
+                return page;
+            }
         }
 
         return nullptr;
@@ -115,7 +146,7 @@ public:
 private:
     size_t PushPage(void* addr) {
         if (Y_UNLIKELY(TAlignedPagePool::IsDefaultAllocatorUsed())) {
-            FreePage(addr);
+            UnmapPage(addr);
             return GetPageSize();
         }
         NYql::NUdf::SanitizerMakeRegionInaccessible(addr, PageSize_);
@@ -124,16 +155,46 @@ private:
         return 0;
     }
 
+    void* PopPage() {
+        void* page = nullptr;
+        if (Pages_.Dequeue(&page)) {
+            --Count_;
+            NYql::NUdf::SanitizerMakeRegionInaccessible(page, PageSize_);
+            return page;
+        }
+
+        return nullptr;
+    }
+
+    // Evicts the page from the cache: its memory is given back to the OS, but the address space
+    // may be kept reserved for the further reuse - see `ReserveFreedPages`.
     void FreePage(void* addr) noexcept {
+        if constexpr (ReserveFreedPages) {
+            NYql::NUdf::SanitizerMakeRegionInaccessible(addr, PageSize_);
+            auto res = Provider_.Madvise(addr, PageSize_, /*needed=*/false);
+            Y_DEBUG_ABORT_UNLESS(0 == res, "Madvise failed: %s", LastSystemErrorText());
+            ReservedPages_.Enqueue(addr);
+        } else {
+            UnmapPage(addr);
+        }
+
+        i64 prev = TotalMmappedBytes_.fetch_sub(PageSize_);
+        Y_DEBUG_ABORT_UNLESS(prev >= 0);
+    }
+
+    void UnmapPage(void* addr) noexcept {
         NYql::NUdf::SanitizerMakeRegionInaccessible(addr, PageSize_);
         auto res = Provider_.Munmap(addr, PageSize_);
-        Y_DEBUG_ABORT_UNLESS(0 == res, "Madvise failed: %s", LastSystemErrorText());
+        Y_DEBUG_ABORT_UNLESS(0 == res, "Munmap failed: %s", LastSystemErrorText());
     }
 
     T& Provider_;
     const size_t PageSize_;
+    std::atomic<i64>& TotalMmappedBytes_;
     std::atomic<ui64> Count_ = 0;
     TLockFreeStack<void*> Pages_;
+    // Mapped, but advised away regions - their address space is reserved for the further reuse.
+    TLockFreeStack<void*> ReservedPages_;
 };
 
 template <typename T, bool SysAlign>
@@ -169,18 +230,16 @@ public:
     void DoCleanupFreeList(ui64 targetSize) {
         for (ui32 level = 0; level <= MidLevels; ++level) {
             auto& p = Get(level);
-            const size_t pageSize = p.GetPageSize();
 
             while (p.GetSize() >= targetSize) {
-                void* page = p.GetPage();
+                // NOTE: take the page from the cache only - the reserved ones are already freed.
+                void* page = p.PopPage();
 
                 if (!page) {
                     break;
                 }
 
                 p.FreePage(page);
-                i64 prev = TotalMmappedBytes_.fetch_sub(pageSize);
-                Y_DEBUG_ABORT_UNLESS(prev >= 0);
             }
         }
     }
@@ -229,7 +288,7 @@ public:
         Pools_.clear();
         Pools_.reserve(MidLevels + 1);
         for (ui32 i = 0; i <= MidLevels; ++i) {
-            Pools_.emplace_back(MakeHolder<TGlobalPagePool<T, SysAlign>>(Provider_, TAlignedPagePool::POOL_PAGE_SIZE << i));
+            Pools_.emplace_back(MakeHolder<TGlobalPagePool<T, SysAlign>>(Provider_, TAlignedPagePool::POOL_PAGE_SIZE << i, TotalMmappedBytes_));
         }
     }
 
@@ -257,6 +316,18 @@ inline int TSystemMmap::Munmap(void* addr, size_t size) noexcept {
     Y_ABORT_UNLESS(AlignUp(size, SYS_PAGE_SIZE) == size, "Got unaligned size");
     return !::VirtualFree(addr, size, MEM_DECOMMIT);
 }
+
+inline int TSystemMmap::Madvise(void* addr, size_t size, bool needed) noexcept {
+    Y_ABORT_UNLESS(AlignUp(addr, SYS_PAGE_SIZE) == addr, "Got unaligned address");
+    Y_ABORT_UNLESS(AlignUp(size, SYS_PAGE_SIZE) == size, "Got unaligned size");
+
+    if (needed) {
+        // The region is still reserved, so it's enough to commit it back.
+        return ::VirtualAlloc(addr, size, MEM_COMMIT, PAGE_READWRITE) ? 0 : -1;
+    }
+
+    return !::VirtualFree(addr, size, MEM_DECOMMIT);
+}
 #else
 inline void* TSystemMmap::Mmap(size_t size)
 {
@@ -267,8 +338,15 @@ inline int TSystemMmap::Munmap(void* addr, size_t size) noexcept {
     Y_DEBUG_ABORT_UNLESS(AlignUp(addr, SYS_PAGE_SIZE) == addr, "Got unaligned address");
     Y_DEBUG_ABORT_UNLESS(AlignUp(size, SYS_PAGE_SIZE) == size, "Got unaligned size");
 
-    if (size > MaxMidSize) {
-        return ::munmap(addr, size);
+    return ::munmap(addr, size);
+}
+
+inline int TSystemMmap::Madvise(void* addr, size_t size, bool needed) noexcept {
+    Y_DEBUG_ABORT_UNLESS(AlignUp(addr, SYS_PAGE_SIZE) == addr, "Got unaligned address");
+    Y_DEBUG_ABORT_UNLESS(AlignUp(size, SYS_PAGE_SIZE) == size, "Got unaligned size");
+
+    if (needed) {
+        return ::madvise(addr, size, MADV_WILLNEED);
     }
 
     // Unlock memory in case somewhere was called `mlockall(MCL_FUTURE)`.
@@ -331,6 +409,15 @@ int TFakeMmap::Munmap(void* addr, size_t size) noexcept {
         }
         return 0;
     }, "TFakeMmap::Munmap");
+}
+
+int TFakeMmap::Madvise(void* addr, size_t size, bool needed) noexcept {
+    return NYql::WithAbortOnException([&] {
+        if (OnMadvise) {
+            OnMadvise(addr, size, needed);
+        }
+        return 0;
+    }, "TFakeMmap::Madvise");
 }
 
 TAlignedPagePoolCounters::TAlignedPagePoolCounters(::NMonitoring::TDynamicCounterPtr countersRoot, const TString& name) {

--- a/yql/essentials/minikql/aligned_page_pool.cpp
+++ b/yql/essentials/minikql/aligned_page_pool.cpp
@@ -120,11 +120,15 @@ public:
         if constexpr (ReserveFreedPages) {
             void* page = nullptr;
             if (ReservedPages_.Dequeue(&page)) {
-                auto res = Provider_.Madvise(page, PageSize_, /*needed=*/true);
-                Y_DEBUG_ABORT_UNLESS(0 == res, "Madvise failed: %s", LastSystemErrorText());
-                TotalMmappedBytes_ += PageSize_;
-                NYql::NUdf::SanitizerMakeRegionInaccessible(page, PageSize_);
-                return page;
+                if (Y_LIKELY(0 == Provider_.Madvise(page, PageSize_, /*needed=*/true))) {
+                    TotalMmappedBytes_ += PageSize_;
+                    NYql::NUdf::SanitizerMakeRegionInaccessible(page, PageSize_);
+                    return page;
+                }
+
+                // The region is still reserved, but the OS refused to back it with the memory
+                // right now. Keep it for the further attempts and let the caller map a new one.
+                ReservedPages_.Enqueue(page);
             }
         }
 
@@ -171,15 +175,19 @@ private:
     void FreePage(void* addr) noexcept {
         if constexpr (ReserveFreedPages) {
             NYql::NUdf::SanitizerMakeRegionInaccessible(addr, PageSize_);
-            auto res = Provider_.Madvise(addr, PageSize_, /*needed=*/false);
-            Y_DEBUG_ABORT_UNLESS(0 == res, "Madvise failed: %s", LastSystemErrorText());
-            ReservedPages_.Enqueue(addr);
+            if (Y_LIKELY(0 == Provider_.Madvise(addr, PageSize_, /*needed=*/false))) {
+                ReservedPages_.Enqueue(addr);
+            } else {
+                // The memory of the region is still held by the process, so there is no point
+                // in keeping its address space reserved - drop the whole mapping.
+                UnmapPage(addr);
+            }
         } else {
             UnmapPage(addr);
         }
 
         i64 prev = TotalMmappedBytes_.fetch_sub(PageSize_);
-        Y_DEBUG_ABORT_UNLESS(prev >= 0);
+        Y_DEBUG_ABORT_UNLESS(prev >= i64(PageSize_));
     }
 
     void UnmapPage(void* addr) noexcept {

--- a/yql/essentials/minikql/aligned_page_pool.h
+++ b/yql/essentials/minikql/aligned_page_pool.h
@@ -54,6 +54,11 @@ public:
     void* Mmap(size_t size);
     int Munmap(void* addr, size_t size) noexcept;
 
+    // Tells the OS whether the content of the region is still needed. The memory is returned to the OS
+    // for `needed == false` and is prepared for the further usage otherwise. Unlike `Munmap()` the region
+    // stays mapped in both cases, so its address space may be reused without a new `Mmap()` call.
+    int Madvise(void* addr, size_t size, bool needed) noexcept;
+
     static TSystemMmap& GetInstance();
 };
 
@@ -61,9 +66,11 @@ class TFakeMmap {
 public:
     std::function<void*(size_t size)> OnMmap;
     std::function<void(void* addr, size_t size)> OnMunmap;
+    std::function<void(void* addr, size_t size, bool needed)> OnMadvise;
 
     void* Mmap(size_t size);
     int Munmap(void* addr, size_t size) noexcept;
+    int Madvise(void* addr, size_t size, bool needed) noexcept;
 
     static TFakeMmap& GetInstance();
 };

--- a/yql/essentials/minikql/aligned_page_pool_ut.cpp
+++ b/yql/essentials/minikql/aligned_page_pool_ut.cpp
@@ -3,7 +3,10 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/system/info.h>
+#include <yql/essentials/public/udf/sanitizer_utils.h>
 #include <yql/essentials/utils/backtrace/backtrace.h>
+
+#include <cstring>
 
 namespace NKikimr::NMiniKQL {
 
@@ -20,13 +23,27 @@ public:
         }
     };
 
+    struct TMadviseEntry {
+        void* Addr;
+        size_t Size;
+        bool Needed;
+        bool operator==(const TMadviseEntry& rhs) {
+            return std::tie(Addr, Size, Needed) == std::tie(rhs.Addr, rhs.Size, rhs.Needed);
+        }
+    };
+
     explicit TScopedMemoryMapper(bool aligned) {
         Aligned_ = aligned;
         TFakeMmap::GetInstance().OnMunmap = [this](void* addr, size_t s) {
             Munmaps_.push_back({addr, s});
         };
 
+        TFakeMmap::GetInstance().OnMadvise = [this](void* addr, size_t s, bool needed) {
+            Madvises_.push_back({addr, s, needed});
+        };
+
         TFakeMmap::GetInstance().OnMmap = [this](size_t size) -> void* {
+            ++Mmaps_;
             // Allocate more memory to ensure we have enough space for alignment
             Storage_ = THolder<char, TDeleteArray>(new char[AlignUp(size + EXTRA_SPACE_FOR_UNALIGNMENT, TAlignedPagePool::POOL_PAGE_SIZE)]);
             UNIT_ASSERT(Storage_.Get());
@@ -45,12 +62,17 @@ public:
 
     ~TScopedMemoryMapper() {
         TFakeMmap::GetInstance().OnMunmap = {};
+        TFakeMmap::GetInstance().OnMadvise = {};
         TFakeMmap::GetInstance().OnMmap = {};
         Storage_.Reset();
     }
 
     void* PointerToAlignedMemory() {
         return AlignUp(Storage_.Get(), TAlignedPagePool::POOL_PAGE_SIZE);
+    }
+
+    size_t MmapsSize() {
+        return Mmaps_;
     }
 
     size_t MunmapsSize() {
@@ -61,9 +83,19 @@ public:
         return Munmaps_[i];
     }
 
+    size_t MadvisesSize() {
+        return Madvises_.size();
+    }
+
+    TMadviseEntry Madvises(size_t i) {
+        return Madvises_[i];
+    }
+
 private:
     THolder<char, TDeleteArray> Storage_;
+    size_t Mmaps_ = 0;
     std::vector<TUnmapEntry> Munmaps_;
+    std::vector<TMadviseEntry> Madvises_;
     bool Aligned_;
 };
 
@@ -145,6 +177,84 @@ Y_UNIT_TEST(UnalignedMmapUnalignedSize) {
     UNIT_ASSERT_VALUES_EQUAL(alloc.GetFreePageCount(), TAlignedPagePool::ALLOC_AHEAD_PAGES - 2);
 
     UNIT_ASSERT_VALUES_EQUAL(alloc.GetAllocated(), size + (TAlignedPagePool::ALLOC_AHEAD_PAGES - 2) * TAlignedPagePool::POOL_PAGE_SIZE);
+}
+
+Y_UNIT_TEST(FreedPagesAreReservedAndReused) {
+    TAlignedPagePoolImpl<TFakeMmap>::ResetGlobalsUT();
+    TScopedMemoryMapper mmapper(/*aligned=*/true);
+
+    const auto size = TAlignedPagePool::POOL_PAGE_SIZE;
+    const auto pages = TAlignedPagePool::ALLOC_AHEAD_PAGES + 1;
+
+    {
+        TAlignedPagePoolImpl<TFakeMmap> alloc(__LOCATION__);
+        auto* block = alloc.GetBlock(size);
+        alloc.ReturnBlock(block, size);
+    }
+
+    // The whole mapped region is cached in the global pool now.
+    UNIT_ASSERT_VALUES_EQUAL(1, mmapper.MmapsSize());
+    UNIT_ASSERT_VALUES_EQUAL(0, mmapper.MunmapsSize());
+    UNIT_ASSERT_VALUES_EQUAL(0, mmapper.MadvisesSize());
+    UNIT_ASSERT_VALUES_EQUAL(pages * size, TAlignedPagePoolImpl<TFakeMmap>::GetGlobalPagePoolSize());
+
+    const i64 mmappedBefore = GetTotalMmapedBytes<TFakeMmap>();
+
+    // Cleanup gives the memory back to the OS, but keeps the address space reserved.
+    TAlignedPagePoolImpl<TFakeMmap>::DoCleanupGlobalFreeList(0);
+
+    UNIT_ASSERT_VALUES_EQUAL(0, mmapper.MunmapsSize());
+    UNIT_ASSERT_VALUES_EQUAL(pages, mmapper.MadvisesSize());
+    for (size_t i = 0; i < pages; ++i) {
+        UNIT_ASSERT_VALUES_EQUAL(size, mmapper.Madvises(i).Size);
+        UNIT_ASSERT(!mmapper.Madvises(i).Needed);
+    }
+    UNIT_ASSERT_VALUES_EQUAL(0, TAlignedPagePoolImpl<TFakeMmap>::GetGlobalPagePoolSize());
+    UNIT_ASSERT_VALUES_EQUAL(mmappedBefore - i64(pages * size), GetTotalMmapedBytes<TFakeMmap>());
+
+    // The reserved address space is reused instead of mapping a new region.
+    {
+        TAlignedPagePoolImpl<TFakeMmap> alloc(__LOCATION__);
+        auto* block = alloc.GetBlock(size);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, mmapper.MmapsSize());
+        UNIT_ASSERT_VALUES_EQUAL(pages + 1, mmapper.MadvisesSize());
+        UNIT_ASSERT_VALUES_EQUAL(block, mmapper.Madvises(pages).Addr);
+        UNIT_ASSERT(mmapper.Madvises(pages).Needed);
+        UNIT_ASSERT_VALUES_EQUAL(mmappedBefore - i64((pages - 1) * size), GetTotalMmapedBytes<TFakeMmap>());
+
+        alloc.ReturnBlock(block, size);
+    }
+}
+
+Y_UNIT_TEST(ReservedPagesAreReusableAfterCleanup) {
+    TAlignedPagePool::ResetGlobalsUT();
+
+    const auto size = 1024 * TAlignedPagePool::POOL_PAGE_SIZE;
+
+    void* first = nullptr;
+    {
+        TAlignedPagePoolImpl alloc(__LOCATION__);
+        first = alloc.GetBlock(size);
+        NYql::NUdf::SanitizerMakeRegionAccessible(first, size);
+        memset(first, 0x42, size);
+        alloc.ReturnBlock(first, size);
+    }
+    UNIT_ASSERT(TAlignedPagePool::GetGlobalPagePoolSize() >= size);
+
+    // The cached pages are given back to the OS, but their address space is kept for the reuse.
+    TAlignedPagePool::DoCleanupGlobalFreeList(0);
+    UNIT_ASSERT_VALUES_EQUAL(0, TAlignedPagePool::GetGlobalPagePoolSize());
+
+    {
+        TAlignedPagePoolImpl alloc(__LOCATION__);
+        auto* block = alloc.GetBlock(size);
+        UNIT_ASSERT_VALUES_EQUAL(first, block);
+
+        NYql::NUdf::SanitizerMakeRegionAccessible(block, size);
+        memset(block, 0x24, size);
+        alloc.ReturnBlock(block, size);
+    }
 }
 
 Y_UNIT_TEST(YellowZoneSwitchesCorrectlyBlock) {

--- a/yql/essentials/minikql/aligned_page_pool_ut.cpp
+++ b/yql/essentials/minikql/aligned_page_pool_ut.cpp
@@ -27,7 +27,7 @@ public:
         void* Addr;
         size_t Size;
         bool Needed;
-        bool operator==(const TMadviseEntry& rhs) {
+        bool operator==(const TMadviseEntry& rhs) const {
             return std::tie(Addr, Size, Needed) == std::tie(rhs.Addr, rhs.Size, rhs.Needed);
         }
     };


### PR DESCRIPTION
Since `munmap()` was replaced with `madvise(MADV_DONTNEED)` the address space of the pages evicted from the global pools is never reused: the mappings stay in place, so the page table (VmPTE) - and thus RSS - grows without bound for a long running process.

Restore the original `TSystemMmap::Munmap()` and introduce `TSystemMmap::Madvise(addr, size, needed)` instead. Whenever the provider supports it, `TGlobalPagePool::FreePage()` advises the page away and keeps it in the new `ReservedPages_` list, while `GetPage()` falls back to that list once the cache is empty, bringing the page back and reusing its address space instead of mapping a new region.

#52719

<img width="1040" height="680" alt="image" src="https://github.com/user-attachments/assets/8b86c6bd-6aad-41d3-b41c-f6c975c500a5" />

```
./kqprun -G 2735 -M 18765 --storage-path tpch100n --dedicated tpch100:8
```

```
./ydb -e ... -d /Root/tpch100 workload tpch run --scale 100 -c --include 9 --iterations N --threads N
```

Before Changes:

| | # | VmSize | VmRSS | VmData | VmPTE |
|---|---:|---:|---:|---:|---:|
|  Started | 1 | 21021248 | 12179860 | 18604212 | 28196 |
|  1 x Q9 | 2 | 69630536 | 29505704 | 66242740 | 122568 |
|  2 x Q9 | 3 | 102937192 | 35205092 | 99035188 | 184852 |
|  4 x Q9 | 4 | 147982316 | 42160392 | 142179764 | 269636 |
|  8 x Q9 | 5 | 250486256 | 46739948 | 238914484 | 458216 |
|  16 x Q9 | 6 | 512816112 | 50826496 | 490938804 | 952552 |
| 16 x Q9 | 7 | 678399376 | 51084124 | 655794996 | 1273980 |
| 16 x Q9 | 8 | 844737968 | 51253752 | 822133556 | 1599412 |
| 16 x Q9 | 9 | 1008087600 | 51151336 | 985044916 | 1916468 |

After Changes:

| | # | VmSize | VmRSS | VmData | VmPTE |
|---|---:|---:|---:|---:|---:|
| Started | 1 | 21021248 | 12290080 | 18708660 | 28420 |
| 1 x Q9 | 2 | 64956552 | 29731496 | 61564660 | 113280 |
| 2 x Q9 | 3 | 89027820 | 35912140 | 84290228 | 157220 |
| 4 x Q9 | 4 | 123958508 | 42381488 | 117772980 | 221884 |
| 8 x Q9 | 5 | 179820908 | 47123644 | 171564852 | 327132 |
| 16 x Q9 | 6 | 370838268 | 51087408 | 355829940 | 688520 |
| 16 x Q9 | 7 | 377888268 | 51311248 | 362879924 | 701932 |
| 16 x Q9 | 8 | 377888276 | 51706916 | 362879924 | 703536 |
| 16 x Q9 | 9 | 377888300 | 51334756 | 362879924 | 703560 |