### PR TITLE
Fix WASM bridge typing for nested and sibling containers

### DIFF
--- a/ydb/services/udf_store/ut/bridge_typecheck_ut.cpp
+++ b/ydb/services/udf_store/ut/bridge_typecheck_ut.cpp
@@ -61,10 +61,14 @@ constexpr TStringBuf BridgeTypeCheckWast = R"(
         (import "env" "BridgeListLength" (func $list_length (param i64) (result i64)))
         (import "env" "BridgeListMakeIterator" (func $list_iter (param i64) (result i64)))
         (import "env" "BridgeMakeArray" (func $make_array (param i64 i32) (result i64)))
+        (import "env" "BridgeMakeArrayTyped" (func $make_array_typed (param i64 i64 i32) (result i64)))
         (import "env" "BridgeMakeDict" (func $make_dict (param i64 i64 i32) (result i64)))
         (import "env" "BridgeMakeList" (func $make_list (param i64 i32) (result i64)))
+        (import "env" "BridgeMakeListTyped" (func $make_list_typed (param i64 i64 i32) (result i64)))
         (import "env" "BridgeMakeOptional" (func $make_optional (param i64) (result i64)))
         (import "env" "BridgeRun" (func $run (param i64 i64 i32) (result i64)))
+        (import "env" "BridgeTypeListItem" (func $type_list_item (param i64) (result i64)))
+        (import "env" "BridgeTypeMember" (func $type_member (param i64 i32) (result i64)))
         (import "env" "BridgeUnref" (func $unref (param i64)))
 
         (func $contains_raw (param $ctx i64) (param $result i64) (param $dict i64) (param $key i64)
@@ -136,6 +140,40 @@ constexpr TStringBuf BridgeTypeCheckWast = R"(
             (i64.store (local.get $result) (call $make_list (local.get $items) (i32.const 2)))
         )
         (export "make_list_two" (func $make_list_two))
+
+        ;; Build a two-item list of the type named by BridgeTypeListItem on the
+        ;; result type -- the inner List of List<List<...>>, or any other list
+        ;; the guest reaches by walking the type tree itself.
+        (func $make_inner_list_typed (param $ctx i64) (param $result i64)
+                (param $a i64) (param $b i64) (param $items i64)
+            (local $outer i64)
+            (local $inner i64)
+            (local.set $outer (call $result_type))
+            (local.set $inner (call $type_list_item (local.get $outer)))
+            (i64.store (local.get $items) (local.get $a))
+            (i64.store (i64.add (local.get $items) (i64.const 8)) (local.get $b))
+            (i64.store (local.get $result)
+                (call $make_list_typed (local.get $inner) (local.get $items) (i32.const 2)))
+            (call $unref (local.get $inner))
+            (call $unref (local.get $outer))
+        )
+        (export "make_inner_list_typed" (func $make_inner_list_typed))
+
+        ;; Build the second Tuple member of a two-member result via typed Make.
+        (func $make_second_tuple_typed (param $ctx i64) (param $result i64)
+                (param $a i64) (param $b i64) (param $elems i64)
+            (local $outer i64)
+            (local $inner i64)
+            (local.set $outer (call $result_type))
+            (local.set $inner (call $type_member (local.get $outer) (i32.const 1)))
+            (i64.store (local.get $elems) (local.get $a))
+            (i64.store (i64.add (local.get $elems) (i64.const 8)) (local.get $b))
+            (i64.store (local.get $result)
+                (call $make_array_typed (local.get $inner) (local.get $elems) (i32.const 2)))
+            (call $unref (local.get $inner))
+            (call $unref (local.get $outer))
+        )
+        (export "make_second_tuple_typed" (func $make_second_tuple_typed))
 
         (func $dict_iter_then_lookup (param $ctx i64) (param $result i64)
                 (param $dict i64) (param $key i64)
@@ -900,6 +938,162 @@ Y_UNIT_TEST(AnIteratorStillWalksThroughItsOwnIntrinsic) {
     UNIT_ASSERT_VALUES_EQUAL(has, 1u);
 
     table.Unref(dictHandle);
+}
+
+Y_UNIT_TEST(MakeListBuildsTheInnerListOfANestedListResult) {
+    // FindListTypeIn used to accept the outer List first, so building the
+    // inner List<Int64> under List<List<Int64>> checked items as lists and
+    // failed every row. Item families now pick the inner candidate.
+    TMiniKqlEnv mkql;
+
+    auto* innerType = NKikimr::NMiniKQL::TListType::Create(MkqlInt64Type(mkql), mkql.Env);
+    auto* outerType = NKikimr::NMiniKQL::TListType::Create(innerType, mkql.Env);
+    TTypeCheckUdf udf(mkql, 62, outerType);
+    auto& table = udf.Table();
+
+    const ui64 a = table.Register(
+        EBridgeNodeKind::Scalar,
+        EBridgeValueKind::Int64,
+        AsBridgeType(MkqlInt64Type(mkql)),
+        TUnboxedValuePod(i64{1}));
+    const ui64 b = table.Register(
+        EBridgeNodeKind::Scalar,
+        EBridgeValueKind::Int64,
+        AsBridgeType(MkqlInt64Type(mkql)),
+        TUnboxedValuePod(i64{2}));
+
+    const ui64 resultHandle = udf.Invoke("make_list_two", {a, b, udf.Scratch(2)});
+    UNIT_ASSERT(resultHandle != NullBridgeHandle);
+    UNIT_ASSERT_VALUES_EQUAL(table.Resolve(resultHandle).Type, AsBridgeType(innerType));
+
+    table.Unref(resultHandle);
+    table.Unref(b);
+    table.Unref(a);
+    UNIT_ASSERT_VALUES_EQUAL(table.DebugSize(), 0u);
+}
+
+Y_UNIT_TEST(MakeListBuildsTheSecondListOfATupleResult) {
+    // Sibling Lists of different item families: the first match was
+    // List<Int64>, so a list of strings failed the item check. Families pick
+    // List<String>.
+    TMiniKqlEnv mkql;
+
+    auto* intList = NKikimr::NMiniKQL::TListType::Create(MkqlInt64Type(mkql), mkql.Env);
+    auto* stringList = NKikimr::NMiniKQL::TListType::Create(MkqlStringType(mkql), mkql.Env);
+    TTypeCheckUdf udf(mkql, 63, MkqlTupleType(mkql, {intList, stringList}));
+    auto& table = udf.Table();
+
+    const ui64 a = table.Register(
+        EBridgeNodeKind::String,
+        EBridgeValueKind::String,
+        AsBridgeType(MkqlStringType(mkql)),
+        mkql.ValueBuilder.NewString(TStringRef("a", 1)));
+    const ui64 b = table.Register(
+        EBridgeNodeKind::String,
+        EBridgeValueKind::String,
+        AsBridgeType(MkqlStringType(mkql)),
+        mkql.ValueBuilder.NewString(TStringRef("b", 1)));
+
+    const ui64 resultHandle = udf.Invoke("make_list_two", {a, b, udf.Scratch(2)});
+    UNIT_ASSERT(resultHandle != NullBridgeHandle);
+    UNIT_ASSERT_VALUES_EQUAL(table.Resolve(resultHandle).Type, AsBridgeType(stringList));
+
+    table.Unref(resultHandle);
+    table.Unref(b);
+    table.Unref(a);
+    UNIT_ASSERT_VALUES_EQUAL(table.DebugSize(), 0u);
+}
+
+Y_UNIT_TEST(MakeArrayBuildsAnInnerTupleOfTheOuterArity) {
+    // Outer and inner Tuples share arity 2, so the first match was the outer
+    // one and string members failed against Tuple slots. Families pick the
+    // Tuple<String,String> member.
+    TMiniKqlEnv mkql;
+
+    auto* ints = MkqlTupleType(mkql, {MkqlInt64Type(mkql), MkqlInt64Type(mkql)});
+    auto* strings = MkqlTupleType(mkql, {MkqlStringType(mkql), MkqlStringType(mkql)});
+    TTypeCheckUdf udf(mkql, 64, MkqlTupleType(mkql, {ints, strings}));
+    auto& table = udf.Table();
+
+    const ui64 a = table.Register(
+        EBridgeNodeKind::String,
+        EBridgeValueKind::String,
+        AsBridgeType(MkqlStringType(mkql)),
+        mkql.ValueBuilder.NewString(TStringRef("a", 1)));
+    const ui64 b = table.Register(
+        EBridgeNodeKind::String,
+        EBridgeValueKind::String,
+        AsBridgeType(MkqlStringType(mkql)),
+        mkql.ValueBuilder.NewString(TStringRef("b", 1)));
+
+    const ui64 resultHandle = udf.Invoke("make_array_two", {a, b, udf.Scratch(2)});
+    UNIT_ASSERT(resultHandle != NullBridgeHandle);
+    UNIT_ASSERT_VALUES_EQUAL(table.Resolve(resultHandle).Type, AsBridgeType(strings));
+
+    table.Unref(resultHandle);
+    table.Unref(b);
+    table.Unref(a);
+    UNIT_ASSERT_VALUES_EQUAL(table.DebugSize(), 0u);
+}
+
+Y_UNIT_TEST(MakeListTypedNamesTheInnerListExplicitly) {
+    // Preferred path for nested containers: the guest walks BridgeGetResultType
+    // with BridgeTypeListItem and names the list, the way BridgeMakeDict does.
+    TMiniKqlEnv mkql;
+
+    auto* innerType = NKikimr::NMiniKQL::TListType::Create(MkqlInt64Type(mkql), mkql.Env);
+    auto* outerType = NKikimr::NMiniKQL::TListType::Create(innerType, mkql.Env);
+    TTypeCheckUdf udf(mkql, 65, outerType);
+    auto& table = udf.Table();
+
+    const ui64 a = table.Register(
+        EBridgeNodeKind::Scalar,
+        EBridgeValueKind::Int64,
+        AsBridgeType(MkqlInt64Type(mkql)),
+        TUnboxedValuePod(i64{1}));
+    const ui64 b = table.Register(
+        EBridgeNodeKind::Scalar,
+        EBridgeValueKind::Int64,
+        AsBridgeType(MkqlInt64Type(mkql)),
+        TUnboxedValuePod(i64{2}));
+
+    const ui64 resultHandle = udf.Invoke("make_inner_list_typed", {a, b, udf.Scratch(2)});
+    UNIT_ASSERT(resultHandle != NullBridgeHandle);
+    UNIT_ASSERT_VALUES_EQUAL(table.Resolve(resultHandle).Type, AsBridgeType(innerType));
+
+    table.Unref(resultHandle);
+    table.Unref(b);
+    table.Unref(a);
+    UNIT_ASSERT_VALUES_EQUAL(table.DebugSize(), 0u);
+}
+
+Y_UNIT_TEST(MakeArrayTypedNamesTheSecondTupleExplicitly) {
+    TMiniKqlEnv mkql;
+
+    auto* ints = MkqlTupleType(mkql, {MkqlInt64Type(mkql), MkqlInt64Type(mkql)});
+    auto* strings = MkqlTupleType(mkql, {MkqlStringType(mkql), MkqlStringType(mkql)});
+    TTypeCheckUdf udf(mkql, 66, MkqlTupleType(mkql, {ints, strings}));
+    auto& table = udf.Table();
+
+    const ui64 a = table.Register(
+        EBridgeNodeKind::String,
+        EBridgeValueKind::String,
+        AsBridgeType(MkqlStringType(mkql)),
+        mkql.ValueBuilder.NewString(TStringRef("a", 1)));
+    const ui64 b = table.Register(
+        EBridgeNodeKind::String,
+        EBridgeValueKind::String,
+        AsBridgeType(MkqlStringType(mkql)),
+        mkql.ValueBuilder.NewString(TStringRef("b", 1)));
+
+    const ui64 resultHandle = udf.Invoke("make_second_tuple_typed", {a, b, udf.Scratch(2)});
+    UNIT_ASSERT(resultHandle != NullBridgeHandle);
+    UNIT_ASSERT_VALUES_EQUAL(table.Resolve(resultHandle).Type, AsBridgeType(strings));
+
+    table.Unref(resultHandle);
+    table.Unref(b);
+    table.Unref(a);
+    UNIT_ASSERT_VALUES_EQUAL(table.DebugSize(), 0u);
 }
 
 } // Y_UNIT_TEST_SUITE

