### PR TITLE
fix producer and distributed lock namespaces

### DIFF
--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed topic producer and distributed lock namespaces to make their ABI consistent between GCC and Clang.
+
 * Added `EQ_HEIGHT_HISTOGRAM` to `EMultiColumnStatisticsType`.
 
 # v3.22.0

--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -1,5 +1,3 @@
-* Fixed topic producer and distributed lock namespaces to make their ABI consistent between GCC and Clang.
-
 * Added `EQ_HEIGHT_HISTOGRAM` to `EMultiColumnStatisticsType`.
 
 # v3.22.0

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/coordination/distributed_lock.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/coordination/distributed_lock.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/coordination/coordination.h>
 #include <stop_token>
-namespace NYdb {
+namespace NYdb::inline Dev {
 namespace NCoordination {
     struct TYdbLockException : public TYdbException {
         TYdbLockException(const std::string& message) : TYdbException(message) {}

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/producer.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/producer.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <utility>
 
-namespace NYdb::NTopic {
+namespace NYdb::inline Dev::NTopic {
 
 struct TProducerSettings : public TWriteSessionSettings {
     using TSelf = TProducerSettings;
@@ -199,4 +199,4 @@ private:
     std::shared_ptr<IProducer> Impl_;
 };
 
-} // namespace NYdb::NTopic
+} // namespace NYdb::inline Dev::NTopic

--- a/ydb/public/sdk/cpp/src/client/coordination/distributed_lock.cpp
+++ b/ydb/public/sdk/cpp/src/client/coordination/distributed_lock.cpp
@@ -4,7 +4,7 @@
 
 #include <mutex>
 
-namespace NYdb {
+namespace NYdb::inline Dev {
 namespace NCoordination {
     struct TDistributedLock::TImpl {
         struct TLockState {


### PR DESCRIPTION
### Description for reviewers

Add missing `inline Dev` namespaces so Clang consumers link against the GCC-built SDK.
