### PR TITLE
Fix flaky KqpStreamingQueriesDdl.CreateAndAlterStreamingQuery

### DIFF
--- a/ydb/core/kqp/ut/federated_query/datastreams/streaming_ddl_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/streaming_ddl_ut.cpp
@@ -100,6 +100,16 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
         WriteTopicMessage(inputTopicName, R"({"key": "key1", "value": "value1"})");
         ReadTopicMessages(outputTopicName, {"key1value1"});
 
+        // Seeing the output only means the message was processed, not that its input offset
+        // is durable. ALTER with a changed query text cancels the running execution and the
+        // new one restores offsets from the last *completed* checkpoint, so an offset that is
+        // not checkpointed yet makes the message replay (at-least-once). Wait for two
+        // checkpoint updates: the first may belong to a checkpoint whose barrier was injected
+        // before the message was consumed, the second is guaranteed to be injected after it.
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+        WaitCheckpointUpdate(checkpointId);
+        WaitCheckpointUpdate(checkpointId);
+
         ExecQuery(fmt::format(R"(
             CREATE TABLE test_table2 (Key Int32 NOT NULL, PRIMARY KEY (Key));
             ALTER STREAMING QUERY `{query_name}` SET (


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Fixes #52335 (`success_rate 96%`, `f-3 / total-75`).

**The failure**

`common.cpp:446` — `expected #2 messages (key1value1, value2key2), got #3 messages (key1value1, value1key1, value2key2)`. The extra `value1key1` is the first message re-processed under the *post*-ALTER query text (`value || key`).

**Root cause**

The test writes one message, waits for its output, then runs `ALTER STREAMING QUERY ... SET (FORCE = TRUE)` with a changed query text and asserts the output topic holds exactly two messages.

Observing the output only means the message was *processed*, not that its input offset is *durable*. ALTER with a changed query text cancels the running execution, and the new execution restores input offsets from the last **completed** checkpoint (`from_last_checkpoint { force: true }`, `stateLoadMode=EMPTY`), so an offset that is not checkpointed yet makes the message replay.

That is intended at-least-once behaviour, not a product defect — `queries.cpp:3005` refuses a text change without `FORCE` precisely because *"Changing the query text will result in the loss of the checkpoint"*. The test asserted exactly-once across that boundary.

From the failing run's log:

| time (07:34:…) | event |
|---|---|
| 40.085 | checkpoint **1:5** task state saved (offset snapshot, pre-message) |
| 40.105 | checkpoint **1:5** completed — last completed checkpoint of generation 1 |
| ~40.106 | test observes `key1value1`, proceeds to ALTER |
| 40.192 | ALTER submitted |
| 40.287457 | checkpoint **1:6** barriers injected |
| **40.287501** | execution generation 1 cancelled — **44 µs later** |
| 40.539 | generation 2: `Will try to restore streaming offsets from checkpoint checkpointId=1:5` |

Checkpoint 1:6 — the one that would have recorded the message's offset — got as far as saving task state and never reached `PendingCommit`/`Completed`.

**Why ~4% and not rarer or constant**

The fixture uses `CheckpointPeriod = 200ms` (`common.h`), while the test's ALTER→cancel latency is ~180 ms. Since 180 < 200, the next checkpoint lands after the cancel *unless* the message happened to be consumed ≳20 ms into a checkpoint window — a ~10% upper bound, observed 4%.

**The fix**

Wait for a durable checkpoint before the ALTER. Two updates are needed: the first may belong to a checkpoint whose barrier was injected *before* the message was consumed and merely completed afterwards; the second is guaranteed to be injected after it, since checkpoints are registered sequentially (in the failing log 1:6 was registered at 40.276, only after 1:5 completed at 40.105).

The sibling test `StreamingQueryTextChangeWithCreateOrReplace` runs the same scenario and already guards this hazard with `Sleep(TDuration::Seconds(2)); // Wait for checkpoint`. This change uses the existing `WaitCheckpointUpdate` helper instead, so the guard is deterministic rather than a wider race. Cost is ~2 s of wall time (the helper polls at a 1 s interval), the same price sibling tests already pay.

**Notes for reviewers**

* This race is **long-standing**, not a recent regression: the test body is byte-identical to the version from 2026-08-18 and `CheckpointPeriod = 200ms` was already in place then. The "first flake 2026-09-03" in the issue is just the left edge of the 4-day Datalens window. The automated analysis on the issue names #51600 as the introducing PR; I don't think that holds up.
* `.github/config/muted_ya.txt` is **not** touched — per `mute_rules.md` unmuting is bot-driven (close the issue as *Completed* to trigger fast-unmute). Note line 12 also mutes the whole `datastreams` chunk, so the test will not run in this PR's CI regardless.
* **Not built or run locally** — a build for this target takes hours on my machine. Review accordingly.
