### PR TITLE
Allow to use EQ_HEIGHT statistics to pre-shard secondary and unique index tables

### DIFF
--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -1,3 +1,4 @@
+#include <ydb/core/statistics/ut_common/ut_common.h>
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 #include <ydb/core/tx/datashard/datashard.h>
 
@@ -7748,6 +7749,94 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
             UNIT_ASSERT_C(result.GetIssues().ToString().contains("Cannot truncate table with async indexes"),
                 "Unexpected error message: " << result.GetIssues().ToString());
         }
+    }
+
+    void DoTestPreSharding(bool serverless, bool multiCol, bool unique) {
+        using namespace NStat;
+
+        TTestEnv env(1, 1, true);
+        if (serverless) {
+            CreateDatabase(env, "Shared", 1, true);
+            CreateServerlessDatabase(env, "Database", "/Root/Shared");
+        } else {
+            CreateDatabase(env, "Database");
+        }
+        TTableClient db(env.GetDriver());
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                CREATE TABLE `/Root/Database/TestTable` (
+                    id Uint64 not null,
+                    name String not null,
+                    data String not null,
+                    PRIMARY KEY (id),
+                    STATISTICS name_hist ON (name) WITH (EQ_HEIGHT_HISTOGRAM)
+                )
+                WITH (PARTITION_AT_KEYS = (5));
+            )").GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            const TString query1 = "UPSERT INTO `/Root/Database/TestTable` (id, name, data) VALUES "
+                "(0, \"alice\", \"0\"),"
+                "(1, \"bob\", \"1\"),"
+                "(2, \"carter\", \"2\"),"
+                "(3, \"donald\", \"3\"),"
+                "(4, \"edgar\", \"4\"),"
+                "(5, \"felix\", \"5\"),"
+                "(6, \"george\", \"6\"),"
+                "(7, \"harry\", \"7\"),"
+                "(8, \"ian\", \"8\"),"
+                "(9, \"john\", \"9\");";
+            auto result = session.ExecuteDataQuery(query1, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto result = session.ExecuteSchemeQuery("ANALYZE `/Root/Database/TestTable`").GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto driver = MakeHolder<NYdb::TDriver>(NYdb::TDriverConfig()
+                .SetEndpoint(env.GetEndpoint())
+                .SetDatabase("/Root/Database")
+                .SetDiscoveryMode(NYdb::EDiscoveryMode::Off));
+            TTableClient db(*driver);
+            auto connres = db.CreateSession().GetValueSync();
+            UNIT_ASSERT_C(connres.GetIssues().Empty(), connres.GetIssues().ToString());
+            auto session = connres.GetSession();
+            const TString q = Sprintf(
+                "ALTER TABLE `/Root/Database/TestTable` ADD INDEX name_idx GLOBAL %s ON (name%s)",
+                unique ? "UNIQUE" : "",
+                multiCol ? ", data" : ""
+            );
+            auto result = session.ExecuteSchemeQuery(q).GetValueSync();
+            UNIT_ASSERT_C(result.GetIssues().Empty(), result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::SUCCESS);
+        }
+
+        {
+            // Check index shard count
+            auto runtime = env.GetServer().GetRuntime();
+            auto shards = GetTableShards(&env.GetServer(), runtime->AllocateEdgeActor(), "/Root/Database/TestTable/name_idx/indexImplTable");
+            UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2);
+        }
+    }
+
+    Y_UNIT_TEST_TWIN(PreSharding, Unique) {
+        DoTestPreSharding(false, false, Unique);
+    }
+
+    Y_UNIT_TEST(PreShardingMultiCol) {
+        DoTestPreSharding(false, true, false);
+    }
+
+    Y_UNIT_TEST(PreShardingServerless) {
+        DoTestPreSharding(true, true, false);
     }
 
 }

