### PR TITLE
[Backport nbs-26-3-1] DDisk/PBuffer APIs and lifecycle

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -640,6 +640,9 @@ struct TEvBlobStorage {
         EvIncrHugeReadLogResult,
         EvIncrHugeScanResult,
 
+        // Device overestimation sample transport (DDisk/PersistentBuffer -> PDisk)
+        EvDeviceOverestimationSamples,
+
         EvEnd
     };
 

--- a/ydb/core/blobstorage/ddisk/ddisk.h
+++ b/ydb/core/blobstorage/ddisk/ddisk.h
@@ -465,6 +465,12 @@ struct TPersistentBufferFormat {
     ui32 DeallocateFreeSpaceThresholdPercent = 90;
     // Deallocate a chunk proactively when it has been freed for this many seconds.
     ui32 DeallocateThresholdSeconds = 30;
+    // TEvListPersistentBuffer must not observe a partially-applied write/erase for its tablet: the
+    // listing is deferred (queued and retried) while any disk operation is in flight for the
+    // requesting tablet. These parameters bound how long/how often we wait before giving up and
+    // replying with an OVERLOADED error to avoid returning a potentially-stale view.
+    ui32 ListPersistentBufferMaxRetries = 10;
+    ui32 ListPersistentBufferRetryPeriodMilliseconds = 20;
 };
 
 #define DECLARE_DDISK_EVENT(NAME) \

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
@@ -372,6 +372,7 @@ namespace {
             hFunc(TEvErasePersistentBuffer, Handle)
             hFunc(TEvBatchErasePersistentBuffer, Handle)
             hFunc(TEvListPersistentBuffer, Handle)
+            hFunc(TEvPrivate::TEvRetryListPersistentBuffer, Handle)
             hFunc(TEvGetPersistentBufferInfo, Handle)
 
             hFunc(TEvPrivate::TEvReadPersistentBufferPart, Handle)

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
@@ -453,6 +453,9 @@ namespace {
         }
 #endif
         CountersBase->RemoveSubgroupChain(CountersChain);
+        if (!IsPersistentBufferActor) {
+            Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), new TEvents::TEvGone());
+        }
         TActorBootstrapped::PassAway();
     }
 

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.h
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.h
@@ -24,6 +24,7 @@
 #endif
 
 #include <ydb/library/pdisk_io/uring_operation.h>
+#include <ydb/library/pdisk_io/device_io_sample.h>
 
 #include <ydb/core/util/spsc_circular_queue.h>
 
@@ -32,6 +33,7 @@
 #include <queue>
 
 #include <util/generic/hash_set.h>
+#include <util/system/mutex.h>
 
 #include <library/cpp/containers/absl/flat_hash_map.h>
 #include <library/cpp/containers/absl/flat_hash_set.h>
