### PR TITLE
http gw: fix races in the areas

### DIFF
--- a/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
@@ -10,6 +10,7 @@
 #include <ydb/core/testlib/basics/appdata.h>
 #include <ydb/core/util/proto_duration.h>
 #include <ydb/library/table_creator/table_creator.h>
+#include <ydb/library/yql/providers/common/http_gateway/ut_helpers/http_gateway_holder.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 #include <ydb/services/ydb/ydb_common_ut.h>
@@ -25,6 +26,12 @@ using namespace NSchemeShard;
 using namespace fmt::literals;
 
 namespace  {
+
+// Pin the IHTTPGateway singleton for the lifetime of the test binary so
+// curl_global_cleanup (which clears c-ares) does not race with gRPC threads
+// still using c-ares during test tear-down.
+[[maybe_unused]] const auto& g_HttpGatewayHolder =
+    NYql::NTestHelpers::GetGlobalHttpGatewayHolder();
 
 constexpr TDuration TestLeaseDuration = TDuration::Seconds(1);
 constexpr TDuration TestTimeout = TDuration::Seconds(10);
@@ -93,6 +100,8 @@ struct TScriptExecutionsYdbSetup {
             signal(sig, &TScriptExecutionsYdbSetup::BackTraceSignalHandler);
         }
 
+        const auto& httpGatewayHolder = NYql::NTestHelpers::GetGlobalHttpGatewayHolder();
+
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableFeatureFlags()->SetEnableSecureScriptExecutions(secureScriptExecutions);
 
@@ -105,6 +114,7 @@ struct TScriptExecutionsYdbSetup {
         ServerSettings->SetGrpcPort(GrpcPort);
         ServerSettings->SetAppConfig(appConfig);
         ServerSettings->SetInitializeFederatedQuerySetupFactory(true);
+        ServerSettings->SetKqpLoggerScope(httpGatewayHolder.LoggerScope);
         Server = MakeHolder<Tests::TServer>(*ServerSettings);
         Client = MakeHolder<Tests::TClient>(*ServerSettings);
 

--- a/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
@@ -27,12 +27,6 @@ using namespace fmt::literals;
 
 namespace  {
 
-// Pin the IHTTPGateway singleton for the lifetime of the test binary so
-// curl_global_cleanup (which clears c-ares) does not race with gRPC threads
-// still using c-ares during test tear-down.
-[[maybe_unused]] const auto& g_HttpGatewayHolder =
-    NYql::NTestHelpers::GetGlobalHttpGatewayHolder();
-
 constexpr TDuration TestLeaseDuration = TDuration::Seconds(1);
 constexpr TDuration TestTimeout = TDuration::Seconds(10);
 constexpr TDuration TestOperationTtl = TDuration::Minutes(1);

--- a/ydb/core/kqp/proxy_service/ut/ya.make
+++ b/ydb/core/kqp/proxy_service/ut/ya.make
@@ -19,6 +19,7 @@ PEERDIR(
     ydb/core/kqp/run_script_actor
     ydb/core/kqp/proxy_service
     ydb/core/kqp/ut/common
+    ydb/library/yql/providers/common/http_gateway/ut_helpers
     ydb/services/workload_manager/ut/common
     ydb/public/lib/ut_helpers
     ydb/public/sdk/cpp/src/client/driver

--- a/ydb/library/yql/providers/common/http_gateway/ut_helpers/http_gateway_holder.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/ut_helpers/http_gateway_holder.cpp
@@ -1,0 +1,28 @@
+#include "http_gateway_holder.h"
+
+#include <library/cpp/logger/null.h>
+#include <util/generic/yexception.h>
+
+namespace NYql::NTestHelpers {
+
+THttpGatewayHolder::THttpGatewayHolder()
+    : LoggerScope(std::make_shared<NYql::NLog::YqlLoggerScope>(
+        new NYql::NLog::TTlsLogBackend(new TNullLogBackend())
+      ))
+    , HttpGateway(NYql::IHTTPGateway::Make())
+{}
+
+THttpGatewayHolder::~THttpGatewayHolder() {
+    // By this point, all threads using c-ares must be stopped.
+    // Use this line to set a breakpoint while debugging c-ares races.
+    HttpGateway.reset();
+    LoggerScope.reset();
+}
+
+const THttpGatewayHolder& GetGlobalHttpGatewayHolder() {
+    static const THttpGatewayHolder holder;
+    Y_ENSURE(holder.HttpGateway);
+    return holder;
+}
+
+}  // namespace NYql::NTestHelpers

--- a/ydb/library/yql/providers/common/http_gateway/ut_helpers/http_gateway_holder.h
+++ b/ydb/library/yql/providers/common/http_gateway/ut_helpers/http_gateway_holder.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
+#include <ydb/library/yql/utils/actor_log/log.h>
+
+namespace NYql::NTestHelpers {
+
+///
+/// Program-lifetime holder for IHTTPGateway (+ its YqlLoggerScope prerequisite).
+///
+/// IHTTPGateway is a refcounted singleton whose destruction runs
+/// curl_global_cleanup, which in turn tears down c-ares. In tests that races
+/// with gRPC threads still using c-ares (see ares_library_cleanup_unsafe).
+/// Referencing this holder from a test binary keeps the refcount >= 1 for the
+/// lifetime of the process, so no destroy/create cycles happen during
+/// test tear-down.
+///
+/// IHTTPGateway::Make() requires logging to be initialized, so YqlLoggerScope
+/// is constructed first and destroyed last.
+///
+struct THttpGatewayHolder {
+    std::shared_ptr<NYql::NLog::YqlLoggerScope> LoggerScope;
+    NYql::IHTTPGateway::TPtr HttpGateway;
+
+    THttpGatewayHolder();
+    ~THttpGatewayHolder();
+};
+
+const THttpGatewayHolder& GetGlobalHttpGatewayHolder();
+
+}  // namespace NYql::NTestHelpers

--- a/ydb/library/yql/providers/common/http_gateway/ut_helpers/ya.make
+++ b/ydb/library/yql/providers/common/http_gateway/ut_helpers/ya.make
@@ -1,0 +1,15 @@
+LIBRARY()
+
+SRCS(
+    http_gateway_holder.cpp
+)
+
+PEERDIR(
+    library/cpp/logger
+    ydb/library/yql/providers/common/http_gateway
+    ydb/library/yql/utils/actor_log
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/library/yql/providers/common/http_gateway/ya.make
+++ b/ydb/library/yql/providers/common/http_gateway/ya.make
@@ -28,6 +28,7 @@ END()
 
 RECURSE(
     mock
+    ut_helpers
 )
 
 RECURSE_FOR_TESTS(

--- a/ydb/services/workload_manager/ut/common/workload_service_ut_common.cpp
+++ b/ydb/services/workload_manager/ut/common/workload_service_ut_common.cpp
@@ -12,7 +12,7 @@
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 
 #include <ydb/core/node_whiteboard/node_whiteboard.h>
-#include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
+#include <ydb/library/yql/providers/common/http_gateway/ut_helpers/http_gateway_holder.h>
 #include <ydb/library/yql/utils/actor_log/log.h>
 #include <ydb/services/metadata/service.h>
 
@@ -248,45 +248,7 @@ IActor* CreateFakeTicketParser(const TTicketParserSettings&) {
     return new TFakeTicketParserActor();
 }
 
-///
-/// The HttpGateway is created as a singleton and stored in a shared_ptr.
-/// The HttpGateway is destroyed when its reference count reaches zero.
-///
-/// Destruction triggers the cleanup of libcurl, which in turn clears c-ares.
-/// During tests, this can race with gRPC threads that also use c-ares.
-///
-/// This class holds a reference to the HttpGateway during test execution
-/// to prevent repeated create/destroy/create cycles.
-///
-/// HttpGateway requires logging, so LoggerScope must be created before
-/// the HttpGateway is initialized
-///
-struct TGlobalObjectHolder {
-    std::shared_ptr<NYql::NLog::YqlLoggerScope> LoggerScope;
-    NYql::IHTTPGateway::TPtr HttpGateway;
-
-    TGlobalObjectHolder()
-        : LoggerScope(std::make_shared<NYql::NLog::YqlLoggerScope>(
-            new NYql::NLog::TTlsLogBackend(new TNullLogBackend())
-          ))
-        , HttpGateway(NYql::IHTTPGateway::Make())
-    {}
-
-    ~TGlobalObjectHolder() {
-        // By this point, all threads using c-ares must be stopped.
-        // Use this line to set a breakpoint while debugging c-ares races.
-        HttpGateway.reset();
-        LoggerScope.reset();
-    }
-};
-
 // Ydb setup
-const TGlobalObjectHolder& GetGlobalObjectHolder() {
-    static const TGlobalObjectHolder holder_;
-    Y_ENSURE(holder_.HttpGateway);
-    return holder_;
-}
-
 class TWorkloadServiceYdbSetup : public IYdbSetup {
 private:
     TAppConfig GetAppConfig() const {
@@ -339,7 +301,7 @@ private:
             .SetInitializeFederatedQuerySetupFactory(true);
 
         if (Settings_.WorkSafeWithGlobalObjects_) {
-            serverSettings.SetKqpLoggerScope(GetGlobalObjectHolder().LoggerScope);
+            serverSettings.SetKqpLoggerScope(NYql::NTestHelpers::GetGlobalHttpGatewayHolder().LoggerScope);
         }
 
         if (Settings_.CreateSampleTenants_) {
@@ -444,7 +406,7 @@ public:
         , SettingsTweakFnc_(fnc)
     {
         if (Settings_.WorkSafeWithGlobalObjects_) {
-            GetGlobalObjectHolder();
+            NYql::NTestHelpers::GetGlobalHttpGatewayHolder();
         }
 
         EnableYDBBacktraceFormat();

--- a/ydb/services/workload_manager/ut/common/ya.make
+++ b/ydb/services/workload_manager/ut/common/ya.make
@@ -8,6 +8,7 @@ SRCS(
 PEERDIR(
     ydb/core/base
     ydb/core/kqp/ut/common
+    ydb/library/yql/providers/common/http_gateway/ut_helpers
     ydb/services/metadata
     ydb/services/workload_manager/metadata_subscription/resource_pool_classifier
 )


### PR DESCRIPTION
### Description for reviewers <!-- (optional) description for those who read this PR -->

Provide with a common holder for the HttpGateway. Reuse it in the Workload Manager tests and fix the races in the ares by providing a holder of the HttpGateway, fixes:
- YDBBUGS-716
- YDBBUGS-482