--- a/ydb/core/kqp/ut/indexes/ya.make
+++ b/ydb/core/kqp/ut/indexes/ya.make
@@ -20,6 +20,12 @@ PEERDIR(
     ydb/library/yql/udfs/common/knn
     yql/essentials/sql/pg_dummy
     ydb/public/sdk/cpp/adapters/issue
+
+    # for ANALYZE
+    ydb/core/statistics/ut_common
+    yql/essentials/udfs/common/digest
+    yql/essentials/udfs/common/hyperloglog
+    ydb/library/yql/udfs/statistics_internal
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/tx/schemeshard/index/build_index.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index.cpp
@@ -71,6 +71,10 @@ void TSchemeShard::Handle(TEvDataShard::TEvBuildFulltextDictResponse::TPtr& ev, 
     Execute(CreateTxReply(ev), ctx);
 }
 
+void TSchemeShard::Handle(TEvIndexBuilder::TEvGetIndexStatsResponse::TPtr& ev, const TActorContext& ctx) {
+    Execute(CreateTxReply(ev), ctx);
+}
+
 void TSchemeShard::Handle(TEvPrivate::TEvIndexBuildingMakeABill::TPtr& ev, const TActorContext& ctx) {
     Execute(CreateTxBilling(ev), ctx);
 }

--- a/ydb/core/tx/schemeshard/index/build_index.h
+++ b/ydb/core/tx/schemeshard/index/build_index.h
@@ -1,10 +1,14 @@
 #pragma once
 
 #include <ydb/core/tx/schemeshard/defs.h>
+#include <ydb/core/scheme/scheme_pathid.h>
 
 #include <ydb/core/protos/index_builder.pb.h>
 
 namespace NKikimr {
+
+class TEqHeightHistogram;
+
 namespace NSchemeShard {
 
 struct TEvIndexBuilder {
@@ -20,6 +24,7 @@ struct TEvIndexBuilder {
         EvListRequest,
         EvListResponse,
         EvUploadSampleKResponse,
+        EvGetIndexStatsResponse,
 
         EvEnd
     };
@@ -123,6 +128,14 @@ struct TEvIndexBuilder {
 
     struct TEvUploadSampleKResponse: public TEventPB<TEvUploadSampleKResponse, NKikimrIndexBuilder::TEvUploadSampleKResponse, EvUploadSampleKResponse> {
     };
+
+    struct TEvGetIndexStatsResponse : public TEventLocal<TEvGetIndexStatsResponse, EvGetIndexStatsResponse> {
+        ui64 BuildId = 0;
+        TPathId PathId;
+        size_t FieldCount = 0;
+        std::shared_ptr<TEqHeightHistogram> Histogram;
+    };
+
 
 }; // TEvIndexBuilder
 

--- a/ydb/core/tx/schemeshard/index/build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index__progress.cpp
@@ -4,6 +4,8 @@
 #include <ydb/core/tx/schemeshard/schemeshard_impl.h>
 #include <ydb/core/tx/schemeshard/index/index_utils.h>
 #include <ydb/core/tx/schemeshard/index/common.h>
+#include <ydb/core/statistics/events.h>
+#include <ydb/core/statistics/service/service.h>
 
 #include <ydb/public/api/protos/ydb_issue_message.pb.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
@@ -196,6 +198,73 @@ private:
     }
 };
 
+class TGetStatisticsHelper: public TActorBootstrapped<TGetStatisticsHelper> {
+    using TThis = TGetStatisticsHelper;
+    using TBase = TActorBootstrapped<TThis>;
+
+    const TActorId ResponseActorId;
+    const TIndexBuildId BuildId;
+    const TPathId PathId;
+    THolder<NStat::TEvStatistics::TEvGetStatistics> Request;
+    TString LogPrefix;
+
+public:
+    TGetStatisticsHelper(const TActorId& responseActorId,
+        TIndexBuildId buildId, THolder<NStat::TEvStatistics::TEvGetStatistics> request)
+        : ResponseActorId(responseActorId)
+        , BuildId(buildId)
+        , PathId(request->StatRequests.at(0).PathId)
+        , Request(request.Release()) {
+        LogPrefix = TStringBuilder()
+            << "TGetStatisticsHelper: BuildIndexId: " << BuildId
+            << " ResponseActorId: " << ResponseActorId;
+    }
+
+    void Bootstrap() {
+        auto statServiceId = NStat::MakeStatServiceID(SelfId().NodeId());
+        this->Send(statServiceId, this->Request.Release(), IEventHandle::FlagTrackDelivery);
+        this->Become(&TThis::StateWork);
+    }
+
+    void HandleResponse(NStat::TEvStatistics::TEvGetStatisticsResult::TPtr& ev) {
+        auto *inRes = ev->Get();
+        auto response = MakeHolder<TEvIndexBuilder::TEvGetIndexStatsResponse>();
+        response->BuildId = ui64(BuildId);
+        response->PathId = PathId;
+        for (auto& stat: inRes->StatResponses) {
+            // Take the most detailed eq_height histogram
+            if (stat.Success &&
+                stat.Req.ColumnTags.AsMulti() &&
+                stat.Req.ColumnTags.AsMulti()->size() > response->FieldCount &&
+                stat.EqHeightHistogram.Data) {
+                response->FieldCount = stat.Req.ColumnTags.AsMulti()->size();
+                response->Histogram = stat.EqHeightHistogram.Data;
+            }
+        }
+        this->Send(ResponseActorId, response.Release());
+        this->PassAway();
+    }
+
+    void HandleUndelivered(TEvents::TEvUndelivered::TPtr& ev) {
+        LOG_E("TGetStatisticsHelper undelivered: " << ev->GetTypeRewrite() << " event: " << ev->ToString());
+        auto response = MakeHolder<TEvIndexBuilder::TEvGetIndexStatsResponse>();
+        response->BuildId = ui64(BuildId);
+        response->PathId = PathId;
+        this->Send(ResponseActorId, response.Release());
+        this->PassAway();
+    }
+
+private:
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NStat::TEvStatistics::TEvGetStatisticsResult, HandleResponse);
+            hFunc(TEvents::TEvUndelivered, HandleUndelivered);
+            default:
+                LOG_E("TGetStatisticsHelper unexpected event type: " << ev->GetTypeRewrite() << " event: " << ev->ToString());
+        }
+    }
+};
+
 // Fulltext rowid auto-provisioning: build a child TIndexBuildInfo that the parent fulltext build runs,
 // sequentially and before acquiring its own lock, to provision the rowid infrastructure. Each child is
 // a fully normal build (it takes and releases its own lock + snapshot via the standard pipeline) and
