### PR TITLE
Do not look at all nodes in scatter balancer

### DIFF
--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -2778,6 +2778,7 @@ THive::THiveStats THive::GetStats(TIter begin, TIter end) const {
     auto minValuesToBalance = GetMinNodeUsageToBalance();
     maxValues = piecewise_max(maxValues, minValuesToBalance);
     minValues = piecewise_max(minValues, minValuesToBalance);
+    stats.MinResourceNormValues = minValues;
     auto discrepancy = maxValues - minValues;
     auto& counterDiscrepancy = std::get<NMetrics::EResource::Counter>(discrepancy);
     if (counterDiscrepancy * CurrentConfig.GetMaxResourceCounter() <= 1.5) {
@@ -2977,12 +2978,26 @@ void THive::Handle(TEvPrivate::TEvProcessTabletBalancer::TPtr&) {
                     balancerType = EBalancerType::Scatter;
                     break;
             }
+            const auto resource = *scatteredResource;
+            const double minScatter = TTabletInfo::ExtractResourceUsage(GetMinScatterToBalance(), resource);
+            if (!(minScatter >= 0.0 && minScatter < 1.0)) {
+                continue;
+            }
+            const double minUsage = TTabletInfo::ExtractResourceUsage(stats.MinResourceNormValues, resource);
+            const double usageThreshold = minUsage / (1.0 - minScatter);
+
             std::vector<TNodeId> nodeIds;
             nodeIds.reserve(stats.Values.size());
-            double usageThreshold = TTabletInfo::ExtractResourceUsage(GetMinNodeUsageToBalance(), *scatteredResource)
-                / TTabletInfo::ExtractResourceUsage(GetMinScatterToBalance(), *scatteredResource);
-            auto filteredNodes = nodes | std::views::filter([&](const TNodeInfo& node) { return node.GetNodeUsage(*scatteredResource) >= usageThreshold; });
-            std::transform(filteredNodes.begin(), filteredNodes.end(), std::back_inserter(nodeIds), [](const TNodeInfo& node) { return node.Id; });
+            for (const auto& node : stats.Values) {
+                const double usage = TTabletInfo::ExtractResourceUsage(node.ResourceNormValues, resource);
+                if (usage > usageThreshold) {
+                    nodeIds.push_back(node.NodeId);
+                }
+            }
+            // An empty filter means all nodes to the balancer.
+            if (nodeIds.empty()) {
+                continue;
+            }
             YDB_LOG_TRACE("ProcessTabletBalancer: scatter over limit triggered balancer",
                 {"logPrefix", GetLogPrefix()},
                 {"scatterByResource", stats.ScatterByResource},

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -2979,7 +2979,10 @@ void THive::Handle(TEvPrivate::TEvProcessTabletBalancer::TPtr&) {
             }
             std::vector<TNodeId> nodeIds;
             nodeIds.reserve(stats.Values.size());
-            std::transform(nodes.begin(), nodes.end(), std::back_inserter(nodeIds), [](const TNodeInfo& node) { return node.Id; });
+            double usageThreshold = TTabletInfo::ExtractResourceUsage(GetMinNodeUsageToBalance(), *scatteredResource)
+                / TTabletInfo::ExtractResourceUsage(GetMinScatterToBalance(), *scatteredResource);
+            auto filteredNodes = nodes | std::views::filter([&](const TNodeInfo& node) { return node.GetNodeUsage(*scatteredResource) >= usageThreshold; });
+            std::transform(filteredNodes.begin(), filteredNodes.end(), std::back_inserter(nodeIds), [](const TNodeInfo& node) { return node.Id; });
             YDB_LOG_TRACE("ProcessTabletBalancer: scatter over limit triggered balancer",
                 {"logPrefix", GetLogPrefix()},
                 {"scatterByResource", stats.ScatterByResource},

--- a/ydb/core/mind/hive/hive_impl.h
+++ b/ydb/core/mind/hive/hive_impl.h
@@ -1124,6 +1124,7 @@ protected:
         TNodeId MaxUsageNodeId;
         double Scatter;
         TResourceNormalizedValues ScatterByResource;
+        TResourceNormalizedValues MinResourceNormValues;
         std::vector<TNodeStat> Values;
     };
 

--- a/ydb/core/mind/hive/hive_impl_ut.cpp
+++ b/ydb/core/mind/hive/hive_impl_ut.cpp
@@ -396,26 +396,12 @@ Y_UNIT_TEST_SUITE(TCutHistoryRestrictions) {
     }
 }
 
-namespace {
-
-class TScatterThresholdStatsHive : public TTestHive {
-public:
-    using TTestHive::TTestHive;
-    using THive::GetStats;
-
-    TNodeInfo& Node(TNodeId nodeId) {
-        return Nodes.at(nodeId);
-    }
-};
-
-} // namespace
-
 Y_UNIT_TEST_SUITE(THiveScatterThresholdStatsTest) {
     Y_UNIT_TEST(ScatterThresholdResourceMinimumUsesPerResourceFloor) {
         TActorSystemStub actorSystem;
         auto storage = MakeIntrusive<TTabletStorageInfo>();
         storage->TabletType = TTabletTypes::Hive;
-        TScatterThresholdStatsHive hive(storage.Get(), TActorId());
+        TTestHive hive(storage.Get(), TActorId());
         hive.UpdateConfig([](NKikimrConfig::THiveConfig& config) {
             config.SetMinNodeUsageToBalance(0.1);
             config.SetMaxResourceCounter(100);
@@ -447,7 +433,7 @@ Y_UNIT_TEST_SUITE(THiveScatterThresholdStatsTest) {
         TActorSystemStub actorSystem;
         auto storage = MakeIntrusive<TTabletStorageInfo>();
         storage->TabletType = TTabletTypes::Hive;
-        TScatterThresholdStatsHive hive(storage.Get(), TActorId());
+        TTestHive hive(storage.Get(), TActorId());
         hive.UpdateConfig([](NKikimrConfig::THiveConfig& config) {
             config.SetMinNodeUsageToBalance(0.1);
         });
@@ -472,7 +458,7 @@ Y_UNIT_TEST_SUITE(THiveScatterThresholdStatsTest) {
         TActorSystemStub actorSystem;
         auto storage = MakeIntrusive<TTabletStorageInfo>();
         storage->TabletType = TTabletTypes::Hive;
-        TScatterThresholdStatsHive hive(storage.Get(), TActorId());
+        TTestHive hive(storage.Get(), TActorId());
         hive.UpdateConfig([](NKikimrConfig::THiveConfig&) {});
         const auto stats = hive.GetStats();
         UNIT_ASSERT(stats.Values.empty());

--- a/ydb/core/mind/hive/hive_impl_ut.cpp
+++ b/ydb/core/mind/hive/hive_impl_ut.cpp
@@ -1,3 +1,4 @@
+#include <ydb/core/testlib/actor_helpers.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/testing/unittest/tests_data.h>
 #include <ydb/library/actors/helpers/selfping_actor.h>
@@ -392,5 +393,89 @@ Y_UNIT_TEST_SUITE(TCutHistoryRestrictions) {
             config.SetCutHistoryDenyList("");
         });
         UNIT_ASSERT(hive.IsCutHistoryAllowed(TTabletTypes::DataShard));
+    }
+}
+
+namespace {
+
+class TScatterThresholdStatsHive : public TTestHive {
+public:
+    using TTestHive::TTestHive;
+    using THive::GetStats;
+
+    TNodeInfo& Node(TNodeId nodeId) {
+        return Nodes.at(nodeId);
+    }
+};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(THiveScatterThresholdStatsTest) {
+    Y_UNIT_TEST(ScatterThresholdResourceMinimumUsesPerResourceFloor) {
+        TActorSystemStub actorSystem;
+        auto storage = MakeIntrusive<TTabletStorageInfo>();
+        storage->TabletType = TTabletTypes::Hive;
+        TScatterThresholdStatsHive hive(storage.Get(), TActorId());
+        hive.UpdateConfig([](NKikimrConfig::THiveConfig& config) {
+            config.SetMinNodeUsageToBalance(0.1);
+            config.SetMaxResourceCounter(100);
+        });
+        hive.MakeNodes(2);
+        hive.Node(1).ResourceMaximumValues = {100, 100, 100, 100};
+        hive.Node(2).ResourceMaximumValues = {100, 100, 100, 100};
+        auto& first = hive.Node(1).ResourceValues;
+        auto& second = hive.Node(2).ResourceValues;
+        std::get<NMetrics::EResource::Counter>(first) = 1;
+        std::get<NMetrics::EResource::Counter>(second) = 9;
+        std::get<NMetrics::EResource::CPU>(first) = 5;
+        std::get<NMetrics::EResource::CPU>(second) = 20;
+        std::get<NMetrics::EResource::Memory>(first) = 40;
+        std::get<NMetrics::EResource::Memory>(second) = 50;
+        std::get<NMetrics::EResource::Network>(first) = 2;
+        std::get<NMetrics::EResource::Network>(second) = 3;
+
+        const auto stats = hive.GetStats();
+        // No tablet eligibility is involved in computing these statistics.
+        UNIT_ASSERT_VALUES_EQUAL(stats.Values.size(), 2);
+        UNIT_ASSERT_DOUBLES_EQUAL(std::get<NMetrics::EResource::Counter>(stats.MinResourceNormValues), 0.01, 1e-12);
+        UNIT_ASSERT_DOUBLES_EQUAL(std::get<NMetrics::EResource::CPU>(stats.MinResourceNormValues), 0.1, 1e-12);
+        UNIT_ASSERT_DOUBLES_EQUAL(std::get<NMetrics::EResource::Memory>(stats.MinResourceNormValues), 0.4, 1e-12);
+        UNIT_ASSERT_DOUBLES_EQUAL(std::get<NMetrics::EResource::Network>(stats.MinResourceNormValues), 0.1, 1e-12);
+    }
+
+    Y_UNIT_TEST(ScatterThresholdResourceMinimumExcludesDownAndDeadNodes) {
+        TActorSystemStub actorSystem;
+        auto storage = MakeIntrusive<TTabletStorageInfo>();
+        storage->TabletType = TTabletTypes::Hive;
+        TScatterThresholdStatsHive hive(storage.Get(), TActorId());
+        hive.UpdateConfig([](NKikimrConfig::THiveConfig& config) {
+            config.SetMinNodeUsageToBalance(0.1);
+        });
+        hive.MakeNodes(4);
+        for (TNodeId nodeId = 1; nodeId <= 4; ++nodeId) {
+            auto& node = hive.Node(nodeId);
+            node.ResourceMaximumValues = {100, 100, 100, 100};
+            std::get<NMetrics::EResource::CPU>(node.ResourceValues) = nodeId * 10;
+        }
+        hive.Node(1).Down = true;
+        hive.Node(2).Local = TActorId();
+
+        const auto stats = hive.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(stats.Values.size(), 2);
+        for (const auto& node : stats.Values) {
+            UNIT_ASSERT_C(node.NodeId == 3 || node.NodeId == 4, node.NodeId);
+        }
+        UNIT_ASSERT_DOUBLES_EQUAL(std::get<NMetrics::EResource::CPU>(stats.MinResourceNormValues), 0.3, 1e-12);
+    }
+
+    Y_UNIT_TEST(ScatterThresholdResourceMinimumForEmptyStats) {
+        TActorSystemStub actorSystem;
+        auto storage = MakeIntrusive<TTabletStorageInfo>();
+        storage->TabletType = TTabletTypes::Hive;
+        TScatterThresholdStatsHive hive(storage.Get(), TActorId());
+        hive.UpdateConfig([](NKikimrConfig::THiveConfig&) {});
+        const auto stats = hive.GetStats();
+        UNIT_ASSERT(stats.Values.empty());
+        UNIT_ASSERT_VALUES_EQUAL(max(stats.MinResourceNormValues), 0);
     }
 }

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -5488,9 +5488,18 @@ Y_UNIT_TEST_SUITE(THiveTest) {
             app.HiveConfig.SetMinMemoryScatterToBalance(1);
             app.HiveConfig.SetMinNetworkScatterToBalance(1);
             switch (resource) {
-            case NHive::EResourceToBalance::Counter:
+            case NHive::EResourceToBalance::Counter: {
                 app.HiveConfig.SetMinCounterScatterToBalance(minScatter);
+                // The default resource profile seeds each tablet with memory.
+                // Use the normal counter-only configuration before creation.
+                using TAllowedMetrics = NKikimrConfig::THiveConfig::THiveTabletAllowedMetrics;
+                auto* allowed = app.HiveConfig.AddDefaultTabletAllowedMetrics();
+                allowed->AddTabletType(TTabletTypes::Dummy);
+                allowed->SetCPU(TAllowedMetrics::Disabled);
+                allowed->SetMemory(TAllowedMetrics::Disabled);
+                allowed->SetNetwork(TAllowedMetrics::Disabled);
                 break;
+            }
             case NHive::EResourceToBalance::CPU:
                 app.HiveConfig.SetMinCPUScatterToBalance(minScatter);
                 break;
@@ -5614,12 +5623,19 @@ Y_UNIT_TEST_SUITE(THiveTest) {
             }
         }
         auto getTabletNodes = [&]() {
-            runtime.SendToPipe(hiveTablet, sender, new TEvHive::TEvRequestHiveInfo());
+            auto request = MakeHolder<TEvHive::TEvRequestHiveInfo>();
+            if (resource == NHive::EResourceToBalance::Counter) {
+                request->Record.SetReturnMetrics(true);
+            }
+            runtime.SendToPipe(hiveTablet, sender, request.Release());
             TAutoPtr<IEventHandle> handle;
             auto* response = runtime.GrabEdgeEventRethrow<TEvHive::TEvResponseHiveInfo>(handle);
             THashMap<ui64, ui32> result;
             for (const auto& tablet : response->Record.GetTablets()) {
                 if (tabletNodes.contains(tablet.GetTabletID())) {
+                    if (resource == NHive::EResourceToBalance::Counter) {
+                        UNIT_ASSERT_VALUES_EQUAL_C(tablet.GetMetrics().GetCounter(), 1, tablet.GetTabletID());
+                    }
                     const ui32 node = tablet.GetNodeID() - runtime.GetNodeId(0);
                     UNIT_ASSERT_LT(node, numNodes);
                     result.emplace(tablet.GetTabletID(), node);

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -5457,6 +5457,303 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         }
     }
 
+    // Each node has a movable 1% probe and ignored tablets supplying the rest of
+    // its load. AllowedNodes gives every probe a different destination, so a
+    // source selected in error is observable even when normal balancing would
+    // decide that moving its tablet is not useful.
+    void TestHiveScatterThresholdSource(
+            NHive::EResourceToBalance resource,
+            const std::vector<ui32>& percentages,
+            double minUsage,
+            double minScatter,
+            const std::vector<ui32>& expectedSources,
+            bool expectBalancer = true,
+            bool ignoreLastNode = false,
+            bool reportHigherNodeTotals = false) {
+        constexpr ui64 MAX_RESOURCE = 1'000'000;
+        constexpr ui64 RESOURCE_PER_PERCENT = MAX_RESOURCE / 100;
+        const ui32 numNodes = percentages.size();
+        UNIT_ASSERT_GE(numNodes, 2);
+        const ui64 hiveTablet = MakeDefaultHiveID();
+        const ui64 owner = MakeTabletID(false, 1);
+        TTestBasicRuntime runtime(numNodes, false);
+        Setup(runtime, true, 1, [&](TAppPrepare& app) {
+            app.HiveConfig.SetMaxResourceCPU(MAX_RESOURCE);
+            app.HiveConfig.SetMaxResourceCounter(resource == NHive::EResourceToBalance::Counter ? 100 : MAX_RESOURCE);
+            app.HiveConfig.SetMaxResourceMemory(MAX_RESOURCE * 1'000);
+            app.HiveConfig.SetMaxResourceNetwork(MAX_RESOURCE);
+            app.HiveConfig.SetMinNodeUsageToBalance(minUsage);
+            app.HiveConfig.SetMinCounterScatterToBalance(1);
+            app.HiveConfig.SetMinCPUScatterToBalance(1);
+            app.HiveConfig.SetMinMemoryScatterToBalance(1);
+            app.HiveConfig.SetMinNetworkScatterToBalance(1);
+            switch (resource) {
+            case NHive::EResourceToBalance::Counter:
+                app.HiveConfig.SetMinCounterScatterToBalance(minScatter);
+                break;
+            case NHive::EResourceToBalance::CPU:
+                app.HiveConfig.SetMinCPUScatterToBalance(minScatter);
+                break;
+            case NHive::EResourceToBalance::Memory:
+                app.HiveConfig.SetMinMemoryScatterToBalance(minScatter);
+                break;
+            case NHive::EResourceToBalance::Network:
+                app.HiveConfig.SetMinNetworkScatterToBalance(minScatter);
+                break;
+            default:
+                UNIT_FAIL("unsupported test resource");
+            }
+            app.HiveConfig.SetMaxNodeUsageToKick(1);
+            app.HiveConfig.SetSpreadNeighbours(false);
+            app.HiveConfig.SetWarmUpEnabled(false);
+            app.HiveConfig.SetTabletKickCooldownPeriod(0);
+            app.HiveConfig.SetResourceChangeReactionPeriod(86'400);
+            app.HiveConfig.SetMetricsWindowSize(3'600'000);
+            app.HiveConfig.SetMaxMovementsOnAutoBalancer(100);
+            app.HiveConfig.SetContinueAutoBalancer(false);
+            app.HiveConfig.SetBalancerInflight(1);
+            app.HiveConfig.SetCheckMoveExpediency(false);
+            app.HiveConfig.SetUseTabletUsageEstimate(false);
+            app.HiveConfig.SetNodeBalanceStrategy(NKikimrConfig::THiveConfig::HIVE_NODE_BALANCE_STRATEGY_HEAVIEST);
+        });
+        // Install the override before any tablet boots. Otherwise an early
+        // real sample could remain in the one-hour maximum metric window.
+        THashMap<ui64, ui64> tabletUsage;
+        bool publishMetrics = false;
+        auto setResource = [resource](NKikimrTabletBase::TMetrics& metrics, ui64 value) {
+            metrics.Clear();
+            switch (resource) {
+            case NHive::EResourceToBalance::Counter:
+                // Tablets without compute metrics contribute one to Counter.
+                metrics.SetCPU(0);
+                metrics.SetMemory(0);
+                metrics.SetNetwork(0);
+                break;
+            case NHive::EResourceToBalance::CPU:
+                metrics.SetCPU(value);
+                break;
+            case NHive::EResourceToBalance::Memory:
+                metrics.SetMemory(value * 1'000);
+                break;
+            case NHive::EResourceToBalance::Network:
+                metrics.SetNetwork(value);
+                break;
+            default:
+                UNIT_FAIL("unsupported test resource");
+            }
+        };
+        auto metricsObserver = runtime.AddObserver<TEvHive::TEvTabletMetrics>([&](auto&& ev) {
+            auto& record = ev->Get()->Record;
+            auto* maximum = record.MutableResourceMaximum();
+            maximum->Clear();
+            maximum->SetCPU(MAX_RESOURCE);
+            maximum->SetMemory(MAX_RESOURCE * 1'000);
+            maximum->SetNetwork(MAX_RESOURCE);
+            if (reportHigherNodeTotals) {
+                // Node totals are deliberately inconsistent with tablet sums;
+                // source selection must use the same sums as the scatter check.
+                setResource(*record.MutableTotalResourceUsage(), 80 * RESOURCE_PER_PERCENT);
+            }
+            for (auto& metric : *record.MutableTabletMetrics()) {
+                auto it = tabletUsage.find(metric.GetTabletID());
+                auto* usage = metric.MutableResourceUsage();
+                usage->Clear();
+                usage->SetCPU(0);
+                usage->SetMemory(0);
+                usage->SetNetwork(0);
+                if (publishMetrics && it != tabletUsage.end()) {
+                    setResource(*usage, it->second);
+                }
+            }
+        });
+        auto limitsObserver = runtime.AddObserver<TEvLocal::TEvStatus>([](auto&& ev) {
+            ev->Get()->Record.ClearResourceMaximum();
+        });
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(hiveTablet, TTabletTypes::Hive), &CreateDefaultHive);
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvLocal::EvStatus, numNodes);
+            runtime.DispatchEvents(options);
+        }
+        const TActorId hiveActor = ResolveTablet(runtime, hiveTablet);
+        auto blockBalancer = runtime.AddObserver<NHive::TEvPrivate::TEvProcessTabletBalancer>([hiveActor](auto& ev) {
+            // Other actors can reuse private event IDs.
+            if (ev->Recipient == hiveActor) {
+                ev.Reset();
+            }
+        });
+        const TActorId sender = runtime.AllocateEdgeActor();
+        std::vector<std::vector<ui64>> initial(numNodes);
+        THashMap<ui64, ui32> tabletNodes;
+        std::vector<ui64> probes(numNodes);
+        ui64 ownerIdx = 100500;
+        for (ui32 node = 0; node < numNodes; ++node) {
+            UNIT_ASSERT_GE(percentages[node], 1);
+            const ui32 numTablets = resource == NHive::EResourceToBalance::Counter ? percentages[node] : 2;
+            for (ui32 part = 0; part < numTablets; ++part, ++ownerIdx) {
+                const bool ignored = part != 0 || (ignoreLastNode && node == numNodes - 1);
+                auto create = MakeHolder<TEvHive::TEvCreateTablet>(owner, ownerIdx, TTabletTypes::Dummy, BINDED_CHANNELS);
+                create->Record.SetObjectId(ownerIdx);
+                create->Record.AddAllowedNodeIDs(runtime.GetNodeId(node));
+                create->Record.SetBalancerPolicy(ignored ? NKikimrHive::POLICY_IGNORE : NKikimrHive::POLICY_BALANCE);
+                const ui64 tabletId = SendCreateTestTablet(runtime, hiveTablet, owner, std::move(create), 0, true);
+                MakeSureTabletIsUp(runtime, tabletId, 0);
+                initial[node].push_back(tabletId);
+                tabletNodes.emplace(tabletId, node);
+                tabletUsage.emplace(tabletId, (part == 0 ? 1 : percentages[node] - 1) * RESOURCE_PER_PERCENT);
+                if (part == 0) {
+                    probes[node] = tabletId;
+                }
+                if (!ignored) {
+                    auto update = MakeHolder<TEvHive::TEvCreateTablet>(owner, ownerIdx, TTabletTypes::Dummy, BINDED_CHANNELS);
+                    update->Record.SetObjectId(ownerIdx);
+                    update->Record.SetBalancerPolicy(NKikimrHive::POLICY_BALANCE);
+                    update->Record.AddAllowedNodeIDs(runtime.GetNodeId(node == 0 ? 1 : 0));
+                    UNIT_ASSERT_VALUES_EQUAL(SendCreateTestTablet(runtime, hiveTablet, owner, std::move(update), 0, false), tabletId);
+                }
+            }
+        }
+        auto getTabletNodes = [&]() {
+            runtime.SendToPipe(hiveTablet, sender, new TEvHive::TEvRequestHiveInfo());
+            TAutoPtr<IEventHandle> handle;
+            auto* response = runtime.GrabEdgeEventRethrow<TEvHive::TEvResponseHiveInfo>(handle);
+            THashMap<ui64, ui32> result;
+            for (const auto& tablet : response->Record.GetTablets()) {
+                if (tabletNodes.contains(tablet.GetTabletID())) {
+                    const ui32 node = tablet.GetNodeID() - runtime.GetNodeId(0);
+                    UNIT_ASSERT_LT(node, numNodes);
+                    result.emplace(tablet.GetTabletID(), node);
+                }
+            }
+            return result;
+        };
+        UNIT_ASSERT_EQUAL(getTabletNodes(), tabletNodes);
+        const auto initialTabletNodes = tabletNodes;
+        // Publish positive values only after every tablet has been created:
+        // tablet-type averages otherwise seed later probes with a larger load.
+        publishMetrics = true;
+
+        for (ui32 node = 0; node < numNodes; ++node) {
+            const TActorId localSender = runtime.AllocateEdgeActor(node);
+            const ui32 samples = reportHigherNodeTotals ? 20 : 1;
+            for (ui32 sample = 0; sample < samples; ++sample) {
+                auto metrics = MakeHolder<TEvHive::TEvTabletMetrics>();
+                for (ui64 tabletId : initial[node]) {
+                    auto* metric = metrics->Record.AddTabletMetrics();
+                    metric->SetTabletID(tabletId);
+                    setResource(*metric->MutableResourceUsage(), tabletUsage.at(tabletId));
+                }
+                runtime.SendToPipe(hiveTablet, localSender, metrics.Release(), node, GetPipeConfigWithRetries());
+                TAutoPtr<IEventHandle> handle;
+                runtime.GrabEdgeEventRethrow<TEvLocal::TEvTabletMetricsAck>(handle);
+            }
+        }
+        UNIT_ASSERT_EQUAL(getTabletNodes(), initialTabletNodes);
+        std::vector<ui32> departures(numNodes, 0);
+        auto movesObserver = runtime.AddObserver<TEvLocal::TEvBootTablet>([&](auto&& ev) {
+            const ui64 tabletId = ev->Get()->Record.GetInfo().GetTabletID();
+            auto it = tabletNodes.find(tabletId);
+            if (it == tabletNodes.end()) {
+                return;
+            }
+            const ui32 target = ev->Recipient.NodeId() - runtime.GetNodeId(0);
+            if (it->second != target) {
+                UNIT_ASSERT_VALUES_EQUAL(tabletId, probes[it->second]);
+                ++departures[it->second];
+                it->second = target;
+            }
+        });
+        bool finished = false;
+        bool balancerStarted = false;
+        auto completionObserver = runtime.AddObserver<NHive::TEvPrivate::TEvBalancerOut>([&](auto&& ev) {
+            if (ev->Recipient == hiveActor) {
+                finished = true;
+                // A check that does not create a balancer sends this event to
+                // itself; a completed balancer sends it from its own actor ID.
+                balancerStarted = ev->Sender != hiveActor;
+            }
+        });
+        blockBalancer.Remove();
+        BalanceTablets(runtime, hiveTablet, sender);
+        runtime.WaitFor("scatter balancer to finish", [&] { return finished; }, TDuration::Seconds(10));
+        UNIT_ASSERT_VALUES_EQUAL(balancerStarted, expectBalancer);
+        std::vector<ui32> expectedDepartures(numNodes, 0);
+        for (ui32 source : expectedSources) {
+            UNIT_ASSERT_LT(source, numNodes);
+            expectedDepartures[source] = 1;
+        }
+        UNIT_ASSERT_EQUAL(departures, expectedDepartures);
+        const auto finalTabletNodes = getTabletNodes();
+        for (ui32 node = 0; node < numNodes; ++node) {
+            for (ui32 part = 1; part < initial[node].size(); ++part) {
+                UNIT_ASSERT_VALUES_EQUAL(finalTabletNodes.at(initial[node][part]), node);
+            }
+            UNIT_ASSERT_VALUES_EQUAL(finalTabletNodes.at(probes[node]), expectedDepartures[node] ? (node == 0 ? 1 : 0) : node);
+        }
+    }
+
+    Y_UNIT_TEST(TestHiveScatterThresholdSourceBelowHalf) {
+        TestHiveScatterThresholdSource(NHive::EResourceToBalance::CPU, {10, 15, 20, 25, 30}, 0.1, 0.2, {1, 2, 3, 4});
+    }
+
+    Y_UNIT_TEST(TestHiveScatterThresholdSourceUsesActualMinimum) {
+        // The 60% node is exactly on the threshold and must not donate.
+        TestHiveScatterThresholdSource(NHive::EResourceToBalance::CPU, {30, 40, 50, 60, 70}, 0.1, 0.5, {4});
+    }
+
+    Y_UNIT_TEST(TestHiveScatterThresholdSourceAppliesUsageFloor) {
+        TestHiveScatterThresholdSource(NHive::EResourceToBalance::CPU, {1, 2, 3, 4, 5}, 0.0175, 0.5, {3, 4});
+    }
+
+    Y_UNIT_TEST(TestHiveScatterThresholdSourceMemory) {
+        TestHiveScatterThresholdSource(NHive::EResourceToBalance::Memory, {30, 40, 50, 60, 70}, 0.1, 0.5, {4});
+    }
+
+    Y_UNIT_TEST(TestHiveScatterThresholdSourceNetwork) {
+        TestHiveScatterThresholdSource(NHive::EResourceToBalance::Network, {30, 40, 50, 60, 70}, 0.1, 0.5, {4});
+    }
+
+    Y_UNIT_TEST(TestHiveScatterThresholdSourceUsesTabletMetricsSnapshot) {
+        TestHiveScatterThresholdSource(NHive::EResourceToBalance::CPU, {30, 40, 50, 60, 70}, 0.1, 0.5, {4}, true, false, true);
+    }
+
+    Y_UNIT_TEST(TestHiveScatterThresholdSourceAllowsEmptyRun) {
+        // Only the 70% node passes the source threshold; both its tablets are
+        // ignored. Other nodes still have movable probes, which must stay put.
+        TestHiveScatterThresholdSource(NHive::EResourceToBalance::CPU, {30, 40, 50, 60, 70}, 0.1, 0.5, {}, true, true);
+    }
+
+    Y_UNIT_TEST(TestHiveScatterThresholdDoesNotExpandSourcesToFillBudget) {
+        // MaxMovements=100 must not expand the original source list after the
+        // two eligible probes have moved. Node 6 has no movable tablet.
+        TestHiveScatterThresholdSource(NHive::EResourceToBalance::CPU, {1, 2, 3, 4, 5, 6}, 0.0175, 0.5, {3, 4}, true, true);
+    }
+
+    Y_UNIT_TEST(TestHiveScatterThresholdSourceEmptyFilterDoesNotMeanAllNodes) {
+        // In double arithmetic (.04 - .03) / .04 > .25, while .03 / .75
+        // rounds to .04. No source passes the strict threshold. Never pass an
+        // empty filter to the balancer: it means all live nodes there.
+        TestHiveScatterThresholdSource(NHive::EResourceToBalance::CPU, {3, 4}, 0.03, 0.25, {}, false);
+    }
+
+    Y_UNIT_TEST(TestHiveScatterThresholdSourceRejectsNegativeScatter) {
+        TestHiveScatterThresholdSource(NHive::EResourceToBalance::CPU, {10, 15, 20, 25, 30}, 0.1, -0.2, {}, false);
+    }
+
+    Y_UNIT_TEST(TestHiveScatterThresholdSourceDoesNotStartAtUnitScatter) {
+        TestHiveScatterThresholdSource(NHive::EResourceToBalance::CPU, {10, 15, 20, 25, 30}, 0.1, 1.0, {}, false);
+    }
+
+    Y_UNIT_TEST(TestHiveScatterThresholdSourceZeroScatter) {
+        TestHiveScatterThresholdSource(NHive::EResourceToBalance::CPU, {10, 15, 20, 25, 30}, 0.1, 0.0, {1, 2, 3, 4});
+    }
+
+    Y_UNIT_TEST(TestHiveScatterThresholdSourceCounterIgnoresUsageFloor) {
+        // Counter loads are the counts of tablets. The compute-resource floor
+        // of 90% must not suppress a Counter balancer or change its sources.
+        TestHiveScatterThresholdSource(NHive::EResourceToBalance::Counter, {3, 4, 5, 6, 7}, 0.9, 0.5, {4});
+    }
+
     Y_UNIT_TEST(TestHiveBalancerDifferentResources) {
         static constexpr ui64 TABLETS_PER_NODE = 4;
         TTestBasicRuntime runtime(2, false);

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -5525,10 +5525,7 @@ Y_UNIT_TEST_SUITE(THiveTest) {
             app.HiveConfig.SetUseTabletUsageEstimate(false);
             app.HiveConfig.SetNodeBalanceStrategy(NKikimrConfig::THiveConfig::HIVE_NODE_BALANCE_STRATEGY_HEAVIEST);
         });
-        // Install the override before any tablet boots. Otherwise an early
-        // real sample could remain in the one-hour maximum metric window.
         THashMap<ui64, ui64> tabletUsage;
-        bool publishMetrics = false;
         auto setResource = [resource](NKikimrTabletBase::TMetrics& metrics, ui64 value) {
             metrics.Clear();
             switch (resource) {
@@ -5551,30 +5548,6 @@ Y_UNIT_TEST_SUITE(THiveTest) {
                 UNIT_FAIL("unsupported test resource");
             }
         };
-        auto metricsObserver = runtime.AddObserver<TEvHive::TEvTabletMetrics>([&](auto&& ev) {
-            auto& record = ev->Get()->Record;
-            auto* maximum = record.MutableResourceMaximum();
-            maximum->Clear();
-            maximum->SetCPU(MAX_RESOURCE);
-            maximum->SetMemory(MAX_RESOURCE * 1'000);
-            maximum->SetNetwork(MAX_RESOURCE);
-            if (reportHigherNodeTotals) {
-                // Node totals are deliberately inconsistent with tablet sums;
-                // source selection must use the same sums as the scatter check.
-                setResource(*record.MutableTotalResourceUsage(), 80 * RESOURCE_PER_PERCENT);
-            }
-            for (auto& metric : *record.MutableTabletMetrics()) {
-                auto it = tabletUsage.find(metric.GetTabletID());
-                auto* usage = metric.MutableResourceUsage();
-                usage->Clear();
-                usage->SetCPU(0);
-                usage->SetMemory(0);
-                usage->SetNetwork(0);
-                if (publishMetrics && it != tabletUsage.end()) {
-                    setResource(*usage, it->second);
-                }
-            }
-        });
         auto limitsObserver = runtime.AddObserver<TEvLocal::TEvStatus>([](auto&& ev) {
             ev->Get()->Record.ClearResourceMaximum();
         });
@@ -5645,15 +5618,21 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         };
         UNIT_ASSERT_EQUAL(getTabletNodes(), tabletNodes);
         const auto initialTabletNodes = tabletNodes;
-        // Publish positive values only after every tablet has been created:
-        // tablet-type averages otherwise seed later probes with a larger load.
-        publishMetrics = true;
 
         for (ui32 node = 0; node < numNodes; ++node) {
             const TActorId localSender = runtime.AllocateEdgeActor(node);
             const ui32 samples = reportHigherNodeTotals ? 20 : 1;
             for (ui32 sample = 0; sample < samples; ++sample) {
                 auto metrics = MakeHolder<TEvHive::TEvTabletMetrics>();
+                auto* maximum = metrics->Record.MutableResourceMaximum();
+                maximum->SetCPU(MAX_RESOURCE);
+                maximum->SetMemory(MAX_RESOURCE * 1'000);
+                maximum->SetNetwork(MAX_RESOURCE);
+                if (reportHigherNodeTotals) {
+                    // Node totals are deliberately inconsistent with tablet sums;
+                    // source selection must use the same sums as the scatter check.
+                    setResource(*metrics->Record.MutableTotalResourceUsage(), 80 * RESOURCE_PER_PERCENT);
+                }
                 for (ui64 tabletId : initial[node]) {
                     auto* metric = metrics->Record.AddTabletMetrics();
                     metric->SetTabletID(tabletId);
@@ -6104,6 +6083,9 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         Setup(runtime, true, 1, [](TAppPrepare& app) {
             app.HiveConfig.SetTabletKickCooldownPeriod(0);
             app.HiveConfig.SetResourceChangeReactionPeriod(0);
+            // Loads are 150%, 30%, and nearly 0%. Keep the 30% donor above
+            // the source threshold: 0.1 / (1 - 0.5) = 20%.
+            app.HiveConfig.SetMinNodeUsageToBalance(0.1);
         });
         const int nodeBase = runtime.GetNodeId(0);
         TActorId senderA = runtime.AllocateEdgeActor();
@@ -6175,6 +6157,7 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         auto newDistribution = getDistribution();
         UNIT_ASSERT_VALUES_EQUAL(newDistribution[0].size(), TABLETS_PER_NODE);
         UNIT_ASSERT_VALUES_EQUAL(newDistribution[1].size(), TABLETS_PER_NODE - 1);
+        UNIT_ASSERT_VALUES_EQUAL(newDistribution[2].size(), TABLETS_PER_NODE + 1);
     }
 
     Y_UNIT_TEST(TestHiveBalancerHighUsage) {

--- a/ydb/core/mind/hive/ut_common.h
+++ b/ydb/core/mind/hive/ut_common.h
@@ -25,6 +25,12 @@ class TTestHive : public THive {
 public:
     TTestHive(TTabletStorageInfo *info, const TActorId &tablet) : THive(info, tablet) {}
 
+    using THive::GetStats;
+
+    TNodeInfo& Node(TNodeId nodeId) {
+        return Nodes.at(nodeId);
+    }
+
     template<typename F>
     void UpdateConfig(F func) {
         func(ClusterConfig);


### PR DESCRIPTION
### Описание для журнала изменений

Hive выбирает источники автоматической балансировки по порогу, согласованному с условием её запуска по разбросу нагрузки. Ноды на границе порога и ниже него не становятся источниками. Пустой результат отбора больше не превращается в разрешение свозить таблетки со всех живых нод.

### Подробности изменений

Раньше после срабатывания проверки разброса нагрузки в список возможных источников попадали все ноды сегмента. Теперь Hive отбирает только ноды, нагрузка которых строго превышает рассчитанный порог.

Для выбранного ресурса сначала определяется минимум нагрузки среди участвующих в расчёте нод. Для процессора, памяти и сети этот минимум ограничивается снизу значением `MinNodeUsageToBalance`; для счётчика таблеток `Counter` нижняя граница равна нулю. Полученное значение делится на `1 - Min<Resource>ScatterToBalance`. Нода становится источником только при строгом превышении результата.

Например, при нагрузках процессора **10%, 15%, 20%, 25%, 30%**, `MinNodeUsageToBalance=0.1` и `MinCPUScatterToBalance=0.2` разброс равен примерно 0,667, поэтому проверка запуска проходит. Порог источника равен **12,5%**: источниками становятся только ноды №2–5. Нода №1 может получать таблетки.

При нагрузках процессора **30%, 40%, 50%, 60%, 70%**, той же нижней границе 0,1 и пороге разброса 0,5 порог источника равен **60%**. Источником становится только нода №5. Нода с нагрузкой ровно 60% не проходит строгое сравнение. Здесь важно использовать фактический минимум 30%, а не только настройку `MinNodeUsageToBalance`: иначе порог оказался бы занижен до 20%.

В примере **1%, 2%, 3%, 4%, 5%, 6%**, при `MinNodeUsageToBalance=0.0175` и `MinCPUScatterToBalance=0.5` начальный порог равен **3,5%**. В список попадают ноды №4–6. Если на №6 нет допустимых для перевозки таблеток, своз возможен только с №4 и №5. Большой лимит `MaxMovementsOnAutoBalancer` не расширяет первоначальный список источников. Если единственная прошедшая порог нода не содержит подходящих таблеток, допускается запуск с нулём перемещений.

Отдельная проверка пустого списка защищает от округления на границе порога. Например, вычисление `(0.04 - 0.03) / 0.04` в формате двойной точности может дать число чуть больше 0,25, тогда как `0.03 / (1 - 0.25)` равно 0,04. Проверка запуска проходит, а строгий отбор пуст. В этом случае актор балансировки по разбросу нагрузки не создаётся. Общий смысл пустого фильтра для других режимов балансировки не изменён.

### Тесты и покрытие
Добавлены 16 тестов: 13 тестов с запуском акторов и реальными перевозками таблеток и 3 модульных теста статистики. Проверяются отбор по процессору, памяти, сети и счётчику таблеток; фактический минимум и нижняя граница; строгое сравнение; превышение суммарных метрик таблеток общей нагрузкой ноды; отсутствие допустимых таблеток на источнике; большой лимит перемещений; округление на границе; нулевое, единичное и отрицательное значения порога разброса. Модульные тесты дополнительно проверяют ресурсные минимумы, нулевую нижнюю границу для счётчика таблеток, исключение недоступных нод и пустую статистику.

### Сложность и сравнение со стабильной веткой 26-2

Минимум сохраняется в существующем проходе `GetStats`, дополнительного прохода и новых коллекций нет. В `THiveStats` добавлены четыре значения типа `double`; резервирование списка `nodeIds` остаётся до N элементов. При 100 тысячах нод решение по-прежнему линейно по N и не приобретает зависимости от количества таблеток. Для неизменённой стратегии `HEAVIEST` сортировка источников внутри актора имеет сложность O(K log K); K может достигать N, поэтому худшая асимптотика не улучшена. Подбор получателей, обход таблеток и дальнейшие перемещения не входят в оценку этапа принятия решения. Это анализ сложности исходников, а не измерение времени или утверждение об ускорении.