--- a/ydb/services/udf_store/ut/bridge_typecheck_ut.cpp
+++ b/ydb/services/udf_store/ut/bridge_typecheck_ut.cpp
@@ -66,9 +66,11 @@ constexpr TStringBuf BridgeTypeCheckWast = R"(
         (import "env" "BridgeMakeList" (func $make_list (param i64 i32) (result i64)))
         (import "env" "BridgeMakeListTyped" (func $make_list_typed (param i64 i64 i32) (result i64)))
         (import "env" "BridgeMakeOptional" (func $make_optional (param i64) (result i64)))
+        (import "env" "BridgeMakeStructTyped" (func $make_struct_typed (param i64 i64 i32) (result i64)))
         (import "env" "BridgeRun" (func $run (param i64 i64 i32) (result i64)))
         (import "env" "BridgeTypeListItem" (func $type_list_item (param i64) (result i64)))
         (import "env" "BridgeTypeMember" (func $type_member (param i64 i32) (result i64)))
+        (import "env" "BridgeTypeOptionalItem" (func $type_optional_item (param i64) (result i64)))
         (import "env" "BridgeUnref" (func $unref (param i64)))
 
         (func $contains_raw (param $ctx i64) (param $result i64) (param $dict i64) (param $key i64)
@@ -175,6 +177,57 @@ constexpr TStringBuf BridgeTypeCheckWast = R"(
         )
         (export "make_second_tuple_typed" (func $make_second_tuple_typed))
 
