### PR TITLE
Sdk operations cancellation token

### DIFF
--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Added optional `TRetryOperationSettings::StopToken` for cooperative cancellation between retry attempts.
+* Made `BulkUpsert` use the shared retry policy from the first attempt, including backoff before its first retry.
 
 * Added `EQ_HEIGHT_HISTOGRAM` to `EMultiColumnStatisticsType`.
 

--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added optional `TRetryOperationSettings::StopToken` for cooperative cancellation between retry attempts.
+
 * Added `EQ_HEIGHT_HISTOGRAM` to `EMultiColumnStatisticsType`.
 
 # v3.22.0

--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -1,5 +1,4 @@
 * Added optional `TRetryOperationSettings::StopToken` for cooperative cancellation between retry attempts.
-* Made `BulkUpsert` use the shared retry policy from the first attempt, including backoff before its first retry.
 
 * Added `EQ_HEIGHT_HISTOGRAM` to `EMultiColumnStatisticsType`.
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h
@@ -16,11 +16,11 @@ namespace NYdb::inline Dev {
     class TProtoAccessor;
 
     namespace NRetry::Async {
-        template <typename TClient, typename TAsyncStatusType>
+        template <typename TClient, typename TOperation, bool WithSession>
         class TRetryContext;
     } // namespace NRetry::Async
     namespace NRetry::Sync {
-        template <typename TClient, typename TStatusType>
+        template <typename TClient, typename TOperation, bool WithSession>
         class TRetryContext;
     } // namespace NRetry::Sync
     namespace NRetry {
@@ -73,11 +73,10 @@ struct TClientSettings : public TCommonClientSettingsBase<TClientSettings> {
 
 class TQueryClient {
     friend class TSession;
-    friend class NRetry::Async::TRetryContext<TQueryClient, TAsyncExecuteQueryResult>;
-    friend class NRetry::Async::TRetryContext<TQueryClient, TAsyncStatus>;
-    friend class NRetry::Async::TRetryContext<TQueryClient, NThreading::TFuture<TScriptExecutionOperation>>;
-    friend class NRetry::Async::TRetryContext<TQueryClient, TAsyncFetchScriptResultsResult>;
-    friend class NRetry::Sync::TRetryContext<TQueryClient, TStatus>;
+    template <typename, typename, bool>
+    friend class NRetry::Async::TRetryContext;
+    template <typename, typename, bool>
+    friend class NRetry::Sync::TRetryContext;
 
 public:
     using TQueryResultFunc = std::function<TAsyncExecuteQueryResult(TSession session)>;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/retry/retry.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/retry/retry.h
@@ -3,6 +3,9 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/fluent_settings_helpers.h>
 #include <util/datetime/base.h>
 
+#include <optional>
+#include <stop_token>
+
 namespace NYdb::inline Dev::NRetry {
 
 struct TBackoffSettings {
@@ -31,6 +34,10 @@ struct TRetryOperationSettings {
     }
     FLUENT_SETTING_FLAG(Verbose);
     FLUENT_SETTING_FLAG(RetryUndefined);
+
+    // Checked before attempts, after backoff, and after attempts complete.
+    // Does not interrupt backoff or cancel an active RPC.
+    FLUENT_SETTING_OPTIONAL(std::stop_token, StopToken);
 
     static TBackoffSettings DefaultFastBackoffSettings() {
         return TBackoffSettings()

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -55,13 +55,13 @@ class LocalBloomNgramFilterIndex;
 namespace NYdb::inline Dev {
 
 namespace NRetry::Async {
-template <typename TClient, typename TStatusType>
-class TRetryContext;
+    template <typename TClient, typename TOperation, bool WithSession>
+    class TRetryContext;
 } // namespace NRetry::Async
 
 namespace NRetry::Sync {
-template <typename TClient, typename TStatusType>
-class TRetryContext;
+    template <typename TClient, typename TOperation, bool WithSession>
+    class TRetryContext;
 } // namespace NRetry::Sync
 
 namespace NRetry {
@@ -1677,13 +1677,13 @@ enum class EDataFormat {
 };
 
 class TTableClient {
+    template <typename, typename, bool>
+    friend class NRetry::Async::TRetryContext;
+    template <typename, typename, bool>
+    friend class NRetry::Sync::TRetryContext;
     friend class TSession;
     friend class TTransaction;
     friend class TSessionPool;
-    friend class NRetry::Sync::TRetryContext<TTableClient, TStatus>;
-    friend class NRetry::Async::TRetryContext<TTableClient, TAsyncStatus>;
-    friend class NRetry::Async::TRetryContext<TTableClient, TAsyncBulkUpsertResult>;
-    friend class NRetry::Async::TRetryContext<TTableClient, TAsyncReadRowsResult>;
 
 public:
     using TOperationFunc = std::function<TAsyncStatus(TSession session)>;

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.cpp
@@ -1,49 +1,48 @@
 #include "retry.h"
 
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/retry/retry.h>
-
-#include <ydb/public/sdk/cpp/src/client/common_client/impl/iface.h>
-
 #include <util/random/random.h>
 
-#include <thread>
+#include <algorithm>
 
 namespace NYdb::inline Dev::NRetry {
 
-using TBackoffDuration = std::chrono::duration<double, std::micro>;
+    TRetryDecision GetRetryDecision(EStatus status, const TRetryOperationSettings& settings) {
+        switch (status) {
+            case EStatus::SUCCESS:
+            case EStatus::CLIENT_CANCELLED:
+                return {NextStep::Finish};
+            case EStatus::ABORTED:
+                return {NextStep::RetryImmediately};
+            case EStatus::OVERLOADED:
+            case EStatus::CLIENT_RESOURCE_EXHAUSTED:
+                return {NextStep::RetrySlowBackoff};
+            case EStatus::UNAVAILABLE:
+                return {NextStep::RetryFastBackoff};
+            case EStatus::BAD_SESSION:
+            case EStatus::SESSION_BUSY:
+                return {NextStep::RetryImmediately, true};
+            case EStatus::NOT_FOUND:
+                return {settings.RetryNotFound_ ? NextStep::RetryImmediately : NextStep::Finish};
+            case EStatus::UNDETERMINED:
+            case EStatus::TRANSPORT_UNAVAILABLE:
+                return {settings.Idempotent_ ? NextStep::RetryFastBackoff : NextStep::Finish,
+                        settings.Idempotent_ && status == EStatus::TRANSPORT_UNAVAILABLE};
+            case EStatus::CLIENT_DEADLINE_EXCEEDED:
+                return {settings.RetryUndefined_ ? NextStep::RetrySlowBackoff : NextStep::Finish, true};
+            default:
+                return {settings.RetryUndefined_ ? NextStep::RetrySlowBackoff : NextStep::Finish};
+        }
+    }
 
-constexpr TBackoffDuration MAX_BACKOFF_DURATION = std::chrono::hours(1);
+    std::chrono::microseconds CalcBackoffTime(const TBackoffSettings& settings, std::uint32_t retryNumber) {
+        using TBackoffDuration = std::chrono::duration<double, std::micro>;
+        constexpr TBackoffDuration maxBackoff = std::chrono::hours(1);
+        const std::uint32_t slots = 1 << std::min(retryNumber, settings.Ceiling_);
+        const TBackoffDuration maxDuration(settings.SlotDuration_.MicroSeconds() * slots);
+        const double uncertainty = std::clamp(settings.UncertainRatio_, 0.0, 1.0);
+        const double multiplier = RandomNumber<double>() * uncertainty - uncertainty + 1.0;
+        return std::chrono::duration_cast<std::chrono::microseconds>(
+            std::clamp(maxDuration * multiplier, TBackoffDuration::zero(), maxBackoff));
+    }
 
-namespace {
-
-TBackoffDuration CalcBackoffTime(const TBackoffSettings& settings, std::uint32_t retryNumber) {
-    std::uint32_t backoffSlots = 1 << std::min(retryNumber, settings.Ceiling_);
-    TBackoffDuration maxDuration(settings.SlotDuration_.MicroSeconds() * backoffSlots);
-
-    double uncertaintyRatio = std::max(std::min(settings.UncertainRatio_, 1.0), 0.0);
-    double uncertaintyMultiplier = RandomNumber<double>() * uncertaintyRatio - uncertaintyRatio + 1.0;
-
-    return std::max(std::min(maxDuration * uncertaintyMultiplier, MAX_BACKOFF_DURATION), TBackoffDuration::zero());
-}
-
-}
-
-std::chrono::microseconds Backoff(const NRetry::TBackoffSettings& settings, std::uint32_t retryNumber) {
-    const auto duration = CalcBackoffTime(settings, retryNumber);
-    std::this_thread::sleep_for(duration);
-    return std::chrono::duration_cast<std::chrono::microseconds>(duration);
-}
-
-std::chrono::microseconds AsyncBackoff(std::shared_ptr<IClientImplCommon> client, const TBackoffSettings& settings,
-    std::uint32_t retryNumber, std::function<void(std::chrono::microseconds)> fn)
-{
-    const auto duration = CalcBackoffTime(settings, retryNumber);
-    const auto durationMicro = std::chrono::duration_cast<std::chrono::microseconds>(duration);
-    client->ScheduleTask(
-        [fn = std::move(fn), durationMicro]() { fn(durationMicro); },
-        std::chrono::duration_cast<TDeadline::Duration>(duration)
-    );
-    return durationMicro;
-}
-
-}
+} // namespace NYdb::inline Dev::NRetry

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.h
@@ -1,194 +1,298 @@
 #pragma once
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/retry/retry.h>
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/fluent_settings_helpers.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status/status.h>
-
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/time/time.h>
+#include <ydb/public/sdk/cpp/src/client/impl/observability/span.h>
 
-#include <library/cpp/threading/future/core/fwd.h>
-#include <util/datetime/base.h>
+#include <library/cpp/threading/future/future.h>
+#include <util/generic/function.h>
 #include <util/generic/ptr.h>
-#include <util/system/types.h>
 #include <util/string/cast.h>
+#include <util/system/type_name.h>
 
+#include <chrono>
+#include <cstdint>
+#include <exception>
 #include <functional>
+#include <iostream>
 #include <memory>
+#include <optional>
 #include <type_traits>
-
-namespace NYdb::inline Dev {
-class IClientImplCommon;
-}
+#include <utility>
 
 namespace NYdb::inline Dev::NRetry {
 
-std::chrono::microseconds Backoff(const NRetry::TBackoffSettings& settings, std::uint32_t retryNumber);
-std::chrono::microseconds AsyncBackoff(std::shared_ptr<IClientImplCommon> client, const TBackoffSettings& settings,
-    std::uint32_t retryNumber, std::function<void(std::chrono::microseconds)> fn);
+    enum class NextStep {
+        RetryImmediately,
+        RetryFastBackoff,
+        RetrySlowBackoff,
+        Finish,
+    };
 
-enum class NextStep {
-    RetryImmediately,
-    RetryFastBackoff,
-    RetrySlowBackoff,
-    Finish,
-};
+    struct TRetryDecision {
+        NextStep Step;
+        bool ResetSession = false;
+    };
 
-inline bool ShouldRetryStatus(EStatus status, const TRetryOperationSettings& settings) {
-    switch (status) {
-        case EStatus::ABORTED:
-        case EStatus::OVERLOADED:
-        case EStatus::CLIENT_RESOURCE_EXHAUSTED:
-        case EStatus::UNAVAILABLE:
-        case EStatus::BAD_SESSION:
-        case EStatus::SESSION_BUSY:
-            return true;
-        case EStatus::NOT_FOUND:
-            return settings.RetryNotFound_;
-        case EStatus::UNDETERMINED:
-        case EStatus::TRANSPORT_UNAVAILABLE:
-            return settings.Idempotent_;
-        default:
-            return settings.RetryUndefined_;
+    TRetryDecision GetRetryDecision(EStatus status, const TRetryOperationSettings& settings);
+    std::chrono::microseconds CalcBackoffTime(const TBackoffSettings& settings, std::uint32_t retryNumber);
+
+    inline bool ShouldRetryStatus(EStatus status, const TRetryOperationSettings& settings) {
+        return GetRetryDecision(status, settings).Step != NextStep::Finish;
     }
-}
 
-class TRetryContextBase : TNonCopyable {
-protected:
-    TRetryOperationSettings Settings_;
-    std::uint32_t RetryNumber_;
-    TInstant RetryStartTime_;
+    template <typename TResult>
+    TResult MakeRetryResultFromStatus(TStatus status) {
+        return TResult(std::move(status));
+    }
 
-protected:
-    TRetryContextBase(const TRetryOperationSettings& settings)
-        : Settings_(settings)
-        , RetryNumber_(0)
-        , RetryStartTime_(TInstant::Now())
-    {}
-
-    virtual void Reset() {}
-
-    void LogRetry(const TStatus& status) {
-        if (Settings_.Verbose_) {
-            std::cerr << "Previous query attempt was finished with unsuccessful status "
-                << ToString(status.GetStatus()) << ": " << status.GetIssues().ToString(true) << std::endl;
-            std::cerr << "Sending retry attempt " << RetryNumber_ << " of " << Settings_.MaxRetries_ << std::endl;
+    template <typename TResult>
+    const TStatus& GetRetryStatus(const TResult& result) {
+        if constexpr (std::is_base_of_v<TStatus, TResult>) {
+            return result;
+        } else {
+            return result.Status();
         }
     }
 
-    NextStep GetNextStep(const TStatus& status) {
-        if (status.IsSuccess()) {
-            return NextStep::Finish;
+    template <typename TResult>
+    EStatus GetRetryStatusCode(const TResult& result) {
+        return GetRetryStatus(result).GetStatus();
+    }
+
+    template <typename TClient>
+    class TRetryDeadlineHelper {
+    public:
+        static void SetDeadline(typename TClient::TSession& session, const TDeadline& deadline) {
+            session.SetPropagatedDeadline(deadline);
         }
-        if (RetryNumber_ >= Settings_.MaxRetries_) {
-            return NextStep::Finish;
+    };
+
+    template <typename TClient>
+    class TInRetryOperationContextClientGuard {
+    public:
+        explicit TInRetryOperationContextClientGuard(TClient& client)
+            : Client_(client)
+            , Previous_(client.GetInRetryOperationContext())
+        {
+            Client_.SetInRetryOperationContext(true);
         }
-        if (TInstant::Now() - RetryStartTime_ >= Settings_.MaxTimeout_) {
-            return NextStep::Finish;
+
+        ~TInRetryOperationContextClientGuard() {
+            Client_.SetInRetryOperationContext(Previous_);
         }
-        switch (status.GetStatus()) {
-            case EStatus::ABORTED:
-                return NextStep::RetryImmediately;
 
-            case EStatus::OVERLOADED:
-            case EStatus::CLIENT_RESOURCE_EXHAUSTED:
-                return NextStep::RetrySlowBackoff;
+    private:
+        TClient& Client_;
+        bool Previous_;
+    };
 
-            case EStatus::UNAVAILABLE:
-                return NextStep::RetryFastBackoff;
+    // The same session acquisition and operation dispatch serve both execution modes.
+    template <typename TClient, bool WithSession>
+    struct TRetrySessionState {
+        void Reset() {
+        }
 
-            case EStatus::BAD_SESSION:
-            case EStatus::SESSION_BUSY:
-                Reset();
-                return NextStep::RetryImmediately;
+        template <typename TContext, typename F>
+        void Execute(TContext& context, F&& operation) {
+            operation(context.GetClient());
+        }
+    };
 
-            case EStatus::NOT_FOUND:
-                if (Settings_.RetryNotFound_) {
-                    return NextStep::RetryImmediately;
-                } else {
-                    return NextStep::Finish;
+    template <typename TClient>
+    struct TRetrySessionState<TClient, true> {
+        std::optional<typename TClient::TSession> Session;
+
+        void Reset() {
+            Session.reset();
+        }
+
+        template <typename TContext, typename F>
+        void Execute(TContext& context, F operation) {
+            if (Session) {
+                operation(*Session);
+                return;
+            }
+            auto settings = typename TClient::TCreateSessionSettings();
+            settings.ClientTimeout(context.GetSettings().GetSessionClientTimeout_).Deadline(context.GetDeadline());
+            context.Await(context.GetClient().GetSession(settings),
+                          [this, &context, operation = std::move(operation)](const auto& result) mutable {
+                              if (!result.IsSuccess()) {
+                                  context.OnAttemptReady(MakeRetryResultFromStatus<typename TContext::TStatusType>(TStatus(result)));
+                                  return;
+                              }
+                              Session = result.GetSession();
+                              TRetryDeadlineHelper<TClient>::SetDeadline(*Session, context.GetDeadline());
+                              if (!context.FinishIfStopped()) {
+                                  operation(*Session);
+                              }
+                          });
+        }
+    };
+
+    // Child hooks: ExecuteImpl, WaitAndExecute, StopRequested, GetRetryDelay, OnReady.
+    template <typename TDerived, typename TResult>
+    class TRetryContextBase: TNonCopyable {
+    public:
+        explicit TRetryContextBase(const TRetryOperationSettings& settings)
+            : Settings_(settings)
+            , Deadline_(TDeadline::AfterDuration(settings.MaxTimeout_))
+        {
+        }
+
+        const TRetryOperationSettings& GetSettings() const {
+            return Settings_;
+        }
+
+        const TDeadline& GetDeadline() const {
+            return Deadline_;
+        }
+
+        bool IsFinished() const {
+            return Finished_;
+        }
+
+        bool FinishIfStopped() {
+            if (!Finished_ && Child().StopRequested()) {
+                Finish(MakeRetryResultFromStatus<TResult>(TStatus(EStatus::CLIENT_CANCELLED, NIssue::TIssues{})));
+            }
+            return Finished_;
+        }
+
+    protected:
+        void Start() {
+            Guarded([&] {
+                ParentSpan_ = Child().GetClientImpl()->CreateRetryRootSpan();
+                RetryStartTime_ = TInstant::Now();
+                RunAttempt();
+            });
+        }
+
+        void DoNext(TResult result) {
+            if (Finished_) {
+                return;
+            }
+            const auto& status = GetRetryStatus(result);
+            EndAttemptSpan(status.GetStatus());
+            if (FinishIfStopped()) {
+                return;
+            }
+            if (status.IsSuccess() || RetryNumber_ >= Settings_.MaxRetries_ || TInstant::Now() - RetryStartTime_ >= Settings_.MaxTimeout_) {
+                Finish(std::move(result));
+                return;
+            }
+            const auto decision = GetRetryDecision(status.GetStatus(), Settings_);
+            if (decision.ResetSession) {
+                Child().ResetSession();
+            }
+            if (decision.Step == NextStep::Finish) {
+                Finish(std::move(result));
+                return;
+            }
+            const auto delay = Child().GetRetryDelay(decision.Step);
+            ++RetryNumber_;
+            Child().CollectRetryStat(status.GetStatus());
+            if (Settings_.Verbose_) {
+                std::cerr << "Previous query attempt was finished with unsuccessful status "
+                          << ToString(status.GetStatus()) << ": " << status.GetIssues().ToString(true) << std::endl;
+                std::cerr << "Sending retry attempt " << RetryNumber_ << " of " << Settings_.MaxRetries_ << std::endl;
+            }
+            LastBackoffMs_ = std::chrono::duration_cast<std::chrono::milliseconds>(delay).count();
+            Child().WaitAndExecute(delay, [this] { RunAttempt(); });
+        }
+
+        std::chrono::microseconds GetRetryDelay(NextStep step, std::uint32_t retryNumber) const {
+            if (step == NextStep::RetryImmediately) {
+                return {};
+            }
+            return CalcBackoffTime(step == NextStep::RetryFastBackoff
+                                       ? Settings_.FastBackoffSettings_
+                                       : Settings_.SlowBackoffSettings_, retryNumber);
+        }
+
+        template <typename TOperation, typename TTarget>
+        auto InvokeOperation(TOperation& operation, TTarget& target) {
+            TInRetryOperationContextClientGuard guard(Child().GetClient());
+            if constexpr (TFunctionArgs<std::decay_t<TOperation>>::Length == 1) {
+                return operation(target);
+            } else {
+                return operation(target, Settings_.MaxTimeout_ - (TInstant::Now() - RetryStartTime_));
+            }
+        }
+
+        template <typename F>
+        void Guarded(F&& fn) {
+            try {
+                [[maybe_unused]] auto scope = AttemptSpan_ ? AttemptSpan_->Activate() : nullptr;
+                fn();
+            } catch (const NStatusHelpers::TYdbRangeErrorException& e) {
+                Child().OnAttemptReady(MakeRetryResultFromStatus<TResult>(TStatus(e.GetStatus())));
+            } catch (...) {
+                Finish(std::current_exception());
+            }
+        }
+
+        TRetryOperationSettings Settings_;
+        std::uint32_t RetryNumber_ = 0;
+
+    private:
+        TDerived& Child() {
+            return static_cast<TDerived&>(*this);
+        }
+
+        void RunAttempt() {
+            Guarded([&] {
+                if (FinishIfStopped()) {
+                    return;
                 }
-
-            case EStatus::UNDETERMINED:
-                if (Settings_.Idempotent_) {
-                    return NextStep::RetryFastBackoff;
-                } else {
-                    return NextStep::Finish;
-                }
-
-            case EStatus::TRANSPORT_UNAVAILABLE:
-                if (Settings_.Idempotent_) {
-                    Reset();
-                    return NextStep::RetryFastBackoff;
-                } else {
-                    return NextStep::Finish;
-                }
-
-            case EStatus::CLIENT_DEADLINE_EXCEEDED:
-                Reset();
-                [[fallthrough]];
-            default:
-                return Settings_.RetryUndefined_ ? NextStep::RetrySlowBackoff : NextStep::Finish;
+                [[maybe_unused]] auto parentScope = ParentSpan_ ? ParentSpan_->Activate() : nullptr;
+                AttemptSpan_ = Child().GetClientImpl()->CreateRetryAttemptSpan(RetryNumber_, LastBackoffMs_, ParentSpan_);
+                [[maybe_unused]] auto attemptScope = AttemptSpan_ ? AttemptSpan_->Activate() : nullptr;
+                Child().ExecuteImpl();
+            });
         }
-    }
 
-    TDuration GetRemainingTimeout() {
-        return Settings_.MaxTimeout_ - (TInstant::Now() - RetryStartTime_);
-    }
-};
+        void EndAttemptSpan(EStatus status) {
+            if (auto span = std::exchange(AttemptSpan_, nullptr)) {
+                span->End(status);
+            }
+        }
 
-template <typename TStatusType>
-TStatusType MakeRetryResultFromStatus(TStatus&& status) {
-    return TStatusType(TStatus(std::move(status)));
-}
+        template <typename T>
+        void Finish(T&& result) {
+            if (std::exchange(Finished_, true)) {
+                return;
+            }
+            if (ParentSpan_) {
+                ParentSpan_->SetRetryCount(RetryNumber_);
+            }
+            if constexpr (std::is_same_v<std::decay_t<T>, std::exception_ptr>) {
+                EndAttemptSpan(EStatus::CLIENT_INTERNAL_ERROR);
+                if (ParentSpan_) {
+                    try {
+                        std::rethrow_exception(result);
+                    } catch (const std::exception& e) {
+                        ParentSpan_->EndWithException(TypeName(e).c_str(), e.what());
+                    } catch (...) {
+                        ParentSpan_->EndWithException("unknown", "unknown exception");
+                    }
+                }
+            } else {
+                EndAttemptSpan(GetRetryStatusCode(result));
+                if (ParentSpan_) {
+                    ParentSpan_->End(GetRetryStatusCode(result));
+                }
+            }
+            Child().OnReady(std::forward<T>(result));
+        }
 
-template <typename TStatusType, typename F>
-TStatusType InvokeWithRangeErrorCatch(F&& f) {
-    try {
-        return f();
-    } catch (const NStatusHelpers::TYdbRangeErrorException& e) {
-        return MakeRetryResultFromStatus<TStatusType>(TStatus(e.GetStatus()));
-    }
-}
+        const TDeadline Deadline_;
+        TInstant RetryStartTime_;
+        std::shared_ptr<NObservability::TRequestSpan> ParentSpan_;
+        std::shared_ptr<NObservability::TRequestSpan> AttemptSpan_;
+        std::int64_t LastBackoffMs_ = 0;
+        bool Finished_ = false;
+    };
 
-template<typename TClient>
-class TRetryDeadlineHelper {
-public:
-    static void SetDeadline(TClient::TSession& session, const TDeadline& deadline) {
-        session.SetPropagatedDeadline(deadline);
-    }
-};
-
-template<typename TClient>
-class TInRetryOperationContextClientGuard {
-public:
-    explicit TInRetryOperationContextClientGuard(TClient& client)
-        : Client_(client)
-        , Previous_(client.GetInRetryOperationContext())
-    {
-        Client_.SetInRetryOperationContext(true);
-    }
-
-    ~TInRetryOperationContextClientGuard() {
-        Client_.SetInRetryOperationContext(Previous_);
-    }
-
-private:
-    TClient& Client_;
-    bool Previous_;
-};
-
-template<typename TStatusType>
-const TStatus& GetRetryStatus(const TStatusType& status) {
-    if constexpr (std::is_base_of_v<TStatus, std::decay_t<TStatusType>>) {
-        return status;
-    } else {
-        return status.Status();
-    }
-}
-
-template<typename TStatusType>
-EStatus GetRetryStatusCode(const TStatusType& status) {
-    return GetRetryStatus(status).GetStatus();
-}
-
-} // namespace NYdb::NRetry
+} // namespace NYdb::inline Dev::NRetry

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_async.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_async.h
@@ -1,262 +1,99 @@
 #pragma once
 
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status/status.h>
-
 #include <ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.h>
-#include <ydb/public/sdk/cpp/src/client/impl/observability/span.h>
-
-#include <util/generic/function.h>
-#include <util/system/type_name.h>
-
-#include <chrono>
-#include <cstdint>
-#include <exception>
-#include <memory>
-#include <typeinfo>
 
 namespace NYdb::inline Dev::NRetry::Async {
 
-template <typename TClient, typename TAsyncStatusType>
-class TRetryContext : public TThrRefBase, public TRetryContextBase {
-public:
-    using TStatusType = typename TAsyncStatusType::value_type;
-    using TPtr = TIntrusivePtr<Async::TRetryContext<TClient, TAsyncStatusType>>;
+    template <typename TClient, typename TOperation, bool WithSession>
+    class TRetryContext: public TThrRefBase,
+                         public TRetryContextBase<TRetryContext<TClient, TOperation, WithSession>, typename TFunctionResult<TOperation>::value_type> {
+        using TBase = TRetryContextBase<TRetryContext, typename TFunctionResult<TOperation>::value_type>;
 
-protected:
-    TClient Client_;
-    NThreading::TPromise<TStatusType> Promise_;
+    public:
+        using TAsyncStatusType = TFunctionResult<TOperation>;
+        using TStatusType = typename TAsyncStatusType::value_type;
+        using TPtr = TIntrusivePtr<TRetryContext>;
 
-public:
-    TAsyncStatusType Execute() {
-        ParentSpan_ = Client_.Impl_->CreateRetryRootSpan();
+        TRetryContext(const TClient& client, TOperation operation, const TRetryOperationSettings& settings)
+            : TBase(settings)
+            , Client_(client)
+            , Operation_(std::move(operation))
+        {
+        }
 
-        this->RetryStartTime_ = TInstant::Now();
-        TPtr self(this);
-        DoRetry(self);
+        TAsyncStatusType Execute() {
+            TPtr self(this);
+            auto future = Promise_.GetFuture();
+            this->Start();
+            return future;
+        }
 
-        return this->Promise_.GetFuture().Apply(
-            [self](const auto& f) mutable {
-                try {
-                    auto value = f.GetValue();
-                    if (self->ParentSpan_) {
-                        self->ParentSpan_->SetRetryCount(self->RetryNumber_);
-                        self->ParentSpan_->End(GetRetryStatusCode(value));
-                    }
-                    return value;
-                } catch (...) {
-                    if (self->ParentSpan_) {
-                        self->ParentSpan_->SetRetryCount(self->RetryNumber_);
-                        try {
-                            std::rethrow_exception(std::current_exception());
-                        } catch (const std::exception& e) {
-                            self->ParentSpan_->EndWithException(TypeName(e).c_str(), e.what());
-                        } catch (...) {
-                            self->ParentSpan_->EndWithException("unknown", "unknown exception");
-                        }
-                    }
-                    throw;
-                }
-            }
-        );
-    }
-
-protected:
-    explicit TRetryContext(const TClient& client, const TRetryOperationSettings& settings)
-        : TRetryContextBase(settings)
-        , Client_(client)
-        , Promise_(NThreading::NewPromise<TStatusType>())
-    {}
-
-    virtual void Retry() = 0;
-
-    virtual TAsyncStatusType RunOperation() = 0;
-
-    static void DoRetry(TPtr self) {
-        [[maybe_unused]] auto parentScope = self->ParentSpan_ ? self->ParentSpan_->Activate() : nullptr;
-
-        self->StartAttemptSpan();
-
-        [[maybe_unused]] auto attemptScope = self->AttemptSpan_ ? self->AttemptSpan_->Activate() : nullptr;
-        self->Retry();
-    }
-
-    static void DoBackoff(TPtr self, bool fast) {
-        auto backoffSettings = fast ? self->Settings_.FastBackoffSettings_
-                                    : self->Settings_.SlowBackoffSettings_;
-        AsyncBackoff(self->Client_.Impl_, backoffSettings, self->RetryNumber_,
-            [self](std::chrono::microseconds backoff) {
-                self->LastBackoffMs_ =
-                    std::chrono::duration_cast<std::chrono::milliseconds>(backoff).count();
-                DoRetry(self);
+        void ExecuteImpl() {
+            Session_.Execute(*this, [this](auto& target) {
+                Await(this->InvokeOperation(Operation_, target), [this](const auto& result) { OnAttemptReady(result); });
             });
-    }
-
-    static void HandleExceptionAsync(TPtr self, std::exception_ptr e) {
-        self->EndAttemptSpan(EStatus::CLIENT_INTERNAL_ERROR);
-        self->Promise_.SetException(e);
-    }
-
-    static void HandleStatusAsync(TPtr self, const TStatusType& status) {
-        const TStatus& retryStatus = GetRetryStatus(status);
-        self->EndAttemptSpan(retryStatus.GetStatus());
-        auto nextStep = self->GetNextStep(retryStatus);
-        if (nextStep != NextStep::Finish) {
-            self->RetryNumber_++;
-            self->Client_.Impl_->CollectRetryStatAsync(retryStatus.GetStatus());
-            self->LogRetry(retryStatus);
         }
-        switch (nextStep) {
-            case NextStep::RetryImmediately:
-                self->LastBackoffMs_ = 0;
-                return DoRetry(self);
-            case NextStep::RetryFastBackoff:
-                return DoBackoff(self, true);
-            case NextStep::RetrySlowBackoff:
-                return DoBackoff(self, false);
-            case NextStep::Finish:
-                return self->Promise_.SetValue(status);
+
+        void WaitAndExecute(std::chrono::microseconds delay, std::function<void()> fn) {
+            Client_.Impl_->ScheduleTask([self = TPtr(this), fn = std::move(fn)] { fn(); },
+                                        std::chrono::duration_cast<TDeadline::Duration>(delay));
         }
-    }
 
-    static void DoRunOperation(TPtr self) {
-        try {
-            self->RunOperation().Subscribe(
-                [self](const TAsyncStatusType& result) {
-                    [[maybe_unused]] auto attemptScope = self->ActivateAttemptSpan();
-                    try {
-                        HandleStatusAsync(self, result.GetValue());
-                    } catch (const NStatusHelpers::TYdbRangeErrorException& e) {
-                        HandleStatusAsync(self, MakeRetryResultFromStatus<TStatusType>(TStatus(e.GetStatus())));
-                    } catch (...) {
-                        HandleExceptionAsync(self, std::current_exception());
-                    }
-                }
-            );
-        } catch (const NStatusHelpers::TYdbRangeErrorException& e) {
-            HandleStatusAsync(self, MakeRetryResultFromStatus<TStatusType>(TStatus(e.GetStatus())));
-        } catch (...) {
-            HandleExceptionAsync(self, std::current_exception());
+        template <typename T, typename F>
+        void Await(NThreading::TFuture<T> future, F fn) {
+            future.Subscribe([self = TPtr(this), fn = std::move(fn)](const auto& result) mutable {
+                self->Guarded([&] { fn(result.GetValue()); });
+            });
         }
-    }
 
-protected:
-    std::unique_ptr<NTrace::IScope> ActivateAttemptSpan() {
-        return AttemptSpan_ ? AttemptSpan_->Activate() : nullptr;
-    }
-
-private:
-    void StartAttemptSpan() {
-        AttemptSpan_ = Client_.Impl_->CreateRetryAttemptSpan(
-            this->RetryNumber_, LastBackoffMs_, ParentSpan_);
-    }
-
-    void EndAttemptSpan(EStatus status) {
-        if (AttemptSpan_) {
-            AttemptSpan_->End(status);
-            AttemptSpan_.reset();
+        bool StopRequested() const {
+            return this->Settings_.StopToken_ && this->Settings_.StopToken_->stop_requested();
         }
-    }
 
-    std::shared_ptr<NObservability::TRequestSpan> ParentSpan_;
-    std::shared_ptr<NObservability::TRequestSpan> AttemptSpan_;
-    std::int64_t LastBackoffMs_ = 0;
-};
-
-template <typename TClient, typename TOperation, typename TAsyncStatusType = TFunctionResult<TOperation>>
-class TRetryWithoutSession : public TRetryContext<TClient, TAsyncStatusType> {
-    using TRetryContext = TRetryContext<TClient, TAsyncStatusType>;
-    using TPtr = typename TRetryContext::TPtr;
-
-private:
-    TOperation Operation_;
-
-public:
-    explicit TRetryWithoutSession(
-        const TClient& client, TOperation&& operation, const TRetryOperationSettings& settings)
-        : TRetryContext(client, settings)
-        , Operation_(operation)
-    {}
-
-    void Retry() override {
-        TPtr self(this);
-        TRetryContext::DoRunOperation(self);
-    }
-
-protected:
-    TAsyncStatusType RunOperation() override {
-        TInRetryOperationContextClientGuard guard(this->Client_);
-        if constexpr (TFunctionArgs<TOperation>::Length == 1) {
-            return Operation_(this->Client_);
-        } else {
-            return Operation_(this->Client_, this->GetRemainingTimeout());
+        auto GetRetryDelay(NextStep step) const {
+            // Async backoff has always used a one-based retry index.
+            return TBase::GetRetryDelay(step, this->RetryNumber_ + 1);
         }
-    }
-};
 
-template <typename TClient, typename TOperation, typename TAsyncStatusType = TFunctionResult<TOperation>>
-class TRetryWithSession : public TRetryContext<TClient, TAsyncStatusType>, public TRetryDeadlineHelper<TClient> {
-    using TRetryContextAsync = TRetryContext<TClient, TAsyncStatusType>;
-    using TStatusType = typename TRetryContextAsync::TStatusType;
-    using TSession = typename TClient::TSession;
-    using TCreateSessionSettings = typename TClient::TCreateSessionSettings;
-    using TAsyncCreateSessionResult = typename TClient::TAsyncCreateSessionResult;
-
-private:
-    const TOperation Operation_;
-    const TDeadline Deadline_;
-    std::optional<TSession> Session_;
-
-public:
-    explicit TRetryWithSession(
-        const TClient& client, TOperation&& operation, const TRetryOperationSettings& settings)
-        : TRetryContextAsync(client, settings)
-        , Operation_(std::move(operation))
-        , Deadline_(TDeadline::AfterDuration(this->Settings_.MaxTimeout_))
-    {}
-
-    void Retry() override {
-        TIntrusivePtr<TRetryWithSession> self(this);
-        if (!Session_) {
-            auto settings = TCreateSessionSettings()
-                .ClientTimeout(this->Settings_.GetSessionClientTimeout_)
-                .Deadline(Deadline_);
-
-            this->Client_.GetSession(settings).Subscribe(
-                [self](const TAsyncCreateSessionResult& resultFuture) {
-                    [[maybe_unused]] auto attemptScope = self->ActivateAttemptSpan();
-                    try {
-                        auto& result = resultFuture.GetValue();
-                        if (!result.IsSuccess()) {
-                            return TRetryContextAsync::HandleStatusAsync(
-                                self, MakeRetryResultFromStatus<TStatusType>(TStatus(result)));
-                        }
-
-                        self->Session_ = result.GetSession();
-                        TRetryDeadlineHelper<TClient>::SetDeadline(*self->Session_, self->Deadline_);
-                        self->DoRunOperation(self);
-                    } catch (...) {
-                        return TRetryContextAsync::HandleExceptionAsync(self, std::current_exception());
-                    }
-                }
-            );
-        } else {
-            TRetryContextAsync::DoRunOperation(self);
+        void OnAttemptReady(TStatusType result) {
+            this->DoNext(std::move(result));
         }
-    }
 
-private:
-    void Reset() override {
-        Session_.reset();
-    }
-
-    TAsyncStatusType RunOperation() override {
-        TInRetryOperationContextClientGuard guard(this->Client_);
-        if constexpr (TFunctionArgs<TOperation>::Length == 1) {
-            return Operation_(this->Session_.value());
-        } else {
-            return Operation_(this->Session_.value(), this->GetRemainingTimeout());
+        void OnReady(TStatusType result) {
+            Promise_.SetValue(std::move(result));
         }
-    }
-};
 
-} // namespace NYdb::NRetry::Async
+        void OnReady(std::exception_ptr error) {
+            Promise_.SetException(error);
+        }
+
+        TClient& GetClient() {
+            return Client_;
+        }
+
+        auto& GetClientImpl() {
+            return Client_.Impl_;
+        }
+
+        void ResetSession() {
+            Session_.Reset();
+        }
+
+        void CollectRetryStat(EStatus status) {
+            Client_.Impl_->CollectRetryStatAsync(status);
+        }
+
+    private:
+        TClient Client_;
+        TOperation Operation_;
+        TRetrySessionState<TClient, WithSession> Session_;
+        NThreading::TPromise<TStatusType> Promise_ = NThreading::NewPromise<TStatusType>();
+    };
+
+    template <bool WithSession, typename TClient, typename TOperation>
+    auto Retry(TClient& client, TOperation&& operation, const TRetryOperationSettings& settings) {
+        using TContext = TRetryContext<TClient, std::decay_t<TOperation>, WithSession>;
+        return MakeIntrusive<TContext>(client, std::forward<TOperation>(operation), settings)->Execute();
+    }
+
+} // namespace NYdb::inline Dev::NRetry::Async

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_settings.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_settings.h
@@ -63,7 +63,7 @@ auto RunUnaryWithRetry(TClient& client, TRetryOperationSettings settings, TRunOn
     if (nested) {
         settings.MaxRetries(0);
     }
-    auto operation = [runOnce = std::forward<TRunOnce>(runOnce), nested](TClient&, TDuration remainingTimeout) {
+    auto operation = [runOnce = std::forward<TRunOnce>(runOnce), nested](TClient&, TDuration remainingTimeout) mutable {
         return runOnce(nested ? TDuration::Max() : remainingTimeout);
     };
     return Async::Retry<false>(client, std::move(operation), settings);

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_settings.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_settings.h
@@ -56,23 +56,17 @@ template <typename TClient, typename TRunOnce>
 auto RunUnaryWithRetry(TClient& client, TRetryOperationSettings settings, TRunOnce&& runOnce)
     -> decltype(runOnce(TDuration::Max()))
 {
-    if (client.GetInRetryOperationContext()) {
-        return runOnce(TDuration::Max());
+    const bool nested = client.GetInRetryOperationContext();
+    if (!settings.StopToken_ && (nested || !IsRetryEnabled(settings))) {
+        return runOnce(nested ? TDuration::Max() : settings.MaxTimeout_);
     }
-    if (!IsRetryEnabled(settings)) {
-        return runOnce(settings.MaxTimeout_);
+    if (nested) {
+        settings.MaxRetries(0);
     }
-
-    using TResult = decltype(runOnce(TDuration::Max()));
-
-    auto operation = [runOnce = std::forward<TRunOnce>(runOnce)](TClient& /*clientRef*/, TDuration remainingTimeout) -> TResult {
-        return runOnce(remainingTimeout);
+    auto operation = [runOnce = std::forward<TRunOnce>(runOnce), nested](TClient&, TDuration remainingTimeout) {
+        return runOnce(nested ? TDuration::Max() : remainingTimeout);
     };
-
-    using TRetryAsync = Async::TRetryWithoutSession<TClient, decltype(operation), TResult>;
-    using TRetryContextAsync = Async::TRetryContext<TClient, TResult>;
-
-    return typename TRetryContextAsync::TPtr(new TRetryAsync(client, std::move(operation), settings))->Execute();
+    return Async::Retry<false>(client, std::move(operation), settings);
 }
 
 } // namespace NYdb::NRetry

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_sync.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_sync.h
@@ -1,201 +1,99 @@
 #pragma once
 
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/retry/retry.h>
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/trace/trace.h>
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status/status.h>
-
 #include <ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.h>
-#include <ydb/public/sdk/cpp/src/client/impl/observability/span.h>
 
-#include <util/system/type_name.h>
-
-#include <exception>
-#include <memory>
-#include <typeinfo>
+#include <thread>
 
 namespace NYdb::inline Dev::NRetry::Sync {
 
-template <typename TClient, typename TStatusType>
-class TRetryContext : public TRetryContextBase {
-protected:
-    TClient& Client_;
+    template <typename TClient, typename TOperation, bool WithSession>
+    class TRetryContext: public TRetryContextBase<TRetryContext<TClient, TOperation, WithSession>, TFunctionResult<TOperation>> {
+        using TBase = TRetryContextBase<TRetryContext, TFunctionResult<TOperation>>;
 
-public:
-    TStatusType Execute() {
-        ParentSpan_ = Client_.Impl_->CreateRetryRootSpan();
+    public:
+        using TStatusType = TFunctionResult<TOperation>;
 
-        [[maybe_unused]] auto parentScope = ParentSpan_ ? ParentSpan_->Activate() : nullptr;
-        auto& parentSpan = ParentSpan_;
-
-        try {
-            auto status = ExecuteImpl();
-            if (parentSpan) {
-                parentSpan->SetRetryCount(this->RetryNumber_);
-                parentSpan->End(status.GetStatus());
-            }
-            return status;
-        } catch (...) {
-            if (parentSpan) {
-                parentSpan->SetRetryCount(this->RetryNumber_);
-                try {
-                    std::rethrow_exception(std::current_exception());
-                } catch (const std::exception& e) {
-                    parentSpan->EndWithException(TypeName(e).c_str(), e.what());
-                } catch (...) {
-                    parentSpan->EndWithException("unknown", "unknown exception");
-                }
-            }
-            throw;
-        }
-    }
-
-protected:
-    TRetryContext(TClient& client, const TRetryOperationSettings& settings)
-        : TRetryContextBase(settings)
-        , Client_(client)
-    {}
-
-    virtual TStatusType Retry() = 0;
-
-    virtual TStatusType RunOperation() = 0;
-
-    std::chrono::microseconds DoBackoff(bool fast) {
-        const auto &settings = fast ? this->Settings_.FastBackoffSettings_
-                                    : this->Settings_.SlowBackoffSettings_;
-        return Backoff(settings, this->RetryNumber_);
-    }
-
-private:
-    TStatusType ExecuteImpl() {
-        this->RetryStartTime_ = TInstant::Now();
-        std::int64_t lastBackoffMs = 0;
-
-        TStatusType status = RunAttempt(lastBackoffMs);
-        for (this->RetryNumber_ = 0; this->RetryNumber_ <= this->Settings_.MaxRetries_;) {
-            auto nextStep = this->GetNextStep(status);
-            std::chrono::microseconds backoff{};
-            switch (nextStep) {
-                case NextStep::RetryImmediately:
-                    break;
-                case NextStep::RetryFastBackoff:
-                    backoff = DoBackoff(true);
-                    break;
-                case NextStep::RetrySlowBackoff:
-                    backoff = DoBackoff(false);
-                    break;
-                case NextStep::Finish:
-                    return status;
-            }
-            this->RetryNumber_++;
-            this->LogRetry(status);
-            this->Client_.Impl_->CollectRetryStatSync(status.GetStatus());
-            lastBackoffMs = std::chrono::duration_cast<std::chrono::milliseconds>(backoff).count();
-            status = RunAttempt(lastBackoffMs);
-        }
-        return status;
-    }
-
-    TStatusType RunAttempt(std::int64_t backoffMs) {
-        auto attemptSpan = Client_.Impl_->CreateRetryAttemptSpan(this->RetryNumber_, backoffMs, ParentSpan_);
-        [[maybe_unused]] std::unique_ptr<NTrace::IScope> scope;
-        if (attemptSpan) {
-            scope = attemptSpan->Activate();
+        TRetryContext(TClient& client, const TOperation& operation, const TRetryOperationSettings& settings)
+            : TBase(settings)
+            , Client_(client)
+            , Operation_(operation)
+        {
         }
 
-        TStatusType status = Retry();
-
-        if (attemptSpan) {
-            attemptSpan->End(status.GetStatus());
-        }
-        return status;
-    }
-
-    std::shared_ptr<NObservability::TRequestSpan> ParentSpan_;
-};
-
-template<typename TClient, typename TOperation, typename TStatusType = TFunctionResult<TOperation>>
-class TRetryWithoutSession : public TRetryContext<TClient, TStatusType> {
-private:
-    const TOperation& Operation_;
-
-public:
-    TRetryWithoutSession(TClient& client, const TOperation& operation, const TRetryOperationSettings& settings)
-        : TRetryContext<TClient, TStatusType>(client, settings)
-        , Operation_(operation)
-    {}
-
-protected:
-    TStatusType Retry() override {
-        return RunOperation();
-    }
-
-    TStatusType RunOperation() override {
-        return InvokeWithRangeErrorCatch<TStatusType>([&]() -> TStatusType {
-            TInRetryOperationContextClientGuard guard(this->Client_);
-            if constexpr (TFunctionArgs<TOperation>::Length == 1) {
-                return Operation_(this->Client_);
-            } else {
-                return Operation_(this->Client_, this->GetRemainingTimeout());
+        TStatusType Execute() {
+            this->Start();
+            while (!this->IsFinished()) {
+                this->Guarded([&] { this->DoNext(std::move(*Result_)); });
             }
-        });
-    }
-};
-
-template<typename TClient, typename TOperation, typename TStatusType = TFunctionResult<TOperation>>
-class TRetryWithSession : public TRetryContext<TClient, TStatusType>, public TRetryDeadlineHelper<TClient> {
-    using TSession = typename TClient::TSession;
-    using TCreateSessionSettings = typename TClient::TCreateSessionSettings;
-
-private:
-    const TOperation& Operation_;
-    const TDeadline Deadline_;
-    std::optional<TSession> Session_;
-
-public:
-    TRetryWithSession(TClient& client, const TOperation& operation, const TRetryOperationSettings& settings)
-        : TRetryContext<TClient, TStatusType>(client, settings)
-        , Operation_(operation)
-        , Deadline_(TDeadline::AfterDuration(this->Settings_.MaxTimeout_))
-    {}
-
-protected:
-    TStatusType Retry() override {
-        std::optional<TStatusType> status;
-
-        if (!Session_) {
-            auto settings = TCreateSessionSettings()
-                .ClientTimeout(this->Settings_.GetSessionClientTimeout_)
-                .Deadline(Deadline_);
-
-            auto sessionResult = this->Client_.GetSession(settings).GetValueSync();
-            if (sessionResult.IsSuccess()) {
-                Session_ = sessionResult.GetSession();
-                TRetryDeadlineHelper<TClient>::SetDeadline(*Session_, Deadline_);
+            if (Exception_) {
+                std::rethrow_exception(Exception_);
             }
-            status = MakeRetryResultFromStatus<TStatusType>(TStatus(sessionResult));
+            return std::move(*Result_);
         }
 
-        if (Session_) {
-            status = RunOperation();
+        void ExecuteImpl() {
+            Session_.Execute(*this, [this](auto& target) {
+                OnAttemptReady(this->InvokeOperation(Operation_, target));
+            });
         }
 
-        return *status;
+        void WaitAndExecute(std::chrono::microseconds delay, std::function<void()> fn) {
+            std::this_thread::sleep_for(delay);
+            fn();
+        }
+
+        template <typename T, typename F>
+        void Await(NThreading::TFuture<T> future, F fn) {
+            fn(future.GetValueSync());
+        }
+
+        bool StopRequested() const {
+            return this->Settings_.StopToken_ && this->Settings_.StopToken_->stop_requested();
+        }
+
+        auto GetRetryDelay(NextStep step) const {
+            return TBase::GetRetryDelay(step, this->RetryNumber_);
+        }
+
+        void OnAttemptReady(TStatusType result) {
+            Result_.emplace(std::move(result));
+        }
+
+        void OnReady(TStatusType result) {
+            OnAttemptReady(std::move(result));
+        }
+
+        void OnReady(std::exception_ptr error) {
+            Exception_ = error;
+        }
+
+        TClient& GetClient() {
+            return Client_;
+        }
+
+        auto& GetClientImpl() {
+            return Client_.Impl_;
+        }
+
+        void ResetSession() {
+            Session_.Reset();
+        }
+
+        void CollectRetryStat(EStatus status) {
+            Client_.Impl_->CollectRetryStatSync(status);
+        }
+
+    private:
+        TClient& Client_;
+        const TOperation& Operation_;
+        TRetrySessionState<TClient, WithSession> Session_;
+        std::optional<TStatusType> Result_;
+        std::exception_ptr Exception_;
+    };
+
+    template <bool WithSession, typename TClient, typename TOperation>
+    auto Retry(TClient& client, const TOperation& operation, const TRetryOperationSettings& settings) {
+        return TRetryContext<TClient, TOperation, WithSession>(client, operation, settings).Execute();
     }
 
-    TStatusType RunOperation() override {
-        return InvokeWithRangeErrorCatch<TStatusType>([&]() -> TStatusType {
-            TInRetryOperationContextClientGuard guard(this->Client_);
-            if constexpr (TFunctionArgs<TOperation>::Length == 1) {
-                return Operation_(this->Session_.value());
-            } else {
-                return Operation_(this->Session_.value(), this->GetRemainingTimeout());
-            }
-        });
-    }
-
-    void Reset() override {
-        Session_.reset();
-    }
-};
-
-} // namespace NYdb::NRetry::Sync
+} // namespace NYdb::inline Dev::NRetry::Sync

--- a/ydb/public/sdk/cpp/src/client/impl/internal/retry/ya.make
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/retry/ya.make
@@ -6,8 +6,8 @@ SRCS(
 )
 
 PEERDIR(
+    library/cpp/threading/future
     ydb/public/api/protos
-    ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections
     ydb/public/sdk/cpp/src/client/impl/observability
     ydb/public/sdk/cpp/src/client/value
 )

--- a/ydb/public/sdk/cpp/src/client/query/client.cpp
+++ b/ydb/public/sdk/cpp/src/client/query/client.cpp
@@ -27,8 +27,6 @@
 namespace NYdb::inline Dev::NQuery {
 
 using TQueryObservation = NObservability::TRequestObservation;
-using TRetryContextResultAsync = NRetry::Async::TRetryContext<TQueryClient, TAsyncExecuteQueryResult>;
-using TRetryContextAsync = NRetry::Async::TRetryContext<TQueryClient, TAsyncStatus>;
 
 NYdb::NRetry::TRetryOperationSettings GetRetrySettings(TDuration timeout, bool isIndempotent) {
     return NYdb::NRetry::TRetryOperationSettings()
@@ -755,13 +753,13 @@ TAsyncExecuteQueryResult TQueryClient::ExecuteQuery(const std::string& query, co
         NRetry::ERetryIdempotentDefault::False);
 
     return NRetry::RunUnaryWithRetry(*this, retrySettings,
-        [this, query, txControl, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->ExecuteQuery(query, txControl, {}, opSettings);
-        });
+                                     [impl = Impl_, query, txControl, settings](TDuration timeout) {
+                                         auto opSettings = settings;
+                                         if (timeout != TDuration::Max()) {
+                                             opSettings.ClientTimeout(timeout);
+                                         }
+                                         return impl->ExecuteQuery(query, txControl, {}, opSettings);
+                                     });
 }
 
 TAsyncExecuteQueryResult TQueryClient::ExecuteQuery(const std::string& query, const TTxControl& txControl,
@@ -774,13 +772,13 @@ TAsyncExecuteQueryResult TQueryClient::ExecuteQuery(const std::string& query, co
         NRetry::ERetryIdempotentDefault::False);
 
     return NRetry::RunUnaryWithRetry(*this, retrySettings,
-        [this, query, txControl, params, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->ExecuteQuery(query, txControl, params, opSettings);
-        });
+                                     [impl = Impl_, query, txControl, params, settings](TDuration timeout) {
+                                         auto opSettings = settings;
+                                         if (timeout != TDuration::Max()) {
+                                             opSettings.ClientTimeout(timeout);
+                                         }
+                                         return impl->ExecuteQuery(query, txControl, params, opSettings);
+                                     });
 }
 
 TAsyncExecuteQueryIterator TQueryClient::StreamExecuteQuery(const std::string& query, const TTxControl& txControl,
@@ -807,13 +805,13 @@ NThreading::TFuture<TScriptExecutionOperation> TQueryClient::ExecuteScript(const
         NRetry::ERetryIdempotentDefault::False);
 
     return NRetry::RunUnaryWithRetry(*this, resolvedRetrySettings,
-        [this, script, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->ExecuteScript(script, {}, opSettings);
-        });
+                                     [impl = Impl_, script, settings](TDuration timeout) {
+                                         auto opSettings = settings;
+                                         if (timeout != TDuration::Max()) {
+                                             opSettings.ClientTimeout(timeout);
+                                         }
+                                         return impl->ExecuteScript(script, {}, opSettings);
+                                     });
 }
 
 NThreading::TFuture<TScriptExecutionOperation> TQueryClient::ExecuteScript(const std::string& script,
@@ -828,13 +826,13 @@ NThreading::TFuture<TScriptExecutionOperation> TQueryClient::ExecuteScript(const
         NRetry::ERetryIdempotentDefault::False);
 
     return NRetry::RunUnaryWithRetry(*this, resolvedRetrySettings,
-        [this, script, params, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->ExecuteScript(script, params, opSettings);
-        });
+                                     [impl = Impl_, script, params, settings](TDuration timeout) {
+                                         auto opSettings = settings;
+                                         if (timeout != TDuration::Max()) {
+                                             opSettings.ClientTimeout(timeout);
+                                         }
+                                         return impl->ExecuteScript(script, params, opSettings);
+                                     });
 }
 
 TAsyncFetchScriptResultsResult TQueryClient::FetchScriptResults(const NKikimr::NOperationId::TOperationId& operationId, int64_t resultSetIndex,
@@ -849,13 +847,13 @@ TAsyncFetchScriptResultsResult TQueryClient::FetchScriptResults(const NKikimr::N
         NRetry::ERetryIdempotentDefault::True);
 
     return NRetry::RunUnaryWithRetry(*this, resolvedRetrySettings,
-        [this, operationId, resultSetIndex, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->FetchScriptResults(operationId, resultSetIndex, opSettings);
-        });
+                                     [impl = Impl_, operationId, resultSetIndex, settings](TDuration timeout) {
+                                         auto opSettings = settings;
+                                         if (timeout != TDuration::Max()) {
+                                             opSettings.ClientTimeout(timeout);
+                                         }
+                                         return impl->FetchScriptResults(operationId, resultSetIndex, opSettings);
+                                     });
 }
 
 TAsyncCreateSessionResult TQueryClient::GetSession(const TCreateSessionSettings& settings)
@@ -872,13 +870,13 @@ TAsyncStatus TQueryClient::DeleteSession(const std::string& sessionId, const TDe
         NRetry::ERetryIdempotentDefault::True);
 
     return NRetry::RunUnaryWithRetry(*this, resolvedRetrySettings,
-        [this, sessionId, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->DeleteSession(sessionId, opSettings);
-        });
+                                     [impl = Impl_, sessionId, settings](TDuration timeout) {
+                                         auto opSettings = settings;
+                                         if (timeout != TDuration::Max()) {
+                                             opSettings.ClientTimeout(timeout);
+                                         }
+                                         return impl->DeleteSession(sessionId, opSettings);
+                                     });
 }
 
 int64_t TQueryClient::GetActiveSessionCount() const {
@@ -907,37 +905,33 @@ void TQueryClient::SetInRetryOperationContext(bool value) {
 
 TAsyncExecuteQueryResult TQueryClient::RetryQuery(TQueryResultFunc&& queryFunc, TRetryOperationSettings settings)
 {
-    return TRetryContextResultAsync::TPtr(
-        new NRetry::Async::TRetryWithSession(*this, std::move(queryFunc), settings))->Execute();
+    return NRetry::Async::Retry<true>(*this, std::move(queryFunc), settings);
 }
 
 TAsyncStatus TQueryClient::RetryQuery(TQueryFunc&& queryFunc, TRetryOperationSettings settings) {
-    return TRetryContextAsync::TPtr(
-        new NRetry::Async::TRetryWithSession(*this, std::move(queryFunc), settings))->Execute();
+    return NRetry::Async::Retry<true>(*this, std::move(queryFunc), settings);
 }
 
 TAsyncStatus TQueryClient::RetryQuery(TQueryWithoutSessionFunc&& queryFunc, TRetryOperationSettings settings) {
-    return TRetryContextAsync::TPtr(
-        new NRetry::Async::TRetryWithoutSession(*this, std::move(queryFunc), settings))->Execute();
+    return NRetry::Async::Retry<false>(*this, std::move(queryFunc), settings);
 }
 
 TStatus TQueryClient::RetryQuerySync(const TQuerySyncFunc& queryFunc, TRetryOperationSettings settings) {
-    return NRetry::Sync::TRetryWithSession(*this, queryFunc, settings).Execute();
+    return NRetry::Sync::Retry<true>(*this, queryFunc, settings);
 }
 
 TStatus TQueryClient::RetryQuerySync(const TQueryWithoutSessionSyncFunc& queryFunc, TRetryOperationSettings settings) {
-    return NRetry::Sync::TRetryWithoutSession(*this, queryFunc, settings).Execute();
+    return NRetry::Sync::Retry<false>(*this, queryFunc, settings);
 }
 
 TAsyncExecuteQueryResult TQueryClient::RetryQuery(const std::string& query, const TTxControl& txControl,
     TDuration timeout, bool isIndempotent)
 {
     auto settings = GetRetrySettings(timeout, isIndempotent);
-    auto queryFunc = [&query, &txControl](TSession session, TDuration duration) -> TAsyncExecuteQueryResult {
+    auto queryFunc = [query, txControl](TSession session, TDuration duration) -> TAsyncExecuteQueryResult {
         return session.ExecuteQuery(query, txControl, TExecuteQuerySettings().ClientTimeout(duration));
     };
-    return TRetryContextResultAsync::TPtr(
-        new NRetry::Async::TRetryWithSession(*this, std::move(queryFunc), settings))->Execute();
+    return NRetry::Async::Retry<true>(*this, std::move(queryFunc), settings);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -42,8 +42,6 @@ namespace NTable {
 using namespace NThreading;
 using namespace NSessionPool;
 
-using TRetryContextAsync = NRetry::Async::TRetryContext<TTableClient, TAsyncStatus>;
-
 ////////////////////////////////////////////////////////////////////////////////
 
 class TStorageSettings::TImpl {
@@ -1680,21 +1678,19 @@ TTypeBuilder TTableClient::GetTypeBuilder() {
 ////////////////////////////////////////////////////////////////////////////////
 
 TAsyncStatus TTableClient::RetryOperation(TOperationFunc&& operation, const TRetryOperationSettings& settings) {
-    return TRetryContextAsync::TPtr(
-        new NRetry::Async::TRetryWithSession(*this, std::move(operation), settings))->Execute();
+    return NRetry::Async::Retry<true>(*this, std::move(operation), settings);
 }
 
 TAsyncStatus TTableClient::RetryOperation(TOperationWithoutSessionFunc&& operation, const TRetryOperationSettings& settings) {
-    return TRetryContextAsync::TPtr(
-        new NRetry::Async::TRetryWithoutSession(*this, std::move(operation), settings))->Execute();
+    return NRetry::Async::Retry<false>(*this, std::move(operation), settings);
 }
 
 TStatus TTableClient::RetryOperationSync(const TOperationWithoutSessionSyncFunc& operation, const TRetryOperationSettings& settings) {
-    return NRetry::Sync::TRetryWithoutSession(*this, operation, settings).Execute();
+    return NRetry::Sync::Retry<false>(*this, operation, settings);
 }
 
 TStatus TTableClient::RetryOperationSync(const TOperationSyncFunc& operation, const TRetryOperationSettings& settings) {
-    return NRetry::Sync::TRetryWithSession(*this, operation, settings).Execute();
+    return NRetry::Sync::Retry<true>(*this, operation, settings);
 }
 
 NThreading::TFuture<void> TTableClient::Stop() {
@@ -1710,7 +1706,9 @@ TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, TValue
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::True);
     if (!NRetry::IsRetryEnabled(retrySettings) || GetInRetryOperationContext()) {
-        return Impl_->BulkUpsert(table, std::move(rows), settings);
+        return NRetry::RunUnaryWithRetry(*this, retrySettings, [&](TDuration) {
+            return Impl_->BulkUpsert(table, std::move(rows), settings);
+        });
     }
 
     auto state = std::make_shared<NRetry::TBulkUpsertRetryState>(retrySettings);
@@ -1718,8 +1716,12 @@ TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, TValue
     opSettings.RetryRowsState_ = state;
     const auto startedAt = TInstant::Now();
 
-    return Impl_->BulkUpsert(table, std::move(rows), opSettings).Apply(
-        [this, table, settings, retrySettings, state, startedAt](const TAsyncBulkUpsertResult& f) {
+    auto firstAttemptSettings = retrySettings;
+    firstAttemptSettings.MaxRetries(0);
+    return NRetry::RunUnaryWithRetry(*this, firstAttemptSettings, [&](TDuration) {
+               return Impl_->BulkUpsert(table, std::move(rows), opSettings);
+           })
+        .Apply([client = *this, table, settings, retrySettings, state, startedAt](const TAsyncBulkUpsertResult& f) mutable {
             const auto result = f.GetValue();
             if (result.IsSuccess()
                 || !NRetry::ShouldRetryStatus(result.GetStatus(), retrySettings)) {
@@ -1738,15 +1740,15 @@ TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, TValue
                 remaining.MaxTimeout(retrySettings.MaxTimeout_ - elapsed);
             }
 
-            return NRetry::RunUnaryWithRetry(*this, remaining,
-                [this, table, state, settings](TDuration timeout) {
-                    auto op = settings;
-                    op.RetryRowsState_.reset();
-                    if (timeout != TDuration::Max()) {
-                        op.ClientTimeout(timeout);
-                    }
-                    return Impl_->BulkUpsert(table, state->GetBackupCopy(), op);
-                });
+            return NRetry::RunUnaryWithRetry(client, remaining,
+                                             [impl = client.Impl_, table, state, settings](TDuration timeout) {
+                                                 auto op = settings;
+                                                 op.RetryRowsState_.reset();
+                                                 if (timeout != TDuration::Max()) {
+                                                     op.ClientTimeout(timeout);
+                                                 }
+                                                 return impl->BulkUpsert(table, state->GetBackupCopy(), op);
+                                             });
         });
 }
 
@@ -1759,17 +1761,19 @@ TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, EDataF
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::True);
     if (!NRetry::IsRetryEnabled(retrySettings) || GetInRetryOperationContext()) {
-        return Impl_->BulkUpsert(table, format, data, schema, settings);
+        return NRetry::RunUnaryWithRetry(*this, retrySettings, [&](TDuration) {
+            return Impl_->BulkUpsert(table, format, data, schema, settings);
+        });
     }
 
     return NRetry::RunUnaryWithRetry(*this, retrySettings,
-        [this, table, format, data, schema, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->BulkUpsert(table, format, data, schema, opSettings);
-        });
+                                     [impl = Impl_, table, format, data, schema, settings](TDuration timeout) {
+                                         auto opSettings = settings;
+                                         if (timeout != TDuration::Max()) {
+                                             opSettings.ClientTimeout(timeout);
+                                         }
+                                         return impl->BulkUpsert(table, format, data, schema, opSettings);
+                                     });
 }
 
 TAsyncReadRowsResult TTableClient::ReadRows(const std::string& table, TValue&& rows, const std::vector<std::string>& columns,
@@ -1781,18 +1785,20 @@ TAsyncReadRowsResult TTableClient::ReadRows(const std::string& table, TValue&& r
         settings.ClientTimeout_,
         NRetry::ERetryIdempotentDefault::True);
     if (!NRetry::IsRetryEnabled(retrySettings) || GetInRetryOperationContext()) {
-        return Impl_->ReadRows(table, std::move(rows), columns, settings);
+        return NRetry::RunUnaryWithRetry(*this, retrySettings, [&](TDuration) {
+            return Impl_->ReadRows(table, std::move(rows), columns, settings);
+        });
     }
     TValue keysCopy = std::move(rows);
 
     return NRetry::RunUnaryWithRetry(*this, retrySettings,
-        [this, table, keysCopy = std::move(keysCopy), columns, settings](TDuration timeout) {
-            auto opSettings = settings;
-            if (timeout != TDuration::Max()) {
-                opSettings.ClientTimeout(timeout);
-            }
-            return Impl_->ReadRows(table, TValue{keysCopy}, columns, opSettings);
-        });
+                                     [impl = Impl_, table, keysCopy = std::move(keysCopy), columns, settings](TDuration timeout) {
+                                         auto opSettings = settings;
+                                         if (timeout != TDuration::Max()) {
+                                             opSettings.ClientTimeout(timeout);
+                                         }
+                                         return impl->ReadRows(table, TValue{keysCopy}, columns, opSettings);
+                                     });
 }
 
 TAsyncScanQueryPartIterator TTableClient::StreamExecuteScanQuery(const std::string& query, const TParams& params,

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -35,6 +35,7 @@
 #include <util/stream/output.h>
 
 #include <map>
+#include <utility>
 
 namespace NYdb::inline Dev {
 namespace NTable {
@@ -1698,7 +1699,7 @@ NThreading::TFuture<void> TTableClient::Stop() {
 }
 
 TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, TValue&& rows,
-    const TBulkUpsertSettings& settings)
+                                                const TBulkUpsertSettings& settings)
 {
     const auto retrySettings = NRetry::ResolveRetrySettings(
         Impl_->Settings_.RetrySettings_,
@@ -1712,44 +1713,19 @@ TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, TValue
     }
 
     auto state = std::make_shared<NRetry::TBulkUpsertRetryState>(retrySettings);
-    auto opSettings = settings;
-    opSettings.RetryRowsState_ = state;
-    const auto startedAt = TInstant::Now();
-
-    auto firstAttemptSettings = retrySettings;
-    firstAttemptSettings.MaxRetries(0);
-    return NRetry::RunUnaryWithRetry(*this, firstAttemptSettings, [&](TDuration) {
-               return Impl_->BulkUpsert(table, std::move(rows), opSettings);
-           })
-        .Apply([client = *this, table, settings, retrySettings, state, startedAt](const TAsyncBulkUpsertResult& f) mutable {
-            const auto result = f.GetValue();
-            if (result.IsSuccess()
-                || !NRetry::ShouldRetryStatus(result.GetStatus(), retrySettings)) {
-                return NThreading::MakeFuture(result);
-            }
-            Y_ABORT_UNLESS(state->HasBackup());
-
-            const auto elapsed = TInstant::Now() - startedAt;
-            if (retrySettings.MaxTimeout_ != TDuration::Max() && elapsed >= retrySettings.MaxTimeout_) {
-                return NThreading::MakeFuture(result);
-            }
-
-            auto remaining = retrySettings;
-            remaining.MaxRetries(retrySettings.MaxRetries_ - 1);
-            if (retrySettings.MaxTimeout_ != TDuration::Max()) {
-                remaining.MaxTimeout(retrySettings.MaxTimeout_ - elapsed);
-            }
-
-            return NRetry::RunUnaryWithRetry(client, remaining,
-                                             [impl = client.Impl_, table, state, settings](TDuration timeout) {
-                                                 auto op = settings;
-                                                 op.RetryRowsState_.reset();
-                                                 if (timeout != TDuration::Max()) {
-                                                     op.ClientTimeout(timeout);
-                                                 }
-                                                 return impl->BulkUpsert(table, state->GetBackupCopy(), op);
-                                             });
-        });
+    return NRetry::RunUnaryWithRetry(*this, retrySettings,
+                                     [impl = Impl_, table, rows = std::move(rows), settings, state, firstAttempt = true](TDuration timeout) mutable {
+                                         auto opSettings = settings;
+                                         if (timeout != TDuration::Max()) {
+                                             opSettings.ClientTimeout(timeout);
+                                         }
+                                         if (std::exchange(firstAttempt, false)) {
+                                             opSettings.RetryRowsState_ = state;
+                                             return impl->BulkUpsert(table, std::move(rows), opSettings);
+                                         }
+                                         opSettings.RetryRowsState_.reset();
+                                         return impl->BulkUpsert(table, state->GetBackupCopy(), opSettings);
+                                     });
 }
 
 TAsyncBulkUpsertResult TTableClient::BulkUpsert(const std::string& table, EDataFormat format,

--- a/ydb/public/sdk/cpp/tests/unit/client/retry/retry_async_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/retry/retry_async_ut.cpp
@@ -1,0 +1,131 @@
+#include "retry_test_helpers.h"
+
+#include <ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_async.h>
+#include <ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_settings.h>
+
+using namespace NYdb;
+using namespace NYdb::NRetry;
+using namespace NYdb::NRetry::NTests;
+using namespace NThreading;
+
+Y_UNIT_TEST_SUITE(RetryAsync) {
+    Y_UNIT_TEST(ReturnsFinalStatus) {
+        for (auto status : {EStatus::SUCCESS, EStatus::BAD_REQUEST}) {
+            TTestClient client;
+            unsigned attempts = 0;
+            auto result = Async::Retry<false>(client, [&](TTestClient&) {
+                ++attempts;
+                return MakeFuture(Status(status));
+            }, Settings());
+
+            UNIT_ASSERT(result.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(result.GetValue().GetStatus(), status);
+            UNIT_ASSERT_VALUES_EQUAL(attempts, 1);
+            UNIT_ASSERT(!client.Impl_->Scheduled);
+        }
+    }
+
+    Y_UNIT_TEST(RetriesTransientFailure) {
+        TTestClient client;
+        unsigned attempts = 0;
+        auto result = Async::Retry<false>(client, [&](TTestClient&) {
+            return MakeFuture(Status(++attempts == 1 ? EStatus::UNAVAILABLE : EStatus::SUCCESS));
+        }, Settings());
+
+        UNIT_ASSERT_VALUES_EQUAL(attempts, 1);
+        UNIT_ASSERT(!result.HasValue());
+        client.Impl_->RunScheduled();
+        UNIT_ASSERT(result.HasValue());
+        UNIT_ASSERT(result.GetValue().IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(attempts, 2);
+        UNIT_ASSERT(!client.Impl_->Scheduled);
+    }
+
+    Y_UNIT_TEST(RespectsRetryLimit) {
+        for (unsigned retries : {0u, 2u}) {
+            TTestClient client;
+            unsigned attempts = 0;
+            auto result = Async::Retry<false>(client, [&](TTestClient&) {
+                ++attempts;
+                return MakeFuture(Status(EStatus::UNAVAILABLE));
+            }, Settings().MaxRetries(retries));
+
+            for (unsigned i = 0; i < retries; ++i) {
+                UNIT_ASSERT(!result.HasValue());
+                client.Impl_->RunScheduled();
+            }
+            UNIT_ASSERT(result.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(result.GetValue().GetStatus(), EStatus::UNAVAILABLE);
+            UNIT_ASSERT_VALUES_EQUAL(attempts, retries + 1);
+            UNIT_ASSERT(!client.Impl_->Scheduled);
+        }
+    }
+
+    Y_UNIT_TEST(CancelledBeforeFirstAttempt) {
+        TTestClient client;
+        std::stop_source stop;
+        stop.request_stop();
+        unsigned attempts = 0;
+        auto result = Async::Retry<false>(client, [&](TTestClient&) {
+            ++attempts;
+            return MakeFuture(Status(EStatus::SUCCESS));
+        }, Settings().MaxRetries(0).StopToken(stop.get_token()));
+
+        UNIT_ASSERT(result.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(result.GetValue().GetStatus(), EStatus::CLIENT_CANCELLED);
+        UNIT_ASSERT_VALUES_EQUAL(attempts, 0);
+        UNIT_ASSERT(!client.Impl_->Scheduled);
+    }
+
+    Y_UNIT_TEST(CancellationWaitsForAttemptResult) {
+        TTestClient client;
+        std::stop_source stop;
+        auto attempt = NewPromise<TStatus>();
+        unsigned attempts = 0;
+        auto result = Async::Retry<false>(client, [&](TTestClient&) {
+            ++attempts;
+            return attempt.GetFuture();
+        }, Settings().StopToken(stop.get_token()));
+
+        stop.request_stop();
+        UNIT_ASSERT(!result.HasValue());
+        attempt.SetValue(Status(EStatus::SUCCESS));
+        UNIT_ASSERT(result.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(result.GetValue().GetStatus(), EStatus::CLIENT_CANCELLED);
+        UNIT_ASSERT_VALUES_EQUAL(attempts, 1);
+        UNIT_ASSERT(!client.Impl_->Scheduled);
+    }
+
+    Y_UNIT_TEST(CancellationDuringBackoffStopsNextAttempt) {
+        TTestClient client;
+        std::stop_source stop;
+        unsigned attempts = 0;
+        auto settings = Settings().StopToken(stop.get_token()).FastBackoffSettings(TBackoffSettings().SlotDuration(TDuration::Seconds(1)).UncertainRatio(0));
+        auto result = Async::Retry<false>(client, [&](TTestClient&) {
+            ++attempts;
+            return MakeFuture(Status(EStatus::UNAVAILABLE));
+        }, settings);
+
+        UNIT_ASSERT(client.Impl_->Delay > TDeadline::Duration::zero());
+        stop.request_stop();
+        UNIT_ASSERT(!result.HasValue());
+        client.Impl_->RunScheduled();
+        UNIT_ASSERT(result.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(result.GetValue().GetStatus(), EStatus::CLIENT_CANCELLED);
+        UNIT_ASSERT_VALUES_EQUAL(attempts, 1);
+        UNIT_ASSERT(!client.Impl_->Scheduled);
+    }
+
+    Y_UNIT_TEST(SupportsMutableUnaryCallback) {
+        TTestClient client;
+        auto result = RunUnaryWithRetry(client, Settings(), [attempts = 0](TDuration) mutable {
+            return MakeFuture(Status(++attempts == 1 ? EStatus::UNAVAILABLE : EStatus::SUCCESS));
+        });
+
+        UNIT_ASSERT(!result.HasValue());
+        client.Impl_->RunScheduled();
+        UNIT_ASSERT(result.HasValue());
+        UNIT_ASSERT(result.GetValue().IsSuccess());
+        UNIT_ASSERT(!client.Impl_->Scheduled);
+    }
+} // Y_UNIT_TEST_SUITE(RetryAsync)

--- a/ydb/public/sdk/cpp/tests/unit/client/retry/retry_test_helpers.h
+++ b/ydb/public/sdk/cpp/tests/unit/client/retry/retry_test_helpers.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <ydb/public/sdk/cpp/src/client/impl/internal/retry/retry.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NYdb::inline Dev::NRetry::NTests {
+
+    struct TTestClient {
+        struct TImpl {
+            std::function<void()> Scheduled;
+            TDeadline::Duration Delay{};
+
+            void ScheduleTask(const std::function<void()>& fn, TDeadline::Duration delay) {
+                UNIT_ASSERT(!Scheduled);
+                Scheduled = fn;
+                Delay = delay;
+            }
+
+            void RunScheduled() {
+                UNIT_ASSERT(Scheduled);
+                auto fn = std::exchange(Scheduled, {});
+                fn();
+            }
+
+            void CollectRetryStatSync(EStatus) {
+            }
+
+            void CollectRetryStatAsync(EStatus) {
+            }
+
+            std::shared_ptr<NObservability::TRequestSpan> CreateRetryRootSpan() {
+                return nullptr;
+            }
+
+            std::shared_ptr<NObservability::TRequestSpan> CreateRetryAttemptSpan(
+                std::uint32_t, std::int64_t, const std::shared_ptr<NObservability::TRequestSpan>&)
+            {
+                return nullptr;
+            }
+        };
+
+        std::shared_ptr<TImpl> Impl_ = std::make_shared<TImpl>();
+        bool InRetry = false;
+
+        bool GetInRetryOperationContext() const {
+            return InRetry;
+        }
+
+        void SetInRetryOperationContext(bool value) {
+            InRetry = value;
+        }
+    };
+
+    inline TStatus Status(EStatus code) {
+        return TStatus(code, NIssue::TIssues{});
+    }
+
+    inline TRetryOperationSettings Settings() {
+        return TRetryOperationSettings()
+            .MaxRetries(2)
+            .FastBackoffSettings(TBackoffSettings().SlotDuration(TDuration::Zero()));
+    }
+
+} // namespace NYdb::inline Dev::NRetry::NTests

--- a/ydb/public/sdk/cpp/tests/unit/client/retry/retry_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/retry/retry_ut.cpp
@@ -1,0 +1,78 @@
+#include "retry_test_helpers.h"
+
+#include <ydb/public/sdk/cpp/src/client/impl/internal/retry/retry_sync.h>
+
+using namespace NYdb;
+using namespace NYdb::NRetry;
+using namespace NYdb::NRetry::NTests;
+
+Y_UNIT_TEST_SUITE(RetrySync) {
+    Y_UNIT_TEST(ReturnsFinalStatus) {
+        for (auto status : {EStatus::SUCCESS, EStatus::BAD_REQUEST}) {
+            TTestClient client;
+            unsigned attempts = 0;
+            auto result = Sync::Retry<false>(client, [&](TTestClient&) {
+                ++attempts;
+                return Status(status);
+            }, Settings());
+
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), status);
+            UNIT_ASSERT_VALUES_EQUAL(attempts, 1);
+            UNIT_ASSERT(!client.Impl_->Scheduled);
+        }
+    }
+
+    Y_UNIT_TEST(RetriesTransientFailure) {
+        TTestClient client;
+        unsigned attempts = 0;
+        auto result = Sync::Retry<false>(client, [&](TTestClient&) {
+            return Status(++attempts == 1 ? EStatus::UNAVAILABLE : EStatus::SUCCESS);
+        }, Settings());
+
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(attempts, 2);
+        UNIT_ASSERT(!client.Impl_->Scheduled);
+    }
+
+    Y_UNIT_TEST(RespectsRetryLimit) {
+        for (unsigned retries : {0u, 2u}) {
+            TTestClient client;
+            unsigned attempts = 0;
+            auto result = Sync::Retry<false>(client, [&](TTestClient&) {
+                ++attempts;
+                return Status(EStatus::UNAVAILABLE);
+            }, Settings().MaxRetries(retries));
+
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::UNAVAILABLE);
+            UNIT_ASSERT_VALUES_EQUAL(attempts, retries + 1);
+        }
+    }
+
+    Y_UNIT_TEST(CancelledBeforeFirstAttempt) {
+        TTestClient client;
+        std::stop_source stop;
+        stop.request_stop();
+        unsigned attempts = 0;
+        auto result = Sync::Retry<false>(client, [&](TTestClient&) {
+            ++attempts;
+            return Status(EStatus::SUCCESS);
+        }, Settings().MaxRetries(0).StopToken(stop.get_token()));
+
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::CLIENT_CANCELLED);
+        UNIT_ASSERT_VALUES_EQUAL(attempts, 0);
+    }
+
+    Y_UNIT_TEST(CancellationStopsRetries) {
+        TTestClient client;
+        std::stop_source stop;
+        unsigned attempts = 0;
+        auto result = Sync::Retry<false>(client, [&](TTestClient&) {
+            ++attempts;
+            stop.request_stop();
+            return Status(EStatus::UNAVAILABLE);
+        }, Settings().StopToken(stop.get_token()));
+
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::CLIENT_CANCELLED);
+        UNIT_ASSERT_VALUES_EQUAL(attempts, 1);
+    }
+} // Y_UNIT_TEST_SUITE(RetrySync)

--- a/ydb/public/sdk/cpp/tests/unit/client/retry/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/retry/ya.make
@@ -1,0 +1,17 @@
+UNITTEST()
+
+SRCS(
+    retry_ut.cpp
+    retry_async_ut.cpp
+)
+
+PEERDIR(
+    library/cpp/threading/future
+    ydb/public/sdk/cpp/src/client/impl/internal/retry
+    ydb/public/sdk/cpp/src/client/impl/observability
+    ydb/public/sdk/cpp/src/client/types
+    ydb/public/sdk/cpp/src/client/types/status
+    ydb/public/sdk/cpp/src/library/time
+)
+
+END()

--- a/ydb/public/sdk/cpp/tests/unit/client/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/ya.make
@@ -14,6 +14,7 @@ RECURSE(
     query
     result
     row_ranges
+    retry
     retry_range
     table
     value


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

Refactored retriers into common machinery using CRTP and simplified bulk-upsert unary retries.

Added cancellation token to stop the retries on request to prevent retry storm.