@@ -247,7 +316,7 @@ std::shared_ptr<TIndexBuildInfo> CreateRowIdProvisioningChild(
 }
 
 THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateIndexPropose(
-    TSchemeShard* ss, const TIndexBuildInfo& buildInfo)
+    TSchemeShard* ss, TIndexBuildInfo& buildInfo)
 {
     auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.InitiateTxId), ss->TabletID());
     propose->Record.SetFailOnExist(true);
@@ -259,6 +328,10 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateIndexPropose(
     modifyScheme.MutableLockGuard()->SetOwnerTxId(ui64(buildInfo.LockTxId));
 
     if (buildInfo.IsBuildIndex()) {
+        auto path = TPath::Init(buildInfo.TablePathId, ss);
+        const auto& tableInfo = ss->Tables.at(path->PathId);
+        // For TIndexBuildInfo::FillIndexPresharding()
+        buildInfo.IndexPartitions = tableInfo->GetPartitionStore().size();
         modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateIndexBuild);
         buildInfo.SerializeToProto(ss, modifyScheme.MutableInitiateIndexBuild());
     } else if (buildInfo.IsBuildColumns()) {
@@ -1416,6 +1489,48 @@ private:
         LOG_N("TTxBuildProgress: TEvBuildIndexCreateRequest: " << ev->Record.ShortDebugString());
 
         ToTabletSend.emplace(shardId, std::move(ev));
+    }
+
+    bool GetColumnStats(TTransactionContext& txc, TIndexBuildInfo& buildInfo) {
+        if (buildInfo.Sample.State == TIndexBuildInfo::TSample::EState::Collect) {
+            LOG_D("GetColumnStats " << buildInfo.DebugString());
+            buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Upload;
+            SendGetColumnStatsRequest(buildInfo);
+            Progress(BuildId);
+        } else if (buildInfo.Sample.State == TIndexBuildInfo::TSample::EState::Done) {
+            LOG_D("GetColumnStats Done " << buildInfo.DebugString());
+            NIceDb::TNiceDb db{txc.DB};
+            buildInfo.SubState = TIndexBuildInfo::ESubState::None;
+            ChangeState(BuildId, TIndexBuildInfo::EState::Initiating);
+            Self->PersistBuildIndexState(db, buildInfo);
+            Progress(BuildId);
+            return true;
+        }
+        // Wait for the response
+        return false;
+    }
+
+    void SendGetColumnStatsRequest(TIndexBuildInfo& buildInfo) {
+        Y_ENSURE(buildInfo.BuildKind == TIndexBuildInfo::EBuildKind::BuildSecondaryIndex ||
+            buildInfo.BuildKind == TIndexBuildInfo::EBuildKind::BuildSecondaryUniqueIndex,
+            "Unknown operation kind in SendGetColumnStats");
+
+        auto event = MakeHolder<NStat::TEvStatistics::TEvGetStatistics>();
+        event->StatType = NKikimr::NStat::EStatType::EQ_HEIGHT_HISTOGRAM;
+        // event->Database is not filled because in a serverless DB statistics belongs
+        // to the shared DB and statistics service resolves the DB itself
+
+        // Request all variants of statistics starting from just the 1st index column
+        // to all index columns + all table key columns
+        auto tags = buildInfo.GetSecondaryIndexKeyTags(Self);
+        for (size_t i = 1; i <= tags.size(); i++) {
+            event->StatRequests.emplace_back(buildInfo.TablePathId, std::vector<ui32>(tags.begin(), tags.begin() + i));
+        }
+
+        auto actor = new TGetStatisticsHelper(Self->SelfId(), buildInfo.Id, std::move(event));
+        TActivationContext::AsActorContext().MakeFor(Self->SelfId()).Register(actor);
+
+        LOG_N("TTxBuildProgress: SendGetColumnStatsRequest: " << buildInfo);
     }
 
     void SendValidateUniqueIndexRequest(TShardIdx shardIdx, TIndexBuildInfo& buildInfo) {
@@ -2872,7 +2987,12 @@ public:
                         ChangeState(BuildId, TIndexBuildInfo::EState::AlterMainTable);
                     }
                 } else {
-                    ChangeState(BuildId, TIndexBuildInfo::EState::Initiating);
+                    if (buildInfo.IsBuildSimpleIndex() && !buildInfo.HasPartitionSettings() &&
+                        !buildInfo.IsRebuild) {
+                        ChangeState(BuildId, TIndexBuildInfo::EState::GatheringStatistics);
+                    } else {
+                        ChangeState(BuildId, TIndexBuildInfo::EState::Initiating);
+                    }
                 }
                 Progress(BuildId);
             }