@@ -242,6 +244,45 @@ namespace NKikimr::NDDisk {
         std::unique_ptr<NPDisk::TUringRouter> UringRouter;
 #endif
 
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // The io_uring completion poller thread (via UringRouter's sample sink)
+        // pushes raw TDeviceIoSample-s into DeviceOverestimationSamples under
+        // DeviceOverestimationSamplesMutex. Periodically (WakeupFlushDeviceOverestimationSamples)
+        // the actor thread drains the buffer and forwards a batch to the owning
+        // PDisk actor (BaseInfo.PDiskActorID), which merges it with samples from
+        // other sources (PDisk's own block device, other DDisk/PB slots on the
+        // same PDisk) sharing the same physical device.
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        static constexpr size_t MaxBufferedDeviceOverestimationSamples = 4096;
+        static constexpr TDuration DeviceOverestimationFlushPeriod = TDuration::Seconds(5);
+
+        TMutex DeviceOverestimationSamplesMutex;
+        std::vector<NPDisk::TDeviceIoSample> DeviceOverestimationSamples;
+
+        // Flat cost-estimation constants derived once from PDiskParams (seek
+        // time, read/write speed) in InitUring(). Deliberately reuses PDisk's
+        // measured constants for the first iteration; IO_URING may warrant
+        // its own calibrated constants later.
+        ui64 DeviceOverestimationReadSpeedBps = 0;
+        ui64 DeviceOverestimationWriteSpeedBps = 0;
+
+        static constexpr ui64 NanosecondsPerSecond = 1'000'000'000ull;
+
+        // Estimates the cost of an operation excluding any seek cost (the
+        // owning PDisk actor's aggregator applies seek cost itself based on
+        // the merged, cross-source stream).
+        ui64 EstimateDeviceIoBaseCostNs(bool isWrite, ui64 size) const {
+            const ui64 speedBps = isWrite ? DeviceOverestimationWriteSpeedBps : DeviceOverestimationReadSpeedBps;
+            if (speedBps == 0) {
+                return 0;
+            }
+            return size * NanosecondsPerSecond / speedBps;
+        }
+
+        void OnDeviceIoSample(const NPDisk::TDeviceIoSample& sample);
+        void FlushDeviceOverestimationSamples();
+
     public:
         struct TEvPrivate {
             enum {
@@ -375,6 +416,7 @@ namespace NKikimr::NDDisk {
             WakeupCollectPbStats = 3,
             WakeupProcessPersistentBufferBatchWrite = 4,
             WakeupProcessDeallocatePersistentBufferChunk = 5,
+            WakeupFlushDeviceOverestimationSamples = 6,
         };
 
         struct TPbOpSnapshot {

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.h
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.h
@@ -255,6 +255,17 @@ namespace NKikimr::NDDisk {
                 EvIssuePersistentBufferChunkAllocation,
                 EvDeallocatePersistentBufferChunk,
                 EvDeallocatePersistentBufferChunkResult,
+                EvRetryListPersistentBuffer,
+            };
+
+           struct TEvRetryListPersistentBuffer : TEventLocal<TEvRetryListPersistentBuffer, EvRetryListPersistentBuffer> {
+                TAutoPtr<TEventHandle<TEvListPersistentBuffer>> Ev;
+                ui32 RetriesLeft;
+
+                TEvRetryListPersistentBuffer(TAutoPtr<TEventHandle<TEvListPersistentBuffer>> ev, ui32 retriesLeft)
+                    : Ev(ev)
+                    , RetriesLeft(retriesLeft)
+                {}
             };
 
             struct TEvIssuePersistentBufferChunkAllocation : TEventLocal<TEvIssuePersistentBufferChunkAllocation, EvIssuePersistentBufferChunkAllocation> {
@@ -883,6 +894,13 @@ namespace NKikimr::NDDisk {
         void Handle(TEvWriteResult::TPtr ev);
         void Handle(TEvents::TEvUndelivered::TPtr ev);
         void Handle(TEvListPersistentBuffer::TPtr ev);
+        void Handle(TEvPrivate::TEvRetryListPersistentBuffer::TPtr ev);
+        // Returns true if the given tablet currently has at least one persistent-buffer disk
+        // operation (write/erase/read) in flight. TEvListPersistentBuffer must not be answered
+        // while this holds, otherwise it could observe a partially-applied write or erase.
+        bool HasPersistentBufferInflightForTablet(ui64 tabletId) const;
+        void ProcessListPersistentBuffer(TAutoPtr<TEventHandle<TEvListPersistentBuffer>> ev, ui32 retriesLeft);
+        void ReplyListPersistentBuffer(TEventHandle<TEvListPersistentBuffer>& ev);
         void Handle(TEvPrivate::TEvIssuePersistentBufferChunkAllocation::TPtr ev);
         void Handle(TEvPrivate::TEvDeallocatePersistentBufferChunk::TPtr ev);
         void Handle(TEvPrivate::TEvDeallocatePersistentBufferChunkResult::TPtr ev);

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_boot.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_boot.cpp
@@ -160,7 +160,23 @@ namespace NKikimr::NDDisk {
                         {"errno", result.error()});
                 }
 
+                // Device overestimation tracking: reuse PDisk's measured seek/speed
+                // constants for the first iteration.
+                // SetSampleSink must be called before Start().
+                if (PDiskParams) {
+                    DeviceOverestimationReadSpeedBps = PDiskParams->ReadSpeedBps;
+                    DeviceOverestimationWriteSpeedBps = PDiskParams->WriteSpeedBps;
+                }
+                UringRouter->SetSampleSink([this](const NPDisk::TDeviceIoSample& sample) {
+                    OnDeviceIoSample(sample);
+                });
+
                 UringRouter->Start();
+
+                // Periodically flush buffered samples to the owning PDisk actor so it
+                // can merge them with samples from other sources sharing this device.
+                Schedule(DeviceOverestimationFlushPeriod,
+                    new TEvents::TEvWakeup(EWakeupTag::WakeupFlushDeviceOverestimationSamples));
             }
         }
 
@@ -187,6 +203,40 @@ namespace NKikimr::NDDisk {
             *Counters.DirectIO.FallbackPDiskCount = 1;
         }
 #endif
+    }
+
+    void TDDiskActor::OnDeviceIoSample(const NPDisk::TDeviceIoSample& sample) {
+        // Called from the io_uring completion poller thread (via UringRouter's
+        // sample sink). Keep this cheap: just fill BaseCostNs using the flat
+        // model and append under a mutex.
+        NPDisk::TDeviceIoSample sampleWithCost = sample;
+        sampleWithCost.BaseCostNs = EstimateDeviceIoBaseCostNs(sample.IsWrite, sample.Size);
+
+        TGuard<TMutex> guard(DeviceOverestimationSamplesMutex);
+        if (DeviceOverestimationSamples.size() >= MaxBufferedDeviceOverestimationSamples) {
+            // Drop oldest half under sustained overflow rather than the actor
+            // never keeping up; this is a monitoring signal, not correctness-critical.
+            const size_t toDrop = DeviceOverestimationSamples.size() / 2 + 1;
+            DeviceOverestimationSamples.erase(
+                DeviceOverestimationSamples.begin(), DeviceOverestimationSamples.begin() + toDrop);
+        }
+        DeviceOverestimationSamples.push_back(sampleWithCost);
+    }
+
+    void TDDiskActor::FlushDeviceOverestimationSamples() {
+        std::vector<NPDisk::TDeviceIoSample> batch;
+        {
+            TGuard<TMutex> guard(DeviceOverestimationSamplesMutex);
+            batch.swap(DeviceOverestimationSamples);
+        }
+
+        if (!batch.empty() && BaseInfo.PDiskActorID) {
+            TVector<NPDisk::TDeviceIoSample> samples(batch.begin(), batch.end());
+            Send(BaseInfo.PDiskActorID, new NPDisk::TEvDeviceOverestimationSamples(std::move(samples)));
+        }
+
+        Schedule(DeviceOverestimationFlushPeriod,
+            new TEvents::TEvWakeup(EWakeupTag::WakeupFlushDeviceOverestimationSamples));
     }
 
     void TDDiskActor::StartHandlingQueries() {

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_persistent_buffer.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_persistent_buffer.cpp
@@ -2081,6 +2081,80 @@ namespace NKikimr::NDDisk {
         Send(ev->Sender, std::move(reply), 0, ev->Cookie);
     }
 
+    bool TDDiskActor::HasPersistentBufferInflightForTablet(ui64 tabletId) const {
+        // A single scan over PersistentBufferDiskOperationInflight is sufficient: every in-flight
+        // persistent-buffer disk operation (write, batched write, erase, barrier/fast erase, read)
+        // registers exactly one entry here, and each entry's Records carry the owning TabletId. The
+        // map is bounded by the disk operations inflight limit, so this scan is cheap.
+        for (const auto& [_, inflight] : PersistentBufferDiskOperationInflight) {
+            for (const auto& record : inflight.Records) {
+                if (record.TabletId == tabletId) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    void TDDiskActor::ReplyListPersistentBuffer(TEventHandle<TEvListPersistentBuffer>& ev) {
+        const auto& record = ev.Get()->Record;
+        const TQueryCredentials creds(record.GetCredentials());
+
+        Counters.Interface.ListPersistentBuffer.Request(0);
+
+        auto reply = std::make_unique<TEvListPersistentBufferResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
+        auto& rr = reply->Record;
+        rr.SetBarrierLsn(PersistentBufferBarriersManager.GetBarrier(creds.TabletId).Lsn);
+        for (auto it = PersistentBuffers.lower_bound({creds.TabletId, 0}); it != PersistentBuffers.end() &&
+                it->first.TabletId == creds.TabletId; ++it) {
+            const TPersistentBuffer& buffer = it->second;
+            for (const auto& [lsn, pr] : buffer.Records) {
+                auto *pb = rr.AddRecords();
+                auto *sel = pb->MutableSelector();
+                sel->SetVChunkIndex(pr.VChunkIndex);
+                sel->SetOffsetInBytes(pr.OffsetInBytes);
+                sel->SetSize(pr.Size);
+                pb->SetGeneration(it->first.Generation);
+                pb->SetLsn(lsn);
+            }
+        }
+
+        Counters.Interface.ListPersistentBuffer.Reply(true, 0);
+        SendReply(ev, std::move(reply));
+    }
+
+    void TDDiskActor::ProcessListPersistentBuffer(TAutoPtr<TEventHandle<TEvListPersistentBuffer>> ev, ui32 retriesLeft) {
+        const auto& record = ev->Get()->Record;
+        const TQueryCredentials creds(record.GetCredentials());
+
+        if (HasPersistentBufferInflightForTablet(creds.TabletId)) {
+            if (retriesLeft == 0) {
+                YDB_LOG_DEBUG_COMP(NKikimrServices::BS_PERSISTENT_BUFFER, "TDDiskActor::ProcessListPersistentBuffer retries exhausted, replying with error",
+                    {"marker", "BSPB"},
+                    {"PBufferId", SelfId()},
+                    {"tabletId", creds.TabletId});
+                Counters.Interface.ListPersistentBuffer.Request(0);
+                Counters.Interface.ListPersistentBuffer.Reply(false, 0);
+                SendReply(*ev, std::make_unique<TEvListPersistentBufferResult>(
+                    NKikimrBlobStorage::NDDisk::TReplyStatus::OVERLOADED,
+                    TStringBuilder() << "persistent buffer disk operation still in flight for tablet "
+                        << creds.TabletId << " after " << PersistentBufferFormat.ListPersistentBufferMaxRetries
+                        << " retries"));
+                return;
+            }
+            YDB_LOG_TRACE_COMP(NKikimrServices::BS_PERSISTENT_BUFFER, "TDDiskActor::ProcessListPersistentBuffer waiting for inflight to drain",
+                {"marker", "BSPB"},
+                {"PBufferId", SelfId()},
+                {"tabletId", creds.TabletId},
+                {"retriesLeft", retriesLeft});
+            Schedule(TDuration::MilliSeconds(PersistentBufferFormat.ListPersistentBufferRetryPeriodMilliseconds),
+                new TEvPrivate::TEvRetryListPersistentBuffer(ev, retriesLeft - 1));
+            return;
+        }
+
+        ReplyListPersistentBuffer(*ev);
+    }
+
     void TDDiskActor::Handle(TEvListPersistentBuffer::TPtr ev) {
         if (!CheckQuery(*ev, &Counters.Interface.ListPersistentBuffer)) {
             return;
@@ -2107,30 +2181,11 @@ namespace NKikimr::NDDisk {
             return;
         }
 
-        const auto& record = ev->Get()->Record;
-        const TQueryCredentials creds(record.GetCredentials());
+        ProcessListPersistentBuffer(ev.Release(), PersistentBufferFormat.ListPersistentBufferMaxRetries);
+    }
 
-        Counters.Interface.ListPersistentBuffer.Request(0);
-
-        auto reply = std::make_unique<TEvListPersistentBufferResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
-        auto& rr = reply->Record;
-        rr.SetBarrierLsn(PersistentBufferBarriersManager.GetBarrier(creds.TabletId).Lsn);
-        for (auto it = PersistentBuffers.lower_bound({creds.TabletId, 0}); it != PersistentBuffers.end() &&
-                it->first.TabletId == creds.TabletId; ++it) {
-            const TPersistentBuffer& buffer = it->second;
-            for (const auto& [lsn, pr] : buffer.Records) {
-                auto *pb = rr.AddRecords();
-                auto *sel = pb->MutableSelector();
-                sel->SetVChunkIndex(pr.VChunkIndex);
-                sel->SetOffsetInBytes(pr.OffsetInBytes);
-                sel->SetSize(pr.Size);
-                pb->SetGeneration(it->first.Generation);
-                pb->SetLsn(lsn);
-            }
-        }
-
-        Counters.Interface.ListPersistentBuffer.Reply(true, 0);
-        SendReply(*ev, std::move(reply));
+    void TDDiskActor::Handle(TEvPrivate::TEvRetryListPersistentBuffer::TPtr ev) {
+        ProcessListPersistentBuffer(ev->Get()->Ev, ev->Get()->RetriesLeft);
     }
 
     TString TDDiskActor::PersistentBufferToString() {

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_read_write.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_read_write.cpp
@@ -427,6 +427,10 @@ namespace NKikimr::NDDisk {
                 ProcessDeallocatePersistentBufferChunk(true);
                 break;
             }
+            case EWakeupTag::WakeupFlushDeviceOverestimationSamples: {
+                FlushDeviceOverestimationSamples();
+                break;
+            }
         }
     }
 

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
@@ -1196,6 +1196,85 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
 
     }
 
+    // TEvListPersistentBuffer must not observe a partially-applied write for its tablet: it has to
+    // wait for any in-flight persistent-buffer disk operation belonging to that tablet to finish
+    // before replying. Regression test for that ordering guarantee.
+    Y_UNIT_TEST(PersistentBufferListWaitsForInflightWrite) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(6, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.PBServiceId, 40, 1);
+
+        const ui64 lsn = 10;
+        const TString payload = MakeData('P', BlockSize);
+        const NDDisk::TBlockSelector selector{3, 0, BlockSize};
+
+        auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(creds, selector, lsn, NDDisk::TWriteInstruction(0));
+        write->AddPayloadThenChecksum(TRope(payload));
+        SendToDDisk(ctx, disk.PBServiceId, write.release());
+
+        // The write's disk op is now in flight (not yet acked by PDisk). Issue the list request for
+        // the same tablet while it is still in flight: it must be deferred and only answered once the
+        // write completes, never with a stale/partial view.
+        auto pbWriteRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+        UNIT_ASSERT(pbWriteRaw->Get()->Data.size() > 0);
+
+        SendToDDisk(ctx, disk.PBServiceId, new NDDisk::TEvListPersistentBuffer(creds));
+
+        ctx.SendPDiskResponse(disk, *pbWriteRaw, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+
+        auto writeResult = WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx);
+        AssertStatus(writeResult, TReplyStatus::OK);
+
+        auto listResult = WaitFromDDisk<NDDisk::TEvListPersistentBufferResult>(ctx);
+        AssertStatus(listResult, TReplyStatus::OK);
+        // The list must reflect the completed write (i.e. it waited for the inflight to drain),
+        // not the state as it was before the write finished.
+        UNIT_ASSERT_VALUES_EQUAL(listResult->Get()->Record.RecordsSize(), 1);
+        const auto& record = listResult->Get()->Record.GetRecords(0);
+        UNIT_ASSERT_VALUES_EQUAL(record.GetLsn(), lsn);
+    }
+
+    // Once retries are exhausted while the tablet's persistent-buffer disk operation is still in
+    // flight, TEvListPersistentBuffer must reply with an error (not hang, and not answer with a
+    // possibly-stale view).
+    Y_UNIT_TEST(PersistentBufferListRepliesErrorAfterRetriesExhausted) {
+        TTestContext ctx;
+        NDDisk::TPersistentBufferFormat fmt;
+        fmt.MaxChunks = 256;
+        fmt.InitChunks = PersistentBufferInitChunks;
+        fmt.MaxInMemoryCache = BlockSize * 128;
+        fmt.MaxChunkRestoreInflight = 8;
+        fmt.UpdateFreeSpaceInfoMilliseconds = 5000;
+        fmt.PerTabletStorageLimit = 512 * 1024;
+        fmt.ListPersistentBufferMaxRetries = 2;
+        fmt.ListPersistentBufferRetryPeriodMilliseconds = 5;
+        const TDiskHandle disk = ctx.CreateDDisk(6, 1, fmt);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.PBServiceId, 40, 1);
+
+        const ui64 lsn = 10;
+        const TString payload = MakeData('P', BlockSize);
+        const NDDisk::TBlockSelector selector{3, 0, BlockSize};
+
+        auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(creds, selector, lsn, NDDisk::TWriteInstruction(0));
+        write->AddPayloadThenChecksum(TRope(payload));
+        SendToDDisk(ctx, disk.PBServiceId, write.release());
+
+        // Leave the write's disk op in flight (never ack it) and issue a list request for the same
+        // tablet: it must keep retrying, then give up and reply with an error once retries run out.
+        auto pbWriteRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+        UNIT_ASSERT(pbWriteRaw->Get()->Data.size() > 0);
+
+        SendToDDisk(ctx, disk.PBServiceId, new NDDisk::TEvListPersistentBuffer(creds));
+
+        auto listResult = WaitFromDDisk<NDDisk::TEvListPersistentBufferResult>(ctx);
+        AssertStatus(listResult, TReplyStatus::OVERLOADED);
+
+        // Complete the write afterwards so the test tears down cleanly.
+        ctx.SendPDiskResponse(disk, *pbWriteRaw, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto writeResult = WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx);
+        AssertStatus(writeResult, TReplyStatus::OK);
+    }
+
     Y_UNIT_TEST(PersistentBufferWriteTunnel) {
         TTestContext ctx;
         const TDiskHandle disk1 = ctx.CreateDDisk(6, 1);

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
@@ -314,6 +314,54 @@ std::unique_ptr<TEventHandle<NDDisk::TEvWriteResult>> DoWrite(TTestContext& ctx,
 } // anonymous namespace
 
 Y_UNIT_TEST_SUITE(TDDiskActorTest) {
+    Y_UNIT_TEST(PoisonNotifiesNodeWardenImmediately) {
+        TTestContext ctx;
+        ctx.Runtime.RegisterService(MakeBlobStorageNodeWardenID(NodeId), ctx.Edge);
+
+        const TDiskHandle disk = ctx.CreateDDisk(43, 1);
+        const TActorId ddiskActorId =
+            ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.ServiceId);
+        const TActorId persistentBufferActorId =
+            ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.PBServiceId);
+        UNIT_ASSERT(ddiskActorId);
+        UNIT_ASSERT(persistentBufferActorId);
+
+        std::unique_ptr<IEventHandle> blockedPersistentBufferPoison;
+        ctx.Runtime.FilterFunction = [&](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev) {
+            if (!blockedPersistentBufferPoison &&
+                    ev->GetTypeRewrite() == TEvents::TSystem::Poison &&
+                    ev->Recipient == persistentBufferActorId) {
+                blockedPersistentBufferPoison = std::move(ev);
+                return false;
+            }
+            return true;
+        };
+
+        SendToDDisk(ctx, disk.ServiceId, new TEvents::TEvPoison());
+        ui32 eventsProcessed = 0;
+        ctx.Runtime.Sim([&] {
+            return !blockedPersistentBufferPoison && ++eventsProcessed <= 200;
+        });
+        UNIT_ASSERT_C(blockedPersistentBufferPoison, "DDisk must poison its persistent buffer actor");
+        UNIT_ASSERT(!ctx.Runtime.WrapInActorContext(ddiskActorId, [](IActor*) {}));
+        UNIT_ASSERT(ctx.Runtime.WrapInActorContext(persistentBufferActorId, [](IActor*) {}));
+
+        ctx.Runtime.FilterFunction = {};
+        const auto gone = WaitFromDDisk<TEvents::TEvGone>(ctx);
+
+        ctx.Runtime.Send(std::move(blockedPersistentBufferPoison), NodeId);
+
+        UNIT_ASSERT_VALUES_EQUAL(gone->Sender, ddiskActorId);
+        UNIT_ASSERT(!ctx.Runtime.WrapInActorContext(ddiskActorId, [](IActor*) {}));
+        ui32 persistentBufferEventsProcessed = 0;
+        ctx.Runtime.Sim([&] {
+            return ctx.Runtime.WrapInActorContext(persistentBufferActorId, [](IActor*) {})
+                && ++persistentBufferEventsProcessed <= 200;
+        });
+        UNIT_ASSERT_C(!ctx.Runtime.WrapInActorContext(persistentBufferActorId, [](IActor*) {}),
+            "Persistent buffer must stop after receiving poison");
+    }
+
     Y_UNIT_TEST(SessionValidation) {
         TTestContext ctx;
         const TDiskHandle disk = ctx.CreateDDisk(1, 1);

--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -1408,6 +1408,163 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         CheckVDiskStateUpdate(runtime, fakeWhiteboard, groupId, 2, 2u);
     }
 
+    class TSilentPDiskActor : public TActorBootstrapped<TSilentPDiskActor> {
+    public:
+        void Bootstrap() {
+            Become(&TThis::StateFunc);
+        }
+
+        STFUNC(StateFunc) {
+            if (ev->GetTypeRewrite() == TEvents::TSystem::Poison) {
+                PassAway();
+            }
+        }
+    };
+
+    class TSilentPDiskServiceFactory : public IPDiskServiceFactory {
+    public:
+        void Create(const TActorContext& ctx, ui32 pdiskId, const TIntrusivePtr<TPDiskConfig>&,
+                const NPDisk::TMainKey&, ui32 poolId, ui32 nodeId) override {
+            const TActorId actorId = ctx.Register(new TSilentPDiskActor, TMailboxType::HTSwap, poolId);
+            ctx.ActorSystem()->RegisterLocalService(MakeBlobStoragePDiskID(nodeId, pdiskId), actorId);
+        }
+    };
+
+    struct TDDiskLifecycleTestSetup {
+        static constexpr ui32 NodeId = 1;
+        static constexpr ui32 PDiskId = 1;
+        static constexpr ui32 VDiskSlotId = 1;
+
+        TTestActorSystem Runtime;
+        const ui32 GroupId;
+        const TVDiskID VDiskId;
+        const TActorId DDiskServiceId;
+        TActorId NodeWardenId;
+
+        TDDiskLifecycleTestSetup()
+            : Runtime(1, NLog::PRI_ERROR, MakeIntrusive<TDomainsInfo>())
+            , GroupId(TGroupID(EGroupConfigurationType::Dynamic, 1, 1).GetRaw())
+            , VDiskId(GroupId, 1, 0, 0, 0)
+            , DDiskServiceId(MakeBlobStorageDDiskId(NodeId, PDiskId, VDiskSlotId))
+        {
+            Runtime.Start();
+
+            auto& appData = *Runtime.GetNode(NodeId)->AppData;
+            appData.DomainsInfo->AddDomain(TDomainsInfo::TDomain::ConstructEmptyDomain("dom", 1).Release());
+            appData.DynamicNameserviceConfig = new TDynamicNameserviceConfig();
+            appData.DynamicNameserviceConfig->MaxStaticNodeId = NodeId;
+
+            TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(
+                new TNodeWardenConfig(new TSilentPDiskServiceFactory));
+            nodeWardenConfig->DDiskConfig.emplace();
+            nodeWardenConfig->DDiskConfig->SetForcePDiskFallback(true);
+
+            auto* serviceSet = nodeWardenConfig->BlobStorageConfig.MutableServiceSet();
+            auto* pdisk = serviceSet->AddPDisks();
+            pdisk->SetNodeID(NodeId);
+            pdisk->SetPDiskID(PDiskId);
+            pdisk->SetPath("silent-pdisk");
+            pdisk->SetPDiskGuid(12345);
+            pdisk->SetPDiskCategory(TPDiskCategory(NPDisk::DEVICE_TYPE_NVME, 0).GetRaw());
+
+            auto* group = serviceSet->AddGroups();
+            FillGroup(group, VDiskId.GroupGeneration);
+
+            FillDDisk(serviceSet->AddVDisks());
+
+            NodeWardenId = Runtime.Register(CreateBSNodeWarden(nodeWardenConfig.Release()), NodeId);
+            Runtime.RegisterService(MakeBlobStorageNodeWardenID(NodeId), NodeWardenId);
+            UNIT_ASSERT(Runtime.WrapInActorContext(NodeWardenId, [](IActor* actor) {
+                dynamic_cast<NStorage::TNodeWarden*>(actor)->Bootstrap();
+            }));
+            UNIT_ASSERT(LookupDDiskActor());
+        }
+
+        ~TDDiskLifecycleTestSetup() {
+            Runtime.Stop();
+        }
+
+        void FillGroup(NKikimrBlobStorage::TGroupInfo* group, ui32 generation) const {
+            group->SetGroupID(GroupId);
+            group->SetGroupGeneration(generation);
+            group->SetErasureSpecies(TBlobStorageGroupType::ErasureNone);
+            group->SetStoragePoolName("ddisk-pool");
+            group->SetDDisk(true);
+            auto* location = group->AddRings()->AddFailDomains()->AddVDiskLocations();
+            FillLocation(location);
+        }
+
+        void FillLocation(NKikimrBlobStorage::TVDiskLocation* location) const {
+            location->SetNodeID(NodeId);
+            location->SetPDiskID(PDiskId);
+            location->SetVDiskSlotID(VDiskSlotId);
+            location->SetPDiskGuid(12345);
+        }
+
+        void FillDDisk(NKikimrBlobStorage::TNodeWardenServiceSet::TVDisk* vdisk) const {
+            VDiskIDFromVDiskID(VDiskId, vdisk->MutableVDiskID());
+            FillLocation(vdisk->MutableVDiskLocation());
+            vdisk->SetStoragePoolName("ddisk-pool");
+        }
+
+        TActorId LookupDDiskActor() {
+            return Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(DDiskServiceId);
+        }
+
+        bool IsActorAlive(const TActorId& actorId) {
+            return Runtime.WrapInActorContext(actorId, [](IActor*) {});
+        }
+
+        template<typename TPredicate>
+        void DispatchUntil(TPredicate&& predicate, TStringBuf description) {
+            ui32 eventsProcessed = 0;
+            Runtime.Sim([&] {
+                return !predicate() && ++eventsProcessed <= 200;
+            });
+            UNIT_ASSERT_C(predicate(), description);
+        }
+
+        void DeleteDDisk() {
+            UNIT_ASSERT(Runtime.WrapInActorContext(NodeWardenId, [&](IActor* actor) {
+                NKikimrBlobStorage::TNodeWardenServiceSet serviceSet;
+                auto* vdisk = serviceSet.AddVDisks();
+                FillDDisk(vdisk);
+                vdisk->SetEntityStatus(NKikimrBlobStorage::DESTROY);
+                dynamic_cast<NStorage::TNodeWarden*>(actor)->ApplyServiceSet(
+                    serviceSet, true, false, false, "test");
+            }));
+        }
+
+        void RestartDDisk() {
+            Runtime.Send(new IEventHandle(NodeWardenId, {}, new TEvBlobStorage::TEvAskRestartVDisk(PDiskId, VDiskId)),
+                NodeId);
+        }
+
+    };
+
+    Y_UNIT_TEST(TestDDiskDeleteStopsRunningActor) {
+        TDDiskLifecycleTestSetup setup;
+        const TActorId actorId = setup.LookupDDiskActor();
+
+        setup.DeleteDDisk();
+        setup.DispatchUntil([&] { return !setup.IsActorAlive(actorId); },
+            "DDisk actor must stop after its VDisk is deleted");
+    }
+
+    Y_UNIT_TEST(TestDDiskGoneAllowsRestart) {
+        TDDiskLifecycleTestSetup setup;
+        const TActorId previousActorId = setup.LookupDDiskActor();
+
+        setup.RestartDDisk();
+        setup.DispatchUntil([&] {
+            const TActorId currentActorId = setup.LookupDDiskActor();
+            return currentActorId && currentActorId != previousActorId;
+        }, "NodeWarden must restart DDisk after receiving TEvGone");
+
+        UNIT_ASSERT(!setup.IsActorAlive(previousActorId));
+        UNIT_ASSERT(setup.IsActorAlive(setup.LookupDDiskActor()));
+    }
+
     struct TStaticGroupProxyTestSetup {
         TTestActorSystem Runtime;
         ui32 NodeId = 1;

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -459,6 +459,8 @@ namespace NKikimr::NStorage {
             // Runtime configuration of VDisk.
             struct TRuntimeData {
                 TIntrusivePtr<TBlobStorageGroupInfo> GroupInfo;
+                TActorId ActorId;
+                TActorId ServiceId;
                 ui32 OrderNumber;
                 bool DonorMode;
                 bool ReadOnly;

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -39,7 +39,7 @@ namespace NKikimr::NStorage {
         if (vdisk.RuntimeData) {
             vdiskRunning = true;
             vdisk.TIntrusiveListItem<TVDiskRecord, TGroupRelationTag>::Unlink();
-            TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, vdisk.GetVDiskServiceId(), {}, nullptr, 0));
+            TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, vdisk.RuntimeData->ActorId, {}, nullptr, 0));
             vdisk.RuntimeData.reset();
         }
 
@@ -430,6 +430,8 @@ namespace NKikimr::NStorage {
 
         vdisk.RuntimeData.emplace(TVDiskRecord::TRuntimeData{
             .GroupInfo = groupInfo,
+            .ActorId = actorId,
+            .ServiceId = vdiskServiceId,
             .OrderNumber = groupInfo->GetOrderNumber(TVDiskIdShort(vdiskId)),
             .DonorMode = donorMode,
             .ReadOnly = readOnly,
@@ -601,7 +603,7 @@ namespace NKikimr::NStorage {
         Y_ABORT_UNLESS(newInfo->GroupID == currentInfo->GroupID);
 
         const ui32 orderNumber = vdisk.RuntimeData->OrderNumber;
-        const TActorId vdiskServiceId = vdisk.GetVDiskServiceId();
+        const TActorId vdiskServiceId = vdisk.RuntimeData->ServiceId;
 
         if (newInfo->GetActorId(orderNumber) != vdiskServiceId) {
             // this disk is in donor mode, we don't care about generation change; donor modes are operated by BSC solely

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -259,6 +259,12 @@ namespace NKikimr::NStorage {
                 if (Cfg->PBufferConfig->HasMinFreeSectorsReserve()) {
                     pbufferFormat.MinFreeSectorsReserve = Cfg->PBufferConfig->GetMinFreeSectorsReserve();
                 }
+                if (Cfg->PBufferConfig->HasListPersistentBufferMaxRetries()) {
+                    pbufferFormat.ListPersistentBufferMaxRetries = Cfg->PBufferConfig->GetListPersistentBufferMaxRetries();
+                }
+                if (Cfg->PBufferConfig->HasListPersistentBufferRetryPeriodMilliseconds()) {
+                    pbufferFormat.ListPersistentBufferRetryPeriodMilliseconds = Cfg->PBufferConfig->GetListPersistentBufferRetryPeriodMilliseconds();
+                }
                 if (Cfg->PBufferConfig->HasPreallocateFreeSpaceThresholdPercent()) {
                     auto newValue = Cfg->PBufferConfig->GetPreallocateFreeSpaceThresholdPercent();
                     if (newValue >= 100) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
@@ -12,6 +12,7 @@
 #include <ydb/core/blobstorage/base/transparent.h>
 #include <ydb/core/blobstorage/base/batched_vec.h>
 #include <ydb/core/util/stlog.h>
+#include <ydb/library/pdisk_io/device_io_sample.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <util/generic/map.h>
 #include <util/system/file.h>
@@ -1527,6 +1528,28 @@ struct TEvCheckSpace : TEventLocal<TEvCheckSpace, TEvBlobStorage::EvCheckSpace> 
         str << "{TEvCheckSpace ownerId# " << (ui32)Owner;
         str << " ownerRound# " << OwnerRound;
         str << "}";
+        return str.Str();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////
+// Device overestimation sample transport: sent by a DDisk / PersistentBuffer
+// actor (an IO_URING source) to the PDisk actor that owns the same physical
+// device, so PDisk can merge these raw samples with its own block-device
+// samples into one completion-ordered stream. See
+// blobstorage_pdisk_device_overestimation.h for the aggregation model.
+////////////////////////////////////////////////////////////////////////////
+struct TEvDeviceOverestimationSamples
+    : TEventLocal<TEvDeviceOverestimationSamples, TEvBlobStorage::EvDeviceOverestimationSamples> {
+    TVector<NPDisk::TDeviceIoSample> Samples;
+
+    explicit TEvDeviceOverestimationSamples(TVector<NPDisk::TDeviceIoSample> samples)
+        : Samples(std::move(samples))
+    {}
+
+    TString ToString() const {
+        TStringStream str;
+        str << "{TEvDeviceOverestimationSamples SamplesCount# " << Samples.size() << "}";
         return str.Str();
     }
 };

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -979,6 +979,19 @@ public:
         PDisk->InputRequest(request);
     }
 
+    // Raw device I/O samples from an IO_URING source (DDisk / PersistentBuffer
+    // actor) sharing this physical device. Feed them into the same merged
+    // aggregator that PDisk's own block device thread pushes samples into, so
+    // TSharedCallback::Exec's periodic window computation merges both.
+    // Pushing is thread-safe (TDeviceOverestimationAggregator::Push takes a
+    // mutex), so this is safe to call from the actor thread regardless of what
+    // the block device thread is doing concurrently.
+    void Handle(NPDisk::TEvDeviceOverestimationSamples::TPtr &ev) {
+        for (const auto& sample : ev->Get()->Samples) {
+            PDisk->Mon.DeviceOverestimationMerged.Push(sample);
+        }
+    }
+
     void Handle(NPDisk::TEvLog::TPtr &ev) {
         double burstMs;
         TLogWrite* request = PDisk->ReqCreator.CreateLogWrite(*ev->Get(), ev->Sender, burstMs, std::move(ev->TraceId));
@@ -1585,6 +1598,7 @@ public:
     STRICT_STFUNC(StateOnline,
             hFunc(NPDisk::TEvYardInit, Handle);
             hFunc(NPDisk::TEvCheckSpace, Handle);
+            hFunc(NPDisk::TEvDeviceOverestimationSamples, Handle);
             hFunc(NPDisk::TEvLog, Handle);
             hFunc(NPDisk::TEvLogResult, Handle);
             hFunc(NPDisk::TEvMultiLog, Handle);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_async.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_async.cpp
@@ -427,6 +427,11 @@ class TRealBlockDevice : public IBlockDevice {
         ui64 PrevEstimatedCostNs = 0;
         ui64 PrevActualCostNs = 0;
 
+        // Per-window accumulators for the merged (cross-source) device
+        // overestimation ratio; reset every ~15s window (see Exec below).
+        ui64 MergedEstimatedNs = 0;
+        ui64 MergedActualNs = 0;
+
         TCompletionAction* WaitingNoops[MaxWaitingNoops] = {nullptr};
         TRealBlockDevice &Device;
         std::shared_ptr<TPDiskCtx> &PCtx;
@@ -480,7 +485,9 @@ class TRealBlockDevice : public IBlockDevice {
             NHPTimer::STime totalExecutionCycles = durationCycles;
             NHPTimer::STime totalCostNs = completionAction->CostNs;
 
-            bool isSeekExpected = (completionAction->SubmitTime + (NHPTimer::STime)Device.SeekCostNs / 25ll >= PrevEventGotAtCycle);
+            bool isSeekExpected = (completionAction->SubmitTime
+                + (NHPTimer::STime)Device.SeekCostNs / (NHPTimer::STime)SeekCostNsToCyclesApproxDivisor
+                >= PrevEventGotAtCycle);
 
             if (opSize == 0) { // Special case for flush operation, which is a read operation with 0 bytes size
                 if (op->GetType() == IAsyncIoOperation::EType::PRead) {
@@ -495,6 +502,22 @@ class TRealBlockDevice : public IBlockDevice {
                     isSeekExpected = true;
                 }
                 EndOffset = op->GetOffset() + opSize;
+
+                // Feed the merged (cross-source) device overestimation aggregator with
+                // a raw sample. BaseCostNs intentionally excludes any seek cost: the
+                // aggregator recomputes seek-expected based on its own merged,
+                // completion-ordered stream (which may include samples from IO_URING
+                // sources sharing the same physical device).
+                {
+                    TDeviceIoSample sample;
+                    sample.SubmitCycles = (ui64)completionAction->SubmitTime;
+                    sample.CompleteCycles = (ui64)eventGotAtCycle;
+                    sample.Offset = (ui64)op->GetOffset();
+                    sample.Size = opSize;
+                    sample.IsWrite = (op->GetType() != IAsyncIoOperation::EType::PRead);
+                    sample.BaseCostNs = completionAction->CostNs;
+                    Device.Mon.DeviceOverestimationMerged.Push(sample);
+                }
 
                 double duration = HPMilliSecondsFloat(HPNow() - completionAction->SubmitTime);
                 if (op->GetType() == IAsyncIoOperation::EType::PRead) {
@@ -547,29 +570,36 @@ class TRealBlockDevice : public IBlockDevice {
             if (PrevEstimationAtCycle > eventGotAtCycle) {
                 PrevEstimationAtCycle = eventGotAtCycle;
             }
-            if (HPMilliSeconds(eventGotAtCycle - PrevEstimationAtCycle) >= 15000) {
+            if (HPMilliSeconds(eventGotAtCycle - PrevEstimationAtCycle) >= OverestimationWindowMs) {
                 ui64 estimated = (*Device.Mon.DeviceEstimatedCostNs - PrevEstimatedCostNs);
-                ui64 actual = (*Device.Mon.DeviceActualCostNs - PrevActualCostNs + 30000000ull);
-                if (estimated != 0) {
-                    *Device.Mon.DeviceOverestimationRatio = 1000ull * actual / (estimated + 30000000ull);
-                    if (actual > estimated) {
-                        if (actual - estimated < 15000000000ull) {
-                            *Device.Mon.DeviceNonperformanceMs = (actual - estimated) / 15000000ull;
-                        } else {
-                            *Device.Mon.DeviceNonperformanceMs = 1000;
-                        }
-                    } else {
-                        *Device.Mon.DeviceNonperformanceMs = 0;
-                    }
-                } else {
-                    *Device.Mon.DeviceOverestimationRatio = 1000ull;
-                    *Device.Mon.DeviceNonperformanceMs = 0ull;
-                }
+                ui64 actual = (*Device.Mon.DeviceActualCostNs - PrevActualCostNs + OverestimationActualCostBiasNs);
+                const TOverestimationRatioResult ratioResult = ComputeOverestimationRatio(estimated, actual);
+                *Device.Mon.DeviceOverestimationRatio = ratioResult.OverestimationRatio;
+                *Device.Mon.DeviceNonperformanceMs = ratioResult.NonperformanceMs;
 
                 PrevEstimatedCostNs = *Device.Mon.DeviceEstimatedCostNs;
                 PrevActualCostNs = *Device.Mon.DeviceActualCostNs;
                 PrevEstimationAtCycle = eventGotAtCycle;
                 *Device.Mon.GetThreadCPU = ThreadCPUTime();
+
+                // Merge this window's samples (this PDisk block device thread plus
+                // any samples received from IO_URING sources sharing this physical
+                // device) and derive the same overestimation ratio for the merged
+                // stream. See blobstorage_pdisk_device_overestimation.h.
+                auto windowResult = Device.Mon.DeviceOverestimationMerged.ComputeAndReset(Device.SeekCostNs);
+                MergedEstimatedNs += windowResult.EstimatedNs;
+                MergedActualNs += windowResult.ActualNs + OverestimationActualCostBiasNs;
+                const TOverestimationRatioResult mergedRatioResult =
+                    ComputeOverestimationRatio(MergedEstimatedNs, MergedActualNs);
+                *Device.Mon.DeviceOverestimationRatioMerged = mergedRatioResult.OverestimationRatio;
+                *Device.Mon.DeviceNonperformanceMsMerged = mergedRatioResult.NonperformanceMs;
+                *Device.Mon.DeviceOverestimationDroppedSamples = Device.Mon.DeviceOverestimationMerged.GetDroppedSamples();
+                // Reset accumulators each window (unlike the legacy PDisk-only
+                // counters above, which are cumulative device-lifetime counters we
+                // diff against Prev*): this makes MergedEstimatedNs/MergedActualNs
+                // pure per-window sums, matching windowResult's own semantics.
+                MergedEstimatedNs = 0;
+                MergedActualNs = 0;
             }
 
             PrevEventGotAtCycle = eventGotAtCycle;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_device_overestimation.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_device_overestimation.h
@@ -1,0 +1,201 @@
+#pragma once
+
+#include <ydb/library/pdisk_io/device_io_sample.h>
+#include <ydb/core/util/hp_timer_helpers.h>
+
+#include <util/generic/algorithm.h>
+#include <util/generic/vector.h>
+#include <util/system/mutex.h>
+
+namespace NKikimr::NPDisk {
+
+////////////////////////////////////////////////////////////////////////////
+// Shared constants for the "device overestimation" statistic. Used both by
+// TDeviceOverestimationAggregator (below, for the merged/cross-source stream)
+// and by TRealBlockDevice::TSharedCallback::Exec in
+// blobstorage_pdisk_blockdevice_async.cpp (for the legacy PDisk-only stream),
+// so that the two computations -- which mirror each other -- stay in sync
+// and the magic numbers aren't duplicated between the two call sites.
+////////////////////////////////////////////////////////////////////////////
+
+// Length of the periodic window over which the overestimation ratio and
+// nonperformance counters are (re)computed.
+constexpr ui64 OverestimationWindowMs = 15000;
+constexpr ui64 OverestimationWindowNs = OverestimationWindowMs * 1'000'000ull;
+
+// Fixed-point scale for the overestimation ratio counters (e.g. a value of
+// 1000 in the counter means a ratio of 1.0).
+constexpr ui64 OverestimationRatioScale = 1000ull;
+
+// Small constant bias added to the actual-cost accumulator (and to the
+// estimated-cost denominator) before computing the ratio, to avoid a
+// near-zero denominator producing a wildly noisy ratio on lightly loaded
+// devices.
+constexpr ui64 OverestimationActualCostBiasNs = 30'000'000ull; // 30ms
+
+// Upper bound for the "nonperformance" counter (expressed on the same
+// OverestimationRatioScale-like scale, capped at one full window).
+constexpr ui64 NonperformanceCapMs = 1000ull;
+
+// Nanoseconds-per-unit divisor used to convert an (actual - estimated) delta
+// into the "nonperformance" counter's scale: the whole window (in ns) maps to
+// NonperformanceCapMs units.
+constexpr ui64 NonperformanceNsPerUnit = OverestimationWindowNs / NonperformanceCapMs;
+
+// Approximate divisor used to convert a nanosecond seek-cost estimate into
+// the NHPTimer cycle domain when comparing against cycle-based timestamps.
+// This mirrors the legacy (pre-existing) PDisk-only computation's constant
+// exactly, kept as-is for consistency rather than replaced with a proper
+// NHPTimer::GetClockRate()-based conversion.
+constexpr ui64 SeekCostNsToCyclesApproxDivisor = 25;
+
+// Result of deriving the overestimation ratio and nonperformance counters
+// for a single window, given that window's summed estimated/actual costs.
+struct TOverestimationRatioResult {
+    ui64 OverestimationRatio = OverestimationRatioScale;
+    ui64 NonperformanceMs = 0;
+};
+
+// Shared computation used both for the legacy PDisk-only stream and for the
+// merged (cross-source) stream: derives the overestimation ratio (on
+// OverestimationRatioScale) and the capped nonperformance counter from a
+// window's summed estimated/actual-with-bias costs. Kept in one place so the
+// two call sites (TSharedCallback::Exec's PDisk-only and merged branches)
+// cannot drift apart.
+inline TOverestimationRatioResult ComputeOverestimationRatio(ui64 estimatedNs, ui64 actualWithBiasNs) {
+    TOverestimationRatioResult result;
+    if (estimatedNs == 0) {
+        return result;
+    }
+
+    result.OverestimationRatio = OverestimationRatioScale * actualWithBiasNs / (estimatedNs + OverestimationActualCostBiasNs);
+
+    if (actualWithBiasNs > estimatedNs) {
+        const ui64 deltaNs = actualWithBiasNs - estimatedNs;
+        result.NonperformanceMs = (deltaNs < OverestimationWindowNs)
+            ? deltaNs / NonperformanceNsPerUnit
+            : NonperformanceCapMs;
+    }
+
+    return result;
+}
+
+// Aggregates raw TDeviceIoSample-s produced by multiple sources that all issue
+// I/O to the same physical device (PDisk's own block device thread, DDisk's
+// io_uring completion poller, PersistentBuffer's io_uring completion poller),
+// merges them into a single completion-ordered stream, and derives the same
+// "device overestimation" statistic that TRealBlockDevice::TSharedCallback
+// computes for the classic (non-uring) path -- see
+// blobstorage_pdisk_blockdevice_async.cpp, TSharedCallback::Exec.
+//
+// Thread-safety: Push() may be called concurrently from any number of threads
+// (each source's own completion thread). ComputeAndReset() is expected to be
+// called periodically from a single thread (the owning TPDisk's actor/device
+// thread) and is not safe to call concurrently with itself.
+class TDeviceOverestimationAggregator {
+public:
+    struct TWindowResult {
+        ui64 EstimatedNs = 0;
+        ui64 ActualNs = 0;
+        ui64 SampleCount = 0;
+    };
+
+    explicit TDeviceOverestimationAggregator(ui64 maxBufferedSamples = 1u << 16)
+        : MaxBufferedSamples(maxBufferedSamples)
+    {}
+
+    // Called from any producer thread. Cheap: acquires a mutex and appends to
+    // a vector. If the buffer is at capacity, the oldest sample is dropped and
+    // DroppedSamples is incremented (backpressure without blocking the I/O
+    // hot path).
+    void Push(const TDeviceIoSample& sample) {
+        TGuard<TMutex> guard(Mutex);
+        if (Buffered.size() >= MaxBufferedSamples) {
+            // Drop oldest half to amortize the cost of frequent single-item drops
+            // under sustained overflow, rather than erasing one element at a time.
+            const size_t toDrop = Buffered.size() / 2 + 1;
+            Buffered.erase(Buffered.begin(), Buffered.begin() + toDrop);
+            DroppedSamples += toDrop;
+        }
+        Buffered.push_back(sample);
+    }
+
+    ui64 GetDroppedSamples() const {
+        TGuard<TMutex> guard(Mutex);
+        return DroppedSamples;
+    }
+
+    // Drains all currently buffered samples, merges them by CompleteCycles
+    // (across all sources and any prior state carried from previous windows),
+    // and applies the parallelism-1 actual-duration model plus the
+    // seek-expected heuristic (mirroring TSharedCallback::Exec) to compute
+    // this window's estimated/actual cost sums. Must be called from a single
+    // thread; carries continuity state (EndOffset/PrevCompleteCycles) across
+    // calls the same way the legacy single-threaded computation does.
+    TWindowResult ComputeAndReset(ui64 seekCostNs) {
+        TVector<TDeviceIoSample> samples;
+        {
+            TGuard<TMutex> guard(Mutex);
+            samples.swap(Buffered);
+        }
+
+        TWindowResult result;
+        if (samples.empty()) {
+            return result;
+        }
+
+        Sort(samples.begin(), samples.end(), [](const TDeviceIoSample& a, const TDeviceIoSample& b) {
+            return a.CompleteCycles < b.CompleteCycles;
+        });
+
+        for (const TDeviceIoSample& sample : samples) {
+            if (sample.Size == 0) {
+                // No zero-size (flush-like) samples are expected from uring
+                // sources today; skip defensively if one shows up.
+                continue;
+            }
+
+            // Mirrors TSharedCallback::Exec's isSeekExpected heuristic exactly,
+            // including its mixing of cycle and nanosecond units -- kept as-is
+            // for consistency with the legacy PDisk-only computation.
+            bool isSeekExpected =
+                (i64)(sample.SubmitCycles + seekCostNs / SeekCostNsToCyclesApproxDivisor) >= (i64)PrevCompleteCycles;
+            if (sample.Offset != EndOffset) {
+                isSeekExpected = true;
+            }
+            EndOffset = sample.Offset + sample.Size;
+
+            const i64 startCycle = Max<i64>(sample.SubmitCycles, PrevCompleteCycles);
+            const i64 durationCycles = ((i64)sample.CompleteCycles > startCycle)
+                ? (i64)sample.CompleteCycles - startCycle
+                : 0;
+
+            ui64 totalCostNs = sample.BaseCostNs;
+            if (isSeekExpected) {
+                totalCostNs += seekCostNs;
+            }
+
+            result.EstimatedNs += totalCostNs;
+            result.ActualNs += HPNanoSeconds(durationCycles);
+            ++result.SampleCount;
+
+            PrevCompleteCycles = sample.CompleteCycles;
+        }
+
+        return result;
+    }
+
+private:
+    const ui64 MaxBufferedSamples;
+
+    mutable TMutex Mutex;
+    TVector<TDeviceIoSample> Buffered;
+    ui64 DroppedSamples = 0;
+
+    // Continuity state carried across ComputeAndReset() calls, mirroring
+    // TSharedCallback's PrevEventGotAtCycle/EndOffset member fields.
+    ui64 EndOffset = 0;
+    i64 PrevCompleteCycles = 0;
+};
+
+} // namespace NKikimr::NPDisk

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_device_overestimation_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_device_overestimation_ut.cpp
@@ -1,0 +1,133 @@
+#include "blobstorage_pdisk_device_overestimation.h"
+
+#include <ydb/core/util/hp_timer_helpers.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr {
+namespace NPDisk {
+
+namespace {
+
+TDeviceIoSample MakeSample(ui64 submitCycles, ui64 completeCycles, ui64 offset, ui64 size,
+        bool isWrite, ui64 baseCostNs) {
+    TDeviceIoSample sample;
+    sample.SubmitCycles = submitCycles;
+    sample.CompleteCycles = completeCycles;
+    sample.Offset = offset;
+    sample.Size = size;
+    sample.IsWrite = isWrite;
+    sample.BaseCostNs = baseCostNs;
+    return sample;
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TDeviceOverestimationAggregatorTest) {
+
+    Y_UNIT_TEST(EmptyBufferProducesEmptyResult) {
+        TDeviceOverestimationAggregator agg;
+        auto result = agg.ComputeAndReset(/*seekCostNs*/ 1000000);
+        UNIT_ASSERT_VALUES_EQUAL(result.SampleCount, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(result.EstimatedNs, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(result.ActualNs, 0u);
+    }
+
+    // A single sample from one source: actual duration should be
+    // min(complete-submit, complete-prevComplete) = complete-submit (since
+    // there's no previous completion, PrevCompleteCycles starts at 0).
+    Y_UNIT_TEST(SingleSampleUsesSubmitToCompleteDuration) {
+        TDeviceOverestimationAggregator agg;
+        const ui64 submit = 1000;
+        const ui64 complete = 2000;
+        agg.Push(MakeSample(submit, complete, /*offset*/ 0, /*size*/ 4096, false, /*baseCostNs*/ 500));
+
+        auto result = agg.ComputeAndReset(/*seekCostNs*/ 100);
+        UNIT_ASSERT_VALUES_EQUAL(result.SampleCount, 1u);
+        UNIT_ASSERT_VALUES_EQUAL(result.ActualNs, HPNanoSeconds((i64)(complete - submit)));
+        // First sample: EndOffset starts at 0, offset is 0, so no seek from
+        // offset mismatch; but the submit-vs-prev-complete check
+        // (isSeekExpected) may still trigger since PrevCompleteCycles==0 and
+        // submit + seekCostNs/25 >= 0 is trivially true. Just check the
+        // magnitude is either BaseCostNs or BaseCostNs+seekCostNs.
+        UNIT_ASSERT(result.EstimatedNs == 500 || result.EstimatedNs == 600);
+    }
+
+    // Two contiguous samples from the SAME source (simulating one device
+    // stream): second sample's actual duration should be clamped by
+    // min(complete2-submit2, complete2-complete1).
+    Y_UNIT_TEST(TwoContiguousSamplesUseParallelismOneClamp) {
+        TDeviceOverestimationAggregator agg;
+        // Sample 1: submit=0, complete=1000
+        agg.Push(MakeSample(0, 1000, 0, 4096, false, 100));
+        // Sample 2: submits early (overlapping with sample 1's execution),
+        // completes at 1500. Actual duration should be clamped to
+        // complete2 - complete1 = 500 (since submit2=200 < complete1=1000,
+        // startCycle = max(200, 1000) = 1000).
+        agg.Push(MakeSample(200, 1500, 4096, 4096, false, 100));
+
+        auto result = agg.ComputeAndReset(/*seekCostNs*/ 0);
+        UNIT_ASSERT_VALUES_EQUAL(result.SampleCount, 2u);
+        // Total actual = (1000-0) + (1500-1000) = 1000 + 500 = 1500 cycles worth.
+        ui64 expectedActualNs = HPNanoSeconds(1000) + HPNanoSeconds(500);
+        UNIT_ASSERT_VALUES_EQUAL(result.ActualNs, expectedActualNs);
+    }
+
+    // Merging samples from two different sources (interleaved by completion
+    // time) should process them in completion order regardless of push order.
+    Y_UNIT_TEST(MergesMultipleSourcesByCompletionOrder) {
+        TDeviceOverestimationAggregator agg;
+
+        // Source A pushes a sample completing at 3000.
+        agg.Push(MakeSample(2000, 3000, 0, 4096, false, 100));
+        // Source B pushes a sample completing earlier, at 1000 (out of push order).
+        agg.Push(MakeSample(500, 1000, 8192, 4096, true, 100));
+
+        auto result = agg.ComputeAndReset(/*seekCostNs*/ 0);
+        UNIT_ASSERT_VALUES_EQUAL(result.SampleCount, 2u);
+        // Processing order should be: sample completing at 1000 first, then
+        // the one completing at 3000. For the second (offset jumps from 8192
+        // region to 0, and it's a different source), seek is expected -- but
+        // seekCostNs=0 here so it doesn't affect EstimatedNs. Actual for
+        // first: startCycle = max(500, 0) = 500, duration = 1000-500=500.
+        // Actual for second: startCycle = max(2000, 1000) = 2000, duration = 3000-2000=1000.
+        ui64 expectedActualNs = HPNanoSeconds(500) /*first sample: 1000-500*/
+            + HPNanoSeconds(1000) /*second sample clamped*/;
+        UNIT_ASSERT_VALUES_EQUAL(result.ActualNs, expectedActualNs);
+        UNIT_ASSERT_VALUES_EQUAL(result.EstimatedNs, 200u); // 100 + 100, seekCostNs=0
+    }
+
+    Y_UNIT_TEST(ZeroSizeSamplesAreSkipped) {
+        TDeviceOverestimationAggregator agg;
+        agg.Push(MakeSample(0, 1000, 0, 0, false, 100));
+        auto result = agg.ComputeAndReset(0);
+        UNIT_ASSERT_VALUES_EQUAL(result.SampleCount, 0u);
+    }
+
+    Y_UNIT_TEST(OverflowDropsOldestAndCountsDropped) {
+        TDeviceOverestimationAggregator agg(/*maxBufferedSamples*/ 4);
+        for (ui64 i = 0; i < 10; ++i) {
+            agg.Push(MakeSample(i * 100, i * 100 + 50, i * 4096, 4096, false, 10));
+        }
+        UNIT_ASSERT(agg.GetDroppedSamples() > 0);
+        auto result = agg.ComputeAndReset(0);
+        // Some samples should remain (at least the last few pushed).
+        UNIT_ASSERT(result.SampleCount > 0);
+        UNIT_ASSERT(result.SampleCount <= 4);
+    }
+
+    Y_UNIT_TEST(ComputeAndResetDrainsBuffer) {
+        TDeviceOverestimationAggregator agg;
+        agg.Push(MakeSample(0, 1000, 0, 4096, false, 100));
+        auto firstResult = agg.ComputeAndReset(0);
+        UNIT_ASSERT_VALUES_EQUAL(firstResult.SampleCount, 1u);
+
+        // Buffer should be empty now; a second call with no new samples
+        // pushed should produce an empty result.
+        auto secondResult = agg.ComputeAndReset(0);
+        UNIT_ASSERT_VALUES_EQUAL(secondResult.SampleCount, 0u);
+    }
+}
+
+} // namespace NPDisk
+} // namespace NKikimr

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
@@ -130,6 +130,9 @@ TPDiskMon::TPDiskMon(const TIntrusivePtr<::NMonitoring::TDynamicCounters>& count
     COUNTER_INIT_IF_EXTENDED(DeviceGroup, DeviceActualCostNs, true);
     COUNTER_INIT(DeviceGroup, DeviceOverestimationRatio, false);
     COUNTER_INIT(DeviceGroup, DeviceNonperformanceMs, false);
+    COUNTER_INIT(DeviceGroup, DeviceOverestimationRatioMerged, false);
+    COUNTER_INIT(DeviceGroup, DeviceNonperformanceMsMerged, false);
+    COUNTER_INIT_IF_EXTENDED(DeviceGroup, DeviceOverestimationDroppedSamples, true);
     COUNTER_INIT_IF_EXTENDED(DeviceGroup, DeviceInterruptedSystemCalls, true);
     COUNTER_INIT_IF_EXTENDED(DeviceGroup, DeviceSubmitThreadBusyTimeNs, true);
     COUNTER_INIT_IF_EXTENDED(DeviceGroup, DeviceCompletionThreadBusyTimeNs, true);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "blobstorage_pdisk_device_overestimation.h"
+
 #include <ydb/core/blobstorage/base/common_latency_hist_bounds.h>
 #include <ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h>
 #include <ydb/core/base/blobstorage_write_source.h>
@@ -311,6 +313,16 @@ struct TPDiskMon {
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceActualCostNs;
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceOverestimationRatio;
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceNonperformanceMs;
+
+    // Merged device overestimation: combines samples from PDisk's own block
+    // device thread together with samples received from IO_URING sources
+    // (DDisk / PersistentBuffer actors) that share the same physical device,
+    // via TDeviceOverestimationAggregator. See blobstorage_pdisk_device_overestimation.h.
+    NPDisk::TDeviceOverestimationAggregator DeviceOverestimationMerged;
+    ::NMonitoring::TDynamicCounters::TCounterPtr DeviceOverestimationRatioMerged;
+    ::NMonitoring::TDynamicCounters::TCounterPtr DeviceNonperformanceMsMerged;
+    ::NMonitoring::TDynamicCounters::TCounterPtr DeviceOverestimationDroppedSamples;
+
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceInterruptedSystemCalls;
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceSubmitThreadBusyTimeNs;
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceCompletionThreadBusyTimeNs;

--- a/ydb/core/blobstorage/pdisk/ut/ya.make
+++ b/ydb/core/blobstorage/pdisk/ut/ya.make
@@ -37,6 +37,7 @@ ENDIF()
 SRCS(
     blobstorage_pdisk_blockdevice_ut.cpp
     blobstorage_pdisk_crypto_ut.cpp
+    blobstorage_pdisk_device_overestimation_ut.cpp
     blobstorage_pdisk_log_cache_ut.cpp
     blobstorage_pdisk_restore_ut.cpp
     blobstorage_pdisk_scheduler_ut.cpp

--- a/ydb/core/blobstorage/ut_blobstorage/ddisk.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/ddisk.cpp
@@ -100,6 +100,54 @@ Y_UNIT_TEST_SUITE(DDisk) {
             return responses;
         }
 
+        // Allocate a single direct block group via the new-style DirectBlockGroupOperations
+        // (as opposed to the compat Queries path) so that DDisks/PersistentBuffers can later
+        // be individually manipulated (deleted, reassigned, etc.) by DirectBlockGroupId.
+        NKikimrBlobStorage::TEvControllerAllocateDDiskBlockGroupResult::TDirectBlockGroup
+        DefineDirectBlockGroup(ui64 directBlockGroupId, ui32 numDDisks, ui32 numChunksPerDDisk, ui32 numPersistentBuffers) {
+            auto ev = std::make_unique<TEvBlobStorage::TEvControllerAllocateDDiskBlockGroup>();
+            auto& r = ev->Record;
+            r.SetDDiskPoolName("ddisk_pool");
+            r.SetPersistentBufferDDiskPoolName("ddisk_pool");
+            r.SetTabletId(1);
+            auto *op = r.AddDirectBlockGroupOperations();
+            op->SetDirectBlockGroupId(directBlockGroupId);
+            auto *def = op->MutableDefineDirectBlockGroup();
+            def->SetNumDDisks(numDDisks);
+            def->SetNumChunksPerDDisk(numChunksPerDDisk);
+            def->SetNumPersistentBuffers(numPersistentBuffers);
+            // Use a fresh edge actor for every request: WaitForEdgeActorEvent()
+            // consumes/terminates the edge actor on capture by default (termOnCapture=true),
+            // so it can't be safely reused across multiple requests.
+            TActorId edge = Env.Runtime->AllocateEdgeActor(Env.Settings.ControllerNodeId, __FILE__, __LINE__);
+            Env.Runtime->SendToPipe(MakeBSControllerID(), edge, ev.release(), 0, TTestActorSystem::GetPipeConfigWithRetries());
+            auto response = Env.WaitForEdgeActorEvent<TEvBlobStorage::TEvControllerAllocateDDiskBlockGroupResult>(edge);
+            auto& rr = response->Get()->Record;
+            UNIT_ASSERT_VALUES_EQUAL_C(rr.GetStatus(), NKikimrProto::OK, rr.GetErrorReason());
+            UNIT_ASSERT_VALUES_EQUAL(rr.DirectBlockGroupsSize(), 1);
+            return rr.GetDirectBlockGroups(0);
+        }
+
+        // Send an arbitrary set of DirectBlockGroupOperation commands for a given
+        // direct block group id and return the whole result record (including status).
+        NKikimrBlobStorage::TEvControllerAllocateDDiskBlockGroupResult SendDirectBlockGroupOperation(
+                ui64 directBlockGroupId,
+                std::function<void(NKikimrBlobStorage::TEvControllerAllocateDDiskBlockGroup::TDirectBlockGroupOperation*)> fill) {
+            auto ev = std::make_unique<TEvBlobStorage::TEvControllerAllocateDDiskBlockGroup>();
+            auto& r = ev->Record;
+            r.SetDDiskPoolName("ddisk_pool");
+            r.SetPersistentBufferDDiskPoolName("ddisk_pool");
+            r.SetTabletId(1);
+            auto *op = r.AddDirectBlockGroupOperations();
+            op->SetDirectBlockGroupId(directBlockGroupId);
+            fill(op);
+            // Fresh edge actor, see comment in DefineDirectBlockGroup() above.
+            TActorId edge = Env.Runtime->AllocateEdgeActor(Env.Settings.ControllerNodeId, __FILE__, __LINE__);
+            Env.Runtime->SendToPipe(MakeBSControllerID(), edge, ev.release(), 0, TTestActorSystem::GetPipeConfigWithRetries());
+            auto response = Env.WaitForEdgeActorEvent<TEvBlobStorage::TEvControllerAllocateDDiskBlockGroupResult>(edge);
+            return response->Get()->Record;
+        }
+
         void GreetDDisks() {
             Creds.TabletId = 1;
             Creds.Generation = 1;
@@ -1408,5 +1456,138 @@ Y_UNIT_TEST_SUITE(DDisk) {
         }
         UNIT_ASSERT_C(foundReleasedChunk,
             "At least one chunk that held persistent-buffer data must have been released back to PDisk");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Tests for TDirectBlockGroupOperation::DeletePersistentBuffers and
+    // TDirectBlockGroupOperation::DeleteDDisks (ddisk.cpp handling of
+    // op.GetDeletePersistentBuffers() / op.GetDeleteDDisks()).
+    // ─────────────────────────────────────────────────────────────────────────
+
+    Y_UNIT_TEST(DeletePersistentBufferRemovesEntry) {
+        TDDiskTestContext f;
+        auto group = f.DefineDirectBlockGroup(/*directBlockGroupId=*/1, /*numDDisks=*/2,
+            /*numChunksPerDDisk=*/1, /*numPersistentBuffers=*/2);
+        UNIT_ASSERT_VALUES_EQUAL(group.DDiskIdSize(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(group.PersistentBufferDDiskIdSize(), 2);
+
+        const auto pbToDelete = group.GetPersistentBufferDDiskId(0);
+
+        auto rr = f.SendDirectBlockGroupOperation(1, [&](auto *op) {
+            auto *cmd = op->AddDeletePersistentBuffers();
+            cmd->MutablePersistentBufferId()->CopyFrom(pbToDelete);
+        });
+        UNIT_ASSERT_VALUES_EQUAL_C(rr.GetStatus(), NKikimrProto::OK, rr.GetErrorReason());
+        UNIT_ASSERT_VALUES_EQUAL(rr.DirectBlockGroupsSize(), 1);
+
+        const auto& updated = rr.GetDirectBlockGroups(0);
+        UNIT_ASSERT_VALUES_EQUAL(updated.PersistentBufferDDiskIdSize(), 1);
+        // the remaining persistent buffer must be the one we did NOT delete
+        UNIT_ASSERT(TDDiskId(updated.GetPersistentBufferDDiskId(0)) == TDDiskId(group.GetPersistentBufferDDiskId(1)));
+        // DDisks themselves are untouched by persistent buffer deletion
+        UNIT_ASSERT_VALUES_EQUAL(updated.DDiskIdSize(), 2);
+    }
+
+    Y_UNIT_TEST(DeletePersistentBufferNotFoundReturnsError) {
+        TDDiskTestContext f;
+        f.DefineDirectBlockGroup(/*directBlockGroupId=*/1, /*numDDisks=*/2,
+            /*numChunksPerDDisk=*/1, /*numPersistentBuffers=*/1);
+
+        auto rr = f.SendDirectBlockGroupOperation(1, [&](auto *op) {
+            auto *cmd = op->AddDeletePersistentBuffers();
+            // bogus, never-allocated identifier
+            cmd->MutablePersistentBufferId()->SetNodeId(999);
+            cmd->MutablePersistentBufferId()->SetPDiskId(999);
+            cmd->MutablePersistentBufferId()->SetDDiskSlotId(999);
+        });
+        UNIT_ASSERT_VALUES_EQUAL(rr.GetStatus(), NKikimrProto::ERROR);
+        UNIT_ASSERT_STRING_CONTAINS(rr.GetErrorReason(), "PersistentBuffer not found");
+    }
+
+    Y_UNIT_TEST(DeleteDDiskRemovesEntry) {
+        TDDiskTestContext f;
+        auto group = f.DefineDirectBlockGroup(/*directBlockGroupId=*/1, /*numDDisks=*/3,
+            /*numChunksPerDDisk=*/1, /*numPersistentBuffers=*/1);
+        UNIT_ASSERT_VALUES_EQUAL(group.DDiskIdSize(), 3);
+
+        const auto ddiskToDelete = group.GetDDiskId(2); // delete the last one so trimming kicks in
+
+        auto rr = f.SendDirectBlockGroupOperation(1, [&](auto *op) {
+            auto *cmd = op->AddDeleteDDisks();
+            cmd->MutableDDiskId()->CopyFrom(ddiskToDelete);
+        });
+        UNIT_ASSERT_VALUES_EQUAL_C(rr.GetStatus(), NKikimrProto::OK, rr.GetErrorReason());
+        UNIT_ASSERT_VALUES_EQUAL(rr.DirectBlockGroupsSize(), 1);
+
+        const auto& updated = rr.GetDirectBlockGroups(0);
+        // the trailing empty item gets trimmed away entirely
+        UNIT_ASSERT_VALUES_EQUAL(updated.DDiskIdSize(), 2);
+        for (ui32 i = 0; i < 2; ++i) {
+            UNIT_ASSERT(TDDiskId(updated.GetDDiskId(i)) == TDDiskId(group.GetDDiskId(i)));
+        }
+        // persistent buffers are untouched by DDisk deletion
+        UNIT_ASSERT_VALUES_EQUAL(updated.PersistentBufferDDiskIdSize(), 1);
+    }
+
+    Y_UNIT_TEST(DeleteDDiskNotFoundReturnsError) {
+        TDDiskTestContext f;
+        f.DefineDirectBlockGroup(/*directBlockGroupId=*/1, /*numDDisks=*/2,
+            /*numChunksPerDDisk=*/1, /*numPersistentBuffers=*/1);
+
+        auto rr = f.SendDirectBlockGroupOperation(1, [&](auto *op) {
+            auto *cmd = op->AddDeleteDDisks();
+            cmd->MutableDDiskId()->SetNodeId(999);
+            cmd->MutableDDiskId()->SetPDiskId(999);
+            cmd->MutableDDiskId()->SetDDiskSlotId(999);
+        });
+        UNIT_ASSERT_VALUES_EQUAL(rr.GetStatus(), NKikimrProto::ERROR);
+        UNIT_ASSERT_STRING_CONTAINS(rr.GetErrorReason(), "DDisk not found");
+    }
+
+    Y_UNIT_TEST(DeleteMiddleDDiskRemovesEntry) {
+        TDDiskTestContext f;
+        auto group = f.DefineDirectBlockGroup(/*directBlockGroupId=*/1, /*numDDisks=*/3,
+            /*numChunksPerDDisk=*/1, /*numPersistentBuffers=*/1);
+        UNIT_ASSERT_VALUES_EQUAL(group.DDiskIdSize(), 3);
+
+        const auto ddiskToDelete = group.GetDDiskId(1); // middle one
+
+        auto rr = f.SendDirectBlockGroupOperation(1, [&](auto *op) {
+            auto *cmd = op->AddDeleteDDisks();
+            cmd->MutableDDiskId()->CopyFrom(ddiskToDelete);
+        });
+        UNIT_ASSERT_VALUES_EQUAL_C(rr.GetStatus(), NKikimrProto::OK, rr.GetErrorReason());
+        UNIT_ASSERT_VALUES_EQUAL(rr.DirectBlockGroupsSize(), 1);
+
+        const auto& updated = rr.GetDirectBlockGroups(0);
+        // the deleted middle entry must be removed from the list entirely --
+        // no hole is left behind, and the remaining entries keep their relative order
+        UNIT_ASSERT_VALUES_EQUAL(updated.DDiskIdSize(), 2);
+        UNIT_ASSERT(TDDiskId(updated.GetDDiskId(0)) == TDDiskId(group.GetDDiskId(0)));
+        UNIT_ASSERT(TDDiskId(updated.GetDDiskId(1)) == TDDiskId(group.GetDDiskId(2)));
+        // persistent buffers are untouched by DDisk deletion
+        UNIT_ASSERT_VALUES_EQUAL(updated.PersistentBufferDDiskIdSize(), 1);
+    }
+
+    Y_UNIT_TEST(DeleteAllPersistentBuffersAndDDisks) {
+        TDDiskTestContext f;
+        auto group = f.DefineDirectBlockGroup(/*directBlockGroupId=*/1, /*numDDisks=*/2,
+            /*numChunksPerDDisk=*/1, /*numPersistentBuffers=*/2);
+
+        auto rr = f.SendDirectBlockGroupOperation(1, [&](auto *op) {
+            for (const auto& pb : group.GetPersistentBufferDDiskId()) {
+                op->AddDeletePersistentBuffers()->MutablePersistentBufferId()->CopyFrom(pb);
+            }
+            for (const auto& dd : group.GetDDiskId()) {
+                op->AddDeleteDDisks()->MutableDDiskId()->CopyFrom(dd);
+            }
+        });
+        UNIT_ASSERT_VALUES_EQUAL_C(rr.GetStatus(), NKikimrProto::OK, rr.GetErrorReason());
+        UNIT_ASSERT_VALUES_EQUAL(rr.DirectBlockGroupsSize(), 1);
+
+        const auto& updated = rr.GetDirectBlockGroups(0);
+        UNIT_ASSERT_VALUES_EQUAL(updated.PersistentBufferDDiskIdSize(), 0);
+        // both DDisks removed and the last one had zero claim -> full trim
+        UNIT_ASSERT_VALUES_EQUAL(updated.DDiskIdSize(), 0);
     }
 }

--- a/ydb/core/blobstorage/ut_blobstorage/ddisk.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/ddisk.cpp
@@ -1488,7 +1488,7 @@ Y_UNIT_TEST_SUITE(DDisk) {
         UNIT_ASSERT_VALUES_EQUAL(updated.DDiskIdSize(), 2);
     }
 
-    Y_UNIT_TEST(DeletePersistentBufferNotFoundReturnsError) {
+    Y_UNIT_TEST(DeletePersistentBufferNotFoundReturnsNotFound) {
         TDDiskTestContext f;
         f.DefineDirectBlockGroup(/*directBlockGroupId=*/1, /*numDDisks=*/2,
             /*numChunksPerDDisk=*/1, /*numPersistentBuffers=*/1);
@@ -1500,7 +1500,9 @@ Y_UNIT_TEST_SUITE(DDisk) {
             cmd->MutablePersistentBufferId()->SetPDiskId(999);
             cmd->MutablePersistentBufferId()->SetDDiskSlotId(999);
         });
-        UNIT_ASSERT_VALUES_EQUAL(rr.GetStatus(), NKikimrProto::ERROR);
+        // A missing PersistentBuffer must be reported as NOT_FOUND, not a generic ERROR,
+        // so that callers can distinguish "target doesn't exist" from other failures.
+        UNIT_ASSERT_VALUES_EQUAL(rr.GetStatus(), NKikimrProto::NOT_FOUND);
         UNIT_ASSERT_STRING_CONTAINS(rr.GetErrorReason(), "PersistentBuffer not found");
     }
 
@@ -1529,7 +1531,7 @@ Y_UNIT_TEST_SUITE(DDisk) {
         UNIT_ASSERT_VALUES_EQUAL(updated.PersistentBufferDDiskIdSize(), 1);
     }
 
-    Y_UNIT_TEST(DeleteDDiskNotFoundReturnsError) {
+    Y_UNIT_TEST(DeleteDDiskNotFoundReturnsNotFound) {
         TDDiskTestContext f;
         f.DefineDirectBlockGroup(/*directBlockGroupId=*/1, /*numDDisks=*/2,
             /*numChunksPerDDisk=*/1, /*numPersistentBuffers=*/1);
@@ -1540,7 +1542,9 @@ Y_UNIT_TEST_SUITE(DDisk) {
             cmd->MutableDDiskId()->SetPDiskId(999);
             cmd->MutableDDiskId()->SetDDiskSlotId(999);
         });
-        UNIT_ASSERT_VALUES_EQUAL(rr.GetStatus(), NKikimrProto::ERROR);
+        // A missing DDisk must be reported as NOT_FOUND, not a generic ERROR,
+        // so that callers can distinguish "target doesn't exist" from other failures.
+        UNIT_ASSERT_VALUES_EQUAL(rr.GetStatus(), NKikimrProto::NOT_FOUND);
         UNIT_ASSERT_STRING_CONTAINS(rr.GetErrorReason(), "DDisk not found");
     }
 
@@ -1589,5 +1593,109 @@ Y_UNIT_TEST_SUITE(DDisk) {
         UNIT_ASSERT_VALUES_EQUAL(updated.PersistentBufferDDiskIdSize(), 0);
         // both DDisks removed and the last one had zero claim -> full trim
         UNIT_ASSERT_VALUES_EQUAL(updated.DDiskIdSize(), 0);
+    }
+
+    // Re-deleting a PersistentBuffer that was already removed by a prior operation
+    // must also be reported as NOT_FOUND (not a stale/cached OK, and not a generic
+    // ERROR), confirming the status is derived from actual current state each time.
+    Y_UNIT_TEST(DeletePersistentBufferTwiceReturnsNotFoundOnSecondAttempt) {
+        TDDiskTestContext f;
+        auto group = f.DefineDirectBlockGroup(/*directBlockGroupId=*/1, /*numDDisks=*/1,
+            /*numChunksPerDDisk=*/1, /*numPersistentBuffers=*/1);
+        const auto pb = group.GetPersistentBufferDDiskId(0);
+
+        auto rr1 = f.SendDirectBlockGroupOperation(1, [&](auto *op) {
+            op->AddDeletePersistentBuffers()->MutablePersistentBufferId()->CopyFrom(pb);
+        });
+        UNIT_ASSERT_VALUES_EQUAL_C(rr1.GetStatus(), NKikimrProto::OK, rr1.GetErrorReason());
+
+        auto rr2 = f.SendDirectBlockGroupOperation(1, [&](auto *op) {
+            op->AddDeletePersistentBuffers()->MutablePersistentBufferId()->CopyFrom(pb);
+        });
+        UNIT_ASSERT_VALUES_EQUAL(rr2.GetStatus(), NKikimrProto::NOT_FOUND);
+        UNIT_ASSERT_STRING_CONTAINS(rr2.GetErrorReason(), "PersistentBuffer not found");
+    }
+
+    // Same as above, but for DeleteDDisks: deleting an already-deleted DDisk a
+    // second time must be reported as NOT_FOUND.
+    Y_UNIT_TEST(DeleteDDiskTwiceReturnsNotFoundOnSecondAttempt) {
+        TDDiskTestContext f;
+        auto group = f.DefineDirectBlockGroup(/*directBlockGroupId=*/1, /*numDDisks=*/2,
+            /*numChunksPerDDisk=*/1, /*numPersistentBuffers=*/1);
+        const auto ddisk = group.GetDDiskId(1);
+
+        auto rr1 = f.SendDirectBlockGroupOperation(1, [&](auto *op) {
+            op->AddDeleteDDisks()->MutableDDiskId()->CopyFrom(ddisk);
+        });
+        UNIT_ASSERT_VALUES_EQUAL_C(rr1.GetStatus(), NKikimrProto::OK, rr1.GetErrorReason());
+
+        auto rr2 = f.SendDirectBlockGroupOperation(1, [&](auto *op) {
+            op->AddDeleteDDisks()->MutableDDiskId()->CopyFrom(ddisk);
+        });
+        UNIT_ASSERT_VALUES_EQUAL(rr2.GetStatus(), NKikimrProto::NOT_FOUND);
+        UNIT_ASSERT_STRING_CONTAINS(rr2.GetErrorReason(), "DDisk not found");
+    }
+
+    // A single request mixing a not-found PersistentBuffer delete together with a
+    // valid DDisk delete must still surface NOT_FOUND for the whole operation
+    // (the exception aborts the entire DirectBlockGroupOperations loop for this
+    // transaction, so no partial changes are committed).
+    Y_UNIT_TEST(DeleteWithMixedNotFoundAndValidTargetsReturnsNotFound) {
+        TDDiskTestContext f;
+        auto group = f.DefineDirectBlockGroup(/*directBlockGroupId=*/1, /*numDDisks=*/2,
+            /*numChunksPerDDisk=*/1, /*numPersistentBuffers=*/1);
+        const auto validDDisk = group.GetDDiskId(0);
+
+        auto rr = f.SendDirectBlockGroupOperation(1, [&](auto *op) {
+            // valid delete, would succeed on its own
+            op->AddDeleteDDisks()->MutableDDiskId()->CopyFrom(validDDisk);
+            // bogus, never-allocated PersistentBuffer identifier
+            auto *cmd = op->AddDeletePersistentBuffers();
+            cmd->MutablePersistentBufferId()->SetNodeId(999);
+            cmd->MutablePersistentBufferId()->SetPDiskId(999);
+            cmd->MutablePersistentBufferId()->SetDDiskSlotId(999);
+        });
+        UNIT_ASSERT_VALUES_EQUAL(rr.GetStatus(), NKikimrProto::NOT_FOUND);
+        UNIT_ASSERT_STRING_CONTAINS(rr.GetErrorReason(), "PersistentBuffer not found");
+
+        // Verify nothing was actually committed: querying the group again must
+        // show both DDisks and the PersistentBuffer still present.
+        auto rr2 = f.SendDirectBlockGroupOperation(1, [&](auto*) {});
+        UNIT_ASSERT_VALUES_EQUAL_C(rr2.GetStatus(), NKikimrProto::OK, rr2.GetErrorReason());
+        const auto& unchanged = rr2.GetDirectBlockGroups(0);
+        UNIT_ASSERT_VALUES_EQUAL(unchanged.DDiskIdSize(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(unchanged.PersistentBufferDDiskIdSize(), 1);
+    }
+
+    // Errors that are NOT "not found" (e.g. combining incompatible Queries and
+    // DirectBlockGroupOperations in the same request) must remain plain ERROR,
+    // not be misreported as NOT_FOUND.
+    Y_UNIT_TEST(NonNotFoundErrorStillReturnsError) {
+        TDDiskTestContext f;
+        f.DefineDirectBlockGroup(/*directBlockGroupId=*/1, /*numDDisks=*/1,
+            /*numChunksPerDDisk=*/1, /*numPersistentBuffers=*/1);
+
+        auto ev = std::make_unique<TEvBlobStorage::TEvControllerAllocateDDiskBlockGroup>();
+        auto& r = ev->Record;
+        r.SetDDiskPoolName("ddisk_pool");
+        r.SetPersistentBufferDDiskPoolName("ddisk_pool");
+        r.SetTabletId(1);
+        // Queries and DirectBlockGroupOperations together are rejected up-front
+        // with a plain ERROR (see Execute() in ddisk.cpp), well before any
+        // not-found checks are reached.
+        auto *q = r.AddQueries();
+        q->SetDirectBlockGroupId(2);
+        q->SetTargetNumVChunks(1);
+        auto *op = r.AddDirectBlockGroupOperations();
+        op->SetDirectBlockGroupId(1);
+        op->AddDeleteDDisks(); // deliberately empty/bogus, shouldn't even be reached
+
+        TActorId edge = f.Env.Runtime->AllocateEdgeActor(f.Env.Settings.ControllerNodeId, __FILE__, __LINE__);
+        f.Env.Runtime->SendToPipe(MakeBSControllerID(), edge, ev.release(), 0, TTestActorSystem::GetPipeConfigWithRetries());
+        auto response = f.Env.WaitForEdgeActorEvent<TEvBlobStorage::TEvControllerAllocateDDiskBlockGroupResult>(edge);
+        auto& rr = response->Get()->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(rr.GetStatus(), NKikimrProto::ERROR);
+        UNIT_ASSERT_STRING_CONTAINS(rr.GetErrorReason(), "can't be provided at the same time");
     }
 }

--- a/ydb/core/cms/console/console_tenants_manager.cpp
+++ b/ydb/core/cms/console/console_tenants_manager.cpp
@@ -1171,6 +1171,7 @@ public:
             case NKikimrProto::RESTART:
             case NKikimrProto::NOT_YET:
             case NKikimrProto::NO_GROUP:
+            case NKikimrProto::NOT_FOUND:
             case NKikimrProto::UNKNOWN:
                 YDB_LOG_ERROR_CTX(ctx, "TScaleRecommenderManip got error reply during configuring hive",
                     {"tenantPath", Tenant->Path},

--- a/ydb/core/mind/bscontroller/ddisk.cpp
+++ b/ydb/core/mind/bscontroller/ddisk.cpp
@@ -5,6 +5,11 @@
 
 namespace NKikimr::NBsController {
 
+    // Thrown when a DDisk or PersistentBuffer referenced by a DeleteDDisks/DeletePersistentBuffers
+    // command can't be found; caught separately from generic errors to report NKikimrProto::NOT_FOUND
+    // instead of NKikimrProto::ERROR.
+    struct TDDiskNotFoundException : yexception {};
+
     class TBlobStorageController::TTxAllocateDDiskBlockGroup : public TTransactionBase<TBlobStorageController> {
         std::unique_ptr<TEventHandle<TEvBlobStorage::TEvControllerAllocateDDiskBlockGroup>> RequestEv;
         std::unique_ptr<TEvBlobStorage::TEvControllerAllocateDDiskBlockGroupResult> Result;
@@ -549,7 +554,7 @@ namespace NKikimr::NBsController {
                         auto it = std::ranges::find(persistentBufferIds, pbId);
 
                         if (it == persistentBufferIds.end()) {
-                            ythrow yexception() << "PersistentBuffer not found";
+                            ythrow TDDiskNotFoundException() << "PersistentBuffer not found";
                         }
                         getPersistentBufferPool().ReleasePersistentBuffer(*it);
                         {
@@ -573,7 +578,7 @@ namespace NKikimr::NBsController {
                             }
                         }
                         if (index < 0) {
-                            ythrow yexception() << "DDisk not found";
+                            ythrow TDDiskNotFoundException() << "DDisk not found";
                         }
 
                         auto *item = ddiskRecord->Mutable(index);
@@ -627,6 +632,10 @@ namespace NKikimr::NBsController {
                         updates.emplace_back(key, std::move(allocation));
                     }
                 }
+            } catch (const TDDiskNotFoundException& e) {
+                rr.SetStatus(NKikimrProto::NOT_FOUND);
+                rr.SetErrorReason(e.what());
+                return true;
             } catch (const std::exception& e) {
                 rr.SetStatus(NKikimrProto::ERROR);
                 rr.SetErrorReason(e.what());

--- a/ydb/core/mind/bscontroller/ddisk.cpp
+++ b/ydb/core/mind/bscontroller/ddisk.cpp
@@ -544,6 +544,55 @@ namespace NKikimr::NBsController {
                         changes = true;
                     }
 
+                    for (const auto& cmd : op.GetDeletePersistentBuffers()) {
+                        const TDDiskId pbId(cmd.GetPersistentBufferId());
+                        auto it = std::ranges::find(persistentBufferIds, pbId);
+
+                        if (it == persistentBufferIds.end()) {
+                            ythrow yexception() << "PersistentBuffer not found";
+                        }
+                        getPersistentBufferPool().ReleasePersistentBuffer(*it);
+                        {
+                            auto& [chunks, refs] = vslotUpdates[it->GetKey()];
+                            --refs;
+                        }
+                        const size_t index = it - persistentBufferIds.begin();
+                        persistentBufferIds.erase(it);
+                        persistentBufferDDiskId->erase(persistentBufferDDiskId->begin() + index);
+                        changes = true;
+                    }
+
+                    for (const auto& cmd : op.GetDeleteDDisks()) {
+                        const TDDiskId ddiskId(cmd.GetDDiskId());
+                        int index = -1;
+                        for (int i = 0; i < ddiskRecord->size(); ++i) {
+                            const auto& rec = ddiskRecord->Get(i);
+                            if (rec.HasDDiskId() && TDDiskId(rec.GetDDiskId()) == ddiskId) {
+                                index = i;
+                                break;
+                            }
+                        }
+                        if (index < 0) {
+                            ythrow yexception() << "DDisk not found";
+                        }
+
+                        auto *item = ddiskRecord->Mutable(index);
+                        const ui32 currentNumChunks = item->GetNumChunksClaimed();
+
+                        getDDiskPool().ReleaseDDisk(ddiskId, currentNumChunks);
+
+                        auto it = std::ranges::find(ddiskIds, ddiskId);
+                        Y_ABORT_UNLESS(it != ddiskIds.end());
+                        std::swap(*it, ddiskIds.back());
+                        ddiskIds.pop_back();
+
+                        auto& [chunks, refs] = vslotUpdates[TVSlotId(ddiskId.GetKey())];
+                        chunks -= currentNumChunks;
+
+                        ddiskRecord->erase(ddiskRecord->begin() + index);
+                        changes = true;
+                    }
+
                     // trim excessive items
                     while (!ddiskRecord->empty() && ddiskRecord->rbegin()->GetNumChunksClaimed() == 0) {
                         ddiskRecord->RemoveLast();

--- a/ydb/core/nbs/cloud/blockstore/config/protos/ddisk_config.proto
+++ b/ydb/core/nbs/cloud/blockstore/config/protos/ddisk_config.proto
@@ -61,4 +61,11 @@ message TPBufferConfig
     // Deallocate a chunk proactively when it has been freed for this many seconds.
     // Default 30 seconds.
     optional uint32 DeallocateThresholdSeconds = 15;
+
+    // TEvListPersistentBuffer must not observe a partially-applied write/erase for its tablet: the
+    // listing is deferred (queued and retried) while any disk operation is in flight for the
+    // requesting tablet. These parameters bound how long/how often we wait before giving up and
+    // replying with an OVERLOADED error to avoid returning a potentially-stale view.
+    optional uint32 ListPersistentBufferMaxRetries = 16;
+    optional uint32 ListPersistentBufferRetryPeriodMilliseconds = 17;
 }

--- a/ydb/core/protos/base.proto
+++ b/ydb/core/protos/base.proto
@@ -24,6 +24,7 @@ enum EReplyStatus {
     RESTART = 19;
     NOT_YET = 20;
     NO_GROUP = 21;
+    NOT_FOUND = 22;
     UNKNOWN = 255;
 };
 

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -1647,6 +1647,17 @@ message TEvControllerAllocateDDiskBlockGroup {
             repeated uint32 PreferredNodeIds = 2; // in order of descending preference
         }
         repeated TReassignPersistentBuffer ReassignPersistentBuffers = 5;
+
+        message TDeletePersistentBuffer {
+            optional NKikimrBlobStorage.NDDisk.TDDiskId PersistentBufferId = 1;
+        }
+        repeated TDeletePersistentBuffer DeletePersistentBuffers = 6;
+
+        message TDeleteDDisk {
+            optional NKikimrBlobStorage.NDDisk.TDDiskId DDiskId = 1;
+        }
+        repeated TDeleteDDisk DeleteDDisks = 7;
+
     }
     repeated TDirectBlockGroupOperation DirectBlockGroupOperations = 5;
 }

--- a/ydb/library/pdisk_io/device_io_sample.h
+++ b/ydb/library/pdisk_io/device_io_sample.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <util/system/types.h>
+
+namespace NKikimr::NPDisk {
+
+// A raw, source-agnostic sample of a single completed device I/O operation.
+//
+// Produced by every path that talks directly to a physical device (PDisk's own
+// block device thread, DDisk's io_uring completion poller, PersistentBuffer's
+// io_uring completion poller). Carries just enough information for a downstream
+// aggregator to recompute, for a globally completion-ordered merge of samples
+// from multiple sources sharing one physical device:
+//   - the actual duration of the operation (via a parallelism-1 model), and
+//   - the estimated ("expected") cost of the operation, so the two can be
+//     compared to derive a device overestimation ratio.
+//
+// SubmitCycles/CompleteCycles are NHPTimer cycle counts (see hp_timer_helpers.h),
+// comparable only among samples produced on hosts with the same clock rate
+// (i.e. within one process). They are not wall-clock timestamps.
+struct TDeviceIoSample {
+    ui64 SubmitCycles = 0;
+    ui64 CompleteCycles = 0;
+
+    // Absolute device (file) byte offset and size of the operation.
+    ui64 Offset = 0;
+    ui64 Size = 0;
+
+    bool IsWrite = false;
+
+    // Estimated ("expected") cost of the operation in nanoseconds, as modeled
+    // by whoever produced the sample (excluding any additional seek cost that
+    // the merge/aggregation step may apply based on cross-source ordering).
+    ui64 BaseCostNs = 0;
+};
+
+} // namespace NKikimr::NPDisk

--- a/ydb/library/pdisk_io/uring_operation.h
+++ b/ydb/library/pdisk_io/uring_operation.h
@@ -19,6 +19,13 @@ class TUringOperationBase {
     friend class TUringRouter;
 
 public:
+    // NHPTimer cycle count captured by TUringRouter right before the operation
+    // is submitted to the kernel (SQE prepared). Used together with the
+    // completion timestamp (captured by the completion poller) to build a
+    // TDeviceIoSample for device-overestimation tracking. 0 if unset.
+    ui64 SubmitCycles = 0;
+
+public:
     enum EOperationType {
         ENOT_SET = 0,
         EREAD,

--- a/ydb/library/pdisk_io/uring_router.cpp
+++ b/ydb/library/pdisk_io/uring_router.cpp
@@ -193,6 +193,24 @@ public:
                     // PrepareSqe/ReadFixed/WriteFixed.
                     NSan::Acquire(op);
                     op->Result = cqe->res;
+
+                    // Capture a device-overestimation sample before invoking
+                    // OnComplete, since OnComplete may recycle/destroy the op.
+                    // Only sample successfully completed operations with a
+                    // known submit timestamp; a per-CQE HPNow() call keeps
+                    // per-operation completion precision within a batch.
+                    if (Owner.SampleSink && op->SubmitCycles != 0 && cqe->res >= 0 &&
+                            (op->OperationType == TUringOperationBase::EREAD ||
+                             op->OperationType == TUringOperationBase::EWRITE)) {
+                        TDeviceIoSample sample;
+                        sample.SubmitCycles = op->SubmitCycles;
+                        sample.CompleteCycles = HPNow();
+                        sample.Offset = op->GetDiskOffset();
+                        sample.Size = op->GetTotalSize();
+                        sample.IsWrite = (op->OperationType == TUringOperationBase::EWRITE);
+                        Owner.SampleSink(sample);
+                    }
+
                     // For read operations the kernel fills the buffer via a syscall
                     // that MSAN cannot observe.  Mark each iovec segment as initialized
                     // so that subsequent reads do not trigger false use-of-uninitialized-
@@ -314,6 +332,13 @@ void TUringRouter::PrepareSqe(struct io_uring_sqe* sqe, TUringOperationBase* op)
         sqe->flags |= IOSQE_FIXED_FILE;
     }
 
+    // Record the submit-time cycle count for device-overestimation sampling.
+    // Only set on the first submission of an op (AdvanceIov short-I/O retries
+    // reuse the same op and call PrepareSqe again via Read()/Write() from the
+    // actor thread; each such resubmission is treated as its own sample by the
+    // completion poller, matching how short I/O is a distinct kernel request).
+    op->SubmitCycles = HPNow();
+
     io_uring_sqe_set_data(sqe, op);
     NSan::Release(op);
 }
@@ -359,6 +384,7 @@ bool TUringRouter::ReadFixed(void* buf, ui32 size, ui64 offset, ui16 bufIndex, T
     if (FixedFdIndex >= 0) {
         sqe->flags |= IOSQE_FIXED_FILE;
     }
+    op->SubmitCycles = HPNow();
     io_uring_sqe_set_data(sqe, op);
     NSan::Release(op);
     return true;
@@ -380,6 +406,7 @@ bool TUringRouter::WriteFixed(const void* buf, ui32 size, ui64 offset, ui16 bufI
     if (FixedFdIndex >= 0) {
         sqe->flags |= IOSQE_FIXED_FILE;
     }
+    op->SubmitCycles = HPNow();
     io_uring_sqe_set_data(sqe, op);
     NSan::Release(op);
     return true;

--- a/ydb/library/pdisk_io/uring_router.h
+++ b/ydb/library/pdisk_io/uring_router.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "uring_operation.h"
+#include "device_io_sample.h"
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
@@ -11,6 +12,7 @@
 
 #include <atomic>
 #include <expected>
+#include <functional>
 #include <memory>
 
 struct io_uring;
@@ -83,6 +85,16 @@ struct TUringCounters {
 // single thread (e.g. the DDisk actor). The only internal concurrency is the
 // dedicated TCompletionPoller thread that consumes the CQ ring and invokes
 // OnComplete callbacks.
+//
+// Optional device I/O sample sink: if set (via SetSampleSink, before Start()),
+// the completion poller thread invokes it once per successfully completed
+// Read/Write CQE with a raw TDeviceIoSample (submit/complete cycles, offset,
+// size, direction). Used to feed a device-overestimation aggregator that
+// merges samples across multiple sources sharing the same physical device.
+// The sink is invoked from the completion poller thread and must be cheap
+// and thread-safe on its own (e.g. push into a lock-protected buffer).
+using TDeviceIoSampleSink = std::function<void(const TDeviceIoSample&)>;
+
 class TUringRouter {
 public:
     TUringRouter(
@@ -95,6 +107,12 @@ public:
 
     const TUringRouterConfig& GetConfig() const {
         return Config;
+    }
+
+    // Must be called before Start(). Not thread-safe with itself or with
+    // completion-poller activity.
+    void SetSampleSink(TDeviceIoSampleSink sink) {
+        SampleSink = std::move(sink);
     }
 
     // --- Setup (call before Start) ---
@@ -169,6 +187,7 @@ private:
     NActors::TActorSystem* ActorSystem;
     TUringRouterConfig Config;
     TUringCounters* Counters;
+    TDeviceIoSampleSink SampleSink;
 
     std::unique_ptr<struct io_uring> Ring;
 


### PR DESCRIPTION
### Changelog entry

Backport DDisk/PBuffer deletion APIs, shutdown and listing fixes, and io_uring device-overestimation support to `nbs-26-3-1`.

### Description for reviewers

#### Original PRs

1. [#46536](https://github.com/ydb-platform/ydb/pull/46536) — Add DDisk and PersistentBuffer deletion to the DBG API.
   Source: `27df2a9f85c4ce2680e09122fab49dd141dce8a5`.
2. [#46818](https://github.com/ydb-platform/ydb/pull/46818) — Introduce NOT_FOUND status for deletion from a DBG.
   Source: `048722a60b29e82ca3fb9b57007ccd725f73115a`.
3. [#46775](https://github.com/ydb-platform/ydb/pull/46775) — Fix DDisk shutdown lifecycle.
   Source: `63a0ca42e418ef5ac8fd2e9fb9d0363ae5c37a35`.
4. [#47424](https://github.com/ydb-platform/ydb/pull/47424) — Make ListPersistentBuffer wait for in-flight disk operations.
   Source: `bd6f6452ea9e669dc2eb99ba558ce24cb73549d6`.
5. [#47741](https://github.com/ydb-platform/ydb/pull/47741) — Add device-overestimation support for the io_uring path.
   Source: `c23af0e56166315b3090ee3b9510ae131db543e1`.