+        ;; Same for a Struct: the member named by BridgeTypeMember is itself a
+        ;; Struct, and its own members are handed over in declared order.
+        (func $make_second_struct_typed (param $ctx i64) (param $result i64)
+                (param $a i64) (param $b i64) (param $members i64)
+            (local $outer i64)
+            (local $inner i64)
+            (local.set $outer (call $result_type))
+            (local.set $inner (call $type_member (local.get $outer) (i32.const 1)))
+            (i64.store (local.get $members) (local.get $a))
+            (i64.store (i64.add (local.get $members) (i64.const 8)) (local.get $b))
+            (i64.store (local.get $result)
+                (call $make_struct_typed (local.get $inner) (local.get $members) (i32.const 2)))
+            (call $unref (local.get $inner))
+            (call $unref (local.get $outer))
+        )
+        (export "make_second_struct_typed" (func $make_second_struct_typed))
+
+        ;; Name the second member of the result and build it as a List: how a
+        ;; guest resolves sibling Lists the handles cannot tell apart.
+        (func $make_second_list_typed (param $ctx i64) (param $result i64)
+                (param $a i64) (param $b i64) (param $items i64)
+            (local $outer i64)
+            (local $inner i64)
+            (local.set $outer (call $result_type))
+            (local.set $inner (call $type_member (local.get $outer) (i32.const 1)))
+            (i64.store (local.get $items) (local.get $a))
+            (i64.store (i64.add (local.get $items) (i64.const 8)) (local.get $b))
+            (i64.store (local.get $result)
+                (call $make_list_typed (local.get $inner) (local.get $items) (i32.const 2)))
+            (call $unref (local.get $inner))
+            (call $unref (local.get $outer))
+        )
+        (export "make_second_list_typed" (func $make_second_list_typed))
+
+        ;; An Optional result: the type to build sits under the wrapper, which
+        ;; is what BridgeTypeOptionalItem peels.
+        (func $make_optional_tuple_typed (param $ctx i64) (param $result i64)
+                (param $a i64) (param $b i64) (param $elems i64)
+            (local $outer i64)
+            (local $inner i64)
+            (local.set $outer (call $result_type))
+            (local.set $inner (call $type_optional_item (local.get $outer)))
+            (i64.store (local.get $elems) (local.get $a))
+            (i64.store (i64.add (local.get $elems) (i64.const 8)) (local.get $b))
+            (i64.store (local.get $result)
+                (call $make_array_typed (local.get $inner) (local.get $elems) (i32.const 2)))
+            (call $unref (local.get $inner))
+            (call $unref (local.get $outer))
+        )
+        (export "make_optional_tuple_typed" (func $make_optional_tuple_typed))
+
         (func $dict_iter_then_lookup (param $ctx i64) (param $result i64)
                 (param $dict i64) (param $key i64)
             (local $iter i64)
@@ -265,10 +318,28 @@ TMkqlType* MkqlInt64Type(TMiniKqlEnv& mkql) {
     return NKikimr::NMiniKQL::TDataType::Create(NYql::NUdf::TDataType<i64>::Id, mkql.Env);
 }
 
+//! Int64's family with a different kind: what tells two sibling containers
+//! apart once the family comparison has accepted both.
+TMkqlType* MkqlInt32Type(TMiniKqlEnv& mkql) {
+    return NKikimr::NMiniKQL::TDataType::Create(NYql::NUdf::TDataType<i32>::Id, mkql.Env);
+}
+
 TMkqlType* MkqlTupleType(TMiniKqlEnv& mkql, const TVector<TMkqlType*>& elements) {
     return NKikimr::NMiniKQL::TTupleType::Create(
         elements.size(),
         elements.data(),
+        mkql.Env);
+}
+
+//! Members go in as given, so the names here are already in the order a
+//! declared Struct arrives in.
+TMkqlType* MkqlStructType(
+    TMiniKqlEnv& mkql,
+    const TVector<std::pair<TString, TMkqlType*>>& members)
+{
+    return NKikimr::NMiniKQL::TStructType::Create(
+        members.data(),
+        members.size(),
         mkql.Env);
 }
 
@@ -1092,6 +1163,175 @@ Y_UNIT_TEST(MakeArrayTypedNamesTheSecondTupleExplicitly) {
 
     table.Unref(resultHandle);
     table.Unref(b);
+    table.Unref(a);
+    UNIT_ASSERT_VALUES_EQUAL(table.DebugSize(), 0u);
+}
+
+Y_UNIT_TEST(MakeStructTypedNamesTheNestedStructExplicitly) {
+    TMiniKqlEnv mkql;
+
+    auto* point = MkqlStructType(mkql, {{"x", MkqlInt64Type(mkql)}, {"y", MkqlInt64Type(mkql)}});
+    auto* outer = MkqlStructType(mkql, {{"label", MkqlStringType(mkql)}, {"point", point}});
+    TTypeCheckUdf udf(mkql, 67, outer);
+    auto& table = udf.Table();
+
+    const ui64 a = table.Register(
+        EBridgeNodeKind::Scalar,
+        EBridgeValueKind::Int64,
+        AsBridgeType(MkqlInt64Type(mkql)),
+        TUnboxedValuePod(i64{1}));
+    const ui64 b = table.Register(
+        EBridgeNodeKind::Scalar,
+        EBridgeValueKind::Int64,
+        AsBridgeType(MkqlInt64Type(mkql)),
+        TUnboxedValuePod(i64{2}));
+
+    const ui64 resultHandle = udf.Invoke("make_second_struct_typed", {a, b, udf.Scratch(2)});
+    UNIT_ASSERT(resultHandle != NullBridgeHandle);
+    UNIT_ASSERT_VALUES_EQUAL(table.Resolve(resultHandle).Type, AsBridgeType(point));
+
+    table.Unref(resultHandle);
+    table.Unref(b);
+    table.Unref(a);
+    UNIT_ASSERT_VALUES_EQUAL(table.DebugSize(), 0u);
+}
+
+Y_UNIT_TEST(MakeArrayTypedNamesTheTupleUnderAnOptionalResult) {
+    // BridgeGetResultType hands out Optional<Tuple<..>>, and the type to build
+    // is what BridgeTypeOptionalItem peels off it.
+    TMiniKqlEnv mkql;
+
+    auto* tupleType = MkqlTupleType(mkql, {MkqlInt64Type(mkql), MkqlInt64Type(mkql)});
+    auto* resultType = NKikimr::NMiniKQL::TOptionalType::Create(tupleType, mkql.Env);
+    TTypeCheckUdf udf(mkql, 68, resultType);
+    auto& table = udf.Table();
+
+    const ui64 a = table.Register(
+        EBridgeNodeKind::Scalar,
+        EBridgeValueKind::Int64,
+        AsBridgeType(MkqlInt64Type(mkql)),
+        TUnboxedValuePod(i64{1}));
+    const ui64 b = table.Register(
+        EBridgeNodeKind::Scalar,
+        EBridgeValueKind::Int64,
+        AsBridgeType(MkqlInt64Type(mkql)),
+        TUnboxedValuePod(i64{2}));
+
+    const ui64 resultHandle = udf.Invoke("make_optional_tuple_typed", {a, b, udf.Scratch(2)});
+    UNIT_ASSERT(resultHandle != NullBridgeHandle);
+    UNIT_ASSERT_VALUES_EQUAL(table.Resolve(resultHandle).Type, AsBridgeType(tupleType));
+
+    table.Unref(resultHandle);
+    table.Unref(b);
+    table.Unref(a);
+    UNIT_ASSERT_VALUES_EQUAL(table.DebugSize(), 0u);
+}
+
+Y_UNIT_TEST(MakeArrayReportsANullSlotWithSeveralCandidates) {
+    // Nothing accepts a null here: both the outer and the inner Tuple declare
+    // one mandatory member. Narrowing has no candidate to pick, and dropping
+    // the type instead would take the mandatory-null check with it and hand
+    // MiniKQL a tuple whose only member is absent.
+    TMiniKqlEnv mkql;
+
+    auto* inner = MkqlTupleType(mkql, {MkqlStringType(mkql)});
+    TTypeCheckUdf udf(mkql, 69, MkqlTupleType(mkql, {inner}));
+
+    UNIT_ASSERT_EXCEPTION_CONTAINS(
+        udf.Invoke("make_array_one", {NullBridgeHandle, udf.Scratch(1)}),
+        yexception,
+        "BridgeMakeArray slot 0 is null");
+
+    UNIT_ASSERT_VALUES_EQUAL(udf.Table().DebugSize(), 0u);
+}
+
+Y_UNIT_TEST(MakeArrayReportsAWrongMemberInsteadOfPickingASibling) {
+    // Int32 and Int64 share a family, so Tuple<Int32,Int32> accepts two Int64
+    // handles. A guest that means the sibling Tuple<Int64,String> and gets its
+    // second member wrong must hear about that member instead of having its
+    // tuple silently rebuilt as the other declaration.
+    TMiniKqlEnv mkql;
+
+    auto* wanted = MkqlTupleType(mkql, {MkqlInt64Type(mkql), MkqlStringType(mkql)});
+    auto* sibling = MkqlTupleType(mkql, {MkqlInt32Type(mkql), MkqlInt32Type(mkql)});
+    TTypeCheckUdf udf(mkql, 70, MkqlTupleType(mkql, {wanted, sibling}));
+    auto& table = udf.Table();
+
+    const ui64 a = table.Register(
+        EBridgeNodeKind::Scalar,
+        EBridgeValueKind::Int64,
+        AsBridgeType(MkqlInt64Type(mkql)),
+        TUnboxedValuePod(i64{1}));
+
+    UNIT_ASSERT_EXCEPTION_CONTAINS(
+        udf.Invoke("make_array_two", {a, a, udf.Scratch(2)}),
+        yexception,
+        "BridgeMakeArray expected a string value, got scalar");
+
+    table.Unref(a);
+    UNIT_ASSERT_VALUES_EQUAL(table.DebugSize(), 0u);
+}
+
+Y_UNIT_TEST(MakeArrayPicksTheSiblingWhoseKindsMatchExactly) {
+    // The control for the test above: with a String second member the same
+    // declaration resolves to Tuple<Int64,String>, which names both kinds
+    // exactly, and not to the Tuple<Int32,Int32> the families also allow.
+    TMiniKqlEnv mkql;
+
+    auto* wanted = MkqlTupleType(mkql, {MkqlInt64Type(mkql), MkqlStringType(mkql)});
+    auto* sibling = MkqlTupleType(mkql, {MkqlInt32Type(mkql), MkqlInt32Type(mkql)});
+    TTypeCheckUdf udf(mkql, 71, MkqlTupleType(mkql, {wanted, sibling}));
+    auto& table = udf.Table();
+
+    const ui64 a = table.Register(
+        EBridgeNodeKind::Scalar,
+        EBridgeValueKind::Int64,
+        AsBridgeType(MkqlInt64Type(mkql)),
+        TUnboxedValuePod(i64{1}));
+    const ui64 b = table.Register(
+        EBridgeNodeKind::String,
+        EBridgeValueKind::String,
+        AsBridgeType(MkqlStringType(mkql)),
+        mkql.ValueBuilder.NewString(TStringRef("b", 1)));
+
+    const ui64 resultHandle = udf.Invoke("make_array_two", {a, b, udf.Scratch(2)});
+    UNIT_ASSERT(resultHandle != NullBridgeHandle);
+    UNIT_ASSERT_VALUES_EQUAL(table.Resolve(resultHandle).Type, AsBridgeType(wanted));
+
+    table.Unref(resultHandle);
+    table.Unref(b);
+    table.Unref(a);
+    UNIT_ASSERT_VALUES_EQUAL(table.DebugSize(), 0u);
+}
+
+Y_UNIT_TEST(MakeListLeavesIndistinguishableSiblingsUntyped) {
+    // Two Lists of the same item type: the handles say nothing about which one
+    // the guest is building, so the node stays untyped rather than being
+    // stamped with a guess.
+    TMiniKqlEnv mkql;
+
+    auto* first = NKikimr::NMiniKQL::TListType::Create(MkqlInt64Type(mkql), mkql.Env);
+    auto* second = NKikimr::NMiniKQL::TListType::Create(MkqlInt64Type(mkql), mkql.Env);
+    TTypeCheckUdf udf(mkql, 72, MkqlTupleType(mkql, {first, second}));
+    auto& table = udf.Table();
+
+    const ui64 a = table.Register(
+        EBridgeNodeKind::Scalar,
+        EBridgeValueKind::Int64,
+        AsBridgeType(MkqlInt64Type(mkql)),
+        TUnboxedValuePod(i64{1}));
+
+    const ui64 untypedHandle = udf.Invoke("make_list_two", {a, a, udf.Scratch(2)});
+    UNIT_ASSERT(untypedHandle != NullBridgeHandle);
+    UNIT_ASSERT_VALUES_EQUAL(table.Resolve(untypedHandle).Type, nullptr);
+
+    // Which is what the typed path is for: naming the member settles it.
+    const ui64 typedHandle = udf.Invoke("make_second_list_typed", {a, a, udf.Scratch(2)});
+    UNIT_ASSERT(typedHandle != NullBridgeHandle);
+    UNIT_ASSERT_VALUES_EQUAL(table.Resolve(typedHandle).Type, AsBridgeType(second));
+
+    table.Unref(typedHandle);
+    table.Unref(untypedHandle);
     table.Unref(a);
     UNIT_ASSERT_VALUES_EQUAL(table.DebugSize(), 0u);
 }

--- a/ydb/services/udf_store/wasm/abi/bridge_abi.h
+++ b/ydb/services/udf_store/wasm/abi/bridge_abi.h
@@ -112,19 +112,37 @@ TBridgeHandle BridgeMakeString(uint64_t srcOff, int64_t len);
 //! Does not consume `inner`, and may return `inner` itself with an added ref
 //! when MiniKQL represents the Optional exactly like its payload.
 TBridgeHandle BridgeMakeOptional(TBridgeHandle inner);
-//! Build a Tuple from an array of handles in linear memory. The result is
-//! typed from the declared result type when that type holds a Tuple of the
-//! same arity; otherwise it stays untyped and BridgeGetElement /
-//! BridgeGetMemberCount on it will fail.
+//! Build a Tuple from an array of handles in linear memory. When the declared
+//! result type names exactly one Tuple of this arity, or several and the
+//! member families pick one, the result is typed; otherwise it stays untyped
+//! and BridgeGetElement / BridgeGetMemberCount on it will fail. Prefer
+//! BridgeMakeArrayTyped when the result nests same-arity Tuples.
 TBridgeHandle BridgeMakeArray(uint64_t elemsOff, int32_t n);
 //! Same layout and the same typing rule, but the result reads back as a
 //! Struct; members follow the declared member order of the result type.
 TBridgeHandle BridgeMakeStruct(uint64_t membersOff, int32_t n);
+//! Same inference as BridgeMakeArray for List types in the result. Prefer
+//! BridgeMakeListTyped when the result nests Lists or holds sibling Lists.
 TBridgeHandle BridgeMakeList(uint64_t itemsOff, int32_t n);
 //! Does not consume `item`: the caller still owns the handle it passed in.
 TBridgeHandle BridgeMakeVariant(int32_t index, TBridgeHandle item);
 //! Type of the value the running UDF must return, as a value-less handle.
 TBridgeHandle BridgeGetResultType(void);
+//! Peel one Optional wrapper from a type handle (BridgeGetResultType or a
+//! member reached through BridgeTypeMember / BridgeTypeListItem).
+TBridgeHandle BridgeTypeOptionalItem(TBridgeHandle typeHandle);
+//! Item type of a List type handle.
+TBridgeHandle BridgeTypeListItem(TBridgeHandle typeHandle);
+//! Member / element type of a Struct or Tuple type handle at `index`.
+TBridgeHandle BridgeTypeMember(TBridgeHandle typeHandle, int32_t index);
+//! Build a Tuple of the type named by `typeHandle`, same layout as
+//! BridgeMakeArray. Does not consume `typeHandle`.
+TBridgeHandle BridgeMakeArrayTyped(TBridgeHandle typeHandle, uint64_t elemsOff, int32_t n);
+//! Same as BridgeMakeArrayTyped for a Struct type.
+TBridgeHandle BridgeMakeStructTyped(TBridgeHandle typeHandle, uint64_t membersOff, int32_t n);
+//! Build a List of the type named by `typeHandle`. Does not consume
+//! `typeHandle`.
+TBridgeHandle BridgeMakeListTyped(TBridgeHandle typeHandle, uint64_t itemsOff, int32_t n);
 //! Build a dict of the type named by `typeHandle` (BridgeGetResultType or an
 //! input dict) from 2*n handles laid out as key, payload, key, payload, ...
 TBridgeHandle BridgeMakeDict(TBridgeHandle typeHandle, uint64_t pairsOff, int32_t n);

--- a/ydb/services/udf_store/wasm/abi/bridge_abi.h
+++ b/ydb/services/udf_store/wasm/abi/bridge_abi.h
@@ -112,14 +112,17 @@ TBridgeHandle BridgeMakeString(uint64_t srcOff, int64_t len);
 //! Does not consume `inner`, and may return `inner` itself with an added ref
 //! when MiniKQL represents the Optional exactly like its payload.
 TBridgeHandle BridgeMakeOptional(TBridgeHandle inner);
-//! Build a Tuple from an array of handles in linear memory. When the declared
-//! result type names exactly one Tuple of this arity, or several and the
-//! member families pick one, the result is typed; otherwise it stays untyped
-//! and BridgeGetElement / BridgeGetMemberCount on it will fail. Prefer
-//! BridgeMakeArrayTyped when the result nests same-arity Tuples.
+//! Build a Tuple from an array of handles in linear memory, typed from the
+//! declared result type: the Tuples of this arity it names are the candidates,
+//! and the members pick which one is being built. A member that fits no
+//! candidate is an error naming the slot. Candidates the members cannot tell
+//! apart -- same arity, same member kinds -- leave the result untyped, and
+//! BridgeGetElement / BridgeGetMemberCount on it will fail. Prefer
+//! BridgeMakeArrayTyped when the result nests or repeats same-arity Tuples.
 TBridgeHandle BridgeMakeArray(uint64_t elemsOff, int32_t n);
 //! Same layout and the same typing rule, but the result reads back as a
-//! Struct; members follow the declared member order of the result type.
+//! Struct; members follow the declared member order of the result type. Prefer
+//! BridgeMakeStructTyped when the result nests or repeats same-arity Structs.
 TBridgeHandle BridgeMakeStruct(uint64_t membersOff, int32_t n);
 //! Same inference as BridgeMakeArray for List types in the result. Prefer
 //! BridgeMakeListTyped when the result nests Lists or holds sibling Lists.

--- a/ydb/services/udf_store/wasm/bridge_host.cpp
+++ b/ydb/services/udf_store/wasm/bridge_host.cpp
@@ -20,6 +20,7 @@
 
 #include <util/generic/array_ref.h>
 #include <util/generic/scope.h>
+#include <util/generic/vector.h>
 #include <util/generic/yexception.h>
 #include <util/string/builder.h>
 #include <util/system/types.h>
@@ -199,20 +200,27 @@ std::optional<ui32> MemberCountOfType(const TType* type) {
 constexpr ui32 MaxResultTypeSearchDepth = 8;
 constexpr ui32 MaxResultTypeSearchNodes = 256;
 
-//! Look through a declared result type for a type `accept` recognises. Every
-//! layer a value can sit under is followed -- Optional, List, Dict key and
-//! payload, Variant alternatives, Tuple and Struct members -- because the
+//! Walk a declared result type and collect every type `accept` recognises.
+//! Every layer a value can sit under is followed -- Optional, List, Dict key
+//! and payload, Variant alternatives, Tuple and Struct members -- because the
 //! guest builds a nested container bottom-up while the intrinsic building it
-//! sees only the result type of the whole call.
+//! sees only the result type of the whole call. A match does not stop the
+//! walk: List<List<T>> and same-arity sibling Tuples all have to be candidates.
 template <class TAccept>
-const TType* FindTypeIn(const TType* type, const TAccept& accept, ui32 depth, ui32& budget) {
+void CollectTypesIn(
+    const TType* type,
+    const TAccept& accept,
+    ui32 depth,
+    ui32& budget,
+    TVector<const TType*>& out)
+{
     const auto* helper = CurrentTypeHelper();
     if (!type || !helper || depth > MaxResultTypeSearchDepth || budget == 0) {
-        return nullptr;
+        return;
     }
     --budget;
     if (accept(type)) {
-        return type;
+        out.push_back(type);
     }
     const TType* const wrapped[] = {
         OptionalItemTypeOf(type),
@@ -221,29 +229,30 @@ const TType* FindTypeIn(const TType* type, const TAccept& accept, ui32 depth, ui
         DictPayloadTypeOf(type),
     };
     for (const TType* item : wrapped) {
-        if (const TType* found = FindTypeIn(item, accept, depth + 1, budget)) {
-            return found;
-        }
+        CollectTypesIn(item, accept, depth + 1, budget, out);
     }
     if (const TVariantTypeInspector variant(*helper, type); variant) {
-        if (const TType* found = FindTypeIn(variant.GetUnderlyingType(), accept, depth + 1, budget)) {
-            return found;
-        }
+        CollectTypesIn(variant.GetUnderlyingType(), accept, depth + 1, budget, out);
     }
     if (const auto arity = MemberCountOfType(type)) {
         for (ui32 i = 0; i < *arity; ++i) {
-            if (const TType* found = FindTypeIn(ElementTypeOf(type, i), accept, depth + 1, budget)) {
-                return found;
-            }
+            CollectTypesIn(ElementTypeOf(type, i), accept, depth + 1, budget, out);
         }
     }
-    return nullptr;
+}
+
+template <class TAccept>
+TVector<const TType*> CollectTypesIn(const TType* type, const TAccept& accept) {
+    TVector<const TType*> out;
+    ui32 budget = MaxResultTypeSearchNodes;
+    CollectTypesIn(type, accept, /*depth*/ 0, budget, out);
+    return out;
 }
 
 template <class TAccept>
 const TType* FindTypeIn(const TType* type, const TAccept& accept) {
-    ui32 budget = MaxResultTypeSearchNodes;
-    return FindTypeIn(type, accept, /*depth*/ 0, budget);
+    const auto found = CollectTypesIn(type, accept);
+    return found.empty() ? nullptr : found.front();
 }
 
 //! The Variant a UDF with this result type is allowed to build.
@@ -257,29 +266,26 @@ const TType* FindVariantTypeIn(const TType* type) {
     });
 }
 
-//! The List a UDF with this result type is allowed to build. Its items are
-//! read back as this list's item type, so a lookup that finds nothing leaves
-//! BridgeMakeList building a list nothing can check.
-const TType* FindListTypeIn(const TType* type) {
+TVector<const TType*> CollectListTypesIn(const TType* type) {
     const auto* helper = CurrentTypeHelper();
     if (!helper) {
-        return nullptr;
+        return {};
     }
-    return FindTypeIn(type, [helper](const TType* candidate) {
+    return CollectTypesIn(type, [helper](const TType* candidate) {
         return static_cast<bool>(TListTypeInspector(*helper, candidate));
     });
 }
 
-//! Same lookup for the Struct / Tuple a UDF with this result type is allowed
-//! to build. A result type may name more than one candidate, so the arity the
-//! guest is building picks between them; `arity` is nothing when the caller
-//! only asks whether the declaration mentions such a type at all.
-const TType* FindMemberedTypeIn(const TType* type, bool wantStruct, std::optional<ui32> arity) {
+TVector<const TType*> CollectMemberedTypesIn(
+    const TType* type,
+    bool wantStruct,
+    std::optional<ui32> arity)
+{
     const auto* helper = CurrentTypeHelper();
     if (!helper) {
-        return nullptr;
+        return {};
     }
-    return FindTypeIn(type, [helper, wantStruct, arity](const TType* candidate) {
+    return CollectTypesIn(type, [helper, wantStruct, arity](const TType* candidate) {
         const bool membered = wantStruct
             ? static_cast<bool>(TStructTypeInspector(*helper, candidate))
             : static_cast<bool>(TTupleTypeInspector(*helper, candidate));
@@ -321,6 +327,8 @@ void EnsureStringKind(const TWasmBridgeNodeTable::TNode& node, const char* what)
 std::optional<EBridgeKindFamily> NodeValueFamily(const TWasmBridgeNodeTable::TNode& node) {
     return BridgeNodeValueFamily(node, CurrentTypeHelper());
 }
+
+bool SlotAcceptsNull(const TType* type);
 
 //! Guard for a guest handle the host is about to hand to MiniKQL as a value of
 //! `expected`. MiniKQL reads it as the declared type without re-checking, and
@@ -372,6 +380,145 @@ void EnsureNodeMatchesType(
     ythrow yexception()
         << "Bridge: " << what << " expected a " << BridgeKindFamilyAsStr(expectedFamily)
         << " value, got " << BridgeKindFamilyAsStr(*family);
+}
+
+//! Same family comparison EnsureNodeMatchesType uses, without throwing. Used
+//! when several declared containers share an arity and the handles themselves
+//! have to pick which one the guest is building.
+bool HandleMatchesExpectedType(ui64 handle, const TType* expected) {
+    if (handle == NullBridgeHandle) {
+        return SlotAcceptsNull(expected);
+    }
+    const auto& node = CurrentBridgeTable().Resolve(handle);
+    if (IsBridgeIteratorKind(node.Kind)) {
+        return false;
+    }
+    const auto* helper = CurrentTypeHelper();
+    if (!expected || !helper) {
+        return true;
+    }
+    const auto expectedFamily =
+        BridgeKindFamily(BridgeKindsFromType(PeelOptional(expected), helper).Value);
+    if (expectedFamily == EBridgeKindFamily::Null) {
+        return true;
+    }
+    if (!node.Value) {
+        return true;
+    }
+    const auto family = NodeValueFamily(node);
+    return !family || *family == expectedFamily;
+}
+
+const ui64* PeekHandles(ui64 handlesOff, i32 n, const char* what) {
+    if (n < 0) {
+        ythrow yexception() << "Bridge: " << what << " negative count";
+    }
+    if (n == 0) {
+        return nullptr;
+    }
+    return PtrFromVM(
+        CurrentCompartmentOrThrow(),
+        std::bit_cast<ui64*>(static_cast<uintptr_t>(handlesOff)),
+        static_cast<size_t>(n));
+}
+
+bool HandlesMatchListType(const ui64* handles, i32 n, const TType* listType) {
+    const TType* itemType = ListItemTypeOf(listType);
+    for (i32 i = 0; i < n; ++i) {
+        if (!HandleMatchesExpectedType(handles[i], itemType)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool HandlesMatchMemberedType(const ui64* handles, i32 n, const TType* type) {
+    for (i32 i = 0; i < n; ++i) {
+        if (!HandleMatchesExpectedType(handles[i], ElementTypeOf(type, static_cast<ui32>(i)))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+//! Pick the List the guest is building from the declared result type. A single
+//! candidate is taken as-is (item checks still run later). Several candidates
+//! -- nested Lists, sibling Lists in a Tuple -- are narrowed by item families;
+//! when that does not leave exactly one, the node stays untyped instead of
+//! being stamped with the outermost match.
+const TType* InferListType(const TType* resultType, ui64 itemsOff, i32 n, const char* what) {
+    auto candidates = CollectListTypesIn(resultType);
+    if (candidates.empty()) {
+        return nullptr;
+    }
+    if (candidates.size() == 1) {
+        return candidates.front();
+    }
+    const ui64* handles = PeekHandles(itemsOff, n, what);
+    const TType* match = nullptr;
+    for (const TType* candidate : candidates) {
+        if (!HandlesMatchListType(handles, n, candidate)) {
+            continue;
+        }
+        if (match) {
+            return nullptr;
+        }
+        match = candidate;
+    }
+    return match;
+}
+
+//! Same narrowing for Struct / Tuple. An arity the declaration never names is
+//! still refused when any container of that kind is present -- a wrong width
+//! used to drop the type and every per-member check with it.
+const TType* InferMemberedType(
+    const TType* resultType,
+    bool wantStruct,
+    i32 n,
+    ui64 elemsOff,
+    const char* what)
+{
+    auto candidates = CollectMemberedTypesIn(resultType, wantStruct, static_cast<ui32>(n));
+    if (candidates.empty()) {
+        if (!CollectMemberedTypesIn(resultType, wantStruct, std::nullopt).empty()) {
+            ythrow yexception()
+                << "Bridge: " << what << " builds " << n
+                << " members, which matches no " << (wantStruct ? "Struct" : "Tuple")
+                << " in the declared result type";
+        }
+        return nullptr;
+    }
+    if (candidates.size() == 1) {
+        return candidates.front();
+    }
+    const ui64* handles = PeekHandles(elemsOff, n, what);
+    const TType* match = nullptr;
+    for (const TType* candidate : candidates) {
+        if (!HandlesMatchMemberedType(handles, n, candidate)) {
+            continue;
+        }
+        if (match) {
+            return nullptr;
+        }
+        match = candidate;
+    }
+    return match;
+}
+
+ui64 RegisterTypeRef(const TType* type) {
+    return CurrentBridgeTable().Register(
+        EBridgeNodeKind::TypeRef,
+        EBridgeValueKind::Null,
+        type,
+        {});
+}
+
+const TType* TypeFromHandle(ui64 typeHandle, const char* what) {
+    const TType* type = CurrentBridgeTable().Resolve(typeHandle).Type;
+    if (!type) {
+        ythrow yexception() << "Bridge: " << what << " needs a typed type node";
+    }
+    return type;
 }
 
 //! Whether a null handle may sit in a slot declared as `type`. MiniKQL stores
@@ -940,28 +1087,48 @@ TVector<TUnboxedValue> ResolveHandleArray(
     return values;
 }
 
-ui64 MakeArrayLike(ui64 elemsOff, i32 n, EBridgeNodeKind kind, EBridgeValueKind valueKind, const char* what) {
+ui64 MakeArrayLike(
+    ui64 elemsOff,
+    i32 n,
+    EBridgeNodeKind kind,
+    EBridgeValueKind valueKind,
+    const char* what,
+    ui64 typeHandle = NullBridgeHandle)
+{
     if (n < 0) {
         ythrow yexception() << "Bridge: " << what << " negative count";
     }
     // Untyped the guest cannot read back what it just built: GetMemberCount,
-    // GetElement and GetMemberIndex all need a type. Take the one the declared
-    // result type names for this arity -- a container of a different width is
-    // a different type.
-    auto* invocation = GetCurrentInvocationContext();
-    const TType* resultType = invocation ? invocation->ResultType : nullptr;
+    // GetElement and GetMemberIndex all need a type. An explicit typeHandle
+    // names it the way BridgeMakeDict does; otherwise take the unique match
+    // among candidates of this arity, narrowed by member families when the
+    // declaration holds several.
     const bool wantStruct = valueKind == EBridgeValueKind::Struct;
-    const TType* type = FindMemberedTypeIn(resultType, wantStruct, static_cast<ui32>(n));
-    if (!type && FindMemberedTypeIn(resultType, wantStruct, std::nullopt)) {
-        // The declaration names such a type, just not of this width. Dropping
-        // the type here instead would take every per-member check with it and
-        // leave MiniKQL reading the declared number of members out of an array
-        // that holds n -- a wrong n would be all it takes to bypass the checks
-        // below. A guest that means a different width means a different type.
-        ythrow yexception()
-            << "Bridge: " << what << " builds " << n
-            << " members, which matches no " << (wantStruct ? "Struct" : "Tuple")
-            << " in the declared result type";
+    const auto* helper = CurrentTypeHelper();
+    const TType* type = nullptr;
+    if (typeHandle != NullBridgeHandle) {
+        type = PeelOptional(TypeFromHandle(typeHandle, what));
+        if (!helper) {
+            ythrow yexception() << "Bridge: " << what << " needs a type info helper";
+        }
+        const bool membered = wantStruct
+            ? static_cast<bool>(TStructTypeInspector(*helper, type))
+            : static_cast<bool>(TTupleTypeInspector(*helper, type));
+        if (!membered) {
+            ythrow yexception()
+                << "Bridge: " << what << " expected a "
+                << (wantStruct ? "Struct" : "Tuple") << " type";
+        }
+        if (MemberCountOfType(type) != static_cast<ui32>(n)) {
+            ythrow yexception()
+                << "Bridge: " << what << " builds " << n
+                << " members, but the named type has "
+                << MemberCountOfType(type).value_or(0);
+        }
+    } else {
+        auto* invocation = GetCurrentInvocationContext();
+        const TType* resultType = invocation ? invocation->ResultType : nullptr;
+        type = InferMemberedType(resultType, wantStruct, n, elemsOff, what);
     }
     // Every member lands in a declared slot and will be read as that slot's
     // type, so each is checked against its own.
@@ -983,6 +1150,36 @@ ui64 MakeArrayLike(ui64 elemsOff, i32 n, EBridgeNodeKind kind, EBridgeValueKind 
     return RegisterOwned(kind, valueKind, std::move(result), type);
 }
 
+ui64 MakeListLike(ui64 itemsOff, i32 n, const char* what, ui64 typeHandle = NullBridgeHandle) {
+    if (n < 0) {
+        ythrow yexception() << "Bridge: " << what << " negative count";
+    }
+    // Items are read back as the item type of the list being built, so they
+    // are checked against it the way BridgeMakeDict checks its pairs. An
+    // explicit typeHandle names that list; otherwise the declaration is
+    // searched and narrowed by item families when several Lists appear.
+    const auto* helper = CurrentTypeHelper();
+    const TType* listType = nullptr;
+    if (typeHandle != NullBridgeHandle) {
+        listType = PeelOptional(TypeFromHandle(typeHandle, what));
+        if (!helper || !TListTypeInspector(*helper, listType)) {
+            ythrow yexception() << "Bridge: " << what << " expected a List type";
+        }
+    } else {
+        auto* invocation = GetCurrentInvocationContext();
+        const TType* resultType = invocation ? invocation->ResultType : nullptr;
+        listType = InferListType(resultType, itemsOff, n, what);
+    }
+    const TType* const itemTypes[] = {ListItemTypeOf(listType)};
+    auto values = ResolveHandleArray(itemsOff, n, what, itemTypes);
+    auto* builder = CurrentValueBuilderOrThrow();
+    auto result = builder->NewList(values.data(), static_cast<ui64>(n));
+    // Typed: a list the guest built is read back later on -- by itself through
+    // the list intrinsics, or by the host as a result -- and the item check
+    // there has nothing to compare against without the type.
+    return RegisterOwned(EBridgeNodeKind::List, EBridgeValueKind::List, std::move(result), listType);
+}
+
 ui64 BridgeMakeArrayHost(ui64 elemsOff, i32 n) {
     return MakeArrayLike(elemsOff, n, EBridgeNodeKind::Tuple, EBridgeValueKind::Tuple, "BridgeMakeArray");
 }
@@ -994,18 +1191,31 @@ ui64 BridgeMakeStructHost(ui64 membersOff, i32 n) {
 }
 
 ui64 BridgeMakeListHost(ui64 itemsOff, i32 n) {
-    // Items are read back as the item type of the list the declaration names,
-    // so they are checked against it the way BridgeMakeDict checks its pairs.
-    auto* invocation = GetCurrentInvocationContext();
-    const TType* listType = invocation ? FindListTypeIn(invocation->ResultType) : nullptr;
-    const TType* const itemTypes[] = {ListItemTypeOf(listType)};
-    auto values = ResolveHandleArray(itemsOff, n, "BridgeMakeList", itemTypes);
-    auto* builder = CurrentValueBuilderOrThrow();
-    auto result = builder->NewList(values.data(), static_cast<ui64>(n));
-    // Typed: a list the guest built is read back later on -- by itself through
-    // the list intrinsics, or by the host as a result -- and the item check
-    // there has nothing to compare against without the type.
-    return RegisterOwned(EBridgeNodeKind::List, EBridgeValueKind::List, std::move(result), listType);
+    return MakeListLike(itemsOff, n, "BridgeMakeList");
+}
+
+ui64 BridgeMakeArrayTypedHost(ui64 typeHandle, ui64 elemsOff, i32 n) {
+    return MakeArrayLike(
+        elemsOff,
+        n,
+        EBridgeNodeKind::Tuple,
+        EBridgeValueKind::Tuple,
+        "BridgeMakeArrayTyped",
+        typeHandle);
+}
+
+ui64 BridgeMakeStructTypedHost(ui64 typeHandle, ui64 membersOff, i32 n) {
+    return MakeArrayLike(
+        membersOff,
+        n,
+        EBridgeNodeKind::Struct,
+        EBridgeValueKind::Struct,
+        "BridgeMakeStructTyped",
+        typeHandle);
+}
+
+ui64 BridgeMakeListTypedHost(ui64 typeHandle, ui64 itemsOff, i32 n) {
+    return MakeListLike(itemsOff, n, "BridgeMakeListTyped", typeHandle);
 }
 
 ui64 BridgeMakeVariantHost(i32 index, ui64 itemHandle) {
@@ -1055,17 +1265,45 @@ ui64 BridgeMakeVariantHost(i32 index, ui64 itemHandle) {
 }
 
 //! Type of the value the running UDF has to return, as a value-less node.
-//! Needed by BridgeMakeDict: only the host knows the MiniKQL dict type.
+//! Needed by BridgeMakeDict and the typed Make* helpers: only the host knows
+//! the MiniKQL type tree.
 ui64 BridgeGetResultTypeHost() {
     auto* invocation = GetCurrentInvocationContext();
     if (!invocation || !invocation->ResultType) {
         ythrow yexception() << "Bridge: BridgeGetResultType outside a typed bridge call";
     }
-    return CurrentBridgeTable().Register(
-        EBridgeNodeKind::TypeRef,
-        EBridgeValueKind::Null,
-        invocation->ResultType,
-        {});
+    return RegisterTypeRef(invocation->ResultType);
+}
+
+ui64 BridgeTypeOptionalItemHost(ui64 typeHandle) {
+    const TType* item = OptionalItemTypeOf(TypeFromHandle(typeHandle, "BridgeTypeOptionalItem"));
+    if (!item) {
+        ythrow yexception() << "Bridge: BridgeTypeOptionalItem expected an Optional type";
+    }
+    return RegisterTypeRef(item);
+}
+
+ui64 BridgeTypeListItemHost(ui64 typeHandle) {
+    const TType* item = ListItemTypeOf(PeelOptional(TypeFromHandle(typeHandle, "BridgeTypeListItem")));
+    if (!item) {
+        ythrow yexception() << "Bridge: BridgeTypeListItem expected a List type";
+    }
+    return RegisterTypeRef(item);
+}
+
+ui64 BridgeTypeMemberHost(ui64 typeHandle, i32 index) {
+    if (index < 0) {
+        ythrow yexception() << "Bridge: BridgeTypeMember negative index";
+    }
+    const TType* type = PeelOptional(TypeFromHandle(typeHandle, "BridgeTypeMember"));
+    const TType* member = ElementTypeOf(type, static_cast<ui32>(index));
+    if (!member) {
+        ythrow yexception()
+            << "Bridge: BridgeTypeMember index " << index
+            << " is out of range for the named type with "
+            << MemberCountOfType(type).value_or(0) << " members";
+    }
+    return RegisterTypeRef(member);
 }
 
 //! `pairsOff` points at 2*n handles: key, payload, key, payload, ...
@@ -1312,6 +1550,12 @@ void BridgeUnrefHost(ui64 handle) {
     X(BridgeMakeList, BridgeMakeListHost, ui64(ui64, i32)) \
     X(BridgeMakeVariant, BridgeMakeVariantHost, ui64(i32, ui64)) \
     X(BridgeGetResultType, BridgeGetResultTypeHost, ui64()) \
+    X(BridgeTypeOptionalItem, BridgeTypeOptionalItemHost, ui64(ui64)) \
+    X(BridgeTypeListItem, BridgeTypeListItemHost, ui64(ui64)) \
+    X(BridgeTypeMember, BridgeTypeMemberHost, ui64(ui64, i32)) \
+    X(BridgeMakeArrayTyped, BridgeMakeArrayTypedHost, ui64(ui64, ui64, i32)) \
+    X(BridgeMakeStructTyped, BridgeMakeStructTypedHost, ui64(ui64, ui64, i32)) \
+    X(BridgeMakeListTyped, BridgeMakeListTypedHost, ui64(ui64, ui64, i32)) \
     X(BridgeMakeDict, BridgeMakeDictHost, ui64(ui64, ui64, i32)) \
     X(BridgeRun, BridgeRunHost, ui64(ui64, ui64, i32)) \
     X(BridgeGetResourceTagLen, BridgeGetResourceTagLenHost, i64(ui64)) \

--- a/ydb/services/udf_store/wasm/bridge_host.cpp
+++ b/ydb/services/udf_store/wasm/bridge_host.cpp
@@ -328,6 +328,10 @@ std::optional<EBridgeKindFamily> NodeValueFamily(const TWasmBridgeNodeTable::TNo
     return BridgeNodeValueFamily(node, CurrentTypeHelper());
 }
 
+std::optional<EBridgeValueKind> NodeValueKind(const TWasmBridgeNodeTable::TNode& node) {
+    return BridgeNodeValueKind(node, CurrentTypeHelper());
+}
+
 bool SlotAcceptsNull(const TType* type);
 
 //! Guard for a guest handle the host is about to hand to MiniKQL as a value of
@@ -384,7 +388,8 @@ void EnsureNodeMatchesType(
 
 //! Same family comparison EnsureNodeMatchesType uses, without throwing. Used
 //! when several declared containers share an arity and the handles themselves
-//! have to pick which one the guest is building.
+//! have to pick which one the guest is building. A handle the guard would not
+//! let into the slot cannot belong to that candidate.
 bool HandleMatchesExpectedType(ui64 handle, const TType* expected) {
     if (handle == NullBridgeHandle) {
         return SlotAcceptsNull(expected);
@@ -409,6 +414,26 @@ bool HandleMatchesExpectedType(ui64 handle, const TType* expected) {
     return !family || *family == expectedFamily;
 }
 
+//! Whether the handle carries the very kind the slot declares, as opposed to
+//! merely a kind of the same family. Families put Int32 next to Int64 and
+//! String next to Utf8 on purpose -- MiniKQL stores those alike, so the guard
+//! has no reason to refuse one for the other -- which leaves the family
+//! comparison unable to tell two sibling containers apart when they differ
+//! only in the width of a member. This is the finer evidence that does.
+bool HandleHasDeclaredKind(ui64 handle, const TType* expected) {
+    const auto* helper = CurrentTypeHelper();
+    if (handle == NullBridgeHandle || !expected || !helper) {
+        return false;
+    }
+    const auto declared = BridgeKindsFromType(PeelOptional(expected), helper).Value;
+    if (declared == EBridgeValueKind::Null) {
+        // A slot the bridge has no name for: nothing to be exact about.
+        return false;
+    }
+    const auto kind = NodeValueKind(CurrentBridgeTable().Resolve(handle));
+    return kind && *kind == declared;
+}
+
 const ui64* PeekHandles(ui64 handlesOff, i32 n, const char* what) {
     if (n < 0) {
         ythrow yexception() << "Bridge: " << what << " negative count";
@@ -422,30 +447,89 @@ const ui64* PeekHandles(ui64 handlesOff, i32 n, const char* what) {
         static_cast<size_t>(n));
 }
 
-bool HandlesMatchListType(const ui64* handles, i32 n, const TType* listType) {
-    const TType* itemType = ListItemTypeOf(listType);
+//! What one declared candidate makes of the handles the guest passed.
+struct TCandidateFit {
+    //! Every handle would pass the guard in the slot it lands in, so the guest
+    //! could be building this candidate.
+    bool Accepts = true;
+    //! Slots whose handle carries the very kind declared there. Finer than the
+    //! family comparison exactly where two candidates look alike to it.
+    i32 ExactSlots = 0;
+};
+
+template <class TSlotOf>
+TCandidateFit FitHandles(const TType* candidate, const ui64* handles, i32 n, const TSlotOf& slotOf) {
+    TCandidateFit fit;
     for (i32 i = 0; i < n; ++i) {
-        if (!HandleMatchesExpectedType(handles[i], itemType)) {
-            return false;
+        const TType* slot = slotOf(candidate, i);
+        if (!HandleMatchesExpectedType(handles[i], slot)) {
+            fit.Accepts = false;
+            continue;
+        }
+        if (HandleHasDeclaredKind(handles[i], slot)) {
+            ++fit.ExactSlots;
         }
     }
-    return true;
+    return fit;
 }
 
-bool HandlesMatchMemberedType(const ui64* handles, i32 n, const TType* type) {
-    for (i32 i = 0; i < n; ++i) {
-        if (!HandleMatchesExpectedType(handles[i], ElementTypeOf(type, static_cast<ui32>(i)))) {
-            return false;
+//! Pick the declared container the guest is building; `slotOf` names the type
+//! of slot `i` inside a candidate. Candidates come from the result type, which
+//! is why there can be several: the guest builds a nested container bottom-up
+//! while the intrinsic sees the whole call's result type.
+//!
+//! A candidate every handle fits is a possible reading of the call, and the
+//! one naming the most slots exactly is the reading taken. A tie there means
+//! the handles cannot tell those candidates apart -- two Lists of the same
+//! item type, say -- and leaves the node untyped for the guest to name with a
+//! typed Make*.
+//!
+//! Otherwise the closest candidate is handed back although it fits no better
+//! than partially, so the per-slot guard reports which slot is wrong and why,
+//! the way it did when the first match was stamped unconditionally. That
+//! covers both "nothing fits" and a coarse match that another candidate beats
+//! on kinds: a guest that means Tuple<Int64,String> and gets its second member
+//! wrong hears about that member, instead of having its tuple silently rebuilt
+//! as the sibling Tuple<Int32,Int32>, which accepts two Int64 handles because
+//! Int32 and Int64 share a family.
+template <class TSlotOf>
+const TType* NarrowCandidates(
+    const TVector<const TType*>& candidates,
+    const ui64* handles,
+    i32 n,
+    const TSlotOf& slotOf)
+{
+    const TType* match = nullptr;
+    i32 matchExact = -1;
+    bool ambiguous = false;
+    const TType* closest = nullptr;
+    i32 closestExact = -1;
+    for (const TType* candidate : candidates) {
+        const auto fit = FitHandles(candidate, handles, n, slotOf);
+        if (fit.ExactSlots > closestExact) {
+            closest = candidate;
+            closestExact = fit.ExactSlots;
+        }
+        if (!fit.Accepts) {
+            continue;
+        }
+        if (fit.ExactSlots > matchExact) {
+            match = candidate;
+            matchExact = fit.ExactSlots;
+            ambiguous = false;
+        } else if (fit.ExactSlots == matchExact) {
+            ambiguous = true;
         }
     }
-    return true;
+    if (!match || closestExact > matchExact) {
+        return closest;
+    }
+    return ambiguous ? nullptr : match;
 }
 
 //! Pick the List the guest is building from the declared result type. A single
-//! candidate is taken as-is (item checks still run later). Several candidates
-//! -- nested Lists, sibling Lists in a Tuple -- are narrowed by item families;
-//! when that does not leave exactly one, the node stays untyped instead of
-//! being stamped with the outermost match.
+//! candidate is taken as-is (item checks still run later); several -- nested
+//! Lists, sibling Lists in a Tuple -- go through the narrowing above.
 const TType* InferListType(const TType* resultType, ui64 itemsOff, i32 n, const char* what) {
     auto candidates = CollectListTypesIn(resultType);
     if (candidates.empty()) {
@@ -455,17 +539,9 @@ const TType* InferListType(const TType* resultType, ui64 itemsOff, i32 n, const 
         return candidates.front();
     }
     const ui64* handles = PeekHandles(itemsOff, n, what);
-    const TType* match = nullptr;
-    for (const TType* candidate : candidates) {
-        if (!HandlesMatchListType(handles, n, candidate)) {
-            continue;
-        }
-        if (match) {
-            return nullptr;
-        }
-        match = candidate;
-    }
-    return match;
+    return NarrowCandidates(candidates, handles, n, [](const TType* candidate, i32) {
+        return ListItemTypeOf(candidate);
+    });
 }
 
 //! Same narrowing for Struct / Tuple. An arity the declaration never names is
@@ -492,17 +568,9 @@ const TType* InferMemberedType(
         return candidates.front();
     }
     const ui64* handles = PeekHandles(elemsOff, n, what);
-    const TType* match = nullptr;
-    for (const TType* candidate : candidates) {
-        if (!HandlesMatchMemberedType(handles, n, candidate)) {
-            continue;
-        }
-        if (match) {
-            return nullptr;
-        }
-        match = candidate;
-    }
-    return match;
+    return NarrowCandidates(candidates, handles, n, [](const TType* candidate, i32 index) {
+        return ElementTypeOf(candidate, static_cast<ui32>(index));
+    });
 }
 
 ui64 RegisterTypeRef(const TType* type) {

--- a/ydb/services/udf_store/wasm/bridge_node_table.cpp
+++ b/ydb/services/udf_store/wasm/bridge_node_table.cpp
@@ -164,25 +164,34 @@ const TType* BridgePeelOptional(const TType* type, const ITypeInfoHelper* helper
     return type;
 }
 
-std::optional<EBridgeKindFamily> BridgeNodeValueFamily(
+std::optional<EBridgeValueKind> BridgeNodeValueKind(
     const TWasmBridgeNodeTable::TNode& node,
     const ITypeInfoHelper* helper)
 {
-    const auto family = BridgeKindFamily(node.ValueKind);
-    if (family != EBridgeKindFamily::Optional) {
-        return family;
+    if (BridgeKindFamily(node.ValueKind) != EBridgeKindFamily::Optional) {
+        return node.ValueKind;
     }
     if (node.InnerValueKind) {
-        return BridgeKindFamily(*node.InnerValueKind);
+        return *node.InnerValueKind;
     }
     if (helper && node.Type) {
         // Registered from a declared Optional<container>, or handed in as an
         // optional argument: the kind stopped at the wrapper, the type names
         // the payload.
-        return BridgeKindFamily(
-            BridgeKindsFromType(BridgePeelOptional(node.Type, helper), helper).Value);
+        return BridgeKindsFromType(BridgePeelOptional(node.Type, helper), helper).Value;
     }
     return std::nullopt;
+}
+
+std::optional<EBridgeKindFamily> BridgeNodeValueFamily(
+    const TWasmBridgeNodeTable::TNode& node,
+    const ITypeInfoHelper* helper)
+{
+    const auto kind = BridgeNodeValueKind(node, helper);
+    if (!kind) {
+        return std::nullopt;
+    }
+    return BridgeKindFamily(*kind);
 }
 
 TWasmBridgeNodeTable::TWasmBridgeNodeTable(ui64 generation)

--- a/ydb/services/udf_store/wasm/bridge_node_table.h
+++ b/ydb/services/udf_store/wasm/bridge_node_table.h
@@ -179,10 +179,16 @@ private:
     NYql::NUdf::ITypeInfoHelper::TPtr TypeInfoHelper_;
 };
 
-//! Family the node's value will present to MiniKQL, which is not always the
-//! family of its own kind: an Optional node is a wrapper, and MiniKQL reads
-//! what the guest put inside it. Nothing when the payload has no name here --
-//! an Optional built over a handle whose kind was never recorded.
+//! Kind the node's value will present to MiniKQL, which is not always the kind
+//! of the node itself: an Optional node is a wrapper, and MiniKQL reads what
+//! the guest put inside it. Nothing when the payload has no name here -- an
+//! Optional built over a handle whose kind was never recorded.
+std::optional<EBridgeValueKind> BridgeNodeValueKind(
+    const TWasmBridgeNodeTable::TNode& node,
+    const NYql::NUdf::ITypeInfoHelper* helper);
+
+//! Family of BridgeNodeValueKind: what a declared slot is compared against,
+//! since MiniKQL stores the kinds inside one family alike.
 std::optional<EBridgeKindFamily> BridgeNodeValueFamily(
     const TWasmBridgeNodeTable::TNode& node,
     const NYql::NUdf::ITypeInfoHelper* helper);

--- a/ydb/services/udf_store/wasm/invocation_context.h
+++ b/ydb/services/udf_store/wasm/invocation_context.h
@@ -12,7 +12,8 @@ namespace NKikimr::NUdfStore::NWasm {
 struct TWasmUdfInvocationContext {
     NYdb::NWasm::TWebAssemblyMemoryPool WebAssemblyPool;
     //! Declared result type of the running bridge UDF, so the guest can ask
-    //! the host to build a container of exactly that type (BridgeMakeDict).
+    //! the host to build a container of exactly that type (BridgeMakeDict,
+    //! BridgeMakeListTyped, and the type-navigation helpers).
     const NYql::NUdf::TType* ResultType = nullptr;
 
     explicit TWasmUdfInvocationContext(NYdb::NWasm::IWebAssemblyCompartment* compartment)

--- a/ydb/udfs/wasm/types/main.cpp
+++ b/ydb/udfs/wasm/types/main.cpp
@@ -59,6 +59,23 @@ uint64_t* AllocHandles(size_t count) {
     return handles;
 }
 
+//! Sum of every Int64 in a List<List<Int64>>. Each item of the outer list is a
+//! list itself, read through the same range as the outer one: the item handle
+//! needs no unwrapping, only a non-owning view, since the range still owns it.
+int64_t SumNestedIntLists(uint64_t listH) {
+    TBridgeList outer(listH, /*owned*/ false);
+    int64_t sum = 0;
+    for (auto row : outer.Items()) {
+        TBridgeList inner(row.Get(), /*owned*/ false);
+        for (auto item : inner.Items()) {
+            sum += BridgeGetInt64(item.Get());
+            item.Reset();
+        }
+        row.Reset();
+    }
+    return sum;
+}
+
 //! Two-item Int64 list, typed from the declared result type: the items name a
 //! List<Int64> and nothing else, so the host has one candidate to pick.
 uint64_t MakeIntListInferred(int64_t first, int64_t second) {
@@ -240,6 +257,52 @@ __attribute__((visibility("default"))) void list_sum_int64(
         item.Reset();
     }
     SetInt64(result, sum);
+}
+
+//! A nested container on the way in: List<List<Int64>> folded to one number.
+__attribute__((visibility("default"))) void nested_list_sum_int64(
+    TExpressionContext* /*ctx*/, uint64_t* result, uint64_t listH)
+{
+    SetInt64(result, SumNestedIntLists(listH));
+}
+
+//! Dict<String, List<List<Int64>>> -> Dict<String, Int64>: every key keeps its
+//! payload's total. The dict is walked with an iterator, and the pairs are
+//! collected before the call because BridgeMakeDict takes them all at once --
+//! which is also why the keys the iterator handed over are released only after
+//! that call has copied them.
+__attribute__((visibility("default"))) void dict_nested_list_sums(
+    TExpressionContext* /*ctx*/, uint64_t* result, uint64_t dictH)
+{
+    TBridgeValue resultType(BridgeGetResultType(), /*owned*/ true);
+    const int64_t length = BridgeDictLength(dictH);
+    if (length == 0) {
+        *result = BridgeMakeDict(resultType.Get(), /*pairsOff*/ 0, 0);
+        return;
+    }
+
+    uint64_t* pairs = AllocHandles(static_cast<size_t>(length) * 2);
+    TBridgeValue iter(BridgeDictMakeIterator(dictH), /*owned*/ true);
+    int64_t pairCount = 0;
+    uint64_t keyHandle = 0;
+    uint64_t payloadHandle = 0;
+    while (pairCount < length
+        && BridgeDictIterNext(iter.Get(), &keyHandle, &payloadHandle) != 0)
+    {
+        TBridgeValue payload(payloadHandle, /*owned*/ true);
+        pairs[pairCount * 2] = keyHandle;
+        pairs[pairCount * 2 + 1] = MakeInt64(SumNestedIntLists(payload.Get())).Release();
+        ++pairCount;
+    }
+
+    *result = BridgeMakeDict(
+        resultType.Get(),
+        reinterpret_cast<uint64_t>(pairs),
+        static_cast<int32_t>(pairCount));
+    for (int64_t i = 0; i < pairCount; ++i) {
+        BridgeUnref(pairs[i * 2]);
+    }
+    free(pairs);
 }
 
 __attribute__((visibility("default"))) void dict_get_int64(

--- a/ydb/udfs/wasm/types/main.cpp
+++ b/ydb/udfs/wasm/types/main.cpp
@@ -59,6 +59,28 @@ uint64_t* AllocHandles(size_t count) {
     return handles;
 }
 
+//! Two-item Int64 list, typed from the declared result type: the items name a
+//! List<Int64> and nothing else, so the host has one candidate to pick.
+uint64_t MakeIntListInferred(int64_t first, int64_t second) {
+    uint64_t* items = AllocHandles(2);
+    items[0] = MakeInt64(first).Release();
+    items[1] = MakeInt64(second).Release();
+    const uint64_t list = BridgeMakeList(reinterpret_cast<uint64_t>(items), 2);
+    free(items);
+    return list;
+}
+
+//! Same list, but of the type `listType` names. Needed wherever the result
+//! declares several Lists the items cannot be told apart by.
+uint64_t MakeIntListOfType(uint64_t listType, int64_t first, int64_t second) {
+    uint64_t* items = AllocHandles(2);
+    items[0] = MakeInt64(first).Release();
+    items[1] = MakeInt64(second).Release();
+    const uint64_t list = BridgeMakeListTyped(listType, reinterpret_cast<uint64_t>(items), 2);
+    free(items);
+    return list;
+}
+
 } // namespace
 
 extern "C" {
@@ -339,6 +361,81 @@ __attribute__((visibility("default"))) void make_variant_uint32(
     TExpressionContext* /*ctx*/, uint64_t* result)
 {
     *result = MakeVariant(0, TBridgeValue(BridgeMakeUint32(5))).Release();
+}
+
+// ---- makers: nested and repeated containers ----
+
+//! Nesting the declared result type resolves on its own. The guest builds
+//! bottom-up, so BridgeMakeList is called twice with the same result type in
+//! scope: Int64 items name the inner List<Int64>, and lists of them name the
+//! outer List<List<Int64>>.
+__attribute__((visibility("default"))) void make_nested_int_lists(
+    TExpressionContext* /*ctx*/, uint64_t* result)
+{
+    uint64_t* inner = AllocHandles(2);
+    inner[0] = MakeIntListInferred(1, 2);
+    inner[1] = MakeIntListInferred(3, 4);
+    *result = BridgeMakeList(reinterpret_cast<uint64_t>(inner), 2);
+    free(inner);
+}
+
+//! Two members of the same type: nothing about two Int64 items says which of
+//! the declared Lists they belong to, so each is named with BridgeTypeMember
+//! and built with BridgeMakeListTyped. The outer Tuple is the only two-member
+//! Tuple declared, which leaves BridgeMakeArray one candidate.
+__attribute__((visibility("default"))) void make_int_list_pair(
+    TExpressionContext* /*ctx*/, uint64_t* result)
+{
+    TBridgeValue resultType(BridgeGetResultType(), /*owned*/ true);
+    TBridgeValue firstType(BridgeTypeMember(resultType.Get(), 0), /*owned*/ true);
+    TBridgeValue secondType(BridgeTypeMember(resultType.Get(), 1), /*owned*/ true);
+
+    uint64_t* members = AllocHandles(2);
+    members[0] = MakeIntListOfType(firstType.Get(), 1, 2);
+    members[1] = MakeIntListOfType(secondType.Get(), 3, 4);
+    *result = BridgeMakeArray(reinterpret_cast<uint64_t>(members), 2);
+    free(members);
+}
+
+//! A Struct inside a Struct of the same member count: the inner one is named
+//! explicitly, while the outer is picked by its own members (a string and a
+//! struct fit no other declaration). Members go in declared order.
+__attribute__((visibility("default"))) void make_labelled_point(
+    TExpressionContext* /*ctx*/, uint64_t* result)
+{
+    static const char kLabel[] = "origin";
+    TBridgeValue resultType(BridgeGetResultType(), /*owned*/ true);
+    TBridgeValue pointType(BridgeTypeMember(resultType.Get(), 1), /*owned*/ true);
+
+    uint64_t* coords = AllocHandles(2);
+    coords[0] = MakeInt64(3).Release();
+    coords[1] = MakeInt64(4).Release();
+    const uint64_t point =
+        BridgeMakeStructTyped(pointType.Get(), reinterpret_cast<uint64_t>(coords), 2);
+    free(coords);
+
+    uint64_t* members = AllocHandles(2);
+    members[0] = MakeString(kLabel, static_cast<int64_t>(sizeof(kLabel) - 1)).Release();
+    members[1] = point;
+    *result = BridgeMakeStruct(reinterpret_cast<uint64_t>(members), 2);
+    free(members);
+}
+
+//! An Optional result: what the guest has to build sits under the wrapper, and
+//! BridgeTypeOptionalItem is what peels it before the members are named.
+__attribute__((visibility("default"))) void make_optional_int_list_pair(
+    TExpressionContext* /*ctx*/, uint64_t* result)
+{
+    TBridgeValue resultType(BridgeGetResultType(), /*owned*/ true);
+    TBridgeValue pairType(BridgeTypeOptionalItem(resultType.Get()), /*owned*/ true);
+    TBridgeValue firstType(BridgeTypeMember(pairType.Get(), 0), /*owned*/ true);
+    TBridgeValue secondType(BridgeTypeMember(pairType.Get(), 1), /*owned*/ true);
+
+    uint64_t* members = AllocHandles(2);
+    members[0] = MakeIntListOfType(firstType.Get(), 5, 6);
+    members[1] = MakeIntListOfType(secondType.Get(), 7, 8);
+    *result = BridgeMakeArrayTyped(pairType.Get(), reinterpret_cast<uint64_t>(members), 2);
+    free(members);
 }
 
 // ---- callable ----

--- a/ydb/udfs/wasm/types/manifest.json
+++ b/ydb/udfs/wasm/types/manifest.json
@@ -95,6 +95,48 @@
       "result_type": {"value": "int64", "tag": "concrete_type"}
     },
     {
+      "name": "NestedListSumInt64",
+      "export": "nested_list_sum_int64",
+      "argument_types": [
+        {
+          "value": "list",
+          "tag": "concrete_type",
+          "item": {
+            "value": "list",
+            "tag": "concrete_type",
+            "item": {"value": "int64", "tag": "concrete_type"}
+          }
+        }
+      ],
+      "result_type": {"value": "int64", "tag": "concrete_type"}
+    },
+    {
+      "name": "DictNestedListSums",
+      "export": "dict_nested_list_sums",
+      "argument_types": [
+        {
+          "value": "dict",
+          "tag": "concrete_type",
+          "key": {"value": "string", "tag": "concrete_type"},
+          "payload": {
+            "value": "list",
+            "tag": "concrete_type",
+            "item": {
+              "value": "list",
+              "tag": "concrete_type",
+              "item": {"value": "int64", "tag": "concrete_type"}
+            }
+          }
+        }
+      ],
+      "result_type": {
+        "value": "dict",
+        "tag": "concrete_type",
+        "key": {"value": "string", "tag": "concrete_type"},
+        "payload": {"value": "int64", "tag": "concrete_type"}
+      }
+    },
+    {
       "name": "DictGetInt64",
       "export": "dict_get_int64",
       "argument_types": [

--- a/ydb/udfs/wasm/types/manifest.json
+++ b/ydb/udfs/wasm/types/manifest.json
@@ -218,6 +218,89 @@
       }
     },
     {
+      "name": "MakeNestedIntLists",
+      "export": "make_nested_int_lists",
+      "argument_types": [],
+      "result_type": {
+        "value": "list",
+        "tag": "concrete_type",
+        "item": {
+          "value": "list",
+          "tag": "concrete_type",
+          "item": {"value": "int64", "tag": "concrete_type"}
+        }
+      }
+    },
+    {
+      "name": "MakeIntListPair",
+      "export": "make_int_list_pair",
+      "argument_types": [],
+      "result_type": {
+        "value": "tuple",
+        "tag": "concrete_type",
+        "elements": [
+          {
+            "value": "list",
+            "tag": "concrete_type",
+            "item": {"value": "int64", "tag": "concrete_type"}
+          },
+          {
+            "value": "list",
+            "tag": "concrete_type",
+            "item": {"value": "int64", "tag": "concrete_type"}
+          }
+        ]
+      }
+    },
+    {
+      "name": "MakeLabelledPoint",
+      "export": "make_labelled_point",
+      "argument_types": [],
+      "result_type": {
+        "value": "struct",
+        "tag": "concrete_type",
+        "members": [
+          {"name": "label", "type": {"value": "string", "tag": "concrete_type"}},
+          {
+            "name": "point",
+            "type": {
+              "value": "struct",
+              "tag": "concrete_type",
+              "members": [
+                {"name": "x", "type": {"value": "int64", "tag": "concrete_type"}},
+                {"name": "y", "type": {"value": "int64", "tag": "concrete_type"}}
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MakeOptionalIntListPair",
+      "export": "make_optional_int_list_pair",
+      "argument_types": [],
+      "result_type": {
+        "value": "optional",
+        "tag": "concrete_type",
+        "item": {
+          "value": "tuple",
+          "tag": "concrete_type",
+          "elements": [
+            {
+              "value": "list",
+              "tag": "concrete_type",
+              "item": {"value": "int64", "tag": "concrete_type"}
+            },
+            {
+              "value": "list",
+              "tag": "concrete_type",
+              "item": {"value": "int64", "tag": "concrete_type"}
+            }
+          ]
+        }
+      }
+    },
+    {
       "name": "MakeVariantUint32",
       "export": "make_variant_uint32",
       "argument_types": [],

--- a/ydb/udfs/wasm/types/query.sql
+++ b/ydb/udfs/wasm/types/query.sql
@@ -28,6 +28,12 @@ SELECT
     BridgeTypes::MakeGreetingStruct() AS greeting,
     BridgeTypes::MakeIntList() AS int_list,
     BridgeTypes::MakeNameDict() AS name_dict,
+    -- Nested and repeated containers: the first is typed by inference alone,
+    -- the rest name the container they build (BridgeMake*Typed).
+    BridgeTypes::MakeNestedIntLists() AS nested_int_lists,
+    BridgeTypes::MakeIntListPair() AS int_list_pair,
+    BridgeTypes::MakeLabelledPoint() AS labelled_point,
+    BridgeTypes::MakeOptionalIntListPair() AS optional_int_list_pair,
     -- Way() returns the alternative index; the ydb CLI cannot format Variant.
     Way(BridgeTypes::MakeVariantUint32()) AS variant_uint32,
     BridgeTypes::RunCallableInt64(($x) -> { RETURN $x + 1; }, 41l) AS run_callable;

--- a/ydb/udfs/wasm/types/query.sql
+++ b/ydb/udfs/wasm/types/query.sql
@@ -20,6 +20,11 @@ SELECT
     -- Manifest maps plain "decimal" to Decimal(35,0); scale must match.
     BridgeTypes::ReadDecimalChecksum(Decimal("12345", 35, 0)) AS read_decimal,
     BridgeTypes::ListSumInt64(AsList(1l, 2l, 3l)) AS list_sum,
+    BridgeTypes::NestedListSumInt64(AsList(AsList(1l, 2l), AsList(3l, 4l, 5l))) AS nested_list_sum,
+    BridgeTypes::DictNestedListSums(
+        AsDict(
+            AsTuple("a", AsList(AsList(1l, 2l), AsList(3l))),
+            AsTuple("b", AsList(AsList(10l, 20l))))) AS dict_nested_sums,
     BridgeTypes::DictGetInt64(AsDict(AsTuple("k", 42l)), "k") AS dict_get,
     BridgeTypes::TupleKindSum(AsTuple(1l, "x", 1.0f)) AS tuple_kind_sum,
     BridgeTypes::StructGetScore(AsStruct(1 AS id, 2.5f AS score, "n" AS name)) AS struct_score,


### PR DESCRIPTION
## Summary
- Fixes the blocker from https://github.com/ydb-platform/ydb/pull/52145#discussion_r3978121237: guest-built lists/tuples were typed from the first `FindTypeIn` match, so nested and same-arity sibling containers failed family checks on every row.
- Untyped `BridgeMakeList` / `MakeArray` / `MakeStruct` now collect all candidates and narrow by item/member families (fall back to untyped when still ambiguous).
- Adds preferred explicit path: `BridgeMakeListTyped` / `ArrayTyped` / `StructTyped` plus `BridgeTypeListItem` / `BridgeTypeMember` / `BridgeTypeOptionalItem`, matching `BridgeMakeDict(typeHandle, ...)`.

## Test plan
- [x] `./ya make --build relwithdebinfo -tA ydb/services/udf_store/ut -F '*WasmBridgeTypeCheck*'` (24 tests GOOD)
- [x] New regressions: `MakeListBuildsTheInnerListOfANestedListResult`, `MakeListBuildsTheSecondListOfATupleResult`, `MakeArrayBuildsAnInnerTupleOfTheOuterArity`
- [x] Typed-path coverage: `MakeListTypedNamesTheInnerListExplicitly`, `MakeArrayTypedNamesTheSecondTupleExplicitly`


Made with [Cursor](https://cursor.com)