@@ -2978,8 +3098,7 @@ public:
             break;
         }
         case TIndexBuildInfo::EState::GatheringStatistics:
-            ChangeState(BuildId, TIndexBuildInfo::EState::Initiating);
-            Progress(BuildId);
+            GetColumnStats(txc, buildInfo);
             break;
         case TIndexBuildInfo::EState::Initiating:
             if (buildInfo.InitiateTxId == InvalidTxId) {
@@ -4764,6 +4883,45 @@ public:
     }
 };
 
+struct TSchemeShard::TIndexBuilder::TTxReplyStatistics: public TSchemeShard::TIndexBuilder::TTxReply {
+private:
+    TEvIndexBuilder::TEvGetIndexStatsResponse::TPtr StatsResult;
+public:
+    explicit TTxReplyStatistics(TSelf* self, TEvIndexBuilder::TEvGetIndexStatsResponse::TPtr& statsResult)
+        : TTxReply(self, TIndexBuildId(statsResult->Get()->BuildId))
+        , StatsResult(statsResult)
+    {}
+
+    bool DoExecute([[maybe_unused]] TTransactionContext& txc, [[maybe_unused]] const TActorContext& ctx) override {
+        auto *res = StatsResult->Get();
+        const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(BuildId);
+        if (!buildInfoPtr) {
+            LOG_I("TTxReply : TEvGetStatisticsResult superfluous message"
+                << ", BuildIndexId " << BuildId << " not found");
+            return true;
+        }
+
+        // Do not persist statistics in the local schemeshard database
+        // (similar to the TUploadSampleK response)
+
+        auto& buildInfo = *buildInfoPtr->get();
+        if (buildInfo.TablePathId != res->PathId) {
+            LOG_I("TTxReply : TEvGetStatisticsResult result for a different table"
+                << ", pathId: " << res->PathId
+                << ", BuildIndexId " << BuildId);
+            buildInfo.IndexHistogramFields = 0;
+            buildInfo.IndexHistogram.reset();
+        } else {
+            buildInfo.IndexHistogramFields = res->FieldCount;
+            buildInfo.IndexHistogram = res->Histogram;
+        }
+        buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Done;
+        Progress(BuildId);
+
+        return true;
+    }
+};
+
 ITransaction* TSchemeShard::CreateTxReply(TEvTxAllocatorClient::TEvAllocateResult::TPtr& allocateResult) {
     return new TIndexBuilder::TTxReplyAllocate(this, allocateResult);
 }
@@ -4818,6 +4976,10 @@ ITransaction* TSchemeShard::CreateTxReply(TEvDataShard::TEvBuildFulltextIndexRes
 
 ITransaction* TSchemeShard::CreateTxReply(TEvDataShard::TEvBuildFulltextDictResponse::TPtr& response) {
     return new TIndexBuilder::TTxReplyFulltextDict(this, response);
+}
+
+ITransaction* TSchemeShard::CreateTxReply(TEvIndexBuilder::TEvGetIndexStatsResponse::TPtr& response) {
+    return new TIndexBuilder::TTxReplyStatistics(this, response);
 }
 
 ITransaction* TSchemeShard::CreatePipeRetry(TIndexBuildId indexBuildId, TTabletId tabletId) {

--- a/ydb/core/tx/schemeshard/index/index_build_info.cpp
+++ b/ydb/core/tx/schemeshard/index/index_build_info.cpp
@@ -1,4 +1,14 @@
 #include <ydb/core/tx/schemeshard/index/index_build_info.h>
+#include <ydb/core/statistics/events.h>
+#include <ydb/core/engine/mkql_keys.h>
+#include <ydb/core/scheme/scheme_tablecell.h>
+#include <yql/essentials/core/histogram/eq_height_histogram_reader.h>
+#include <yql/essentials/minikql/computation/presort.h>
+#include <yql/essentials/minikql/mkql_alloc.h>
+#include <yql/essentials/minikql/mkql_node.h>
+#include <yql/essentials/public/udf/udf_data_type.h>
+
+#include <optional>
 
 namespace NKikimr {
 
@@ -10,6 +20,120 @@ TIndexBuildShardStatus::TIndexBuildShardStatus(TSerializedTableRange range, TStr
     : Range(std::move(range))
     , LastKeyAck(std::move(lastKeyAck))
 {}
+
+namespace {
+
+std::optional<TString> PresortKeyToSerializedCellVec(TStringBuf presortKey,
+    const TVector<NScheme::TTypeInfo>& types, const TVector<bool>& isOptional)
+{
+    using namespace NKikimr::NMiniKQL;
+    try {
+        TScopedAlloc alloc(__LOCATION__);
+        TTypeEnvironment env(alloc);
+
+        TPresortDecoder decoder;
+        for (size_t i = 0; i < types.size(); ++i) {
+            auto slot = NUdf::FindDataSlot(types[i].GetTypeId());
+            if (!slot) {
+                return std::nullopt;  // e.g. Pg types: not presort-decodable here
+            }
+            decoder.AddType(*slot, isOptional[i], /*isDesc=*/false);
+        }
+        decoder.Start(presortKey);
+
+        TVector<TCell> cells;
+        cells.reserve(types.size());
+        for (size_t i = 0; i < types.size(); ++i) {
+            NUdf::TUnboxedValue value = decoder.Decode();
+            // Cell memory is copied into env's arena (copy=true) and stays valid until Serialize.
+            cells.push_back(value ? MakeCell(types[i], value, env, /*copy=*/true) : TCell());
+        }
+        decoder.Finish();
+
+        return TSerializedCellVec::Serialize(cells);
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+} // namespace
+
+std::vector<ui32> TIndexBuildInfo::GetSecondaryIndexKeyTags(TSchemeShard* ss) const {
+    TTableInfo::TPtr mainTable = ss->Tables.at(this->TablePathId);
+    THashMap<TString, ui32> columnTags;
+    for (auto& [tag, column]: mainTable->Columns) {
+        if (!column.IsDropped()) {
+            columnTags[column.Name] = tag;
+        }
+    }
+    std::vector<ui32> tags;
+    for (auto& column: IndexColumns) {
+        tags.push_back(columnTags.at(column));
+        columnTags.erase(column);
+    }
+    for (auto& tag: mainTable->KeyColumnIds) {
+        auto& colName = mainTable->Columns.at(tag).Name;
+        if (columnTags.erase(colName)) {
+            tags.push_back(tag);
+        }
+    }
+    return tags;
+}
+
+void TIndexBuildInfo::FillIndexPresharding(TSchemeShard* ss, NKikimrSchemeOp::TTableDescription& implDesc) const {
+    if (!IndexHistogram || !IndexHistogramFields) {
+        return;
+    }
+
+    const auto tableIt = ss->Tables.find(TablePathId);
+    if (tableIt == ss->Tables.end()) {
+        return;
+    }
+    const auto& mainTable = tableIt->second;
+
+    auto tags = GetSecondaryIndexKeyTags(ss);
+    tags.resize(IndexHistogramFields);
+
+    TVector<NScheme::TTypeInfo> types;
+    TVector<bool> isOptional;
+    types.reserve(tags.size());
+    isOptional.reserve(tags.size());
+    for (ui32 tag : tags) {
+        const auto& column = mainTable->Columns.at(tag);
+        types.push_back(column.PType);
+        isOptional.push_back(!column.NotNull);
+    }
+
+    const ui64 buckets = IndexHistogram->GetNumBuckets();
+    const ui64 shardCount = std::min<ui64>(buckets, IndexPartitions);
+    if (shardCount < 2) {
+        return;
+    }
+
+    TVector<TString> boundaries;
+    boundaries.reserve(shardCount - 1);
+    for (ui64 i = 1; i < shardCount; ++i) {
+        const ui64 nb = i * buckets / shardCount;
+        auto serialized = PresortKeyToSerializedCellVec(
+            IndexHistogram->GetBucket(nb).UpperBound, types, isOptional);
+        if (!serialized) {
+            // undecodable
+            return;
+        }
+        boundaries.push_back(std::move(*serialized));
+    }
+
+    for (auto& boundary : boundaries) {
+        implDesc.AddSplitBoundary()->SetSerializedKeyPrefix(std::move(boundary));
+    }
+}
+
+bool TIndexBuildInfo::HasPartitionSettings() const {
+    return ImplTableDescriptions.size() &&
+        (ImplTableDescriptions[0].GetUniformPartitionsCount() ||
+        ImplTableDescriptions[0].SplitBoundarySize() ||
+        ImplTableDescriptions[0].GetPartitionConfig().HasPartitioningPolicy());
+}
 
 void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrSchemeOp::TIndexBuildConfig* result) const {
     Y_ENSURE(IsBuildIndex());
@@ -40,6 +164,15 @@ void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrSchemeOp::TIndex
         case NKikimrSchemeOp::EIndexTypeGlobalUnique:
             // no specialized index description
             Y_ASSERT(std::holds_alternative<std::monostate>(SpecializedIndexDescription));
+            if (IndexHistogram) {
+                if (!index.IndexImplTableDescriptionsSize()) {
+                    FillIndexPresharding(ss, *index.AddIndexImplTableDescriptions());
+                } else if (!index.GetIndexImplTableDescriptions(0).GetUniformPartitionsCount() &&
+                    !index.GetIndexImplTableDescriptions(0).SplitBoundarySize() &&
+                    !index.GetIndexImplTableDescriptions(0).GetPartitionConfig().HasPartitioningPolicy()) {
+                    FillIndexPresharding(ss, *index.MutableIndexImplTableDescriptions(0));
+                }
+            }
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
         case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:

--- a/ydb/core/tx/schemeshard/index/index_build_info.h
+++ b/ydb/core/tx/schemeshard/index/index_build_info.h
@@ -218,6 +218,10 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
     TString TargetName;
     TVector<NKikimrSchemeOp::TTableDescription> ImplTableDescriptions;
 
+    size_t IndexPartitions = 0;
+    size_t IndexHistogramFields = 0;
+    std::shared_ptr<TEqHeightHistogram> IndexHistogram;
+
     std::variant<std::monostate,
         NKikimrSchemeOp::TVectorIndexKmeansTreeDescription,
         NKikimrSchemeOp::TFulltextIndexDescription> SpecializedIndexDescription;
@@ -824,6 +828,11 @@ public:
         return BuildKind == EBuildKind::BuildSecondaryUniqueIndex;
     }
 
+    bool IsBuildSimpleIndex() const {
+        return BuildKind == EBuildKind::BuildSecondaryIndex ||
+            BuildKind == EBuildKind::BuildSecondaryUniqueIndex;
+    }
+
     bool IsBuildPrefixedVectorIndex() const {
         return BuildKind == EBuildKind::BuildPrefixedVectorIndex;
     }
@@ -1006,6 +1015,9 @@ public:
         return 0.f;
     }
 
+    std::vector<ui32> GetSecondaryIndexKeyTags(TSchemeShard* ss) const;
+    void FillIndexPresharding(TSchemeShard* ss, NKikimrSchemeOp::TTableDescription& implDesc) const;
+    bool HasPartitionSettings() const;
     void SerializeToProto(TSchemeShard* ss, NKikimrIndexBuilder::TColumnBuildSettings* to) const;
     void SerializeToProto(TSchemeShard* ss, NKikimrSchemeOp::TIndexBuildConfig* to) const;
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -6083,6 +6083,7 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         HFuncTraced(TEvDataShard::TEvValidateUniqueIndexResponse, Handle);
         HFuncTraced(TEvDataShard::TEvBuildFulltextIndexResponse, Handle);
         HFuncTraced(TEvDataShard::TEvBuildFulltextDictResponse, Handle);
+        HFuncTraced(TEvIndexBuilder::TEvGetIndexStatsResponse, Handle);
         // } // NIndexBuilder
 
         // namespace NForcedCompaction {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1918,6 +1918,7 @@ public:
         struct TTxReplyValidateUniqueIndex;
         struct TTxReplyFulltextIndex;
         struct TTxReplyFulltextDict;
+        struct TTxReplyStatistics;
 
         struct TTxPipeReset;
         struct TTxBilling;
@@ -1950,6 +1951,7 @@ public:
     NTabletFlatExecutor::ITransaction* CreateTxReply(TEvDataShard::TEvValidateUniqueIndexResponse::TPtr& response);
     NTabletFlatExecutor::ITransaction* CreateTxReply(TEvDataShard::TEvBuildFulltextIndexResponse::TPtr& response);
     NTabletFlatExecutor::ITransaction* CreateTxReply(TEvDataShard::TEvBuildFulltextDictResponse::TPtr& response);
+    NTabletFlatExecutor::ITransaction* CreateTxReply(TEvIndexBuilder::TEvGetIndexStatsResponse::TPtr& response);
     NTabletFlatExecutor::ITransaction* CreatePipeRetry(TIndexBuildId indexBuildId, TTabletId tabletId);
     NTabletFlatExecutor::ITransaction* CreateTxBilling(TEvPrivate::TEvIndexBuildingMakeABill::TPtr& ev);
 
@@ -1970,6 +1972,7 @@ public:
     void Handle(TEvDataShard::TEvValidateUniqueIndexResponse::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvBuildFulltextIndexResponse::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvBuildFulltextDictResponse::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvIndexBuilder::TEvGetIndexStatsResponse::TPtr& ev, const TActorContext& ctx);
 
     void Handle(TEvPrivate::TEvIndexBuildingMakeABill::TPtr& ev, const TActorContext& ctx);
 


### PR DESCRIPTION
### Description for reviewers

Данная доработка позволяет оптимизировать создание вторичных индексов на больших таблицах путём автоматического их партиционирования с использованием статистики таблицы, если она доступна.

Как пользоваться:

Делаем на таблице статистику, либо в CREATE либо в ALTER:

`CREATE TABLE ... ( ..., STATISTICS name_hist ON (name) WITH (EQ_HEIGHT_HISTOGRAM) )`
либо
`ALTER TABLE ... ADD STATISTICS name_hist ON (name) WITH (EQ_HEIGHT_HISTOGRAM)`

Список полей статистики - любой префикс списка ключевых колонок индексной таблицы, т.е. от 1 индексной колонки до всех индексных колонок + всех колонок PK исходной таблицы. При построении возьмётся максимальный доступный префикс.

После этого делаем ANALYZE table.

И после этого строим индекс.