### PR TITLE
[PQ] Log tablet, topic, and session as structured fields

### DIFF
--- a/ydb/core/http_proxy/auth_actors.cpp
+++ b/ydb/core/http_proxy/auth_actors.cpp
@@ -60,7 +60,7 @@ namespace NKikimr::NHttpProxy {
         {
         }
 
-        NPQ::TStructuredLogPrefix BuildLogPrefix() const override {
+        NPQ::TStructuredMessage BuildLogPrefix() const override {
             return YDB_LOG_CREATE_MESSAGE(
                 Prefix,
                 {"component", "auth"});

--- a/ydb/core/http_proxy/auth_actors.cpp
+++ b/ydb/core/http_proxy/auth_actors.cpp
@@ -4,11 +4,11 @@
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/base/ticket_parser.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/protos/config.pb.h>
 #include <ydb/core/protos/serverless_proxy_config.pb.h>
 #include <ydb/core/security/ticket_parser_impl.h>
 #include <ydb/core/tx/scheme_board/cache.h>
-#include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/http_proxy/authorization/signature.h>
 #include <ydb/library/ycloud/impl/access_service.h>
@@ -16,8 +16,6 @@
 #include <ydb/services/persqueue_v1/actors/persqueue_utils.h>
 
 #include <util/stream/file.h>
-
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::HTTP_PROXY
 
 namespace NKikimr::NHttpProxy {
     NActors::IActor* CreateAccessServiceActor(const NKikimrConfig::TServerlessProxyConfig& config, const TString& userAgentHint, bool enableV2Interface)
@@ -40,13 +38,15 @@ namespace NKikimr::NHttpProxy {
         return NCloud::CreateIamTokenService(tsSettings);
     }
 
-    class THttpAuthActor: public NActors::TActorBootstrapped<THttpAuthActor> {
+    class THttpAuthActor: public NPQ::TBaseActor<THttpAuthActor>
+                         , public NPQ::TConstantLogPrefix {
     public:
-        using TBase = NActors::TActorBootstrapped<THttpAuthActor>;
+        using TBase = NPQ::TBaseActor<THttpAuthActor>;
 
         THttpAuthActor(const TActorId sender, THttpRequestContext& context,
                        THolder<NKikimr::NSQS::TAwsRequestSignV4>&& signature)
-            : Sender(sender)
+            : TBase(NKikimrServices::HTTP_PROXY)
+            , Sender(sender)
             , Prefix(context.LogPrefix())
             , ServiceAccountId(context.ServiceAccountId)
             , ServiceAccountCredentialsProvider(context.ServiceAccountCredentialsProvider)
@@ -60,7 +60,7 @@ namespace NKikimr::NHttpProxy {
         {
         }
 
-        NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+        NPQ::TStructuredLogPrefix BuildLogPrefix() const override {
             return YDB_LOG_CREATE_MESSAGE(
                 Prefix,
                 {"component", "auth"});
@@ -137,8 +137,7 @@ namespace NKikimr::NHttpProxy {
             }
             ctx.Send(Sender, new TEvServerlessProxy::TEvToken(userToken.GetUserSID(), "", userToken.GetSerializedToken(), {"", DatabaseId, DatabasePath, CloudId, FolderId}));
 
-            YDB_LOG_DEBUG_CTX(ctx, "Authorized successfully",
-                {LogPrefix()});
+            LOG_D("Authorized successfully");
 
             TBase::Die(ctx);
         }
@@ -264,8 +263,7 @@ namespace NKikimr::NHttpProxy {
         void HandleAuthenticationResultImpl(typename TEvResponse::TPtr& ev, const TActorContext& ctx) {
             if (!ev->Get()->Status.Ok()) {
                 RetryCounter.Click();
-                YDB_LOG_INFO_CTX(ctx, "Retry can not authenticate service account",
-                    {LogPrefix()},
+                LOG_I("Retry can not authenticate service account",
                     {"attempN", RetryCounter.AttempN()},
                     {"user", ev->Get()->Status.Msg});
                 if (RetryCounter.HasAttemps()) {
@@ -283,8 +281,7 @@ namespace NKikimr::NHttpProxy {
             RetryCounter.Void();
 
             ServiceAccountId = ev->Get()->Response.subject().service_account().id();
-            YDB_LOG_INFO_CTX(ctx, "Authenticated",
-                {LogPrefix()},
+            LOG_I("Authenticated",
                 {"serviceAccountId", ServiceAccountId});
             SendIamTokenRequest(ctx);
         }
@@ -318,8 +315,7 @@ namespace NKikimr::NHttpProxy {
                                           const TActorContext& ctx) {
             if (!ev->Get()->Status.Ok()) {
                 RetryCounter.Click();
-                YDB_LOG_INFO_CTX(ctx, "Retry IAM token issue",
-                    {LogPrefix()},
+                LOG_I("Retry IAM token issue",
                     {"attempN", RetryCounter.AttempN()},
                     {"error", ev->Get()->Status.Msg});
 
@@ -337,8 +333,7 @@ namespace NKikimr::NHttpProxy {
             ctx.Send(Sender,
                      new TEvServerlessProxy::TEvToken(ServiceAccountId, ev->Get()->Response.iam_token(), "", {}));
 
-            YDB_LOG_DEBUG_CTX(ctx, "IAM token generated",
-                {LogPrefix()});
+            LOG_D("IAM token generated");
 
             TBase::Die(ctx);
         }

--- a/ydb/core/http_proxy/auth_actors.cpp
+++ b/ydb/core/http_proxy/auth_actors.cpp
@@ -9,6 +9,7 @@
 #include <ydb/core/security/ticket_parser_impl.h>
 #include <ydb/core/tx/scheme_board/cache.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/log.h>
 #include <ydb/library/http_proxy/authorization/signature.h>
 #include <ydb/library/ycloud/impl/access_service.h>
 #include <ydb/library/ycloud/impl/iam_token_service.h>
@@ -59,8 +60,10 @@ namespace NKikimr::NHttpProxy {
         {
         }
 
-        TStringBuilder LogPrefix() const {
-            return TStringBuilder() << Prefix << " [auth] ";
+        NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+            return YDB_LOG_CREATE_MESSAGE(
+                Prefix,
+                {"component", "auth"});
         }
 
     private:
@@ -135,7 +138,7 @@ namespace NKikimr::NHttpProxy {
             ctx.Send(Sender, new TEvServerlessProxy::TEvToken(userToken.GetUserSID(), "", userToken.GetSerializedToken(), {"", DatabaseId, DatabasePath, CloudId, FolderId}));
 
             YDB_LOG_DEBUG_CTX(ctx, "Authorized successfully",
-                {"logPrefix", LogPrefix()});
+                {LogPrefix()});
 
             TBase::Die(ctx);
         }
@@ -262,7 +265,7 @@ namespace NKikimr::NHttpProxy {
             if (!ev->Get()->Status.Ok()) {
                 RetryCounter.Click();
                 YDB_LOG_INFO_CTX(ctx, "Retry can not authenticate service account",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"attempN", RetryCounter.AttempN()},
                     {"user", ev->Get()->Status.Msg});
                 if (RetryCounter.HasAttemps()) {
@@ -281,7 +284,7 @@ namespace NKikimr::NHttpProxy {
 
             ServiceAccountId = ev->Get()->Response.subject().service_account().id();
             YDB_LOG_INFO_CTX(ctx, "Authenticated",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"serviceAccountId", ServiceAccountId});
             SendIamTokenRequest(ctx);
         }
@@ -316,7 +319,7 @@ namespace NKikimr::NHttpProxy {
             if (!ev->Get()->Status.Ok()) {
                 RetryCounter.Click();
                 YDB_LOG_INFO_CTX(ctx, "Retry IAM token issue",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"attempN", RetryCounter.AttempN()},
                     {"error", ev->Get()->Status.Msg});
 
@@ -335,7 +338,7 @@ namespace NKikimr::NHttpProxy {
                      new TEvServerlessProxy::TEvToken(ServiceAccountId, ev->Get()->Response.iam_token(), "", {}));
 
             YDB_LOG_DEBUG_CTX(ctx, "IAM token generated",
-                {"logPrefix", LogPrefix()});
+                {LogPrefix()});
 
             TBase::Die(ctx);
         }
@@ -359,7 +362,7 @@ namespace NKikimr::NHttpProxy {
 
     private:
         const TActorId Sender;
-        const TString Prefix;
+        const NActors::NStructuredLog::TStructuredMessage Prefix;
         TString ServiceAccountId;
         std::shared_ptr<NYdb::ICredentialsProvider> ServiceAccountCredentialsProvider;
         const TString RequestId;

--- a/ydb/core/http_proxy/datastreams.cpp
+++ b/ydb/core/http_proxy/datastreams.cpp
@@ -266,7 +266,7 @@ namespace NKikimr::NHttpProxy {
             {
             }
 
-            NPQ::TStructuredLogPrefix BuildLogPrefix() const override {
+            NPQ::TStructuredMessage BuildLogPrefix() const override {
                 return HttpContext.LogPrefix();
             }
 

--- a/ydb/core/http_proxy/datastreams.cpp
+++ b/ydb/core/http_proxy/datastreams.cpp
@@ -11,6 +11,7 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/grpc_services/local_rpc/local_rpc.h>
 #include <ydb/core/protos/serverless_proxy_config.pb.h>
+#include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/http/http_proxy.h>
 #include <ydb/library/http_proxy/authorization/auth_helpers.h>
 #include <ydb/library/http_proxy/error/error.h>
@@ -264,7 +265,7 @@ namespace NKikimr::NHttpProxy {
             {
             }
 
-            TStringBuilder LogPrefix() const {
+            NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
                 return HttpContext.LogPrefix();
             }
 
@@ -295,7 +296,7 @@ namespace NKikimr::NHttpProxy {
 
             void CreateClient(const TActorContext& ctx) {
                 YDB_LOG_INFO_CTX(ctx, "Create client to database: iam token",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"discoveryEndpoint", HttpContext.DiscoveryEndpoint},
                     {"databasePath", HttpContext.DatabasePath},
                     {"size", HttpContext.IamToken.size()});
@@ -324,7 +325,7 @@ namespace NKikimr::NHttpProxy {
 
             void SendGrpcRequestNoDriver(const TActorContext& ctx) {
                 YDB_LOG_INFO_CTX(ctx, "Sending grpc request to database: iam token",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"discoveryEndpoint", HttpContext.DiscoveryEndpoint},
                     {"databasePath", HttpContext.DatabasePath},
                     {"size", HttpContext.IamToken.size()});
@@ -352,7 +353,7 @@ namespace NKikimr::NHttpProxy {
 
             void SendGrpcRequest(const TActorContext& ctx) {
                 YDB_LOG_INFO_CTX(ctx, "Sending grpc request to database: iam token",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"discoveryEndpoint", HttpContext.DiscoveryEndpoint},
                     {"databasePath", HttpContext.DatabasePath},
                     {"size", HttpContext.IamToken.size()});
@@ -363,7 +364,7 @@ namespace NKikimr::NHttpProxy {
                 TProtoResponse response;
 
                 YDB_LOG_DEBUG_CTX(ctx, "Sending grpc request",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"request", Request.DebugString()});
 
                 Future = MakeHolder<NThreading::TFuture<TProtoResultWrapper<TProtoResult>>>(
@@ -617,7 +618,7 @@ namespace NKikimr::NHttpProxy {
                     return ReplyWithError(ctx, NYdb::EStatus::BAD_REQUEST, e.what(), static_cast<size_t>(issueCode));
                 } catch (const std::exception& e) {
                     YDB_LOG_WARN_CTX(ctx, "Got new request with incorrect json from database",
-                        {"logPrefix", LogPrefix()},
+                        {LogPrefix()},
                         {"sourceAddress", HttpContext.SourceAddress},
                         {"databasePath", HttpContext.DatabasePath});
                     return ReplyWithError(ctx, NYdb::EStatus::BAD_REQUEST, e.what(), static_cast<size_t>(NYds::EErrorCodes::INVALID_ARGUMENT));
@@ -628,7 +629,7 @@ namespace NKikimr::NHttpProxy {
                 }
 
                 YDB_LOG_INFO_CTX(ctx, "Got new request from database stream",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"sourceAddress", HttpContext.SourceAddress},
                     {"databasePath", HttpContext.DatabasePath},
                     {"request", ExtractStreamName<TProtoRequest>(Request)});

--- a/ydb/core/http_proxy/datastreams.cpp
+++ b/ydb/core/http_proxy/datastreams.cpp
@@ -10,6 +10,7 @@
 
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/grpc_services/local_rpc/local_rpc.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/protos/serverless_proxy_config.pb.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/http/http_proxy.h>
@@ -27,8 +28,6 @@
 
 #include <numeric>
 #include <optional>
-
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::HTTP_PROXY
 
 namespace NKikimr::NHttpProxy {
 
@@ -251,21 +250,23 @@ namespace NKikimr::NHttpProxy {
 
     private:
 
-        class THttpRequestActor : public NActors::TActorBootstrapped<THttpRequestActor> {
+        class THttpRequestActor : public NPQ::TBaseActor<THttpRequestActor>
+                                  , public NPQ::TConstantLogPrefix {
         public:
-            using TBase = NActors::TActorBootstrapped<THttpRequestActor>;
+            using TBase = NPQ::TBaseActor<THttpRequestActor>;
 
             THttpRequestActor(THttpRequestContext&& httpContext,
                               THolder<NKikimr::NSQS::TAwsRequestSignV4>&& signature,
                               TProtoCall protoCall, const TString& method)
-                : HttpContext(std::move(httpContext))
+                : TBase(NKikimrServices::HTTP_PROXY)
+                , HttpContext(std::move(httpContext))
                 , Signature(std::move(signature))
                 , ProtoCall(protoCall)
                 , Method(method)
             {
             }
 
-            NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+            NPQ::TStructuredLogPrefix BuildLogPrefix() const override {
                 return HttpContext.LogPrefix();
             }
 
@@ -295,8 +296,7 @@ namespace NKikimr::NHttpProxy {
             }
 
             void CreateClient(const TActorContext& ctx) {
-                YDB_LOG_INFO_CTX(ctx, "Create client to database: iam token",
-                    {LogPrefix()},
+                LOG_I("Create client to database: iam token",
                     {"discoveryEndpoint", HttpContext.DiscoveryEndpoint},
                     {"databasePath", HttpContext.DatabasePath},
                     {"size", HttpContext.IamToken.size()});
@@ -324,8 +324,7 @@ namespace NKikimr::NHttpProxy {
             }
 
             void SendGrpcRequestNoDriver(const TActorContext& ctx) {
-                YDB_LOG_INFO_CTX(ctx, "Sending grpc request to database: iam token",
-                    {LogPrefix()},
+                LOG_I("Sending grpc request to database: iam token",
                     {"discoveryEndpoint", HttpContext.DiscoveryEndpoint},
                     {"databasePath", HttpContext.DatabasePath},
                     {"size", HttpContext.IamToken.size()});
@@ -352,8 +351,7 @@ namespace NKikimr::NHttpProxy {
             }
 
             void SendGrpcRequest(const TActorContext& ctx) {
-                YDB_LOG_INFO_CTX(ctx, "Sending grpc request to database: iam token",
-                    {LogPrefix()},
+                LOG_I("Sending grpc request to database: iam token",
                     {"discoveryEndpoint", HttpContext.DiscoveryEndpoint},
                     {"databasePath", HttpContext.DatabasePath},
                     {"size", HttpContext.IamToken.size()});
@@ -363,8 +361,7 @@ namespace NKikimr::NHttpProxy {
 
                 TProtoResponse response;
 
-                YDB_LOG_DEBUG_CTX(ctx, "Sending grpc request",
-                    {LogPrefix()},
+                LOG_D("Sending grpc request",
                     {"request", Request.DebugString()});
 
                 Future = MakeHolder<NThreading::TFuture<TProtoResultWrapper<TProtoResult>>>(
@@ -617,8 +614,7 @@ namespace NKikimr::NHttpProxy {
                         issueCode = NYds::EErrorCodes::INVALID_ARGUMENT;
                     return ReplyWithError(ctx, NYdb::EStatus::BAD_REQUEST, e.what(), static_cast<size_t>(issueCode));
                 } catch (const std::exception& e) {
-                    YDB_LOG_WARN_CTX(ctx, "Got new request with incorrect json from database",
-                        {LogPrefix()},
+                    LOG_W("Got new request with incorrect json from database",
                         {"sourceAddress", HttpContext.SourceAddress},
                         {"databasePath", HttpContext.DatabasePath});
                     return ReplyWithError(ctx, NYdb::EStatus::BAD_REQUEST, e.what(), static_cast<size_t>(NYds::EErrorCodes::INVALID_ARGUMENT));
@@ -628,8 +624,7 @@ namespace NKikimr::NHttpProxy {
                     HttpContext.DatabasePath = ExtractStreamName<TProtoRequest>(Request);
                 }
 
-                YDB_LOG_INFO_CTX(ctx, "Got new request from database stream",
-                    {LogPrefix()},
+                LOG_I("Got new request from database stream",
                     {"sourceAddress", HttpContext.SourceAddress},
                     {"databasePath", HttpContext.DatabasePath},
                     {"request", ExtractStreamName<TProtoRequest>(Request)});

--- a/ydb/core/http_proxy/discovery_actor.cpp
+++ b/ydb/core/http_proxy/discovery_actor.cpp
@@ -1,7 +1,7 @@
 #include "discovery_actor.h"
 #include "events.h"
 
-#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
@@ -22,11 +22,13 @@ namespace NKikimr::NHttpProxy {
 
     using namespace NActors;
 
-    class TDiscoveryActor : public NActors::TActorBootstrapped<TDiscoveryActor> {
-        using TBase = NActors::TActorBootstrapped<TDiscoveryActor>;
+    class TDiscoveryActor : public NPQ::TBaseActor<TDiscoveryActor>
+                            , public NPQ::TConstantLogPrefix {
+        using TBase = NPQ::TBaseActor<TDiscoveryActor>;
     public:
         explicit TDiscoveryActor(std::shared_ptr<NYdb::ICredentialsProvider> credentialsProvider, TDiscoverySettings&& settings)
-            : Settings(std::move(settings))
+            : TBase(NKikimrServices::PERSQUEUE)
+            , Settings(std::move(settings))
             , CredentialsProvider(credentialsProvider)
         {
             NYdbGrpc::TGRpcClientConfig grpcConf;
@@ -38,14 +40,13 @@ namespace NKikimr::NHttpProxy {
             Connection = GrpcClient.CreateGRpcServiceConnection<TProtoService>(grpcConf);
         }
 
-        void Bootstrap(const TActorContext& ctx) {
-            YDB_LOG_INFO_CTX(ctx, "Discovery actor created",
-                {LogPrefix()});
+        void Bootstrap() {
+            LOG_I("Discovery actor created");
 
             TBase::Become(&TDiscoveryActor::StateWork);
         }
 
-        NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+        NPQ::TStructuredLogPrefix BuildLogPrefix() const override {
             return YDB_LOG_CREATE_MESSAGE(
                 {"database", Settings.Database},
                 {"endpoint", Settings.DiscoveryEndpoint});
@@ -112,8 +113,7 @@ namespace NKikimr::NHttpProxy {
 
         Ydb::Discovery::ListEndpointsRequest request;
         request.set_database(Settings.Database);
-        YDB_LOG_INFO_CTX(ctx, "List endpoints request",
-            {LogPrefix()});
+        LOG_I("List endpoints request");
 
         NYdbGrpc::TResponseCallback<Ydb::Discovery::ListEndpointsResponse> responseCb =
                 [actorSystem = ctx.ActorSystem(), actorId = ctx.SelfID](NYdbGrpc::TGrpcStatus&& status, Ydb::Discovery::ListEndpointsResponse&& response) -> void {

--- a/ydb/core/http_proxy/discovery_actor.cpp
+++ b/ydb/core/http_proxy/discovery_actor.cpp
@@ -40,13 +40,15 @@ namespace NKikimr::NHttpProxy {
 
         void Bootstrap(const TActorContext& ctx) {
             YDB_LOG_INFO_CTX(ctx, "Discovery actor created",
-                {"logPrefix", LogPrefix()});
+                {LogPrefix()});
 
             TBase::Become(&TDiscoveryActor::StateWork);
         }
 
-        TStringBuilder LogPrefix() const {
-            return TStringBuilder() << "database: " << Settings.Database << " endpoint: " << Settings.DiscoveryEndpoint;
+        NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+            return YDB_LOG_CREATE_MESSAGE(
+                {"database", Settings.Database},
+                {"endpoint", Settings.DiscoveryEndpoint});
         }
         ~TDiscoveryActor() {
             GrpcClient.Stop(true);
@@ -111,7 +113,7 @@ namespace NKikimr::NHttpProxy {
         Ydb::Discovery::ListEndpointsRequest request;
         request.set_database(Settings.Database);
         YDB_LOG_INFO_CTX(ctx, "List endpoints request",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
 
         NYdbGrpc::TResponseCallback<Ydb::Discovery::ListEndpointsResponse> responseCb =
                 [actorSystem = ctx.ActorSystem(), actorId = ctx.SelfID](NYdbGrpc::TGrpcStatus&& status, Ydb::Discovery::ListEndpointsResponse&& response) -> void {

--- a/ydb/core/http_proxy/discovery_actor.cpp
+++ b/ydb/core/http_proxy/discovery_actor.cpp
@@ -46,7 +46,7 @@ namespace NKikimr::NHttpProxy {
             TBase::Become(&TDiscoveryActor::StateWork);
         }
 
-        NPQ::TStructuredLogPrefix BuildLogPrefix() const override {
+        NPQ::TStructuredMessage BuildLogPrefix() const override {
             return YDB_LOG_CREATE_MESSAGE(
                 {"database", Settings.Database},
                 {"endpoint", Settings.DiscoveryEndpoint});

--- a/ydb/core/http_proxy/grpc_service.cpp
+++ b/ydb/core/http_proxy/grpc_service.cpp
@@ -3,7 +3,7 @@
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/core/grpc_services/grpc_request_proxy.h>
 #include <ydb/core/grpc_services/rpc_calls.h>
-#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
@@ -14,33 +14,30 @@
 
 #include <util/generic/guid.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::GRPC_PROXY
-
 namespace NKikimr::NHttpProxy {
 
 using namespace NGRpcService;
-class TGRpcRequestActor : public NActors::TActorBootstrapped<TGRpcRequestActor> {
+class TGRpcRequestActor : public NPQ::TBaseActor<TGRpcRequestActor>
+                          , public NPQ::TConstantLogPrefix {
 public:
-    using TBase = NActors::TActorBootstrapped<TGRpcRequestActor>;
+    using TBase = NPQ::TBaseActor<TGRpcRequestActor>;
 
-
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+    NPQ::TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "TGRpcRequestActor"},
             {"requestId", RequestId});
         // << ReqCtx->GetPeerMetaValues(NYdb::YDB_DATABASE_HEADER)
         //                << " trace: " << ReqCtx->GetPeerMetaValues(NYdb::YDB_TRACE_ID_HEADER) << " ";
     }
 
     TGRpcRequestActor(NYdbGrpc::IRequestContextBase *ctx)
-        : ReqCtx(ctx)
+        : TBase(NKikimrServices::GRPC_PROXY)
+        , ReqCtx(ctx)
         , RequestId(CreateGuidAsString())
     {
     }
 
     void Bootstrap(const TActorContext& ctx) {
-        YDB_LOG_INFO_CTX(ctx, "Got new request",
-            {LogPrefix()},
+        LOG_I("Got new request",
             {"peer", ReqCtx->GetPeer()});
         SendYdbDriverRequest(ctx);
         Become(&TGRpcRequestActor::StateWork);
@@ -68,8 +65,7 @@ private:
             database = dynamic_cast<const Ydb::Discovery::ListEndpointsRequest*>(ReqCtx->GetRequest())->database();
         }
         request->DatabasePath = database;
-        YDB_LOG_DEBUG_CTX(ctx, "Database discovery request sent",
-            {LogPrefix()});
+        LOG_D("Database discovery request sent");
 
         ctx.Send(MakeTenantDiscoveryID(), std::move(request));
     }
@@ -78,8 +74,7 @@ private:
 
         if (ev->Get()->DatabaseInfo) {
             auto& db = ev->Get()->DatabaseInfo;
-            YDB_LOG_DEBUG_CTX(ctx, "Database discovery result",
-                {LogPrefix()},
+            LOG_D("Database discovery result",
                 {"dbPath", db->Path});
             SendGrpcRequest(ctx, db->Endpoint, db->Path);
         } else {
@@ -89,8 +84,7 @@ private:
 
     void Handle(TEvServerlessProxy::TEvListEndpointsResponse::TPtr ev, const TActorContext& ctx) {
         if (ev->Get()->Record) {
-            YDB_LOG_INFO_CTX(ctx, "Replying ok",
-                {LogPrefix()});
+            LOG_I("Replying ok");
 
             Ydb::Discovery::ListEndpointsResponse * resp = CreateResponseMessage();
             resp->CopyFrom(*(ev->Get()->Record.get()));
@@ -99,24 +93,21 @@ private:
             TBase::Die(ctx);
             return;
         } else if (ev->Get()->Status) {
-            YDB_LOG_INFO_CTX(ctx, "Replying error",
-                {LogPrefix()},
+            LOG_I("Replying error",
                 {"grpcStatusCode", ev->Get()->Status->GRpcStatusCode},
                 {"statusMsg", ev->Get()->Status->Msg});
             if (ev->Get()->Status->GRpcStatusCode == grpc::StatusCode::NOT_FOUND)
                 return ReplyWithError(ctx, NYdb::EStatus::NOT_FOUND, TString{ev->Get()->Status->Msg});
             return ReplyWithError(ctx, NYdb::EStatus::INTERNAL_ERROR, TString{ev->Get()->Status->Msg});
         } else {
-            YDB_LOG_INFO_CTX(ctx, "Replying INTERNAL ERROR",
-                {LogPrefix()});
+            LOG_I("Replying INTERNAL ERROR");
             return ReplyWithError(ctx, NYdb::EStatus::INTERNAL_ERROR, "Error happened while discovering database endpoint");
         }
     }
 
 
     void SendGrpcRequest(const TActorContext& ctx, const TString& endpoint, const TString& database) {
-        YDB_LOG_DEBUG_CTX(ctx, "Send grpc request to endpoint",
-            {LogPrefix()},
+        LOG_D("Send grpc request to endpoint",
             {"database", database},
             {"endpoint", endpoint});
         ctx.Send(MakeDiscoveryProxyID(), new TEvServerlessProxy::TEvListEndpointsRequest(endpoint, database));

--- a/ydb/core/http_proxy/grpc_service.cpp
+++ b/ydb/core/http_proxy/grpc_service.cpp
@@ -22,7 +22,7 @@ class TGRpcRequestActor : public NPQ::TBaseActor<TGRpcRequestActor>
 public:
     using TBase = NPQ::TBaseActor<TGRpcRequestActor>;
 
-    NPQ::TStructuredLogPrefix BuildLogPrefix() const override {
+    NPQ::TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"requestId", RequestId});
         // << ReqCtx->GetPeerMetaValues(NYdb::YDB_DATABASE_HEADER)

--- a/ydb/core/http_proxy/grpc_service.cpp
+++ b/ydb/core/http_proxy/grpc_service.cpp
@@ -6,6 +6,7 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/http/http.h>
 #include <ydb/library/grpc/server/grpc_method_setup.h>
 
@@ -23,8 +24,10 @@ public:
     using TBase = NActors::TActorBootstrapped<TGRpcRequestActor>;
 
 
-    TStringBuilder LogPrefix() const {
-        return TStringBuilder() << "[GrpcProxy] ListEndpointRequest requestId : " << RequestId;
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"actorClassName", "TGRpcRequestActor"},
+            {"requestId", RequestId});
         // << ReqCtx->GetPeerMetaValues(NYdb::YDB_DATABASE_HEADER)
         //                << " trace: " << ReqCtx->GetPeerMetaValues(NYdb::YDB_TRACE_ID_HEADER) << " ";
     }
@@ -37,7 +40,7 @@ public:
 
     void Bootstrap(const TActorContext& ctx) {
         YDB_LOG_INFO_CTX(ctx, "Got new request",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"peer", ReqCtx->GetPeer()});
         SendYdbDriverRequest(ctx);
         Become(&TGRpcRequestActor::StateWork);
@@ -66,7 +69,7 @@ private:
         }
         request->DatabasePath = database;
         YDB_LOG_DEBUG_CTX(ctx, "Database discovery request sent",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
 
         ctx.Send(MakeTenantDiscoveryID(), std::move(request));
     }
@@ -76,7 +79,7 @@ private:
         if (ev->Get()->DatabaseInfo) {
             auto& db = ev->Get()->DatabaseInfo;
             YDB_LOG_DEBUG_CTX(ctx, "Database discovery result",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"dbPath", db->Path});
             SendGrpcRequest(ctx, db->Endpoint, db->Path);
         } else {
@@ -87,7 +90,7 @@ private:
     void Handle(TEvServerlessProxy::TEvListEndpointsResponse::TPtr ev, const TActorContext& ctx) {
         if (ev->Get()->Record) {
             YDB_LOG_INFO_CTX(ctx, "Replying ok",
-                {"logPrefix", LogPrefix()});
+                {LogPrefix()});
 
             Ydb::Discovery::ListEndpointsResponse * resp = CreateResponseMessage();
             resp->CopyFrom(*(ev->Get()->Record.get()));
@@ -97,7 +100,7 @@ private:
             return;
         } else if (ev->Get()->Status) {
             YDB_LOG_INFO_CTX(ctx, "Replying error",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"grpcStatusCode", ev->Get()->Status->GRpcStatusCode},
                 {"statusMsg", ev->Get()->Status->Msg});
             if (ev->Get()->Status->GRpcStatusCode == grpc::StatusCode::NOT_FOUND)
@@ -105,7 +108,7 @@ private:
             return ReplyWithError(ctx, NYdb::EStatus::INTERNAL_ERROR, TString{ev->Get()->Status->Msg});
         } else {
             YDB_LOG_INFO_CTX(ctx, "Replying INTERNAL ERROR",
-                {"logPrefix", LogPrefix()});
+                {LogPrefix()});
             return ReplyWithError(ctx, NYdb::EStatus::INTERNAL_ERROR, "Error happened while discovering database endpoint");
         }
     }
@@ -113,7 +116,7 @@ private:
 
     void SendGrpcRequest(const TActorContext& ctx, const TString& endpoint, const TString& database) {
         YDB_LOG_DEBUG_CTX(ctx, "Send grpc request to endpoint",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"database", database},
             {"endpoint", endpoint});
         ctx.Send(MakeDiscoveryProxyID(), new TEvServerlessProxy::TEvListEndpointsRequest(endpoint, database));

--- a/ydb/core/http_proxy/http_req.cpp
+++ b/ydb/core/http_proxy/http_req.cpp
@@ -17,9 +17,6 @@
 #include <util/string/ascii.h>
 #include <util/string/vector.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::HTTP_PROXY
-
-
 namespace NKikimr::NHttpProxy {
 
     using namespace google::protobuf;
@@ -71,7 +68,8 @@ namespace NKikimr::NHttpProxy {
         NActors::TActorId sender,
         NYdb::TDriver* driver,
         std::shared_ptr<NYdb::ICredentialsProvider> serviceAccountCredentialsProvider)
-        : ServiceConfig(config)
+        : NPQ::TLogPrefix(NKikimrServices::HTTP_PROXY)
+        , ServiceConfig(config)
         , Request(request)
         , Sender(sender)
         , Driver(driver)
@@ -117,8 +115,7 @@ namespace NKikimr::NHttpProxy {
 
     void THttpRequestContext::DoReply(THttpResponseData&& data) {
         auto ctx = TlsActivationContext->AsActorContext();
-        YDB_LOG_INFO_CTX(ctx, "Reply with",
-            {LogPrefix()},
+        LOG_I("Reply with",
             {"status", data.HttpCode},
             {"message", data.Message});
 

--- a/ydb/core/http_proxy/http_req.cpp
+++ b/ydb/core/http_proxy/http_req.cpp
@@ -118,7 +118,7 @@ namespace NKikimr::NHttpProxy {
     void THttpRequestContext::DoReply(THttpResponseData&& data) {
         auto ctx = TlsActivationContext->AsActorContext();
         YDB_LOG_INFO_CTX(ctx, "Reply with",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"status", data.HttpCode},
             {"message", data.Message});
 

--- a/ydb/core/http_proxy/http_req.h
+++ b/ydb/core/http_proxy/http_req.h
@@ -3,6 +3,7 @@
 #include "events.h"
 
 #include <ydb/core/protos/serverless_proxy_config.pb.h>
+#include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/http/http.h>
 #include <ydb/library/http_proxy/authorization/signature.h>
 #include <ydb/public/api/grpc/draft/ydb_datastreams_v1.grpc.pb.h>
@@ -85,8 +86,10 @@ struct THttpRequestContext {
     TString SerializedUserToken;
     TString UserName;
 
-    TStringBuilder LogPrefix() const {
-        return TStringBuilder() << "http request [" << MethodName << "] requestId [" << RequestId << "]";
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"methodName", MethodName},
+            {"requestId", RequestId});
     }
 
     THolder<NKikimr::NSQS::TAwsRequestSignV4> GetSignature();

--- a/ydb/core/http_proxy/http_req.h
+++ b/ydb/core/http_proxy/http_req.h
@@ -2,6 +2,7 @@
 
 #include "events.h"
 
+#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/core/protos/serverless_proxy_config.pb.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/http/http.h>
@@ -53,7 +54,7 @@ struct THttpResponseData {
     TString Body;
 };
 
-struct THttpRequestContext {
+struct THttpRequestContext : public NPQ::TLogPrefix {
     THttpRequestContext(const NKikimrConfig::TServerlessProxyConfig& config,
                         NHttp::THttpIncomingRequestPtr request,
                         NActors::TActorId sender,
@@ -86,7 +87,7 @@ struct THttpRequestContext {
     TString SerializedUserToken;
     TString UserName;
 
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+    NPQ::TStructuredLogPrefix LogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"methodName", MethodName},
             {"requestId", RequestId});

--- a/ydb/core/http_proxy/http_req.h
+++ b/ydb/core/http_proxy/http_req.h
@@ -86,7 +86,7 @@ struct THttpRequestContext : public NPQ::TLogPrefix {
     TString SerializedUserToken;
     TString UserName;
 
-    NPQ::TStructuredLogPrefix LogPrefix() const override {
+    NPQ::TStructuredMessage LogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"methodName", MethodName},
             {"requestId", RequestId});

--- a/ydb/core/http_proxy/http_req.h
+++ b/ydb/core/http_proxy/http_req.h
@@ -4,7 +4,6 @@
 
 #include <ydb/core/persqueue/common/logging.h>
 #include <ydb/core/protos/serverless_proxy_config.pb.h>
-#include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/http/http.h>
 #include <ydb/library/http_proxy/authorization/signature.h>
 #include <ydb/public/api/grpc/draft/ydb_datastreams_v1.grpc.pb.h>

--- a/ydb/core/http_proxy/http_service.cpp
+++ b/ydb/core/http_proxy/http_service.cpp
@@ -2,8 +2,8 @@
 
 #include "http_req.h"
 
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/protos/config.pb.h>
-#include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
@@ -14,21 +14,19 @@
 #include <util/string/ascii.h>
 #include <util/system/error.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::HTTP_PROXY
-
 namespace NKikimr::NHttpProxy {
 
     using namespace NActors;
 
     TString BuildError(MimeTypes mimeType, HttpCodes httpCode, const TString& errorName, const TString& errorText);
 
-    class THttpProxyActor : public NActors::TActorBootstrapped<THttpProxyActor> {
-        using TBase = NActors::TActorBootstrapped<THttpProxyActor>;
+    class THttpProxyActor : public NPQ::TBaseActor<THttpProxyActor>
+                           , public NPQ::TConstantLogPrefix {
+        using TBase = NPQ::TBaseActor<THttpProxyActor>;
     public:
         explicit THttpProxyActor(const THttpProxyConfig& cfg);
 
         void Bootstrap(const TActorContext& ctx);
-        NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
 
     private:
         STFUNC(StateWork) {
@@ -47,7 +45,8 @@ namespace NKikimr::NHttpProxy {
     };
 
     THttpProxyActor::THttpProxyActor(const THttpProxyConfig& cfg)
-        : Config(cfg.Config)
+        : TBase(NKikimrServices::HTTP_PROXY)
+        , Config(cfg.Config)
     {
         ServiceAccountCredentialsProvider = cfg.CredentialsProvider;
         Processors = MakeHolder<THttpRequestProcessors>(Config);
@@ -70,11 +69,6 @@ namespace NKikimr::NHttpProxy {
                  << " (LastSystemError=" << LastSystemError() << "); acceptor will retry asynchronously"
                  << Endl;
         }
-    }
-
-    NActors::NStructuredLog::TStructuredMessage THttpProxyActor::LogPrefix() const {
-        return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "THttpProxyActor"});
     }
 
     void THttpProxyActor::Bootstrap(const TActorContext& ctx) {
@@ -108,8 +102,7 @@ namespace NKikimr::NHttpProxy {
                                     Driver.Get(),
                                     ServiceAccountCredentialsProvider);
 
-        YDB_LOG_INFO_CTX(ctx, "Incoming request from request url database",
-            {LogPrefix()},
+        LOG_I("Incoming request from request url database",
             {"sourceAddress", context.SourceAddress},
             {"methodName", context.MethodName},
             {"url", context.Request->URL},

--- a/ydb/core/http_proxy/http_service.cpp
+++ b/ydb/core/http_proxy/http_service.cpp
@@ -28,7 +28,7 @@ namespace NKikimr::NHttpProxy {
         explicit THttpProxyActor(const THttpProxyConfig& cfg);
 
         void Bootstrap(const TActorContext& ctx);
-        TStringBuilder LogPrefix() const;
+        NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
 
     private:
         STFUNC(StateWork) {
@@ -72,8 +72,9 @@ namespace NKikimr::NHttpProxy {
         }
     }
 
-    TStringBuilder THttpProxyActor::LogPrefix() const {
-        return TStringBuilder() << "proxy service:";
+    NActors::NStructuredLog::TStructuredMessage THttpProxyActor::LogPrefix() const {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"actorClassName", "THttpProxyActor"});
     }
 
     void THttpProxyActor::Bootstrap(const TActorContext& ctx) {
@@ -108,7 +109,7 @@ namespace NKikimr::NHttpProxy {
                                     ServiceAccountCredentialsProvider);
 
         YDB_LOG_INFO_CTX(ctx, "Incoming request from request url database",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"sourceAddress", context.SourceAddress},
             {"methodName", context.MethodName},
             {"url", context.Request->URL},

--- a/ydb/core/http_proxy/metrics_actor.cpp
+++ b/ydb/core/http_proxy/metrics_actor.cpp
@@ -30,7 +30,7 @@ namespace NKikimr::NHttpProxy {
             TBase::Become(&TMetricsActor::StateWork);
         }
 
-        TStringBuilder LogPrefix() const {
+        NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
             return {};
         }
 

--- a/ydb/core/http_proxy/sqs.cpp
+++ b/ydb/core/http_proxy/sqs.cpp
@@ -80,7 +80,7 @@ namespace NKikimr::NHttpProxy {
                 }
             }
 
-            NPQ::TStructuredLogPrefix BuildLogPrefix() const override {
+            NPQ::TStructuredMessage BuildLogPrefix() const override {
                 return HttpContext.LogPrefix();
             }
 

--- a/ydb/core/http_proxy/sqs.cpp
+++ b/ydb/core/http_proxy/sqs.cpp
@@ -11,6 +11,7 @@
 #include <ydb/core/base/ticket_parser.h>
 #include <ydb/library/aclib/aclib.h>
 #include <ydb/core/grpc_services/local_rpc/local_rpc.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/protos/serverless_proxy_config.pb.h>
 #include <ydb/core/ymq/actor/auth_multi_factory.h>
 #include <ydb/core/ymq/actor/serviceid.h>
@@ -30,8 +31,6 @@
 #include <ydb/services/ymq/ymq_proxy.h>
 
 #include <yql/essentials/public/issue/yql_issue_message.h>
-
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::HTTP_PROXY
 
 namespace NKikimr::NHttpProxy {
 
@@ -62,14 +61,16 @@ namespace NKikimr::NHttpProxy {
 
     private:
 
-        class TSqsTopicHttpRequestActor : public NActors::TActorBootstrapped<TSqsTopicHttpRequestActor> {
+        class TSqsTopicHttpRequestActor : public NPQ::TBaseActor<TSqsTopicHttpRequestActor>
+                                         , public NPQ::TConstantLogPrefix {
         public:
-            using TBase = NActors::TActorBootstrapped<TSqsTopicHttpRequestActor>;
+            using TBase = NPQ::TBaseActor<TSqsTopicHttpRequestActor>;
 
             TSqsTopicHttpRequestActor(THttpRequestContext&& httpContext,
                               THolder<NKikimr::NSQS::TAwsRequestSignV4>&& signature,
                               TProtoCall protoCall, const TString& method)
-                : HttpContext(std::move(httpContext))
+                : TBase(NKikimrServices::HTTP_PROXY)
+                , HttpContext(std::move(httpContext))
                 , Signature(std::move(signature))
                 , ProtoCall(protoCall)
                 , Method(method)
@@ -79,7 +80,7 @@ namespace NKikimr::NHttpProxy {
                 }
             }
 
-            NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+            NPQ::TStructuredLogPrefix BuildLogPrefix() const override {
                 return HttpContext.LogPrefix();
             }
 
@@ -100,8 +101,7 @@ namespace NKikimr::NHttpProxy {
 
             void SendGrpcRequestNoDriver(const TActorContext& ctx) {
                 ReportInputCounters(ctx);
-                YDB_LOG_INFO_CTX(ctx, "Sending grpc request to database: iam token",
-                    {LogPrefix()},
+                LOG_I("Sending grpc request to database: iam token",
                     {"discoveryEndpoint", HttpContext.DiscoveryEndpoint},
                     {"databasePath", HttpContext.DatabasePath},
                     {"size", HttpContext.IamToken.size()});
@@ -361,8 +361,7 @@ namespace NKikimr::NHttpProxy {
                                 NKikimr::NSQS::NErrors::INTERNAL_FAILURE.HttpStatusCode)
                             : NKikimr::NSQS::TErrorClass::GetErrorAndCode(issues.begin()->GetCode());
 
-                        YDB_LOG_DEBUG_CTX(ctx, "Not retrying GRPC response",
-                            {LogPrefix()},
+                        LOG_D("Not retrying GRPC response",
                             {"code", errorCode},
                             {"error", error});
                         return ReplyWithMessageQueueError(
@@ -411,8 +410,7 @@ namespace NKikimr::NHttpProxy {
                     }
                     return ReplyWithYdbError(ctx, NYdb::EStatus::BAD_REQUEST, e.what(), static_cast<size_t>(issueCode));
                 } catch (const std::exception& e) {
-                    YDB_LOG_WARN_CTX(ctx, "Got new request with incorrect json from database",
-                        {LogPrefix()},
+                    LOG_W("Got new request with incorrect json from database",
                         {"sourceAddress", HttpContext.SourceAddress},
                         {"databasePath", HttpContext.DatabasePath});
                     return ReplyWithYdbError(ctx, NYdb::EStatus::BAD_REQUEST, e.what(), static_cast<size_t>(NYds::EErrorCodes::INVALID_ARGUMENT));
@@ -434,8 +432,7 @@ namespace NKikimr::NHttpProxy {
                     }
                 }
 
-                YDB_LOG_INFO_CTX(ctx, "Got new request from database stream",
-                    {LogPrefix()},
+                LOG_I("Got new request from database stream",
                     {"sourceAddress", HttpContext.SourceAddress},
                     {"databasePath", HttpContext.DatabasePath},
                     {"request", MaybeGetQueueUrl<TProtoRequest>(Request)});

--- a/ydb/core/http_proxy/sqs.cpp
+++ b/ydb/core/http_proxy/sqs.cpp
@@ -14,6 +14,7 @@
 #include <ydb/core/protos/serverless_proxy_config.pb.h>
 #include <ydb/core/ymq/actor/auth_multi_factory.h>
 #include <ydb/core/ymq/actor/serviceid.h>
+#include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/http/http_proxy.h>
 #include <ydb/library/http_proxy/authorization/auth_helpers.h>
 #include <ydb/library/http_proxy/error/error.h>
@@ -78,7 +79,7 @@ namespace NKikimr::NHttpProxy {
                 }
             }
 
-            TStringBuilder LogPrefix() const {
+            NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
                 return HttpContext.LogPrefix();
             }
 
@@ -100,7 +101,7 @@ namespace NKikimr::NHttpProxy {
             void SendGrpcRequestNoDriver(const TActorContext& ctx) {
                 ReportInputCounters(ctx);
                 YDB_LOG_INFO_CTX(ctx, "Sending grpc request to database: iam token",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"discoveryEndpoint", HttpContext.DiscoveryEndpoint},
                     {"databasePath", HttpContext.DatabasePath},
                     {"size", HttpContext.IamToken.size()});
@@ -361,7 +362,7 @@ namespace NKikimr::NHttpProxy {
                             : NKikimr::NSQS::TErrorClass::GetErrorAndCode(issues.begin()->GetCode());
 
                         YDB_LOG_DEBUG_CTX(ctx, "Not retrying GRPC response",
-                            {"logPrefix", LogPrefix()},
+                            {LogPrefix()},
                             {"code", errorCode},
                             {"error", error});
                         return ReplyWithMessageQueueError(
@@ -411,7 +412,7 @@ namespace NKikimr::NHttpProxy {
                     return ReplyWithYdbError(ctx, NYdb::EStatus::BAD_REQUEST, e.what(), static_cast<size_t>(issueCode));
                 } catch (const std::exception& e) {
                     YDB_LOG_WARN_CTX(ctx, "Got new request with incorrect json from database",
-                        {"logPrefix", LogPrefix()},
+                        {LogPrefix()},
                         {"sourceAddress", HttpContext.SourceAddress},
                         {"databasePath", HttpContext.DatabasePath});
                     return ReplyWithYdbError(ctx, NYdb::EStatus::BAD_REQUEST, e.what(), static_cast<size_t>(NYds::EErrorCodes::INVALID_ARGUMENT));
@@ -434,7 +435,7 @@ namespace NKikimr::NHttpProxy {
                 }
 
                 YDB_LOG_INFO_CTX(ctx, "Got new request from database stream",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"sourceAddress", HttpContext.SourceAddress},
                     {"databasePath", HttpContext.DatabasePath},
                     {"request", MaybeGetQueueUrl<TProtoRequest>(Request)});

--- a/ydb/core/http_proxy/ya.make
+++ b/ydb/core/http_proxy/ya.make
@@ -54,6 +54,7 @@ PEERDIR(
     ydb/library/actors/core
     ydb/library/grpc/actor_client
     ydb/core/base
+    ydb/core/persqueue/common
     ydb/core/protos
     ydb/core/grpc_services/local_rpc
     ydb/core/http_proxy/sqs_xml

--- a/ydb/core/http_proxy/ymq.cpp
+++ b/ydb/core/http_proxy/ymq.cpp
@@ -75,7 +75,7 @@ namespace NKikimr::NHttpProxy {
             {
             }
 
-            TStringBuilder LogPrefix() const {
+            NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
                 return HttpContext.LogPrefix();
             }
 
@@ -94,7 +94,7 @@ namespace NKikimr::NHttpProxy {
 
             void SendGrpcRequestNoDriver(const TActorContext& ctx) {
                 YDB_LOG_INFO_CTX(ctx, "Sending grpc request to database: iam token",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"discoveryEndpoint", HttpContext.DiscoveryEndpoint},
                     {"databasePath", HttpContext.DatabasePath},
                     {"size", HttpContext.IamToken.size()});
@@ -220,7 +220,7 @@ namespace NKikimr::NHttpProxy {
                     }
 
                     YDB_LOG_DEBUG_CTX(ctx, "Send metering event",
-                        {"logPrefix", LogPrefix()},
+                        {LogPrefix()},
                         {"httpStatusCode", requestAttributes.HttpStatusCode},
                         {"isFifo", requestAttributes.IsFifo},
                         {"folderId", requestAttributes.FolderId},
@@ -246,7 +246,7 @@ namespace NKikimr::NHttpProxy {
                                     const TActorContext& ctx) {
                 if (ev->Get()->Status->IsSuccess()) {
                     YDB_LOG_DEBUG_CTX(ctx, "Got succesfult GRPC response",
-                        {"logPrefix", LogPrefix()});
+                        {LogPrefix()});
 
                     ReplyToHttpContext({
                         .HttpCode = 200,
@@ -263,7 +263,7 @@ namespace NKikimr::NHttpProxy {
                     case ERetryErrorClass::ShortRetry:
                     case ERetryErrorClass::LongRetry:
                         YDB_LOG_DEBUG_CTX(ctx, "Retrying failed GRPC response",
-                            {"logPrefix", LogPrefix()});
+                            {LogPrefix()});
                         RetryCounter.Click();
                         if (RetryCounter.HasAttemps()) {
                             return SendGrpcRequestNoDriver(ctx);
@@ -284,7 +284,7 @@ namespace NKikimr::NHttpProxy {
                             : NKikimr::NSQS::TErrorClass::GetErrorAndCode(issues.begin()->GetCode());
 
                         YDB_LOG_DEBUG_CTX(ctx, "Not retrying GRPC response",
-                            {"logPrefix", LogPrefix()},
+                            {LogPrefix()},
                             {"code", get<1>(errorAndCode)},
                             {"error", get<0>(errorAndCode)});
 
@@ -307,7 +307,7 @@ namespace NKikimr::NHttpProxy {
             void HandleYmqCloudAuthorizationResponse(TEvYmqCloudAuthResponse::TPtr ev, const TActorContext& ctx) {
                 if (ev->Get()->IsSuccess) {
                     YDB_LOG_DEBUG_CTX(ctx, "Got cloud auth response",
-                        {"logPrefix", LogPrefix()},
+                        {LogPrefix()},
                         {"folderId", ev->Get()->FolderId},
                         {"cloudId", ev->Get()->CloudId},
                         {"userSid", ev->Get()->Sid});
@@ -318,7 +318,7 @@ namespace NKikimr::NHttpProxy {
                     SendGrpcRequestNoDriver(ctx);
                 } else {
                     YDB_LOG_DEBUG_CTX(ctx, "Got cloud auth response",
-                        {"logPrefix", LogPrefix()},
+                        {LogPrefix()},
                         {"httpStatusCode", ev->Get()->Error->HttpStatusCode},
                         {"errorCode", ev->Get()->Error->ErrorCode},
                         {"message", ev->Get()->Error->Message});
@@ -359,7 +359,7 @@ namespace NKikimr::NHttpProxy {
                     return ReplyWithError(ctx, NYdb::EStatus::BAD_REQUEST, e.what(), static_cast<size_t>(issueCode));
                 } catch (const std::exception& e) {
                     YDB_LOG_WARN_CTX(ctx, "Got new request with incorrect json",
-                        {"logPrefix", LogPrefix()},
+                        {LogPrefix()},
                         {"sourceAddress", HttpContext.SourceAddress});
                     return ReplyWithError(
                         ctx,
@@ -370,7 +370,7 @@ namespace NKikimr::NHttpProxy {
                 }
 
                 YDB_LOG_INFO_CTX(ctx, "Got new request",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"sourceAddress", HttpContext.SourceAddress});
 
                 if (!HttpContext.ServiceConfig.GetHttpConfig().GetYandexCloudMode()) {

--- a/ydb/core/http_proxy/ymq.cpp
+++ b/ydb/core/http_proxy/ymq.cpp
@@ -75,7 +75,7 @@ namespace NKikimr::NHttpProxy {
             {
             }
 
-            NPQ::TStructuredLogPrefix BuildLogPrefix() const override {
+            NPQ::TStructuredMessage BuildLogPrefix() const override {
                 return HttpContext.LogPrefix();
             }
 

--- a/ydb/core/http_proxy/ymq.cpp
+++ b/ydb/core/http_proxy/ymq.cpp
@@ -6,9 +6,9 @@
 #include "utils.h"
 
 #include <ydb/core/grpc_services/local_rpc/local_rpc.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/ymq/actor/auth_multi_factory.h>
 #include <ydb/core/ymq/actor/serviceid.h>
-#include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
@@ -24,8 +24,6 @@
 
 #include <expected>
 #include <functional>
-
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::HTTP_PROXY
 
 namespace NKikimr::NHttpProxy {
 
@@ -57,9 +55,10 @@ namespace NKikimr::NHttpProxy {
         }
 
     private:
-        class TYmqHttpRequestActor : public NActors::TActorBootstrapped<TYmqHttpRequestActor> {
+        class TYmqHttpRequestActor : public NPQ::TBaseActor<TYmqHttpRequestActor>
+                                     , public NPQ::TConstantLogPrefix {
         public:
-            using TBase = NActors::TActorBootstrapped<TYmqHttpRequestActor>;
+            using TBase = NPQ::TBaseActor<TYmqHttpRequestActor>;
 
             TYmqHttpRequestActor(
                     THttpRequestContext&& httpContext,
@@ -67,7 +66,8 @@ namespace NKikimr::NHttpProxy {
                     TProtoCall protoCall,
                     const TString& method,
                     std::function<TString(TProtoRequest&)> queueUrlExtractor)
-                : HttpContext(std::move(httpContext))
+                : TBase(NKikimrServices::HTTP_PROXY)
+                , HttpContext(std::move(httpContext))
                 , Signature(std::move(signature))
                 , ProtoCall(protoCall)
                 , Method(method)
@@ -75,7 +75,7 @@ namespace NKikimr::NHttpProxy {
             {
             }
 
-            NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+            NPQ::TStructuredLogPrefix BuildLogPrefix() const override {
                 return HttpContext.LogPrefix();
             }
 
@@ -93,8 +93,7 @@ namespace NKikimr::NHttpProxy {
             }
 
             void SendGrpcRequestNoDriver(const TActorContext& ctx) {
-                YDB_LOG_INFO_CTX(ctx, "Sending grpc request to database: iam token",
-                    {LogPrefix()},
+                LOG_I("Sending grpc request to database: iam token",
                     {"discoveryEndpoint", HttpContext.DiscoveryEndpoint},
                     {"databasePath", HttpContext.DatabasePath},
                     {"size", HttpContext.IamToken.size()});
@@ -196,7 +195,7 @@ namespace NKikimr::NHttpProxy {
 
             void DoMetering(const THttpResponseData& data, THolder<THashMap<TString, TString>>&& queueTags, const TActorContext& ctx) {
                 if (!IamAuthenticated) {
-                    YDB_LOG_DEBUG_CTX(ctx, "Skip metering event due to IAM auth failure");
+                    LOG_D("Skip metering event due to IAM auth failure");
                     return;
                 }
                 if (HttpContext.ServiceConfig.GetHttpConfig().GetYandexCloudMode()) {
@@ -219,8 +218,7 @@ namespace NKikimr::NHttpProxy {
                         }
                     }
 
-                    YDB_LOG_DEBUG_CTX(ctx, "Send metering event",
-                        {LogPrefix()},
+                    LOG_D("Send metering event",
                         {"httpStatusCode", requestAttributes.HttpStatusCode},
                         {"isFifo", requestAttributes.IsFifo},
                         {"folderId", requestAttributes.FolderId},
@@ -245,8 +243,7 @@ namespace NKikimr::NHttpProxy {
             void HandleGrpcResponse(TEvServerlessProxy::TEvGrpcRequestResult::TPtr ev,
                                     const TActorContext& ctx) {
                 if (ev->Get()->Status->IsSuccess()) {
-                    YDB_LOG_DEBUG_CTX(ctx, "Got succesfult GRPC response",
-                        {LogPrefix()});
+                    LOG_D("Got succesfult GRPC response");
 
                     ReplyToHttpContext({
                         .HttpCode = 200,
@@ -262,8 +259,7 @@ namespace NKikimr::NHttpProxy {
                     switch (retryClass) {
                     case ERetryErrorClass::ShortRetry:
                     case ERetryErrorClass::LongRetry:
-                        YDB_LOG_DEBUG_CTX(ctx, "Retrying failed GRPC response",
-                            {LogPrefix()});
+                        LOG_D("Retrying failed GRPC response");
                         RetryCounter.Click();
                         if (RetryCounter.HasAttemps()) {
                             return SendGrpcRequestNoDriver(ctx);
@@ -283,8 +279,7 @@ namespace NKikimr::NHttpProxy {
                                 NKikimr::NSQS::NErrors::INTERNAL_FAILURE.HttpStatusCode)
                             : NKikimr::NSQS::TErrorClass::GetErrorAndCode(issues.begin()->GetCode());
 
-                        YDB_LOG_DEBUG_CTX(ctx, "Not retrying GRPC response",
-                            {LogPrefix()},
+                        LOG_D("Not retrying GRPC response",
                             {"code", get<1>(errorAndCode)},
                             {"error", get<0>(errorAndCode)});
 
@@ -306,8 +301,7 @@ namespace NKikimr::NHttpProxy {
 
             void HandleYmqCloudAuthorizationResponse(TEvYmqCloudAuthResponse::TPtr ev, const TActorContext& ctx) {
                 if (ev->Get()->IsSuccess) {
-                    YDB_LOG_DEBUG_CTX(ctx, "Got cloud auth response",
-                        {LogPrefix()},
+                    LOG_D("Got cloud auth response",
                         {"folderId", ev->Get()->FolderId},
                         {"cloudId", ev->Get()->CloudId},
                         {"userSid", ev->Get()->Sid});
@@ -317,8 +311,7 @@ namespace NKikimr::NHttpProxy {
                     IamAuthenticated = true;
                     SendGrpcRequestNoDriver(ctx);
                 } else {
-                    YDB_LOG_DEBUG_CTX(ctx, "Got cloud auth response",
-                        {LogPrefix()},
+                    LOG_D("Got cloud auth response",
                         {"httpStatusCode", ev->Get()->Error->HttpStatusCode},
                         {"errorCode", ev->Get()->Error->ErrorCode},
                         {"message", ev->Get()->Error->Message});
@@ -358,8 +351,7 @@ namespace NKikimr::NHttpProxy {
                     }
                     return ReplyWithError(ctx, NYdb::EStatus::BAD_REQUEST, e.what(), static_cast<size_t>(issueCode));
                 } catch (const std::exception& e) {
-                    YDB_LOG_WARN_CTX(ctx, "Got new request with incorrect json",
-                        {LogPrefix()},
+                    LOG_W("Got new request with incorrect json",
                         {"sourceAddress", HttpContext.SourceAddress});
                     return ReplyWithError(
                         ctx,
@@ -369,8 +361,7 @@ namespace NKikimr::NHttpProxy {
                     );
                 }
 
-                YDB_LOG_INFO_CTX(ctx, "Got new request",
-                    {LogPrefix()},
+                LOG_I("Got new request",
                     {"sourceAddress", HttpContext.SourceAddress});
 
                 if (!HttpContext.ServiceConfig.GetHttpConfig().GetYandexCloudMode()) {

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -66,7 +66,7 @@ public:
         Become(&TTopicLocationActor::StateWork);
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "TopicLocationActor"},
             {"path", Path});

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -73,7 +73,7 @@ public:
     }
 
     bool OnUnhandledException(const std::exception& exc) override {
-        DoLogUnhandledException(Service, NPQ_LOG_PREFIX, exc);
+        DoLogUnhandledException(Service, *this, exc);
         ReplyError(
             Ydb::StatusIds::INTERNAL_ERROR,
             TStringBuilder() << "Unhandled exception: " << exc.what());

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -66,7 +66,7 @@ public:
         Become(&TTopicLocationActor::StateWork);
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "TopicLocationActor"},
             {"path", Path});

--- a/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.cpp
@@ -57,7 +57,7 @@ public:
     }
 
     bool OnUnhandledException(const std::exception& exc) override {
-        DoLogUnhandledException(Service, NPQ_LOG_PREFIX, exc);
+        DoLogUnhandledException(Service, *this, exc);
         if (Response) {
             ReplyError(
                 Ydb::StatusIds::INTERNAL_ERROR,

--- a/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.cpp
@@ -50,7 +50,7 @@ public:
         Become(&TTopicOffsetsActor::StateWork);
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "TopicOffsetsActor"},
             {"path", Settings.Path});

--- a/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.cpp
@@ -50,7 +50,7 @@ public:
         Become(&TTopicOffsetsActor::StateWork);
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "TopicOffsetsActor"},
             {"path", Settings.Path});

--- a/ydb/core/persqueue/common/actor.cpp
+++ b/ydb/core/persqueue/common/actor.cpp
@@ -6,7 +6,7 @@
 
 namespace NKikimr::NPQ {
 
-void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, const TStructuredLogPrefix& prefix, const std::exception& exc) {
+void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, const TStructuredMessage& prefix, const std::exception& exc) {
     YDB_LOG_CRIT("Unhandled exception",
         prefix,
         {"exceptionType", TypeName(exc)},
@@ -16,13 +16,6 @@ void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, const TStr
 
 void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, TStringBuf prefix, const std::exception& exc) {
     DoLogUnhandledException(service, YDB_LOG_CREATE_MESSAGE({"prefix", TString(prefix)}), exc);
-}
-
-const TStructuredLogPrefix& TConstantLogPrefix::GetLogPrefix() const {
-    if (!LogPrefix_.Defined()) {
-        LogPrefix_ = BuildLogPrefix();
-    }
-    return *LogPrefix_;
 }
 
 void NPrivate::IncrementUnhandledExceptionCounter(const NActors::TActorContext& ctx) {

--- a/ydb/core/persqueue/common/actor.cpp
+++ b/ydb/core/persqueue/common/actor.cpp
@@ -18,7 +18,7 @@ void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, TStringBuf
     DoLogUnhandledException(service, YDB_LOG_CREATE_MESSAGE({"prefix", TString(prefix)}), exc);
 }
 
-void NPrivate::IncrementUnhandledExceptionCounter(const NActors::TActorContext& ctx) {
+void IncrementUnhandledExceptionCounter(const NActors::TActorContext& ctx) {
     GetServiceCounters(AppData(ctx)->Counters, "tablets")->GetCounter("alerts_exception", true)->Inc();
 }
 

--- a/ydb/core/persqueue/common/actor.cpp
+++ b/ydb/core/persqueue/common/actor.cpp
@@ -6,7 +6,7 @@
 
 namespace NKikimr::NPQ {
 
-void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, const TLogPrefix& prefix, const std::exception& exc) {
+void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, const TStructuredLogPrefix& prefix, const std::exception& exc) {
     YDB_LOG_CRIT("Unhandled exception",
         prefix,
         {"exceptionType", TypeName(exc)},
@@ -18,7 +18,7 @@ void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, TStringBuf
     DoLogUnhandledException(service, YDB_LOG_CREATE_MESSAGE({"prefix", TString(prefix)}), exc);
 }
 
-const TLogPrefix& TConstantLogPrefix::GetLogPrefix() const {
+const TStructuredLogPrefix& TConstantLogPrefix::GetLogPrefix() const {
     if (!LogPrefix_.Defined()) {
         LogPrefix_ = BuildLogPrefix();
     }

--- a/ydb/core/persqueue/common/actor.h
+++ b/ydb/core/persqueue/common/actor.h
@@ -11,10 +11,13 @@ namespace NKikimr::NPQ {
 
 void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, const TStructuredMessage& prefix, const std::exception& exc);
 void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, TStringBuf prefix, const std::exception& exc);
+void IncrementUnhandledExceptionCounter(const NActors::TActorContext& ctx);
 
-namespace NPrivate {
-    void IncrementUnhandledExceptionCounter(const NActors::TActorContext& ctx);
-} // namespace NPrivate
+template <typename T>
+    requires std::is_base_of_v<TLogPrefix, T>
+void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, const T& actor, const std::exception& exc) {
+    DoLogUnhandledException(service, MakeRuntimeLogPrefix(actor), exc);
+}
 
 template<typename TDerived>
 class TBaseActor : public NActors::TActorBootstrapped<TDerived>
@@ -32,11 +35,11 @@ public:
 
     bool OnUnhandledException(const std::exception& exc) override {
         if (AppData()->FeatureFlags.GetEnableTabletRestartOnUnhandledExceptions()) {
-            DoLogUnhandledException(Service, MakeRuntimeLogPrefix(static_cast<const TDerived&>(*this)), exc);
+            DoLogUnhandledException(Service, static_cast<const TDerived&>(*this), exc);
 
             OnException(exc);
 
-            NPrivate::IncrementUnhandledExceptionCounter(this->ActorContext());
+            IncrementUnhandledExceptionCounter(this->ActorContext());
             this->PassAway();
 
             return true;

--- a/ydb/core/persqueue/common/actor.h
+++ b/ydb/core/persqueue/common/actor.h
@@ -40,7 +40,7 @@ public:
 
     bool OnUnhandledException(const std::exception& exc) override {
         if (AppData()->FeatureFlags.GetEnableTabletRestartOnUnhandledExceptions()) {
-            DoLogUnhandledException(Service, NPQ_LOG_PREFIX, exc);
+            DoLogUnhandledException(Service, MakeRuntimeLogPrefix(static_cast<const TDerived&>(*this)), exc);
 
             OnException(exc);
 
@@ -57,13 +57,8 @@ public:
         Y_UNUSED(exc);
     }
 
-    TStructuredLogPrefix LogBuilder() const {
-        return YDB_LOG_CREATE_MESSAGE(
-            {"selfId", TBase::SelfId()});
-    }
-
     TStructuredLogPrefix LogPrefix() const override {
-        return MakeNpqLogPrefix(LogBuilder(), GetLogPrefix());
+        return GetLogPrefix();
     }
 
     void PassAway() override {
@@ -102,17 +97,9 @@ public:
         self.Send(TabletActorId, new NActors::TEvents::TEvPoison());
     }
 
-    TStructuredLogPrefix LogBuilder() const {
-        return YDB_LOG_CREATE_MESSAGE(
-            {"tabletId", TabletId});
-    }
-
-    TStructuredLogPrefix LogPrefix() const override {
-        return MakeNpqLogPrefix(LogBuilder(), this->GetLogPrefix());
-    }
+    const ui64 TabletId;
 
 protected:
-    const ui64 TabletId;
     const NActors::TActorId TabletActorId;
 };
 

--- a/ydb/core/persqueue/common/actor.h
+++ b/ydb/core/persqueue/common/actor.h
@@ -1,46 +1,22 @@
 #pragma once
 
+#include "logging.h"
+
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/log.h>
-#include <ydb/library/actors/struct_log/text_writer.h>
 #include <ydb/library/services/services.pb.h>
-
-#define NPQ_LOG_PREFIX ::NKikimr::NPQ::MakeNpqLogPrefix(this->LogBuilder(), this->GetLogPrefix())
-#define LOG(level, T, ...) YDB_LOG_COMP(level, this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_T(T, ...) YDB_LOG_TRACE_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_D(T, ...) YDB_LOG_DEBUG_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_I(T, ...) YDB_LOG_INFO_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_N(T, ...) YDB_LOG_NOTICE_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_W(T, ...) YDB_LOG_WARN_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_E(T, ...) YDB_LOG_ERROR_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_C(T, ...) YDB_LOG_CRIT_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_A(T, ...) YDB_LOG_ALERT_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
 
 namespace NKikimr::NPQ {
 
-using TLogPrefix = NActors::NStructuredLog::TStructuredMessage;
-
-inline TLogPrefix MakeNpqLogPrefix(TLogPrefix builder, const TLogPrefix& prefix) {
-    builder.AppendMessage(prefix);
-    return builder;
-}
-
-inline TString StructuredLogPrefixText(const TLogPrefix& prefix) {
-    TStringBuilder out;
-    NActors::NStructuredLog::TTextWriter writer;
-    writer.Write(out, prefix);
-    return out;
-}
-
-void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, const TLogPrefix& prefix, const std::exception& exc);
+void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, const TStructuredLogPrefix& prefix, const std::exception& exc);
 void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, TStringBuf prefix, const std::exception& exc);
 
 namespace NPrivate {
     class ILogPrefixBase {
     public:
-        virtual const TLogPrefix& GetLogPrefix() const = 0;
+        virtual const TStructuredLogPrefix& GetLogPrefix() const = 0;
     protected:
         ~ILogPrefixBase() = default;
     };
@@ -51,13 +27,14 @@ namespace NPrivate {
 template<typename TDerived>
 class TBaseActor : public NActors::TActorBootstrapped<TDerived>
                  , public NActors::IActorExceptionHandler
-                 , virtual public NPrivate::ILogPrefixBase {
+                 , virtual public NPrivate::ILogPrefixBase
+                 , public TLogPrefix {
 public:
     using TBase = NActors::TActorBootstrapped<TDerived>;
     using TThis = TDerived;
 
     TBaseActor(NKikimrServices::EServiceKikimr service)
-        : Service(service)
+        : TLogPrefix(service)
     {
     }
 
@@ -80,9 +57,13 @@ public:
         Y_UNUSED(exc);
     }
 
-    TLogPrefix LogBuilder() const {
+    TStructuredLogPrefix LogBuilder() const {
         return YDB_LOG_CREATE_MESSAGE(
             {"selfId", TBase::SelfId()});
+    }
+
+    TStructuredLogPrefix LogPrefix() const override {
+        return MakeNpqLogPrefix(LogBuilder(), GetLogPrefix());
     }
 
     void PassAway() override {
@@ -96,9 +77,6 @@ protected:
             << ", Sender " << ev->Sender.ToString() << ", Recipient " << ev->Recipient.ToString()
             << ", Cookie: " << ev->Cookie;
     }
-
-protected:
-    const NKikimrServices::EServiceKikimr Service;
 };
 
 
@@ -124,9 +102,13 @@ public:
         self.Send(TabletActorId, new NActors::TEvents::TEvPoison());
     }
 
-    TLogPrefix LogBuilder() const {
+    TStructuredLogPrefix LogBuilder() const {
         return YDB_LOG_CREATE_MESSAGE(
             {"tabletId", TabletId});
+    }
+
+    TStructuredLogPrefix LogPrefix() const override {
+        return MakeNpqLogPrefix(LogBuilder(), this->GetLogPrefix());
     }
 
 protected:
@@ -137,13 +119,13 @@ protected:
 
 class TConstantLogPrefix: virtual public NPrivate::ILogPrefixBase {
 public:
-    const TLogPrefix& GetLogPrefix() const final;
-    virtual TLogPrefix BuildLogPrefix() const {
+    const TStructuredLogPrefix& GetLogPrefix() const final;
+    virtual TStructuredLogPrefix BuildLogPrefix() const {
         return {};
     }
 
 private:
-    mutable TMaybe<TLogPrefix> LogPrefix_;
+    mutable TMaybe<TStructuredLogPrefix> LogPrefix_;
 };
 
 class TPipeCacheClient {

--- a/ydb/core/persqueue/common/actor.h
+++ b/ydb/core/persqueue/common/actor.h
@@ -9,19 +9,12 @@
 
 namespace NKikimr::NPQ {
 
-void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, const TStructuredLogPrefix& prefix, const std::exception& exc);
+void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, const TStructuredMessage& prefix, const std::exception& exc);
 void DoLogUnhandledException(NKikimrServices::EServiceKikimr service, TStringBuf prefix, const std::exception& exc);
 
 namespace NPrivate {
-    class ILogPrefixBase {
-    public:
-        virtual const TStructuredLogPrefix& GetLogPrefix() const = 0;
-    protected:
-        ~ILogPrefixBase() = default;
-    };
-
     void IncrementUnhandledExceptionCounter(const NActors::TActorContext& ctx);
-};
+} // namespace NPrivate
 
 template<typename TDerived>
 class TBaseActor : public NActors::TActorBootstrapped<TDerived>
@@ -56,7 +49,7 @@ public:
         Y_UNUSED(exc);
     }
 
-    TStructuredLogPrefix LogPrefix() const override {
+    TStructuredMessage LogPrefix() const override {
         return GetLogPrefix();
     }
 
@@ -102,17 +95,6 @@ protected:
     const NActors::TActorId TabletActorId;
 };
 
-
-class TConstantLogPrefix: virtual public NPrivate::ILogPrefixBase {
-public:
-    const TStructuredLogPrefix& GetLogPrefix() const final;
-    virtual TStructuredLogPrefix BuildLogPrefix() const {
-        return {};
-    }
-
-private:
-    mutable TMaybe<TStructuredLogPrefix> LogPrefix_;
-};
 
 class TPipeCacheClient {
 public:

--- a/ydb/core/persqueue/common/actor.h
+++ b/ydb/core/persqueue/common/actor.h
@@ -5,7 +5,6 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/log.h>
 #include <ydb/library/services/services.pb.h>
 
 namespace NKikimr::NPQ {

--- a/ydb/core/persqueue/common/logging.h
+++ b/ydb/core/persqueue/common/logging.h
@@ -38,6 +38,10 @@ public:
 template <typename T>
 TStructuredLogPrefix MakeRuntimeLogPrefix(const T& self) {
     TStructuredLogPrefix prefix;
+    if constexpr (requires { T::ActorActivityType(); }) {
+        prefix.AppendMessage(YDB_LOG_CREATE_MESSAGE(
+            {"actorActivityType", NKikimrServices::TActivity::EType_Name(T::ActorActivityType())}));
+    }
     if constexpr (requires { self.TabletId; }) {
         prefix.AppendMessage(YDB_LOG_CREATE_MESSAGE({"tabletId", self.TabletId}));
     } else if constexpr (requires { self.TabletID(); }) {

--- a/ydb/core/persqueue/common/logging.h
+++ b/ydb/core/persqueue/common/logging.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <ydb/library/actors/core/log.h>
-#include <ydb/library/actors/struct_log/text_writer.h>
 #include <ydb/library/services/services.pb.h>
 
 #include <util/generic/maybe.h>
@@ -88,13 +87,6 @@ TStructuredMessage MakeRuntimeLogPrefix(const T& self) {
         prefix.AppendMessage(self.LogPrefix());
     }
     return prefix;
-}
-
-inline TString StructuredLogPrefixText(const TStructuredMessage& prefix) {
-    TStringBuilder out;
-    NActors::NStructuredLog::TTextWriter writer;
-    writer.Write(out, prefix);
-    return out;
 }
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/common/logging.h
+++ b/ydb/core/persqueue/common/logging.h
@@ -4,6 +4,8 @@
 #include <ydb/library/actors/struct_log/text_writer.h>
 #include <ydb/library/services/services.pb.h>
 
+#include <util/generic/maybe.h>
+
 #include <type_traits>
 
 #define NPQ_LOG_PREFIX ::NKikimr::NPQ::MakeRuntimeLogPrefix(*this)
@@ -19,7 +21,7 @@
 
 namespace NKikimr::NPQ {
 
-using TStructuredLogPrefix = NActors::NStructuredLog::TStructuredMessage;
+using NActors::NStructuredLog::TStructuredMessage;
 
 class TLogPrefix {
 public:
@@ -30,15 +32,44 @@ public:
 
     virtual ~TLogPrefix() = default;
 
-    virtual TStructuredLogPrefix LogPrefix() const = 0;
+    virtual TStructuredMessage LogPrefix() const = 0;
 
 public:
     NKikimrServices::EServiceKikimr Service;
 };
 
+namespace NPrivate {
+    class ILogPrefixBase {
+    public:
+        virtual const TStructuredMessage& GetLogPrefix() const {
+            static const TStructuredMessage empty;
+            return empty;
+        }
+    protected:
+        ~ILogPrefixBase() = default;
+    };
+} // namespace NPrivate
+
+class TConstantLogPrefix: virtual public NPrivate::ILogPrefixBase {
+public:
+    const TStructuredMessage& GetLogPrefix() const final {
+        if (!LogPrefix_.Defined()) {
+            LogPrefix_ = BuildLogPrefix();
+        }
+        return *LogPrefix_;
+    }
+
+    virtual TStructuredMessage BuildLogPrefix() const {
+        return {};
+    }
+
+private:
+    mutable TMaybe<TStructuredMessage> LogPrefix_;
+};
+
 template <typename T>
-TStructuredLogPrefix MakeRuntimeLogPrefix(const T& self) {
-    TStructuredLogPrefix prefix;
+TStructuredMessage MakeRuntimeLogPrefix(const T& self) {
+    TStructuredMessage prefix;
     if constexpr (requires { T::ActorActivityType(); }) {
         prefix.AppendMessage(YDB_LOG_CREATE_MESSAGE(
             {"actorActivityType", NKikimrServices::TActivity::EType_Name(T::ActorActivityType())}));
@@ -50,8 +81,6 @@ TStructuredLogPrefix MakeRuntimeLogPrefix(const T& self) {
     }
     if constexpr (requires { self.SelfId(); }) {
         prefix.AppendMessage(YDB_LOG_CREATE_MESSAGE({"selfId", self.SelfId()}));
-    } else if constexpr (requires { self.SelfID; }) {
-        prefix.AppendMessage(YDB_LOG_CREATE_MESSAGE({"selfId", self.SelfID}));
     }
     if constexpr (std::is_base_of_v<TLogPrefix, T>) {
         prefix.AppendMessage(static_cast<const TLogPrefix&>(self).LogPrefix());
@@ -61,7 +90,7 @@ TStructuredLogPrefix MakeRuntimeLogPrefix(const T& self) {
     return prefix;
 }
 
-inline TString StructuredLogPrefixText(const TStructuredLogPrefix& prefix) {
+inline TString StructuredLogPrefixText(const TStructuredMessage& prefix) {
     TStringBuilder out;
     NActors::NStructuredLog::TTextWriter writer;
     writer.Write(out, prefix);

--- a/ydb/core/persqueue/common/logging.h
+++ b/ydb/core/persqueue/common/logging.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <ydb/library/actors/core/log.h>
+#include <ydb/library/actors/struct_log/text_writer.h>
+#include <ydb/library/services/services.pb.h>
+
+#define NPQ_LOG_PREFIX this->LogPrefix()
+#define LOG(level, T, ...) YDB_LOG_COMP(level, this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
+#define LOG_T(T, ...) YDB_LOG_TRACE_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
+#define LOG_D(T, ...) YDB_LOG_DEBUG_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
+#define LOG_I(T, ...) YDB_LOG_INFO_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
+#define LOG_N(T, ...) YDB_LOG_NOTICE_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
+#define LOG_W(T, ...) YDB_LOG_WARN_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
+#define LOG_E(T, ...) YDB_LOG_ERROR_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
+#define LOG_C(T, ...) YDB_LOG_CRIT_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
+#define LOG_A(T, ...) YDB_LOG_ALERT_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
+
+namespace NKikimr::NPQ {
+
+using TStructuredLogPrefix = NActors::NStructuredLog::TStructuredMessage;
+
+inline TStructuredLogPrefix MakeNpqLogPrefix(TStructuredLogPrefix builder, const TStructuredLogPrefix& prefix) {
+    builder.AppendMessage(prefix);
+    return builder;
+}
+
+inline TString StructuredLogPrefixText(const TStructuredLogPrefix& prefix) {
+    TStringBuilder out;
+    NActors::NStructuredLog::TTextWriter writer;
+    writer.Write(out, prefix);
+    return out;
+}
+
+class TLogPrefix {
+public:
+    explicit TLogPrefix(NKikimrServices::EServiceKikimr service = NKikimrServices::PERSQUEUE)
+        : Service(service)
+    {
+    }
+
+    virtual ~TLogPrefix() = default;
+
+    virtual TStructuredLogPrefix LogPrefix() const = 0;
+
+    NKikimrServices::EServiceKikimr Service;
+};
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/common/logging.h
+++ b/ydb/core/persqueue/common/logging.h
@@ -4,7 +4,9 @@
 #include <ydb/library/actors/struct_log/text_writer.h>
 #include <ydb/library/services/services.pb.h>
 
-#define NPQ_LOG_PREFIX this->LogPrefix()
+#include <type_traits>
+
+#define NPQ_LOG_PREFIX ::NKikimr::NPQ::MakeRuntimeLogPrefix(*this)
 #define LOG(level, T, ...) YDB_LOG_COMP(level, this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
 #define LOG_T(T, ...) YDB_LOG_TRACE_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
 #define LOG_D(T, ...) YDB_LOG_DEBUG_COMP(this->Service, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
@@ -19,18 +21,6 @@ namespace NKikimr::NPQ {
 
 using TStructuredLogPrefix = NActors::NStructuredLog::TStructuredMessage;
 
-inline TStructuredLogPrefix MakeNpqLogPrefix(TStructuredLogPrefix builder, const TStructuredLogPrefix& prefix) {
-    builder.AppendMessage(prefix);
-    return builder;
-}
-
-inline TString StructuredLogPrefixText(const TStructuredLogPrefix& prefix) {
-    TStringBuilder out;
-    NActors::NStructuredLog::TTextWriter writer;
-    writer.Write(out, prefix);
-    return out;
-}
-
 class TLogPrefix {
 public:
     explicit TLogPrefix(NKikimrServices::EServiceKikimr service = NKikimrServices::PERSQUEUE)
@@ -44,5 +34,33 @@ public:
 
     NKikimrServices::EServiceKikimr Service;
 };
+
+template <typename T>
+TStructuredLogPrefix MakeRuntimeLogPrefix(const T& self) {
+    TStructuredLogPrefix prefix;
+    if constexpr (requires { self.TabletId; }) {
+        prefix.AppendMessage(YDB_LOG_CREATE_MESSAGE({"tabletId", self.TabletId}));
+    } else if constexpr (requires { self.TabletID(); }) {
+        prefix.AppendMessage(YDB_LOG_CREATE_MESSAGE({"tabletId", self.TabletID()}));
+    }
+    if constexpr (requires { self.SelfId(); }) {
+        prefix.AppendMessage(YDB_LOG_CREATE_MESSAGE({"selfId", self.SelfId()}));
+    } else if constexpr (requires { self.SelfID; }) {
+        prefix.AppendMessage(YDB_LOG_CREATE_MESSAGE({"selfId", self.SelfID}));
+    }
+    if constexpr (std::is_base_of_v<TLogPrefix, T>) {
+        prefix.AppendMessage(static_cast<const TLogPrefix&>(self).LogPrefix());
+    } else {
+        prefix.AppendMessage(self.LogPrefix());
+    }
+    return prefix;
+}
+
+inline TString StructuredLogPrefixText(const TStructuredLogPrefix& prefix) {
+    TStringBuilder out;
+    NActors::NStructuredLog::TTextWriter writer;
+    writer.Write(out, prefix);
+    return out;
+}
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/common/logging.h
+++ b/ydb/core/persqueue/common/logging.h
@@ -32,6 +32,7 @@ public:
 
     virtual TStructuredLogPrefix LogPrefix() const = 0;
 
+public:
     NKikimrServices::EServiceKikimr Service;
 };
 

--- a/ydb/core/persqueue/common/ut/actor_ut.cpp
+++ b/ydb/core/persqueue/common/ut/actor_ut.cpp
@@ -42,14 +42,14 @@ struct TEvText : TEventLocal<TEvText, EvText> {
 class TPrefixActor : public TBaseActor<TPrefixActor>
                    , public TConstantLogPrefix {
 public:
+    static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
+        return NKikimrServices::TActivity::OTHER;
+    }
+
     explicit TPrefixActor(TActorId parent)
         : TBaseActor<TPrefixActor>(NKikimrServices::PERSQUEUE)
         , Parent(parent)
     {
-    }
-
-    TStructuredLogPrefix BuildLogPrefix() const override {
-        return YDB_LOG_CREATE_MESSAGE({"actorClassName", "prefix"});
     }
 
     void Bootstrap() {
@@ -93,10 +93,6 @@ public:
         : TBaseActor<TExceptionActor>(NKikimrServices::PERSQUEUE)
         , Parent(parent)
     {
-    }
-
-    TStructuredLogPrefix BuildLogPrefix() const override {
-        return YDB_LOG_CREATE_MESSAGE({"actorClassName", "exc"});
     }
 
     void Bootstrap() {
@@ -145,13 +141,13 @@ private:
 class TTabletExceptionActor : public TBaseTabletActor<TTabletExceptionActor>
                             , public TConstantLogPrefix {
 public:
+    static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
+        return NKikimrServices::TActivity::OTHER;
+    }
+
     TTabletExceptionActor(ui64 tabletId, TActorId tabletActorId)
         : TBaseTabletActor<TTabletExceptionActor>(tabletId, tabletActorId, NKikimrServices::PERSQUEUE)
     {
-    }
-
-    TStructuredLogPrefix BuildLogPrefix() const override {
-        return YDB_LOG_CREATE_MESSAGE({"actorClassName", "tablet"});
     }
 
     void Bootstrap() {
@@ -174,10 +170,6 @@ public:
         , Pipes(this)
         , Parent(parent)
     {
-    }
-
-    TStructuredLogPrefix BuildLogPrefix() const override {
-        return YDB_LOG_CREATE_MESSAGE({"actorClassName", "pipe"});
     }
 
     void Bootstrap() {
@@ -228,7 +220,7 @@ Y_UNIT_TEST(LogPrefixEventStrAndMacros) {
 
     auto prefix = runtime.GrabEdgeEvent<TEvText>(edge, TDuration::Seconds(5));
     UNIT_ASSERT(prefix);
-    UNIT_ASSERT(prefix->Get()->Value.Contains("actorClassName=prefix"));
+    UNIT_ASSERT(prefix->Get()->Value.Contains("actorActivityType=OTHER"));
     UNIT_ASSERT(prefix->Get()->Value.Contains("selfId="));
 
     runtime.Send(new IEventHandle(actorId, edge, new TEvents::TEvWakeup()), 0, true);
@@ -290,6 +282,7 @@ Y_UNIT_TEST(TabletActorRestartsOnException) {
 
     auto prefix = runtime.GrabEdgeEvent<TEvText>(tablet, TDuration::Seconds(5));
     UNIT_ASSERT(prefix);
+    UNIT_ASSERT(prefix->Get()->Value.Contains("actorActivityType=OTHER"));
     UNIT_ASSERT(prefix->Get()->Value.Contains("tabletId=42"));
     UNIT_ASSERT(prefix->Get()->Value.Contains("selfId="));
 

--- a/ydb/core/persqueue/common/ut/actor_ut.cpp
+++ b/ydb/core/persqueue/common/ut/actor_ut.cpp
@@ -62,8 +62,8 @@ public:
         LOG_E("error");
         LOG_C("crit");
         LOG_A("alert");
-        const TStructuredLogPrefix& first = GetLogPrefix();
-        const TStructuredLogPrefix& second = GetLogPrefix();
+        const TStructuredMessage& first = GetLogPrefix();
+        const TStructuredMessage& second = GetLogPrefix();
         Y_UNUSED(first);
         Y_UNUSED(second);
         Send(Parent, new TEvText(StructuredLogPrefixText(NPQ_LOG_PREFIX)));
@@ -111,6 +111,39 @@ public:
 
 private:
     const TActorId Parent;
+};
+
+class TRebuildActor : public TBaseActor<TRebuildActor> {
+public:
+    static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
+        return NKikimrServices::TActivity::OTHER;
+    }
+
+    explicit TRebuildActor(TActorId parent)
+        : TBaseActor<TRebuildActor>(NKikimrServices::PERSQUEUE)
+        , Parent(parent)
+    {
+    }
+
+    TStructuredMessage LogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE({"tag", Tag});
+    }
+
+    void Bootstrap() {
+        Become(&TThis::StateWork);
+        Send(Parent, new TEvText(StructuredLogPrefixText(NPQ_LOG_PREFIX)));
+        Tag = "second";
+        Send(Parent, new TEvText(StructuredLogPrefixText(NPQ_LOG_PREFIX)));
+        PassAway();
+    }
+
+    STRICT_STFUNC(StateWork,
+        cFunc(TEvents::TEvPoison::EventType, PassAway);
+    )
+
+private:
+    const TActorId Parent;
+    TString Tag = "first";
 };
 
 class TDefaultHooksActor : public TBaseActor<TDefaultHooksActor>
@@ -231,6 +264,21 @@ Y_UNIT_TEST(LogPrefixEventStrAndMacros) {
     UNIT_ASSERT(eventStr->Get()->Value.Contains("Cookie"));
 
     runtime.Send(new IEventHandle(actorId, edge, new TEvents::TEvPoison()), 0, true);
+}
+
+Y_UNIT_TEST(RebuildLogPrefix) {
+    NActors::TTestBasicRuntime runtime(1, false);
+    InitRuntime(runtime, false);
+    auto edge = runtime.AllocateEdgeActor();
+    runtime.Register(new TRebuildActor(edge));
+
+    auto first = runtime.GrabEdgeEvent<TEvText>(edge, TDuration::Seconds(5));
+    UNIT_ASSERT(first);
+    UNIT_ASSERT(first->Get()->Value.Contains("tag=first"));
+
+    auto second = runtime.GrabEdgeEvent<TEvText>(edge, TDuration::Seconds(5));
+    UNIT_ASSERT(second);
+    UNIT_ASSERT(second->Get()->Value.Contains("tag=second"));
 }
 
 Y_UNIT_TEST(UnhandledExceptionDisabled) {

--- a/ydb/core/persqueue/common/ut/actor_ut.cpp
+++ b/ydb/core/persqueue/common/ut/actor_ut.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/struct_log/text_writer.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -17,6 +18,13 @@ using namespace NKikimr;
 using namespace NKikimr::NPQ;
 
 namespace {
+
+TString StructuredLogPrefixText(const TStructuredMessage& prefix) {
+    TStringBuilder out;
+    NActors::NStructuredLog::TTextWriter writer;
+    writer.Write(out, prefix);
+    return out;
+}
 
 enum EEv {
     EvHandled = EventSpaceBegin(TEvents::ES_PRIVATE),

--- a/ydb/core/persqueue/common/ut/actor_ut.cpp
+++ b/ydb/core/persqueue/common/ut/actor_ut.cpp
@@ -64,8 +64,9 @@ public:
         LOG_A("alert");
         const TStructuredLogPrefix& first = GetLogPrefix();
         const TStructuredLogPrefix& second = GetLogPrefix();
+        Y_UNUSED(first);
         Y_UNUSED(second);
-        Send(Parent, new TEvText(TStringBuilder() << StructuredLogPrefixText(LogBuilder()) << StructuredLogPrefixText(first)));
+        Send(Parent, new TEvText(StructuredLogPrefixText(NPQ_LOG_PREFIX)));
     }
 
     void Handle(TEvents::TEvWakeup::TPtr& ev) {
@@ -228,6 +229,7 @@ Y_UNIT_TEST(LogPrefixEventStrAndMacros) {
     auto prefix = runtime.GrabEdgeEvent<TEvText>(edge, TDuration::Seconds(5));
     UNIT_ASSERT(prefix);
     UNIT_ASSERT(prefix->Get()->Value.Contains("actorClassName=prefix"));
+    UNIT_ASSERT(prefix->Get()->Value.Contains("selfId="));
 
     runtime.Send(new IEventHandle(actorId, edge, new TEvents::TEvWakeup()), 0, true);
     auto eventStr = runtime.GrabEdgeEvent<TEvText>(edge, TDuration::Seconds(5));
@@ -289,6 +291,7 @@ Y_UNIT_TEST(TabletActorRestartsOnException) {
     auto prefix = runtime.GrabEdgeEvent<TEvText>(tablet, TDuration::Seconds(5));
     UNIT_ASSERT(prefix);
     UNIT_ASSERT(prefix->Get()->Value.Contains("tabletId=42"));
+    UNIT_ASSERT(prefix->Get()->Value.Contains("selfId="));
 
     auto poison = runtime.GrabEdgeEvent<TEvents::TEvPoison>(tablet, TDuration::Seconds(5));
     UNIT_ASSERT(poison);

--- a/ydb/core/persqueue/common/ut/actor_ut.cpp
+++ b/ydb/core/persqueue/common/ut/actor_ut.cpp
@@ -48,7 +48,7 @@ public:
     {
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE({"actorClassName", "prefix"});
     }
 
@@ -62,8 +62,8 @@ public:
         LOG_E("error");
         LOG_C("crit");
         LOG_A("alert");
-        const TLogPrefix& first = GetLogPrefix();
-        const TLogPrefix& second = GetLogPrefix();
+        const TStructuredLogPrefix& first = GetLogPrefix();
+        const TStructuredLogPrefix& second = GetLogPrefix();
         Y_UNUSED(second);
         Send(Parent, new TEvText(TStringBuilder() << StructuredLogPrefixText(LogBuilder()) << StructuredLogPrefixText(first)));
     }
@@ -94,7 +94,7 @@ public:
     {
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE({"actorClassName", "exc"});
     }
 
@@ -149,7 +149,7 @@ public:
     {
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE({"actorClassName", "tablet"});
     }
 
@@ -175,7 +175,7 @@ public:
     {
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE({"actorClassName", "pipe"});
     }
 

--- a/ydb/core/persqueue/pqrb/mirror_describer.cpp
+++ b/ydb/core/persqueue/pqrb/mirror_describer.cpp
@@ -216,7 +216,7 @@ void TMirrorDescriber::ScheduleDescription(const TActorContext& ctx) {
     ScheduleWithIncreasingTimeout<TEvents::TEvWakeup>(SelfId(), DescribeRetryTimeout, DESCRIBE_RETRY_TIMEOUT_MAX, ctx);
 }
 
-TStructuredLogPrefix TMirrorDescriber::BuildLogPrefix() const {
+TStructuredMessage TMirrorDescriber::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"topic", TopicName});
 }

--- a/ydb/core/persqueue/pqrb/mirror_describer.cpp
+++ b/ydb/core/persqueue/pqrb/mirror_describer.cpp
@@ -216,7 +216,7 @@ void TMirrorDescriber::ScheduleDescription(const TActorContext& ctx) {
     ScheduleWithIncreasingTimeout<TEvents::TEvWakeup>(SelfId(), DescribeRetryTimeout, DESCRIBE_RETRY_TIMEOUT_MAX, ctx);
 }
 
-TLogPrefix TMirrorDescriber::BuildLogPrefix() const {
+TStructuredLogPrefix TMirrorDescriber::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "MirrorDescriber"},
         {"topic", TopicName});

--- a/ydb/core/persqueue/pqrb/mirror_describer.cpp
+++ b/ydb/core/persqueue/pqrb/mirror_describer.cpp
@@ -218,7 +218,6 @@ void TMirrorDescriber::ScheduleDescription(const TActorContext& ctx) {
 
 TStructuredLogPrefix TMirrorDescriber::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "MirrorDescriber"},
         {"topic", TopicName});
 }
 

--- a/ydb/core/persqueue/pqrb/mirror_describer.h
+++ b/ydb/core/persqueue/pqrb/mirror_describer.h
@@ -63,7 +63,7 @@ private:
 
     void DescribeTopic(const TActorContext& ctx);
 
-    TLogPrefix BuildLogPrefix() const override;
+    TStructuredLogPrefix BuildLogPrefix() const override;
 
 public:
     TMirrorDescriber(

--- a/ydb/core/persqueue/pqrb/mirror_describer.h
+++ b/ydb/core/persqueue/pqrb/mirror_describer.h
@@ -63,7 +63,7 @@ private:
 
     void DescribeTopic(const TActorContext& ctx);
 
-    TStructuredLogPrefix BuildLogPrefix() const override;
+    TStructuredMessage BuildLogPrefix() const override;
 
 public:
     TMirrorDescriber(

--- a/ydb/core/persqueue/pqrb/partition_scale_manager.cpp
+++ b/ydb/core/persqueue/pqrb/partition_scale_manager.cpp
@@ -29,8 +29,10 @@ TPartitionScaleManager::TPartitionScaleManager(
     , MirroredFromSomewhere(MirroringEnabled(config)) {
     }
 
-TString TPartitionScaleManager::LogPrefix() const {
-    return TStringBuilder() << "[TPartitionScaleManager: " << TopicName << "] ";
+NActors::NStructuredLog::TStructuredMessage TPartitionScaleManager::LogPrefix() const {
+    return YDB_LOG_CREATE_MESSAGE(
+        {"actorClassName", "TPartitionScaleManager"},
+        {"topic", TopicName});
 }
 
 void TPartitionScaleManager::HandleScaleStatusChange(const ui32 partitionId, NKikimrPQ::EScaleStatus scaleStatus,
@@ -38,11 +40,11 @@ void TPartitionScaleManager::HandleScaleStatusChange(const ui32 partitionId, NKi
     TMaybe<TString> splitBoundary,
     const TActorContext& ctx) {
     YDB_LOG_DEBUG("Handle HandleScaleStatusChange. Scale",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"status", NKikimrPQ::EScaleStatus_Name(scaleStatus)});
     if (scaleStatus == NKikimrPQ::EScaleStatus::NEED_SPLIT) {
         YDB_LOG_DEBUG("::HandleScaleStatusChange need to split partition",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId});
         TPartitionScaleOperationInfo op{
             .PartitionId = partitionId,
@@ -65,13 +67,13 @@ void TPartitionScaleManager::TrySendScaleRequest(const TActorContext& ctx) {
     auto splitMergeRequest = BuildScaleRequest(ctx);
     if (splitMergeRequest.Empty()) {
         YDB_LOG_DEBUG("SplitMergeRequest empty",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         return;
     }
 
     RequestInflight = true;
     YDB_LOG_DEBUG("Send split request",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
     CurrentScaleRequest = ctx.Register(new TPartitionScaleRequest(
         TopicName,
         TopicPath,
@@ -137,7 +139,7 @@ TPartitionScaleManager::TScaleRequest TPartitionScaleManager::BuildScaleRequest(
     auto splitsToApply = BuildSplitRequest(allowedSplitsCount);
 
     YDB_LOG_DEBUG("Scale request",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"splits", splitsToApply.Requests.size()},
         {"unprocessed", splitsToApply.Unprocessed},
         {"splitsLimit", allowedSplitsCountLimit},
@@ -174,7 +176,7 @@ TPartitionScaleManager::TRequests<TPartitionScaleManager::TPartitionBoundary> TP
                 boundsToApply.push_back(std::move(part));
             } else {
                 YDB_LOG_WARN("MaxActivePartitions is too low to recreate root partitions from the mirror source topic",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"maxActivePartitions", BalancerConfig.MaxActivePartitions},
                     {"createPartitions", RootPartitionsToCreate->size()});
                 // don't send request at all, if there is not enough quota
@@ -184,7 +186,7 @@ TPartitionScaleManager::TRequests<TPartitionScaleManager::TPartitionBoundary> TP
             }
         }
         YDB_LOG_DEBUG("Set partition boundaries requsts",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"modify", modifyPartitions},
             {"create", createPartitions});
     }
@@ -233,13 +235,13 @@ TPartitionScaleManager::TBuildSplitScaleRequestResult TPartitionScaleManager::Bu
     if (MirroredFromSomewhere)  {
         if (!AppData()->FeatureFlags.GetEnableMirroredTopicSplitMerge()) {
             YDB_LOG_DEBUG("Split request for mirrored topic is disabled",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"partition", partitionId});
             return {.Split = Nothing(), .Remove = false};
         }
         if (!splitParameters.PartitionScaleParticipants.Defined()) {
             YDB_LOG_NOTICE("Split request for mirrored topic doesn't have prescribed partition ids",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"partition", partitionId});
             return {.Split = Nothing(), .Remove = true};
         }
@@ -248,12 +250,12 @@ TPartitionScaleManager::TBuildSplitScaleRequestResult TPartitionScaleManager::Bu
     if (node == nullptr) {
         if (splitParameters.PartitionScaleParticipants.Defined()) {
             YDB_LOG_NOTICE("Attempt to split partition that was not created yet",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"partition", partitionId});
             return {.Split = Nothing(), .Remove = false};
         } else {
             YDB_LOG_ERROR("Partition not found",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"partition", partitionId});
             return {.Split = Nothing(), .Remove = true};
         }
@@ -264,20 +266,20 @@ TPartitionScaleManager::TBuildSplitScaleRequestResult TPartitionScaleManager::Bu
         auto mid = splitParameters.SplitBoundary.GetOrElse(MiddleOf(from, to));
         if (mid.empty()) {
             YDB_LOG_ERROR("Wrong partition key range. Can't get mid",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"partition", partitionId});
             return {.Split = Nothing(), .Remove = true};
         }
 
         if (splitParameters.PartitionScaleParticipants.Defined() && splitParameters.PartitionScaleParticipants->AdjacentPartitionIdsSize() != 0) {
             YDB_LOG_ERROR("Split request cannot have adjacent partitions",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"partition", partitionId});
             return {.Split = Nothing(), .Remove = true};
         }
 
         YDB_LOG_DEBUG("Partition split ranges",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"fromHex", ToHex(from)},
             {"toHex", ToHex(to)},
             {"midHex", ToHex(mid)},
@@ -291,7 +293,7 @@ TPartitionScaleManager::TBuildSplitScaleRequestResult TPartitionScaleManager::Bu
                 split.add_childpartitionids(childPartitionId);
                 if (const auto* childNode = PartitionGraph.GetPartition(childPartitionId); childNode != nullptr) {
                     YDB_LOG_NOTICE("Child partition already exists. Performing unordered split",
-                        {"logPrefix", LogPrefix()},
+                        {LogPrefix()},
                         {"childPartition", childPartitionId},
                         {"partition", partitionId});
                     split.set_createrootlevelsibling(true);
@@ -306,7 +308,7 @@ TPartitionScaleManager::TBuildSplitScaleRequestResult TPartitionScaleManager::Bu
             if (!std::ranges::is_permutation(nodeChildrenIds, prescribedChildrenIds)) {
                 const std::string mappingStr = fmt::format("([{}]->[{}])", fmt::join(nodeChildrenIds, ","), fmt::join(prescribedChildrenIds, ","));
                 YDB_LOG_ERROR("Trying to split partition into different set of children partitions",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"mappingStr", mappingStr},
                     {"partition", partitionId});
             }
@@ -321,7 +323,7 @@ void TPartitionScaleManager::HandleScaleRequestResult(TPartitionScaleRequest::TE
     LastResponseTime = ctx.Now();
     auto result = ev->Get();
     YDB_LOG_DEBUG("HandleScaleRequestResult scale request",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"result", result->Status});
     if (result->Status == TEvTxUserProxy::TResultStatus::ExecComplete) {
         RequestTimeout = TDuration::Zero();
@@ -356,7 +358,7 @@ void TPartitionScaleManager::UpdateMirrorRootPartitionsSet() {
     NMirror::TMirrorGraphComparisonResult cmp = NMirror::ComparePartitionGraphs(PartitionGraph, MirrorTopicDescription->GetPartitions());
     if (!cmp.RootPartitionsMismatch.has_value()) {
         YDB_LOG_DEBUG("Topic has all root partitions from the source topic",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         RootPartitionsToCreate.reset();
         MirrorTopicError.reset();
         return;
@@ -364,7 +366,7 @@ void TPartitionScaleManager::UpdateMirrorRootPartitionsSet() {
     auto& rootPartitionsMismatch = cmp.RootPartitionsMismatch.value();
     if (rootPartitionsMismatch.Error.has_value()) {
         YDB_LOG_ERROR("Incompatable configuration of root partitions between source and target topics",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"topics", rootPartitionsMismatch.Error.value()});
         RootPartitionsToCreate.reset();
         MirrorTopicError = std::move(*rootPartitionsMismatch.Error);
@@ -373,7 +375,7 @@ void TPartitionScaleManager::UpdateMirrorRootPartitionsSet() {
     const size_t existingPartitions = std::ranges::count(rootPartitionsMismatch.AlterRootPartitions, NMirror::EPartitionAction::Modify, &NMirror::TPartitionWithBounds::Action);
     const size_t newPartitions = std::ranges::count(rootPartitionsMismatch.AlterRootPartitions, NMirror::EPartitionAction::Create, &NMirror::TPartitionWithBounds::Action);
     YDB_LOG_INFO("Topic has less root partitions than the mirror source",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"existing", existingPartitions},
         {"new", newPartitions});
 
@@ -388,7 +390,7 @@ std::expected<void, std::string> TPartitionScaleManager::HandleMirrorTopicDescri
         auto& description = ev->Get()->Description;
         if (!description.has_value() || !description.value().IsSuccess()) {
             YDB_LOG_WARN("Ignoring invalid mirror source description",
-                {"logPrefix", LogPrefix()});
+                {LogPrefix()});
             return {};
         }
         MirrorTopicDescription.emplace(std::move(description->GetTopicDescription()));

--- a/ydb/core/persqueue/pqrb/partition_scale_manager.cpp
+++ b/ydb/core/persqueue/pqrb/partition_scale_manager.cpp
@@ -31,7 +31,7 @@ TPartitionScaleManager::TPartitionScaleManager(
 
 NActors::NStructuredLog::TStructuredMessage TPartitionScaleManager::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "TPartitionScaleManager"},
+        {"className", "TPartitionScaleManager"},
         {"topic", TopicName});
 }
 

--- a/ydb/core/persqueue/pqrb/partition_scale_manager.cpp
+++ b/ydb/core/persqueue/pqrb/partition_scale_manager.cpp
@@ -30,7 +30,7 @@ TPartitionScaleManager::TPartitionScaleManager(
     , MirroredFromSomewhere(MirroringEnabled(config)) {
     }
 
-TStructuredLogPrefix TPartitionScaleManager::LogPrefix() const {
+TStructuredMessage TPartitionScaleManager::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"className", "TPartitionScaleManager"},
         {"topic", TopicName});

--- a/ydb/core/persqueue/pqrb/partition_scale_manager.cpp
+++ b/ydb/core/persqueue/pqrb/partition_scale_manager.cpp
@@ -21,7 +21,8 @@ TPartitionScaleManager::TPartitionScaleManager(
     const NKikimrPQ::TPQTabletConfig& config,
     const TPartitionGraph& partitionGraph
 )
-    : TopicName(topicName)
+    : TLogPrefix(NKikimrServices::PERSQUEUE_READ_BALANCER)
+    , TopicName(topicName)
     , TopicPath(topicPath)
     , DatabasePath(databasePath)
     , BalancerConfig(pathId, version, config)
@@ -29,7 +30,7 @@ TPartitionScaleManager::TPartitionScaleManager(
     , MirroredFromSomewhere(MirroringEnabled(config)) {
     }
 
-NActors::NStructuredLog::TStructuredMessage TPartitionScaleManager::LogPrefix() const {
+TStructuredLogPrefix TPartitionScaleManager::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"className", "TPartitionScaleManager"},
         {"topic", TopicName});
@@ -39,13 +40,9 @@ void TPartitionScaleManager::HandleScaleStatusChange(const ui32 partitionId, NKi
     TMaybe<NKikimrPQ::TPartitionScaleParticipants> participants,
     TMaybe<TString> splitBoundary,
     const TActorContext& ctx) {
-    YDB_LOG_DEBUG("Handle HandleScaleStatusChange. Scale",
-        {LogPrefix()},
-        {"status", NKikimrPQ::EScaleStatus_Name(scaleStatus)});
+    LOG_D("Handle HandleScaleStatusChange. Scale", {"status", NKikimrPQ::EScaleStatus_Name(scaleStatus)});
     if (scaleStatus == NKikimrPQ::EScaleStatus::NEED_SPLIT) {
-        YDB_LOG_DEBUG("::HandleScaleStatusChange need to split partition",
-            {LogPrefix()},
-            {"partitionId", partitionId});
+        LOG_D("::HandleScaleStatusChange need to split partition", {"partitionId", partitionId});
         TPartitionScaleOperationInfo op{
             .PartitionId = partitionId,
             .PartitionScaleParticipants = std::move(participants),
@@ -66,14 +63,12 @@ void TPartitionScaleManager::TrySendScaleRequest(const TActorContext& ctx) {
 
     auto splitMergeRequest = BuildScaleRequest(ctx);
     if (splitMergeRequest.Empty()) {
-        YDB_LOG_DEBUG("SplitMergeRequest empty",
-            {LogPrefix()});
+        LOG_D("SplitMergeRequest empty");
         return;
     }
 
     RequestInflight = true;
-    YDB_LOG_DEBUG("Send split request",
-        {LogPrefix()});
+    LOG_D("Send split request");
     CurrentScaleRequest = ctx.Register(new TPartitionScaleRequest(
         TopicName,
         TopicPath,
@@ -138,9 +133,7 @@ TPartitionScaleManager::TScaleRequest TPartitionScaleManager::BuildScaleRequest(
     auto mergesToApply = BuildMergeRequest(allowedSplitsCount);
     auto splitsToApply = BuildSplitRequest(allowedSplitsCount);
 
-    YDB_LOG_DEBUG("Scale request",
-        {LogPrefix()},
-        {"splits", splitsToApply.Requests.size()},
+    LOG_D("Scale request", {"splits", splitsToApply.Requests.size()},
         {"unprocessed", splitsToApply.Unprocessed},
         {"splitsLimit", allowedSplitsCountLimit},
         {"merges", mergesToApply.Requests.size()});
@@ -175,9 +168,7 @@ TPartitionScaleManager::TRequests<TPartitionScaleManager::TPartitionBoundary> TP
                 allowedSplitsCount -= cost;
                 boundsToApply.push_back(std::move(part));
             } else {
-                YDB_LOG_WARN("MaxActivePartitions is too low to recreate root partitions from the mirror source topic",
-                    {LogPrefix()},
-                    {"maxActivePartitions", BalancerConfig.MaxActivePartitions},
+                LOG_W("MaxActivePartitions is too low to recreate root partitions from the mirror source topic", {"maxActivePartitions", BalancerConfig.MaxActivePartitions},
                     {"createPartitions", RootPartitionsToCreate->size()});
                 // don't send request at all, if there is not enough quota
                 return {
@@ -185,9 +176,7 @@ TPartitionScaleManager::TRequests<TPartitionScaleManager::TPartitionBoundary> TP
                 };
             }
         }
-        YDB_LOG_DEBUG("Set partition boundaries requsts",
-            {LogPrefix()},
-            {"modify", modifyPartitions},
+        LOG_D("Set partition boundaries requsts", {"modify", modifyPartitions},
             {"create", createPartitions});
     }
     return {
@@ -234,29 +223,21 @@ TPartitionScaleManager::TBuildSplitScaleRequestResult TPartitionScaleManager::Bu
     const ui32 partitionId = splitParameters.PartitionId;
     if (MirroredFromSomewhere)  {
         if (!AppData()->FeatureFlags.GetEnableMirroredTopicSplitMerge()) {
-            YDB_LOG_DEBUG("Split request for mirrored topic is disabled",
-                {LogPrefix()},
-                {"partition", partitionId});
+            LOG_D("Split request for mirrored topic is disabled", {"partition", partitionId});
             return {.Split = Nothing(), .Remove = false};
         }
         if (!splitParameters.PartitionScaleParticipants.Defined()) {
-            YDB_LOG_NOTICE("Split request for mirrored topic doesn't have prescribed partition ids",
-                {LogPrefix()},
-                {"partition", partitionId});
+            LOG_N("Split request for mirrored topic doesn't have prescribed partition ids", {"partition", partitionId});
             return {.Split = Nothing(), .Remove = true};
         }
     }
     const auto* node = PartitionGraph.GetPartition(partitionId);
     if (node == nullptr) {
         if (splitParameters.PartitionScaleParticipants.Defined()) {
-            YDB_LOG_NOTICE("Attempt to split partition that was not created yet",
-                {LogPrefix()},
-                {"partition", partitionId});
+            LOG_N("Attempt to split partition that was not created yet", {"partition", partitionId});
             return {.Split = Nothing(), .Remove = false};
         } else {
-            YDB_LOG_ERROR("Partition not found",
-                {LogPrefix()},
-                {"partition", partitionId});
+            LOG_E("Partition not found", {"partition", partitionId});
             return {.Split = Nothing(), .Remove = true};
         }
     }
@@ -265,22 +246,16 @@ TPartitionScaleManager::TBuildSplitScaleRequestResult TPartitionScaleManager::Bu
         auto to = node->To;
         auto mid = splitParameters.SplitBoundary.GetOrElse(MiddleOf(from, to));
         if (mid.empty()) {
-            YDB_LOG_ERROR("Wrong partition key range. Can't get mid",
-                {LogPrefix()},
-                {"partition", partitionId});
+            LOG_E("Wrong partition key range. Can't get mid", {"partition", partitionId});
             return {.Split = Nothing(), .Remove = true};
         }
 
         if (splitParameters.PartitionScaleParticipants.Defined() && splitParameters.PartitionScaleParticipants->AdjacentPartitionIdsSize() != 0) {
-            YDB_LOG_ERROR("Split request cannot have adjacent partitions",
-                {LogPrefix()},
-                {"partition", partitionId});
+            LOG_E("Split request cannot have adjacent partitions", {"partition", partitionId});
             return {.Split = Nothing(), .Remove = true};
         }
 
-        YDB_LOG_DEBUG("Partition split ranges",
-            {LogPrefix()},
-            {"fromHex", ToHex(from)},
+        LOG_D("Partition split ranges", {"fromHex", ToHex(from)},
             {"toHex", ToHex(to)},
             {"midHex", ToHex(mid)},
             {"partition", partitionId});
@@ -292,9 +267,7 @@ TPartitionScaleManager::TBuildSplitScaleRequestResult TPartitionScaleManager::Bu
             for (const auto& childPartitionId : splitParameters.PartitionScaleParticipants->GetChildPartitionIds()) {
                 split.add_childpartitionids(childPartitionId);
                 if (const auto* childNode = PartitionGraph.GetPartition(childPartitionId); childNode != nullptr) {
-                    YDB_LOG_NOTICE("Child partition already exists. Performing unordered split",
-                        {LogPrefix()},
-                        {"childPartition", childPartitionId},
+                    LOG_N("Child partition already exists. Performing unordered split", {"childPartition", childPartitionId},
                         {"partition", partitionId});
                     split.set_createrootlevelsibling(true);
                 }
@@ -307,9 +280,7 @@ TPartitionScaleManager::TBuildSplitScaleRequestResult TPartitionScaleManager::Bu
             const auto& prescribedChildrenIds = splitParameters.PartitionScaleParticipants->GetChildPartitionIds();
             if (!std::ranges::is_permutation(nodeChildrenIds, prescribedChildrenIds)) {
                 const std::string mappingStr = fmt::format("([{}]->[{}])", fmt::join(nodeChildrenIds, ","), fmt::join(prescribedChildrenIds, ","));
-                YDB_LOG_ERROR("Trying to split partition into different set of children partitions",
-                    {LogPrefix()},
-                    {"mappingStr", mappingStr},
+                LOG_E("Trying to split partition into different set of children partitions", {"mappingStr", mappingStr},
                     {"partition", partitionId});
             }
         }
@@ -322,9 +293,7 @@ void TPartitionScaleManager::HandleScaleRequestResult(TPartitionScaleRequest::TE
     CurrentScaleRequest = {};
     LastResponseTime = ctx.Now();
     auto result = ev->Get();
-    YDB_LOG_DEBUG("HandleScaleRequestResult scale request",
-        {LogPrefix()},
-        {"result", result->Status});
+    LOG_D("HandleScaleRequestResult scale request", {"result", result->Status});
     if (result->Status == TEvTxUserProxy::TResultStatus::ExecComplete) {
         RequestTimeout = TDuration::Zero();
         Backoff.Reset();
@@ -357,26 +326,21 @@ void TPartitionScaleManager::UpdateMirrorRootPartitionsSet() {
 
     NMirror::TMirrorGraphComparisonResult cmp = NMirror::ComparePartitionGraphs(PartitionGraph, MirrorTopicDescription->GetPartitions());
     if (!cmp.RootPartitionsMismatch.has_value()) {
-        YDB_LOG_DEBUG("Topic has all root partitions from the source topic",
-            {LogPrefix()});
+        LOG_D("Topic has all root partitions from the source topic");
         RootPartitionsToCreate.reset();
         MirrorTopicError.reset();
         return;
     }
     auto& rootPartitionsMismatch = cmp.RootPartitionsMismatch.value();
     if (rootPartitionsMismatch.Error.has_value()) {
-        YDB_LOG_ERROR("Incompatable configuration of root partitions between source and target topics",
-            {LogPrefix()},
-            {"topics", rootPartitionsMismatch.Error.value()});
+        LOG_E("Incompatable configuration of root partitions between source and target topics", {"topics", rootPartitionsMismatch.Error.value()});
         RootPartitionsToCreate.reset();
         MirrorTopicError = std::move(*rootPartitionsMismatch.Error);
         return;
     }
     const size_t existingPartitions = std::ranges::count(rootPartitionsMismatch.AlterRootPartitions, NMirror::EPartitionAction::Modify, &NMirror::TPartitionWithBounds::Action);
     const size_t newPartitions = std::ranges::count(rootPartitionsMismatch.AlterRootPartitions, NMirror::EPartitionAction::Create, &NMirror::TPartitionWithBounds::Action);
-    YDB_LOG_INFO("Topic has less root partitions than the mirror source",
-        {LogPrefix()},
-        {"existing", existingPartitions},
+    LOG_I("Topic has less root partitions than the mirror source", {"existing", existingPartitions},
         {"new", newPartitions});
 
     RootPartitionsToCreate = std::move(rootPartitionsMismatch.AlterRootPartitions);
@@ -389,8 +353,7 @@ std::expected<void, std::string> TPartitionScaleManager::HandleMirrorTopicDescri
     } else {
         auto& description = ev->Get()->Description;
         if (!description.has_value() || !description.value().IsSuccess()) {
-            YDB_LOG_WARN("Ignoring invalid mirror source description",
-                {LogPrefix()});
+            LOG_W("Ignoring invalid mirror source description");
             return {};
         }
         MirrorTopicDescription.emplace(std::move(description->GetTopicDescription()));

--- a/ydb/core/persqueue/pqrb/partition_scale_manager.h
+++ b/ydb/core/persqueue/pqrb/partition_scale_manager.h
@@ -12,6 +12,7 @@
 #include <ydb/core/tx/schemeshard/schemeshard_info_types.h>
 #include <ydb/core/util/backoff.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/log.h>
 
 #include <util/system/types.h>
 #include <util/generic/fwd.h>
@@ -106,7 +107,7 @@ private:
     TRequests<TPartitionMerge> BuildMergeRequest(size_t& allowedSplitsCount);
     TBuildSplitScaleRequestResult BuildSplitScaleRequest(const TPartitionScaleOperationInfo& splitParameters) const;
     std::vector<ui32> ReorderSplits() const;
-    TString LogPrefix() const;
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
     void ClearMirrorInfo();
     void UpdateMirrorRootPartitionsSet();
 

--- a/ydb/core/persqueue/pqrb/partition_scale_manager.h
+++ b/ydb/core/persqueue/pqrb/partition_scale_manager.h
@@ -5,6 +5,7 @@
 #include "partition_scale_manager_graph_cmp.h"
 
 #include <ydb/core/base/path.h>
+#include <ydb/core/persqueue/common/logging.h>
 #include "ydb/core/persqueue/public/utils.h"
 #include <ydb/core/protos/pqconfig.pb.h>
 #include <ydb/core/tx/tx_proxy/proxy.h>
@@ -24,7 +25,7 @@
 namespace NKikimr {
 namespace NPQ {
 
-class TPartitionScaleManager {
+class TPartitionScaleManager : public TLogPrefix {
 private:
     struct TBalancerConfig {
         TBalancerConfig(
@@ -107,7 +108,7 @@ private:
     TRequests<TPartitionMerge> BuildMergeRequest(size_t& allowedSplitsCount);
     TBuildSplitScaleRequestResult BuildSplitScaleRequest(const TPartitionScaleOperationInfo& splitParameters) const;
     std::vector<ui32> ReorderSplits() const;
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
+    TStructuredLogPrefix LogPrefix() const override;
     void ClearMirrorInfo();
     void UpdateMirrorRootPartitionsSet();
 

--- a/ydb/core/persqueue/pqrb/partition_scale_manager.h
+++ b/ydb/core/persqueue/pqrb/partition_scale_manager.h
@@ -13,7 +13,6 @@
 #include <ydb/core/tx/schemeshard/schemeshard_info_types.h>
 #include <ydb/core/util/backoff.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/log.h>
 
 #include <util/system/types.h>
 #include <util/generic/fwd.h>

--- a/ydb/core/persqueue/pqrb/partition_scale_manager.h
+++ b/ydb/core/persqueue/pqrb/partition_scale_manager.h
@@ -107,7 +107,7 @@ private:
     TRequests<TPartitionMerge> BuildMergeRequest(size_t& allowedSplitsCount);
     TBuildSplitScaleRequestResult BuildSplitScaleRequest(const TPartitionScaleOperationInfo& splitParameters) const;
     std::vector<ui32> ReorderSplits() const;
-    TStructuredLogPrefix LogPrefix() const override;
+    TStructuredMessage LogPrefix() const override;
     void ClearMirrorInfo();
     void UpdateMirrorRootPartitionsSet();
 

--- a/ydb/core/persqueue/pqrb/partition_scale_request.cpp
+++ b/ydb/core/persqueue/pqrb/partition_scale_request.cpp
@@ -21,7 +21,8 @@ TPartitionScaleRequest::TPartitionScaleRequest(
     std::vector<NKikimrSchemeOp::TPersQueueGroupDescription_TPartitionBoundary> setBoundaries,
     const NActors::TActorId& parentActorId
 )
-    : Topic(topicName)
+    : TLogPrefix(NKikimrServices::PERSQUEUE_READ_BALANCER)
+    , Topic(topicName)
     , TopicPath(topicPath)
     , DatabasePath(databasePath)
     , PathId(pathId)
@@ -33,7 +34,7 @@ TPartitionScaleRequest::TPartitionScaleRequest(
 
     }
 
-NActors::NStructuredLog::TStructuredMessage TPartitionScaleRequest::LogPrefix() const {
+TStructuredLogPrefix TPartitionScaleRequest::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "TPartitionScaleRequest"},
         {"topic", Topic},
@@ -88,8 +89,7 @@ void TPartitionScaleRequest::FillProposeRequest(TEvTxUserProxy::TEvProposeTransa
         }
         logMessage << ".";
     }
-    YDB_LOG_DEBUG(logMessage,
-        {LogPrefix()});
+    LOG_D(logMessage);
 
     for(const auto& merge: Merges) {
         auto* newMerge = groupDescription.AddMerge();
@@ -166,9 +166,7 @@ void TPartitionScaleRequest::Handle(TEvTxUserProxy::TEvProposeTransactionStatus:
         }
         case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecComplete:
         case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecAlready:
-            YDB_LOG_DEBUG("TPartitionScaleRequest completed",
-                {LogPrefix()},
-                {"status", TEvTxUserProxy::TResultStatus::Str(status)});
+            LOG_D("TPartitionScaleRequest completed", {"status", TEvTxUserProxy::TResultStatus::Str(status)});
             ReplyAndDie(status, ctx);
             return;
         default: {
@@ -176,9 +174,7 @@ void TPartitionScaleRequest::Handle(TEvTxUserProxy::TEvProposeTransactionStatus:
             for (auto& issue : msg->Record.GetIssues()) {
                 issues << issue.ShortDebugString() + ", ";
             }
-            YDB_LOG_ERROR("TPartitionScaleRequest SchemaShard error when trying to execute a scale request",
-                {LogPrefix()},
-                {"status", TEvTxUserProxy::TResultStatus::Str(status)},
+            LOG_E("TPartitionScaleRequest SchemaShard error when trying to execute a scale request", {"status", TEvTxUserProxy::TResultStatus::Str(status)},
                 {"request", issues});
             ReplyAndDie(status, ctx);
             return;

--- a/ydb/core/persqueue/pqrb/partition_scale_request.cpp
+++ b/ydb/core/persqueue/pqrb/partition_scale_request.cpp
@@ -33,6 +33,14 @@ TPartitionScaleRequest::TPartitionScaleRequest(
 
     }
 
+NActors::NStructuredLog::TStructuredMessage TPartitionScaleRequest::LogPrefix() const {
+    return YDB_LOG_CREATE_MESSAGE(
+        {"actorClassName", "TPartitionScaleRequest"},
+        {"topic", Topic},
+        {"topicPath", TopicPath},
+        {"pathId", PathId});
+}
+
 void TPartitionScaleRequest::Bootstrap(const NActors::TActorContext &ctx) {
     SendProposeRequest(ctx);
     Become(&TPartitionScaleRequest::StateWork);
@@ -81,7 +89,7 @@ void TPartitionScaleRequest::FillProposeRequest(TEvTxUserProxy::TEvProposeTransa
         logMessage << ".";
     }
     YDB_LOG_DEBUG(logMessage,
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     for(const auto& merge: Merges) {
         auto* newMerge = groupDescription.AddMerge();
@@ -159,7 +167,7 @@ void TPartitionScaleRequest::Handle(TEvTxUserProxy::TEvProposeTransactionStatus:
         case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecComplete:
         case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecAlready:
             YDB_LOG_DEBUG("TPartitionScaleRequest completed",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"status", TEvTxUserProxy::TResultStatus::Str(status)});
             ReplyAndDie(status, ctx);
             return;
@@ -169,7 +177,7 @@ void TPartitionScaleRequest::Handle(TEvTxUserProxy::TEvProposeTransactionStatus:
                 issues << issue.ShortDebugString() + ", ";
             }
             YDB_LOG_ERROR("TPartitionScaleRequest SchemaShard error when trying to execute a scale request",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"status", TEvTxUserProxy::TResultStatus::Str(status)},
                 {"request", issues});
             ReplyAndDie(status, ctx);

--- a/ydb/core/persqueue/pqrb/partition_scale_request.cpp
+++ b/ydb/core/persqueue/pqrb/partition_scale_request.cpp
@@ -36,7 +36,6 @@ TPartitionScaleRequest::TPartitionScaleRequest(
 
 TStructuredLogPrefix TPartitionScaleRequest::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "TPartitionScaleRequest"},
         {"topic", Topic},
         {"topicPath", TopicPath},
         {"pathId", PathId});

--- a/ydb/core/persqueue/pqrb/partition_scale_request.cpp
+++ b/ydb/core/persqueue/pqrb/partition_scale_request.cpp
@@ -34,7 +34,7 @@ TPartitionScaleRequest::TPartitionScaleRequest(
 
     }
 
-TStructuredLogPrefix TPartitionScaleRequest::LogPrefix() const {
+TStructuredMessage TPartitionScaleRequest::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"topic", Topic},
         {"topicPath", TopicPath},

--- a/ydb/core/persqueue/pqrb/partition_scale_request.h
+++ b/ydb/core/persqueue/pqrb/partition_scale_request.h
@@ -4,6 +4,7 @@
 #include "ydb/core/persqueue/events/internal.h"
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/tx/tx_proxy/proxy.h>
+#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/log.h>
@@ -13,7 +14,7 @@
 namespace NKikimr {
 namespace NPQ {
 
-class TPartitionScaleRequest: public NActors::TActorBootstrapped<TPartitionScaleRequest> {
+class TPartitionScaleRequest: public NActors::TActorBootstrapped<TPartitionScaleRequest>, public TLogPrefix {
     using TBase = NActors::TActorBootstrapped<TPartitionScaleRequest>;
 
 public:
@@ -54,7 +55,7 @@ private:
     }
     void SendProposeRequest(const NActors::TActorContext &ctx);
     void FillProposeRequest(TEvTxUserProxy::TEvProposeTransaction& proposal, const NActors::TActorContext &ctx);
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
+    TStructuredLogPrefix LogPrefix() const override;
     bool IsOurPipe(const TActorId& clientId) const;
     void ReplyAndDie(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus status, const TActorContext& ctx);
 

--- a/ydb/core/persqueue/pqrb/partition_scale_request.h
+++ b/ydb/core/persqueue/pqrb/partition_scale_request.h
@@ -6,6 +6,7 @@
 #include <ydb/core/tx/tx_proxy/proxy.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/log.h>
 
 #include <util/generic/string.h>
 
@@ -53,6 +54,7 @@ private:
     }
     void SendProposeRequest(const NActors::TActorContext &ctx);
     void FillProposeRequest(TEvTxUserProxy::TEvProposeTransaction& proposal, const NActors::TActorContext &ctx);
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
     bool IsOurPipe(const TActorId& clientId) const;
     void ReplyAndDie(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus status, const TActorContext& ctx);
 

--- a/ydb/core/persqueue/pqrb/partition_scale_request.h
+++ b/ydb/core/persqueue/pqrb/partition_scale_request.h
@@ -54,7 +54,7 @@ private:
     }
     void SendProposeRequest(const NActors::TActorContext &ctx);
     void FillProposeRequest(TEvTxUserProxy::TEvProposeTransaction& proposal, const NActors::TActorContext &ctx);
-    TStructuredLogPrefix LogPrefix() const override;
+    TStructuredMessage LogPrefix() const override;
     bool IsOurPipe(const TActorId& clientId) const;
     void ReplyAndDie(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus status, const TActorContext& ctx);
 

--- a/ydb/core/persqueue/pqrb/partition_scale_request.h
+++ b/ydb/core/persqueue/pqrb/partition_scale_request.h
@@ -1,13 +1,12 @@
 #pragma once
 
 #include "ydb/core/base/tablet_pipe.h"
+#include <ydb/core/persqueue/common/logging.h>
 #include "ydb/core/persqueue/events/internal.h"
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/tx/tx_proxy/proxy.h>
-#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
-#include <ydb/library/actors/core/log.h>
 
 #include <util/generic/string.h>
 

--- a/ydb/core/persqueue/pqrb/read_balancer.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer.cpp
@@ -421,7 +421,6 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvUpdateBalancerConfig::TPtr 
 
 TStructuredLogPrefix TPersQueueReadBalancer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"tabletId", TabletID()},
         {"topic", Topic});
 }
 

--- a/ydb/core/persqueue/pqrb/read_balancer.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer.cpp
@@ -241,8 +241,6 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvUpdateBalancerConfig::TPtr 
         } else { //version already applied
             YDB_LOG_DEBUG("BALANCER Topic Tablet Config already applied version actor txId",
                 {LogPrefix()},
-                {"topic", Topic},
-                {"tabletID", TabletID()},
                 {"version", record.GetVersion()},
                 {"sender", ev->Sender},
                 {"txId", record.GetTxId()});
@@ -439,14 +437,14 @@ void TPersQueueReadBalancer::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev,
     if (it == TabletPipes.end() || it->second.PipeActor != ev->Get()->ClientId) {
         YDB_LOG_DEBUG("TEvClientDestroyed for stale pipe",
             {LogPrefix()},
-            {"tabletId", tabletId},
+            {"partitionTabletId", tabletId},
             {"clientId", ev->Get()->ClientId});
         return;
     }
 
     YDB_LOG_DEBUG("TEvClientDestroyed",
         {LogPrefix()},
-        {"tabletId", tabletId});
+        {"partitionTabletId", tabletId});
 
     ClosePipe(tabletId, ctx);
     RequestTabletIfNeeded(tabletId, ctx, true);
@@ -460,7 +458,7 @@ void TPersQueueReadBalancer::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev,
     if (it == TabletPipes.end() || it->second.PipeActor != ev->Get()->ClientId) {
         YDB_LOG_DEBUG("TEvClientConnected for stale pipe",
             {LogPrefix()},
-            {"tabletId", tabletId},
+            {"partitionTabletId", tabletId},
             {"clientId", ev->Get()->ClientId});
         return;
     }
@@ -474,7 +472,7 @@ void TPersQueueReadBalancer::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev,
         YDB_LOG_ERROR("TEvClientConnected Status TabletId",
             {LogPrefix()},
             {"status", ev->Get()->Status},
-            {"tabletId", tabletId});
+            {"partitionTabletId", tabletId});
         return;
     }
 
@@ -490,7 +488,7 @@ void TPersQueueReadBalancer::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev,
 
     YDB_LOG_DEBUG("TEvClientConnected TabletId NodeId Generation",
         {LogPrefix()},
-        {"tabletId", tabletId},
+        {"partitionTabletId", tabletId},
         {"nodeId", ev->Get()->ServerId.NodeId()},
         {"generation", ev->Get()->Generation});
 
@@ -549,7 +547,7 @@ void TPersQueueReadBalancer::RequestTabletIfNeeded(const ui64 tabletId, const TA
 
         YDB_LOG_DEBUG("Send TEvPersQueue::TEvStatus",
             {LogPrefix()},
-            {"tabletId", tabletId},
+            {"partitionTabletId", tabletId},
             {"cookie", cookie});
         NTabletPipe::SendData(ctx, pipeClient, new TEvPersQueue::TEvStatus("", true), cookie);
     }
@@ -754,8 +752,7 @@ void TPersQueueReadBalancer::Handle(NSchemeShard::TEvSchemeShard::TEvSubDomainPa
     {
         YDB_LOG_DEBUG("Discovered subdomain at RB",
             {LogPrefix()},
-            {"localPathId", msg->LocalPathId},
-            {"tabletID", TabletID()});
+            {"localPathId", msg->LocalPathId});
 
         SubDomainPathId.emplace(msg->SchemeShardId, msg->LocalPathId);
         Execute(new TTxWriteSubDomainPathId(this), ctx);
@@ -812,8 +809,7 @@ void TPersQueueReadBalancer::Handle(TEvTxProxySchemeCache::TEvWatchNotifyUpdated
         YDB_LOG_DEBUG("Discovered subdomain state, at RB",
             {LogPrefix()},
             {"pathId", msg->PathId},
-            {"outOfSpace", outOfSpace},
-            {"tabletID", TabletID()});
+            {"outOfSpace", outOfSpace});
 
         SubDomainOutOfSpace = outOfSpace;
 

--- a/ydb/core/persqueue/pqrb/read_balancer.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer.cpp
@@ -41,6 +41,7 @@ TString EncodeAnchor(const TString& v) {
 TPersQueueReadBalancer::TPersQueueReadBalancer(const TActorId &tablet, TTabletStorageInfo *info)
         : TActor(&TThis::StateInit)
         , TTabletExecutedFlat(info, tablet, new NMiniKQL::TMiniKQLFactory)
+        , TLogPrefix(NKikimrServices::PERSQUEUE_READ_BALANCER)
         , Inited(false)
         , PathId(0)
         , Generation(0)
@@ -154,9 +155,7 @@ void TPersQueueReadBalancer::InitDone(const TActorContext &ctx) {
         }
         return s;
     };
-    YDB_LOG_DEBUG("BALANCER INIT DONE dump logPrefix, getInitLog",
-        {LogPrefix()},
-        {"getInitLog", getInitLog()});
+    LOG_D("BALANCER INIT DONE dump logPrefix, getInitLog", {"getInitLog", getInitLog()});
 
     for (auto &ev : UpdateEvents) {
         ctx.Send(ctx.SelfID, ev.Release());
@@ -178,8 +177,7 @@ void TPersQueueReadBalancer::InitDone(const TActorContext &ctx) {
 }
 
 void TPersQueueReadBalancer::HandleWakeup(TEvents::TEvWakeup::TPtr& ev, const TActorContext &ctx) {
-    YDB_LOG_DEBUG("TPersQueueReadBalancer::HandleWakeup",
-        {LogPrefix()});
+    LOG_D("TPersQueueReadBalancer::HandleWakeup");
 
     switch (ev->Get()->Tag) {
         case TPartitionScaleManager::TRY_SCALE_REQUEST_WAKE_UP_TAG: {
@@ -239,9 +237,7 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvUpdateBalancerConfig::TPtr 
         if (!WaitingResponse.empty()) { //got transaction infly
             WaitingResponse.push_back(ev->Sender);
         } else { //version already applied
-            YDB_LOG_DEBUG("BALANCER Topic Tablet Config already applied version actor txId",
-                {LogPrefix()},
-                {"version", record.GetVersion()},
+            LOG_D("BALANCER Topic Tablet Config already applied version actor txId", {"version", record.GetVersion()},
                 {"sender", ev->Sender},
                 {"txId", record.GetTxId()});
             THolder<TEvPersQueue::TEvUpdateConfigResponse> res{new TEvPersQueue::TEvUpdateConfigResponse};
@@ -423,7 +419,7 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvUpdateBalancerConfig::TPtr 
 }
 
 
-NActors::NStructuredLog::TStructuredMessage TPersQueueReadBalancer::LogPrefix() const {
+TStructuredLogPrefix TPersQueueReadBalancer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"tabletId", TabletID()},
         {"topic", Topic});
@@ -435,16 +431,12 @@ void TPersQueueReadBalancer::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev,
     auto tabletId = ev->Get()->TabletId;
     auto it = TabletPipes.find(tabletId);
     if (it == TabletPipes.end() || it->second.PipeActor != ev->Get()->ClientId) {
-        YDB_LOG_DEBUG("TEvClientDestroyed for stale pipe",
-            {LogPrefix()},
-            {"partitionTabletId", tabletId},
+        LOG_D("TEvClientDestroyed for stale pipe", {"partitionTabletId", tabletId},
             {"clientId", ev->Get()->ClientId});
         return;
     }
 
-    YDB_LOG_DEBUG("TEvClientDestroyed",
-        {LogPrefix()},
-        {"partitionTabletId", tabletId});
+    LOG_D("TEvClientDestroyed", {"partitionTabletId", tabletId});
 
     ClosePipe(tabletId, ctx);
     RequestTabletIfNeeded(tabletId, ctx, true);
@@ -456,9 +448,7 @@ void TPersQueueReadBalancer::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev,
     auto tabletId = ev->Get()->TabletId;
     auto it = TabletPipes.find(tabletId);
     if (it == TabletPipes.end() || it->second.PipeActor != ev->Get()->ClientId) {
-        YDB_LOG_DEBUG("TEvClientConnected for stale pipe",
-            {LogPrefix()},
-            {"partitionTabletId", tabletId},
+        LOG_D("TEvClientConnected for stale pipe", {"partitionTabletId", tabletId},
             {"clientId", ev->Get()->ClientId});
         return;
     }
@@ -469,9 +459,7 @@ void TPersQueueReadBalancer::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev,
         ClosePipe(ev->Get()->TabletId, ctx);
         RequestTabletIfNeeded(ev->Get()->TabletId, ctx, true);
 
-        YDB_LOG_ERROR("TEvClientConnected Status TabletId",
-            {LogPrefix()},
-            {"status", ev->Get()->Status},
+        LOG_E("TEvClientConnected Status TabletId", {"status", ev->Get()->Status},
             {"partitionTabletId", tabletId});
         return;
     }
@@ -486,9 +474,7 @@ void TPersQueueReadBalancer::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev,
         ++ReadyPartitionTablets;
     }
 
-    YDB_LOG_DEBUG("TEvClientConnected TabletId NodeId Generation",
-        {LogPrefix()},
-        {"partitionTabletId", tabletId},
+    LOG_D("TEvClientConnected TabletId NodeId Generation", {"partitionTabletId", tabletId},
         {"nodeId", ev->Get()->ServerId.NodeId()},
         {"generation", ev->Get()->Generation});
 
@@ -545,9 +531,7 @@ void TPersQueueReadBalancer::RequestTabletIfNeeded(const ui64 tabletId, const TA
             StatsRequestTracker.Cookies[tabletId] = cookie;
         }
 
-        YDB_LOG_DEBUG("Send TEvPersQueue::TEvStatus",
-            {LogPrefix()},
-            {"partitionTabletId", tabletId},
+        LOG_D("Send TEvPersQueue::TEvStatus", {"partitionTabletId", tabletId},
             {"cookie", cookie});
         NTabletPipe::SendData(ctx, pipeClient, new TEvPersQueue::TEvStatus("", true), cookie);
     }
@@ -629,9 +613,7 @@ void TPersQueueReadBalancer::CheckStat(const TActorContext& ctx) {
     UpdateCounters(ctx);
 
     TEvPersQueue::TEvPeriodicTopicStats* ev = GetStatsEvent();
-    YDB_LOG_DEBUG("Send TEvPeriodicTopicStats",
-        {LogPrefix()},
-        {"pathId", PathId},
+    LOG_D("Send TEvPeriodicTopicStats", {"pathId", PathId},
         {"generation", Generation},
         {"statsReportRound", StatsReportRound},
         {"dataSize", TopicMetricsHandler->GetTopicMetrics().TotalDataSize},
@@ -750,9 +732,7 @@ void TPersQueueReadBalancer::Handle(NSchemeShard::TEvSchemeShard::TEvSubDomainPa
     if (SchemeShardId == msg->SchemeShardId &&
        (!SubDomainPathId || SubDomainPathId->OwnerId != msg->SchemeShardId))
     {
-        YDB_LOG_DEBUG("Discovered subdomain at RB",
-            {LogPrefix()},
-            {"localPathId", msg->LocalPathId});
+        LOG_D("Discovered subdomain at RB", {"localPathId", msg->LocalPathId});
 
         SubDomainPathId.emplace(msg->SchemeShardId, msg->LocalPathId);
         Execute(new TTxWriteSubDomainPathId(this), ctx);
@@ -806,9 +786,7 @@ void TPersQueueReadBalancer::Handle(TEvTxProxySchemeCache::TEvWatchNotifyUpdated
             .GetDomainState()
             .GetDiskQuotaExceeded();
 
-        YDB_LOG_DEBUG("Discovered subdomain state, at RB",
-            {LogPrefix()},
-            {"pathId", msg->PathId},
+        LOG_D("Discovered subdomain state, at RB", {"pathId", msg->PathId},
             {"outOfSpace", outOfSpace});
 
         SubDomainOutOfSpace = outOfSpace;
@@ -888,9 +866,7 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvGetReadSessionsInfo::TPtr& 
 void TPersQueueReadBalancer::Handle(TEvPQ::TEvMLPConsumerStatus::TPtr& ev, const TActorContext& ctx)
 {
     Y_UNUSED(ctx);
-    YDB_LOG_DEBUG("Handle TEvPQ::TEvMLPConsumerStatus",
-        {LogPrefix()},
-        {"ev", ev->Get()->Record.ShortDebugString()});
+    LOG_D("Handle TEvPQ::TEvMLPConsumerStatus", {"ev", ev->Get()->Record.ShortDebugString()});
     MLPBalancer->Handle(ev);
 }
 
@@ -917,16 +893,13 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvBalancingUnsubscribe::TPtr&
 
 void TPersQueueReadBalancer::Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr& ev, const TActorContext& ctx) {
     if (!SplitMergeEnabled(TabletConfig)) {
-        YDB_LOG_DEBUG("Skip TEvPartitionScaleStatusChanged: autopartitioning disabled",
-            {LogPrefix()});
+        LOG_D("Skip TEvPartitionScaleStatusChanged: autopartitioning disabled");
         return;
     }
     auto& record = ev->Get()->Record;
     auto* node = PartitionGraph.GetPartition(record.GetPartitionId());
     if (!node) {
-        YDB_LOG_DEBUG("Skip TEvPartitionScaleStatusChanged: partition not found",
-            {LogPrefix()},
-            {"partitionId", record.GetPartitionId()});
+        LOG_D("Skip TEvPartitionScaleStatusChanged: partition not found", {"partitionId", record.GetPartitionId()});
         return;
     }
 
@@ -939,8 +912,7 @@ void TPersQueueReadBalancer::Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr&
             ctx
         );
     } else {
-        YDB_LOG_NOTICE("Skip TEvPartitionScaleStatusChanged: scale manager isn`t initialized",
-            {LogPrefix()});
+        LOG_N("Skip TEvPartitionScaleStatusChanged: scale manager isn`t initialized");
     }
 }
 
@@ -956,8 +928,7 @@ void TPersQueueReadBalancer::Handle(TPartitionScaleRequest::TEvPartitionScaleReq
 }
 
 void TPersQueueReadBalancer::Handle(TEvPQ::TEvMirrorTopicDescription::TPtr& ev, const TActorContext& ctx) {
-    YDB_LOG_DEBUG("Received TEvMirrorTopicDescription",
-        {LogPrefix()});
+    LOG_D("Received TEvMirrorTopicDescription");
     if (!MirroringEnabled(TabletConfig)) {
         return;
     }
@@ -978,9 +949,7 @@ void TPersQueueReadBalancer::BroadcastPartitionError(const TString& message, con
 }
 
 void TPersQueueReadBalancer::Handle(TEvPQ::TEvMLPGetPartitionRequest::TPtr& ev) {
-    YDB_LOG_DEBUG("Handle TEvPQ::TEvMLPGetPartitionRequest",
-        {LogPrefix()},
-        {"ev", ev->Get()->Record.ShortDebugString()});
+    LOG_D("Handle TEvPQ::TEvMLPGetPartitionRequest", {"ev", ev->Get()->Record.ShortDebugString()});
     PendingMLPGetPartitionRequests.push_back(std::move(ev));
     if (!Inited) {
         return;
@@ -989,9 +958,7 @@ void TPersQueueReadBalancer::Handle(TEvPQ::TEvMLPGetPartitionRequest::TPtr& ev) 
 }
 
 void TPersQueueReadBalancer::Handle(TEvPQ::TEvMLPGetRuntimeAttributesRequest::TPtr& ev) {
-    YDB_LOG_DEBUG("Handle",
-        {LogPrefix()},
-        {"mlpGetRuntimeAttributesRequest", ev->Get()->Record.ShortDebugString()});
+    LOG_D("Handle", {"mlpGetRuntimeAttributesRequest", ev->Get()->Record.ShortDebugString()});
     if (StatsRequestTracker.StatsReceived) {
         return MLPBalancer->Handle(ev);
     }

--- a/ydb/core/persqueue/pqrb/read_balancer.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer.cpp
@@ -155,7 +155,7 @@ void TPersQueueReadBalancer::InitDone(const TActorContext &ctx) {
         return s;
     };
     YDB_LOG_DEBUG("BALANCER INIT DONE dump logPrefix, getInitLog",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"getInitLog", getInitLog()});
 
     for (auto &ev : UpdateEvents) {
@@ -179,7 +179,7 @@ void TPersQueueReadBalancer::InitDone(const TActorContext &ctx) {
 
 void TPersQueueReadBalancer::HandleWakeup(TEvents::TEvWakeup::TPtr& ev, const TActorContext &ctx) {
     YDB_LOG_DEBUG("TPersQueueReadBalancer::HandleWakeup",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     switch (ev->Get()->Tag) {
         case TPartitionScaleManager::TRY_SCALE_REQUEST_WAKE_UP_TAG: {
@@ -240,7 +240,7 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvUpdateBalancerConfig::TPtr 
             WaitingResponse.push_back(ev->Sender);
         } else { //version already applied
             YDB_LOG_DEBUG("BALANCER Topic Tablet Config already applied version actor txId",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"topic", Topic},
                 {"tabletID", TabletID()},
                 {"version", record.GetVersion()},
@@ -425,8 +425,10 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvUpdateBalancerConfig::TPtr 
 }
 
 
-TStringBuilder TPersQueueReadBalancer::LogPrefix() const {
-    return TStringBuilder() << "[" << TabletID() << "][" << Topic << "] ";
+NActors::NStructuredLog::TStructuredMessage TPersQueueReadBalancer::LogPrefix() const {
+    return YDB_LOG_CREATE_MESSAGE(
+        {"tabletId", TabletID()},
+        {"topic", Topic});
 }
 
 
@@ -436,14 +438,14 @@ void TPersQueueReadBalancer::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev,
     auto it = TabletPipes.find(tabletId);
     if (it == TabletPipes.end() || it->second.PipeActor != ev->Get()->ClientId) {
         YDB_LOG_DEBUG("TEvClientDestroyed for stale pipe",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"tabletId", tabletId},
             {"clientId", ev->Get()->ClientId});
         return;
     }
 
     YDB_LOG_DEBUG("TEvClientDestroyed",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"tabletId", tabletId});
 
     ClosePipe(tabletId, ctx);
@@ -457,7 +459,7 @@ void TPersQueueReadBalancer::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev,
     auto it = TabletPipes.find(tabletId);
     if (it == TabletPipes.end() || it->second.PipeActor != ev->Get()->ClientId) {
         YDB_LOG_DEBUG("TEvClientConnected for stale pipe",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"tabletId", tabletId},
             {"clientId", ev->Get()->ClientId});
         return;
@@ -470,7 +472,7 @@ void TPersQueueReadBalancer::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev,
         RequestTabletIfNeeded(ev->Get()->TabletId, ctx, true);
 
         YDB_LOG_ERROR("TEvClientConnected Status TabletId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"status", ev->Get()->Status},
             {"tabletId", tabletId});
         return;
@@ -487,7 +489,7 @@ void TPersQueueReadBalancer::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev,
     }
 
     YDB_LOG_DEBUG("TEvClientConnected TabletId NodeId Generation",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"tabletId", tabletId},
         {"nodeId", ev->Get()->ServerId.NodeId()},
         {"generation", ev->Get()->Generation});
@@ -546,7 +548,7 @@ void TPersQueueReadBalancer::RequestTabletIfNeeded(const ui64 tabletId, const TA
         }
 
         YDB_LOG_DEBUG("Send TEvPersQueue::TEvStatus",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"tabletId", tabletId},
             {"cookie", cookie});
         NTabletPipe::SendData(ctx, pipeClient, new TEvPersQueue::TEvStatus("", true), cookie);
@@ -630,7 +632,7 @@ void TPersQueueReadBalancer::CheckStat(const TActorContext& ctx) {
 
     TEvPersQueue::TEvPeriodicTopicStats* ev = GetStatsEvent();
     YDB_LOG_DEBUG("Send TEvPeriodicTopicStats",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"pathId", PathId},
         {"generation", Generation},
         {"statsReportRound", StatsReportRound},
@@ -751,7 +753,7 @@ void TPersQueueReadBalancer::Handle(NSchemeShard::TEvSchemeShard::TEvSubDomainPa
        (!SubDomainPathId || SubDomainPathId->OwnerId != msg->SchemeShardId))
     {
         YDB_LOG_DEBUG("Discovered subdomain at RB",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"localPathId", msg->LocalPathId},
             {"tabletID", TabletID()});
 
@@ -808,7 +810,7 @@ void TPersQueueReadBalancer::Handle(TEvTxProxySchemeCache::TEvWatchNotifyUpdated
             .GetDiskQuotaExceeded();
 
         YDB_LOG_DEBUG("Discovered subdomain state, at RB",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"pathId", msg->PathId},
             {"outOfSpace", outOfSpace},
             {"tabletID", TabletID()});
@@ -891,7 +893,7 @@ void TPersQueueReadBalancer::Handle(TEvPQ::TEvMLPConsumerStatus::TPtr& ev, const
 {
     Y_UNUSED(ctx);
     YDB_LOG_DEBUG("Handle TEvPQ::TEvMLPConsumerStatus",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"ev", ev->Get()->Record.ShortDebugString()});
     MLPBalancer->Handle(ev);
 }
@@ -920,14 +922,14 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvBalancingUnsubscribe::TPtr&
 void TPersQueueReadBalancer::Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr& ev, const TActorContext& ctx) {
     if (!SplitMergeEnabled(TabletConfig)) {
         YDB_LOG_DEBUG("Skip TEvPartitionScaleStatusChanged: autopartitioning disabled",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         return;
     }
     auto& record = ev->Get()->Record;
     auto* node = PartitionGraph.GetPartition(record.GetPartitionId());
     if (!node) {
         YDB_LOG_DEBUG("Skip TEvPartitionScaleStatusChanged: partition not found",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", record.GetPartitionId()});
         return;
     }
@@ -942,7 +944,7 @@ void TPersQueueReadBalancer::Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr&
         );
     } else {
         YDB_LOG_NOTICE("Skip TEvPartitionScaleStatusChanged: scale manager isn`t initialized",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
     }
 }
 
@@ -959,7 +961,7 @@ void TPersQueueReadBalancer::Handle(TPartitionScaleRequest::TEvPartitionScaleReq
 
 void TPersQueueReadBalancer::Handle(TEvPQ::TEvMirrorTopicDescription::TPtr& ev, const TActorContext& ctx) {
     YDB_LOG_DEBUG("Received TEvMirrorTopicDescription",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
     if (!MirroringEnabled(TabletConfig)) {
         return;
     }
@@ -981,7 +983,7 @@ void TPersQueueReadBalancer::BroadcastPartitionError(const TString& message, con
 
 void TPersQueueReadBalancer::Handle(TEvPQ::TEvMLPGetPartitionRequest::TPtr& ev) {
     YDB_LOG_DEBUG("Handle TEvPQ::TEvMLPGetPartitionRequest",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"ev", ev->Get()->Record.ShortDebugString()});
     PendingMLPGetPartitionRequests.push_back(std::move(ev));
     if (!Inited) {
@@ -992,7 +994,7 @@ void TPersQueueReadBalancer::Handle(TEvPQ::TEvMLPGetPartitionRequest::TPtr& ev) 
 
 void TPersQueueReadBalancer::Handle(TEvPQ::TEvMLPGetRuntimeAttributesRequest::TPtr& ev) {
     YDB_LOG_DEBUG("Handle",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"mlpGetRuntimeAttributesRequest", ev->Get()->Record.ShortDebugString()});
     if (StatsRequestTracker.StatsReceived) {
         return MLPBalancer->Handle(ev);

--- a/ydb/core/persqueue/pqrb/read_balancer.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer.cpp
@@ -419,7 +419,7 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvUpdateBalancerConfig::TPtr 
 }
 
 
-TStructuredLogPrefix TPersQueueReadBalancer::LogPrefix() const {
+TStructuredMessage TPersQueueReadBalancer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"topic", Topic});
 }

--- a/ydb/core/persqueue/pqrb/read_balancer.h
+++ b/ydb/core/persqueue/pqrb/read_balancer.h
@@ -6,6 +6,7 @@
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/engine/minikql/flat_local_tx_factory.h>
+#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/persqueue/public/utils.h>
@@ -13,9 +14,7 @@
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/tx/schemeshard/schemeshard_info_types.h>
-#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/library/actors/core/hfunc.h>
-#include <ydb/library/actors/core/log.h>
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
 
 #include <util/system/hp_timer.h>

--- a/ydb/core/persqueue/pqrb/read_balancer.h
+++ b/ydb/core/persqueue/pqrb/read_balancer.h
@@ -13,6 +13,7 @@
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/tx/schemeshard/schemeshard_info_types.h>
+#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
@@ -98,7 +99,8 @@ private:
 
 
 class TPersQueueReadBalancer : public TActor<TPersQueueReadBalancer>,
-                               public TTabletExecutedFlat {
+                               public TTabletExecutedFlat,
+                               public TLogPrefix {
     struct TTxPreInit;
     struct TTxInit;
     struct TTxWrite;
@@ -163,7 +165,7 @@ class TPersQueueReadBalancer : public TActor<TPersQueueReadBalancer>,
     void Handle(TEvPersQueue::TEvBalancingUnsubscribe::TPtr &ev, const TActorContext& ctx);
     // End kafka integration
 
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
+    TStructuredLogPrefix LogPrefix() const override;
 
     TActorId GetPipeClient(const ui64 tabletId, const TActorContext&);
     void RequestTabletIfNeeded(const ui64 tabletId, const TActorContext&, bool pipeReconnected = false);

--- a/ydb/core/persqueue/pqrb/read_balancer.h
+++ b/ydb/core/persqueue/pqrb/read_balancer.h
@@ -14,6 +14,7 @@
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/tx/schemeshard/schemeshard_info_types.h>
 #include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/log.h>
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
 
 #include <util/system/hp_timer.h>
@@ -162,7 +163,7 @@ class TPersQueueReadBalancer : public TActor<TPersQueueReadBalancer>,
     void Handle(TEvPersQueue::TEvBalancingUnsubscribe::TPtr &ev, const TActorContext& ctx);
     // End kafka integration
 
-    TStringBuilder LogPrefix() const;
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
 
     TActorId GetPipeClient(const ui64 tabletId, const TActorContext&);
     void RequestTabletIfNeeded(const ui64 tabletId, const TActorContext&, bool pipeReconnected = false);

--- a/ydb/core/persqueue/pqrb/read_balancer.h
+++ b/ydb/core/persqueue/pqrb/read_balancer.h
@@ -164,7 +164,7 @@ class TPersQueueReadBalancer : public TActor<TPersQueueReadBalancer>,
     void Handle(TEvPersQueue::TEvBalancingUnsubscribe::TPtr &ev, const TActorContext& ctx);
     // End kafka integration
 
-    TStructuredLogPrefix LogPrefix() const override;
+    TStructuredMessage LogPrefix() const override;
 
     TActorId GetPipeClient(const ui64 tabletId, const TActorContext&);
     void RequestTabletIfNeeded(const ui64 tabletId, const TActorContext&, bool pipeReconnected = false);

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -187,7 +187,7 @@ NActors::NStructuredLog::TStructuredMessage TPartitionFamily::LogPrefix() const 
     return YDB_LOG_CREATE_MESSAGE(
         Consumer.LogPrefix(),
         {"familyId", Id},
-            {"status", FamilyStatusName(Status)},
+        {"status", FamilyStatusName(Status)},
         {"partitions", Partitions});
 }
 
@@ -240,8 +240,7 @@ bool TPartitionFamily::Unlock(const TActorId& sender, ui32 partitionId, const TA
     if (Status != EStatus::Releasing) {
         YDB_LOG_CRIT("Try unlock partition but family status is",
             {LogPrefix()},
-            {"partitionId", partitionId},
-            {"status", Status});
+            {"partitionId", partitionId});
         return false;
     }
 
@@ -366,8 +365,7 @@ void TPartitionFamily::StartReading(TSession& session, const TActorContext& ctx)
         "StartReading session is not registered, family %lu", Id);
     if (Status != EStatus::Free) {
         YDB_LOG_CRIT("Try start reading but the family status is",
-            {LogPrefix()},
-            {"status", Status});
+            {LogPrefix()});
         return;
     }
 

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -197,15 +197,13 @@ void TPartitionFamily::Release(const TActorContext& ctx, ETargetStatus targetSta
     Y_DEBUG_ABORT_UNLESS(Session, "Releasing a family without a session, family %lu", Id);
     if (Status != EStatus::Active) {
         YDB_LOG_CRIT("Releasing the family that isn't active",
-            {LogPrefix()},
-            {"debugStr", DebugStr()});
+            {LogPrefix()});
         return;
     }
 
     if (!Session) {
         YDB_LOG_CRIT("Releasing the family that does not have a session",
-            {LogPrefix()},
-            {"debugStr", DebugStr()});
+            {LogPrefix()});
         return;
     }
 
@@ -410,7 +408,7 @@ void TPartitionFamily::StartReading(TSession& session, const TActorContext& ctx)
 void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, const TActorContext& ctx) {
     YDB_LOG_DEBUG("Attaching partitions",
         {LogPrefix()},
-        {"partitions", JoinRange(", ", partitions.begin(), partitions.end())});
+        {"attachedPartitions", JoinRange(", ", partitions.begin(), partitions.end())});
 
     absl::flat_hash_set<ui32> existedPartitions;
     existedPartitions.insert(Partitions.begin(), Partitions.end());

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -109,7 +109,8 @@ bool TPartition::Reset() {
 //
 
 TPartitionFamily::TPartitionFamily(TConsumer& consumerInfo, size_t id, std::vector<ui32>&& partitions)
-    : Consumer(consumerInfo)
+    : TLogPrefix(NKikimrServices::PERSQUEUE_READ_BALANCER)
+    , Consumer(consumerInfo)
     , Id(id)
     , Status(EStatus::Free)
     , TargetStatus(ETargetStatus::Free)
@@ -174,7 +175,7 @@ ui32 TPartitionFamily::NextStep() {
     return Consumer.NextStep();
 }
 
-NActors::NStructuredLog::TStructuredMessage TPartitionFamily::LogPrefix() const {
+TStructuredLogPrefix TPartitionFamily::LogPrefix() const {
     if (Session) {
         return YDB_LOG_CREATE_MESSAGE(
             Consumer.LogPrefix(),
@@ -196,20 +197,16 @@ void TPartitionFamily::Release(const TActorContext& ctx, ETargetStatus targetSta
     Y_DEBUG_ABORT_UNLESS(IsActive(), "Releasing a family that is not active, family %lu", Id);
     Y_DEBUG_ABORT_UNLESS(Session, "Releasing a family without a session, family %lu", Id);
     if (Status != EStatus::Active) {
-        YDB_LOG_CRIT("Releasing the family that isn't active",
-            {LogPrefix()});
+        LOG_C("Releasing the family that isn't active");
         return;
     }
 
     if (!Session) {
-        YDB_LOG_CRIT("Releasing the family that does not have a session",
-            {LogPrefix()});
+        LOG_C("Releasing the family that does not have a session");
         return;
     }
 
-    YDB_LOG_INFO("Release partitions. Target status",
-        {LogPrefix()},
-        {"lockedPartitions", JoinRange(", ", LockedPartitions.begin(), LockedPartitions.end())},
+    LOG_I("Release partitions. Target status", {"lockedPartitions", JoinRange(", ", LockedPartitions.begin(), LockedPartitions.end())},
         {"targetStatus", targetStatus});
 
     Status = EStatus::Releasing;
@@ -229,23 +226,17 @@ void TPartitionFamily::Release(const TActorContext& ctx, ETargetStatus targetSta
 
 bool TPartitionFamily::Unlock(const TActorId& sender, ui32 partitionId, const TActorContext& ctx) {
     if (!Session || Session->Pipe != sender) {
-        YDB_LOG_DEBUG("Try unlock the partition from other sender",
-            {LogPrefix()},
-            {"partitionId", partitionId});
+        LOG_D("Try unlock the partition from other sender", {"partitionId", partitionId});
         return false;
     }
 
     if (Status != EStatus::Releasing) {
-        YDB_LOG_CRIT("Try unlock partition but family status is",
-            {LogPrefix()},
-            {"partitionId", partitionId});
+        LOG_C("Try unlock partition but family status is", {"partitionId", partitionId});
         return false;
     }
 
     if (!LockedPartitions.erase(partitionId)) {
-        YDB_LOG_CRIT("Try unlock partition but partition isn't locked. Locked partitions are",
-            {LogPrefix()},
-            {"partitionId", partitionId},
+        LOG_C("Try unlock partition but partition isn't locked. Locked partitions are", {"partitionId", partitionId},
             {"lockedPartitions", JoinRange(", ", LockedPartitions.begin(), LockedPartitions.end())});
         return false;
     }
@@ -253,9 +244,7 @@ bool TPartitionFamily::Unlock(const TActorId& sender, ui32 partitionId, const TA
     --Session->ReleasingPartitionCount;
 
     if (!LockedPartitions.empty()) {
-        YDB_LOG_DEBUG("Partition was unlocked, but wait",
-            {LogPrefix()},
-            {"partitionId", partitionId},
+        LOG_D("Partition was unlocked, but wait", {"partitionId", partitionId},
             {"lockedPartitions", JoinRange(", ", LockedPartitions.begin(), LockedPartitions.end())});
         return false;
     }
@@ -285,8 +274,7 @@ bool TPartitionFamily::Reset(ETargetStatus targetStatus, const TActorContext& ct
             return false;
 
         case ETargetStatus::Free:
-            YDB_LOG_TRACE("Is free",
-                {LogPrefix()});
+            LOG_T("Is free");
 
             Status = EStatus::Free;
             AfterRelease();
@@ -300,8 +288,7 @@ bool TPartitionFamily::Reset(ETargetStatus targetStatus, const TActorContext& ct
 
             auto it = Consumer.Families.find(MergeTo);
             if (it == Consumer.Families.end()) {
-                YDB_LOG_DEBUG("Has been released for merge but target family is not exists",
-                    {LogPrefix()});
+                LOG_D("Has been released for merge but target family is not exists");
                 return true;
             }
             auto* targetFamily = it->second.get();
@@ -318,8 +305,7 @@ bool TPartitionFamily::Reset(ETargetStatus targetStatus, const TActorContext& ct
 }
 
 void TPartitionFamily::Destroy(const TActorContext&) {
-    YDB_LOG_DEBUG("Destroyed",
-        {LogPrefix()});
+    LOG_D("Destroyed");
 
     if (Session) {
         Session->Families.erase(Id);
@@ -362,13 +348,11 @@ void TPartitionFamily::StartReading(TSession& session, const TActorContext& ctx)
     Y_DEBUG_ABORT_UNLESS(Consumer.Sessions.contains(session.Pipe),
         "StartReading session is not registered, family %lu", Id);
     if (Status != EStatus::Free) {
-        YDB_LOG_CRIT("Try start reading but the family status is",
-            {LogPrefix()});
+        LOG_C("Try start reading but the family status is");
         return;
     }
 
-    YDB_LOG_TRACE("Start reading",
-        {LogPrefix()});
+    LOG_T("Start reading");
 
     Y_DEBUG_ABORT_UNLESS(IsCommon() || IsLonely(),
         "StartReading special-session family %zu has %zu partitions", Id, Partitions.size());
@@ -377,9 +361,7 @@ void TPartitionFamily::StartReading(TSession& session, const TActorContext& ctx)
     if (!specialLonely) {
         for (auto partitionId : Partitions) {
             if (!IsReadable(partitionId)) {
-                YDB_LOG_DEBUG("Skip start reading because the family has an unreadable partition",
-                    {LogPrefix()},
-                    {"partitionId", partitionId});
+                LOG_D("Skip start reading because the family has an unreadable partition", {"partitionId", partitionId});
                 return;
             }
         }
@@ -406,9 +388,7 @@ void TPartitionFamily::StartReading(TSession& session, const TActorContext& ctx)
 }
 
 void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, const TActorContext& ctx) {
-    YDB_LOG_DEBUG("Attaching partitions",
-        {LogPrefix()},
-        {"attachedPartitions", JoinRange(", ", partitions.begin(), partitions.end())});
+    LOG_D("Attaching partitions", {"attachedPartitions", JoinRange(", ", partitions.begin(), partitions.end())});
 
     absl::flat_hash_set<ui32> existedPartitions;
     existedPartitions.insert(Partitions.begin(), Partitions.end());
@@ -436,8 +416,7 @@ void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, co
         Y_DEBUG_ABORT_UNLESS(Session,
             "Attaching partitions to an active family without a session, family %zu", Id);
         if (!Session) {
-            YDB_LOG_CRIT("Attaching partitions to an active family without a session",
-                {LogPrefix()});
+            LOG_C("Attaching partitions to an active family without a session");
             return;
         }
         if (!Session->AllPartitionsReadable(newPartitions)) {
@@ -485,17 +464,13 @@ void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, co
 }
 
 void TPartitionFamily::ActivatePartition(ui32 partitionId) {
-    YDB_LOG_DEBUG("Activating partition",
-        {LogPrefix()},
-        {"partitionId", partitionId});
+    LOG_D("Activating partition", {"partitionId", partitionId});
 
     ChangePartitionCounters(1, -1);
 }
 
 void TPartitionFamily::InactivatePartition(ui32 partitionId) {
-    YDB_LOG_DEBUG("Inactivating partition",
-        {LogPrefix()},
-        {"partitionId", partitionId});
+    LOG_D("Inactivating partition", {"partitionId", partitionId});
 
     ChangePartitionCounters(-1, 1);
 }
@@ -516,9 +491,7 @@ void TPartitionFamily::ChangePartitionCounters(ssize_t active, ssize_t inactive)
  }
 
 void TPartitionFamily::Merge(TPartitionFamily* other) {
-    YDB_LOG_DEBUG("Merge family with",
-        {LogPrefix()},
-        {"debug", other->DebugStr()});
+    LOG_D("Merge family with", {"debug", other->DebugStr()});
 
     Y_DEBUG_ABORT_UNLESS(!HasSpecialSession(),
         "Cannot merge into a special-session family %zu", Id);
@@ -758,17 +731,13 @@ void TPartitionFamily::LockPartition(ui32 partitionId, const TActorContext& ctx)
     Y_DEBUG_ABORT_UNLESS(IsReadable(partitionId) || (Session && Session->WithGroups() && IsLonely()),
         "Lock unreadable partition %u, family %lu", partitionId, Id);
     if (!Session) {
-        YDB_LOG_CRIT("Lock partition without a session",
-            {LogPrefix()},
-            {"partitionId", partitionId});
+        LOG_C("Lock partition without a session", {"partitionId", partitionId});
         return;
     }
 
     auto step = NextStep();
 
-    YDB_LOG_INFO("Lock partition for generation step",
-        {LogPrefix()},
-        {"partitionId", partitionId},
+    LOG_I("Lock partition for generation step", {"partitionId", partitionId},
         {"debug", Session->DebugStr()},
         {"tabletGeneration", TabletGeneration()},
         {"step", step});
@@ -818,7 +787,8 @@ std::unique_ptr<TEvPersQueue::TEvLockPartition> TPartitionFamily::MakeEvLockPart
 //
 
 TConsumer::TConsumer(TBalancer& balancer, const TString& consumerName)
-    : Balancer(balancer)
+    : TLogPrefix(NKikimrServices::PERSQUEUE_READ_BALANCER)
+    , Balancer(balancer)
     , ConsumerName(consumerName)
     , NextFamilyId(0)
     , WithCommonSessions(false)
@@ -861,9 +831,7 @@ ui32 TConsumer::NextStep() {
 void TConsumer::RegisterPartition(ui32 partitionId, const TActorContext& ctx) {
     auto [_, inserted] = Partitions.try_emplace(partitionId, TPartition());
     if (inserted && IsReadable(partitionId)) {
-        YDB_LOG_DEBUG("Register readable partition",
-            {LogPrefix()},
-            {"partitionId", partitionId});
+        LOG_D("Register readable partition", {"partitionId", partitionId});
 
         CreateFamily({partitionId}, ctx);
     }
@@ -895,9 +863,7 @@ TPartitionFamily* TConsumer::CreateFamily(std::vector<ui32>&& partitions, TParti
         family->AssertInvariants();
     }
 
-    YDB_LOG_DEBUG("Family created",
-        {LogPrefix()},
-        {"family", family->DebugStr()});
+    LOG_D("Family created", {"family", family->DebugStr()});
 
     return family;
 }
@@ -941,9 +907,7 @@ bool TConsumer::BreakUpFamily(TPartitionFamily* family, ui32 partitionId, bool d
     std::vector<TPartitionFamily*> newFamilies;
 
     if (!family->IsLonely()) {
-        YDB_LOG_DEBUG("Break up",
-            {LogPrefix()},
-            {"family", family->DebugStr()},
+        LOG_D("Break up", {"family", family->DebugStr()},
             {"partition", partitionId});
 
         absl::flat_hash_set<ui32> partitions;
@@ -1029,9 +993,7 @@ bool TConsumer::BreakUpFamily(TPartitionFamily* family, ui32 partitionId, bool d
                 }
             }
         } else {
-            YDB_LOG_DEBUG("Can't break up because is not root of family",
-                {LogPrefix()},
-                {"family", family->DebugStr()},
+            LOG_D("Can't break up because is not root of family", {"family", family->DebugStr()},
                 {"partition", partitionId});
         }
     }
@@ -1168,9 +1130,7 @@ TPartitionFamily* TConsumer::FindFamily(ui32 partitionId) {
 }
 
 void TConsumer::RegisterReadingSession(TSession* session, const TActorContext& ctx) {
-    YDB_LOG_INFO("Register reading session",
-        {LogPrefix()},
-        {"debug", session->DebugStr()});
+    LOG_I("Register reading session", {"debug", session->DebugStr()});
 
     Sessions[session->Pipe] = session;
 
@@ -1233,9 +1193,7 @@ void TConsumer::UnregisterReadingSession(TSession* session, const TActorContext&
                 continue;
             }
             if (partition->StopReading()) {
-                YDB_LOG_DEBUG("Finish was reset because the reading session disconnected",
-                    {LogPrefix()},
-                    {"partitionId", partitionId},
+                LOG_D("Finish was reset because the reading session disconnected", {"partitionId", partitionId},
                     {"session", session->SessionName});
                 parentsToReleaseChildren.push_back(partitionId);
             }
@@ -1287,9 +1245,7 @@ void TConsumer::UnregisterReadingSession(TSession* session, const TActorContext&
 bool TConsumer::Unlock(const TActorId& sender, ui32 partitionId, const TActorContext& ctx) {
     auto* family = FindFamily(partitionId);
     if (!family) {
-        YDB_LOG_CRIT("Unlocking the partition from unknown family",
-            {LogPrefix()},
-            {"partitionId", partitionId});
+        LOG_C("Unlocking the partition from unknown family", {"partitionId", partitionId});
         return false;
     }
 
@@ -1331,7 +1287,7 @@ bool TConsumer::ScalingSupport() const {
     return Balancer.ScalingSupport();
 }
 
-NActors::NStructuredLog::TStructuredMessage TConsumer::LogPrefix() const {
+TStructuredLogPrefix TConsumer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         Balancer.LogPrefix(),
         {"consumer", ConsumerName});
@@ -1375,9 +1331,7 @@ bool TConsumer::ProccessReadingFinished(ui32 partitionId, bool wasInactive, cons
     });
 
     if (partition.NeedReleaseChildren()) {
-        YDB_LOG_DEBUG("Attache partitions",
-            {LogPrefix()},
-            {"newPartitions", JoinRange(", ", newPartitions.begin(), newPartitions.end())},
+        LOG_D("Attache partitions", {"newPartitions", JoinRange(", ", newPartitions.begin(), newPartitions.end())},
             {"family", family->DebugStr()});
         for (auto id : newPartitions) {
             std::array<ui32, 1> partitionIds{id};
@@ -1431,9 +1385,7 @@ bool TConsumer::ProccessReadingFinished(ui32 partitionId, bool wasInactive, cons
                     }
                 }
             } else {
-                YDB_LOG_DEBUG("Can't attache partition",
-                    {LogPrefix()},
-                    {"id", id},
+                LOG_D("Can't attache partition", {"id", id},
                     {"family", family->DebugStr()});
                 TPartitionFamily* commonParent = nullptr;
                 if (family->HasSpecialSession()) {
@@ -1478,27 +1430,21 @@ bool TConsumer::ProccessReadingFinished(ui32 partitionId, bool wasInactive, cons
 
 void TConsumer::StartReading(ui32 partitionId, const TActorContext& ctx) {
     if (!GetPartitionInfo(partitionId)) {
-        YDB_LOG_NOTICE("Reading of the partition was started by but partition has been deleted",
-            {LogPrefix()},
-            {"partitionId", partitionId},
+        LOG_N("Reading of the partition was started by but partition has been deleted", {"partitionId", partitionId},
             {"consumerName", ConsumerName});
         return;
     }
 
     auto* partition = GetPartition(partitionId);
     if (!partition) {
-        YDB_LOG_NOTICE("Reading of the partition was started by but partition does not exist",
-            {LogPrefix()},
-            {"partitionId", partitionId},
+        LOG_N("Reading of the partition was started by but partition does not exist", {"partitionId", partitionId},
             {"consumerName", ConsumerName});
         return;
     }
 
     auto wasInactive = partition->IsInactive();
     if (partition->StartReading()) {
-        YDB_LOG_DEBUG("Reading of the partition was started by We stop reading from child partitions",
-            {LogPrefix()},
-            {"partitionId", partitionId},
+        LOG_D("Reading of the partition was started by We stop reading from child partitions", {"partitionId", partitionId},
             {"consumerName", ConsumerName});
 
         auto* family = FindFamily(partitionId);
@@ -1544,26 +1490,20 @@ void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::
     auto partitionId = r.GetPartitionId();
 
     if (!IsReadable(partitionId)) {
-        YDB_LOG_DEBUG("Reading of the partition was finished by but the partition isn't readable",
-            {LogPrefix()},
-            {"partitionId", partitionId},
+        LOG_D("Reading of the partition was finished by but the partition isn't readable", {"partitionId", partitionId},
             {"consumerName", ConsumerName});
         return;
     }
 
     auto* family = FindFamily(partitionId);
     if (!family) {
-        YDB_LOG_DEBUG("Reading of the partition was finished by but the partition hasn't family",
-            {LogPrefix()},
-            {"partitionId", partitionId},
+        LOG_D("Reading of the partition was finished by but the partition hasn't family", {"partitionId", partitionId},
             {"consumerName", ConsumerName});
         return;
     }
 
     if (!family->Session) {
-        YDB_LOG_DEBUG("Reading of the partition was finished by but the partition hasn't reading session",
-            {LogPrefix()},
-            {"partitionId", partitionId},
+        LOG_D("Reading of the partition was finished by but the partition hasn't reading session", {"partitionId", partitionId},
             {"consumerName", ConsumerName});
         return;
     }
@@ -1575,10 +1515,7 @@ void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::
 
     const bool wasInactive = partition.IsInactive();
     if (partition.SetFinishedState(r.GetScaleAwareSDK(), r.GetStartedReadingFromEndOffset()) || wasInactive) {
-        YDB_LOG_DEBUG("Reading of the partition was finished by",
-            {LogPrefix()},
-            {"partitionId", partitionId},
-            {"consumer", r.GetConsumer()},
+        LOG_D("Reading of the partition was finished by", {"partitionId", partitionId},
             {"firstMessage", r.GetStartedReadingFromEndOffset()},
             {"scaleAwareSdk", GetSdkDebugString0(r.GetScaleAwareSDK())});
 
@@ -1588,10 +1525,7 @@ void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::
     } else if (!partition.IsInactive()) {
         auto delay = std::min<size_t>(1ul << partition.Iteration, Balancer.GetLifetimeSeconds()); // TODO use split/merge time
 
-        YDB_LOG_DEBUG("Reading of the partition was finished by Scheduled release of the partition for re-reading. seconds",
-            {LogPrefix()},
-            {"partitionId", partitionId},
-            {"consumer", r.GetConsumer()},
+        LOG_D("Reading of the partition was finished by Scheduled release of the partition for re-reading. seconds", {"partitionId", partitionId},
             {"delay", delay},
             {"firstMessage", r.GetStartedReadingFromEndOffset()},
             {"scaleAwareSdk", GetSdkDebugString0(r.GetScaleAwareSDK())});
@@ -1602,15 +1536,13 @@ void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::
 
 void TConsumer::ScheduleBalance(const TActorContext& ctx) {
     if (BalanceScheduled) {
-        YDB_LOG_TRACE("Rebalancing already was scheduled",
-            {LogPrefix()});
+        LOG_T("Rebalancing already was scheduled");
         return;
     }
 
     BalanceScheduled = true;
 
-    YDB_LOG_DEBUG("Rebalancing was scheduled",
-        {LogPrefix()});
+    LOG_D("Rebalancing was scheduled");
 
     ctx.Send(Balancer.TopicActor.SelfId(), new TEvPQ::TEvBalanceConsumer(ConsumerName));
 }
@@ -1666,9 +1598,7 @@ size_t GetStatistics(const TFamilies& values, TPredicate predicate) {
 }
 
 void TConsumer::Balance(const TActorContext& ctx) {
-    YDB_LOG_DEBUG("Balancing",
-        {LogPrefix()},
-        {"sessions", Sessions.size()},
+    LOG_D("Balancing", {"sessions", Sessions.size()},
         {"families", Families.size()},
         {"unreadableFamilies", UnreadableFamilies.size()},
         {"unreadableFamiliesDebug", DebugStr(UnreadableFamilies)},
@@ -1691,9 +1621,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
             continue;
         }
         if (!family->Session || !family->SpecialSessions.contains(family->Session->Pipe)) {
-            YDB_LOG_DEBUG("Rebalance because exists the special session for it",
-                {LogPrefix()},
-                {"family", family->DebugStr()});
+            LOG_D("Rebalance because exists the special session for it", {"family", family->DebugStr()});
             family->Release(ctx);
         }
     }
@@ -1710,9 +1638,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
 
             const bool hasUnreadable = AnyOf(family->Partitions, [&](ui32 id) { return !IsReadable(id); });
             if (hasUnreadable && (family->IsCommon() || !family->IsLonely())) {
-                YDB_LOG_DEBUG("Skip balancing because the family has an unreadable partition",
-                    {LogPrefix()},
-                    {"family", family->DebugStr()});
+                LOG_D("Skip balancing because the family has an unreadable partition", {"family", family->DebugStr()});
                 continue;
             }
 
@@ -1725,9 +1651,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
             }
 
             if (sit == sessions.end()) {
-                YDB_LOG_DEBUG("Balancing of the failed because there are no suitable reading sessions",
-                    {LogPrefix()},
-                    {"family", family->DebugStr()});
+                LOG_D("Balancing of the failed because there are no suitable reading sessions", {"family", family->DebugStr()});
 
                 continue;
             }
@@ -1737,9 +1661,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
             // Reorder sessions
             sessions.erase(sit);
 
-            YDB_LOG_DEBUG("Balancing",
-                {LogPrefix()},
-                {"family", family->DebugStr()},
+            LOG_D("Balancing", {"family", family->DebugStr()},
                 {"debug", session->DebugStr()});
             family->StartReading(*session, ctx);
 
@@ -1761,9 +1683,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
         auto desiredFamilyCount = familyCount / commonSessions.size();
         auto allowPlusOne = familyCount % commonSessions.size();
 
-        YDB_LOG_DEBUG("Start rebalancing",
-            {LogPrefix()},
-            {"familyCount", familyCount},
+        LOG_D("Start rebalancing", {"familyCount", familyCount},
             {"sessionCount", commonSessions.size()},
             {"desiredFamilyCount", desiredFamilyCount},
             {"allowPlusOne", allowPlusOne});
@@ -1803,9 +1723,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
             }
 
             if (!family->IsActive() || !family->Session) {
-                YDB_LOG_DEBUG("Skip balancing because it is not active",
-                    {LogPrefix()},
-                    {"family", family->DebugStr()});
+                LOG_D("Skip balancing because it is not active", {"family", family->DebugStr()});
 
                 FamiliesRequireBalancing.erase(family->Id);
                 continue;
@@ -1818,18 +1736,14 @@ void TConsumer::Balance(const TActorContext& ctx) {
             }
 
             if (family->Session->ActiveFamilyCount == 1) {
-                YDB_LOG_DEBUG("Skip balancing because it is considered a session that does not read anything else",
-                    {LogPrefix()},
-                    {"family", family->DebugStr()});
+                LOG_D("Skip balancing because it is considered a session that does not read anything else", {"family", family->DebugStr()});
 
                 FamiliesRequireBalancing.erase(family->Id);
                 continue;
             }
 
             if (family->SpecialSessions.size() <= 1) {
-                YDB_LOG_DEBUG("Skip balancing because there are no other suitable reading sessions",
-                    {LogPrefix()},
-                    {"family", family->DebugStr()});
+                LOG_D("Skip balancing because there are no other suitable reading sessions", {"family", family->DebugStr()});
 
                 FamiliesRequireBalancing.erase(family->Id);
                 continue;
@@ -1851,17 +1765,13 @@ void TConsumer::Balance(const TActorContext& ctx) {
                 family->Release(ctx);
                 FamiliesRequireBalancing.erase(family->Id);
             } else {
-                YDB_LOG_DEBUG("Skip balancing because it is already being read by the best session",
-                    {LogPrefix()},
-                    {"family", family->DebugStr()});
+                LOG_D("Skip balancing because it is already being read by the best session", {"family", family->DebugStr()});
             }
         }
     }
 
     auto duration = TAppData::TimeProvider->Now() - startTime;
-    YDB_LOG_DEBUG("Balancing",
-        {LogPrefix()},
-        {"duration", duration});
+    LOG_D("Balancing", {"duration", duration});
 }
 
 void TConsumer::Release(ui32 partitionId, const TActorContext& ctx) {
@@ -1919,7 +1829,8 @@ TString TSession::DebugStr() const {
 //
 
 TBalancer::TBalancer(TPersQueueReadBalancer& topicActor)
-    : TopicActor(topicActor)
+    : TLogPrefix(NKikimrServices::PERSQUEUE_READ_BALANCER)
+    , TopicActor(topicActor)
     , Step(0) {
 }
 
@@ -1977,9 +1888,7 @@ const absl::flat_hash_map<TActorId, std::unique_ptr<TSession>, THash<TActorId>>&
 
 
 void TBalancer::UpdateConfig(const std::vector<ui32>& addedPartitions, const std::vector<ui32>& deletedPartitions, const TActorContext& ctx) {
-    YDB_LOG_DEBUG("Updating configuration. Deleted partitions Added partitions",
-        {LogPrefix()},
-        {"deletedPartitions", JoinRange(", ", deletedPartitions.begin(), deletedPartitions.end())},
+    LOG_D("Updating configuration. Deleted partitions Added partitions", {"deletedPartitions", JoinRange(", ", deletedPartitions.begin(), deletedPartitions.end())},
         {"addedPartitions", JoinRange(", ", addedPartitions.begin(), addedPartitions.end())});
 
     for (auto partitionId : deletedPartitions) {
@@ -2006,18 +1915,14 @@ bool TBalancer::SetCommittedState(const TString& consumerName, ui32 partitionId,
     }
 
     if (!consumer->IsReadable(partitionId)) {
-        YDB_LOG_DEBUG("The offset of the partition was commited by but the partition isn't readable",
-            {LogPrefix()},
-            {"partitionId", partitionId},
+        LOG_D("The offset of the partition was commited by but the partition isn't readable", {"partitionId", partitionId},
             {"consumerName", consumerName});
         return false;
     }
 
     auto wasInactive = consumer->IsInactive(partitionId);
     if (consumer->SetCommittedState(partitionId, generation, cookie)) {
-        YDB_LOG_DEBUG("The offset of the partition was commited by",
-            {LogPrefix()},
-            {"partitionId", partitionId},
+        LOG_D("The offset of the partition was commited by", {"partitionId", partitionId},
             {"consumerName", consumerName});
 
         if (consumer->ProccessReadingFinished(partitionId, wasInactive, ctx)) {
@@ -2042,17 +1947,13 @@ void TBalancer::Handle(TEvPersQueue::TEvReadingPartitionStartedRequest::TPtr& ev
     auto pipeClient = ActorIdFromProto(r.GetPipeClient());
 
     if (pipeClient && !Sessions.contains(pipeClient)) {
-        YDB_LOG_DEBUG("Received TEvReadingPartitionStartedRequest from unknown pipe",
-            {LogPrefix()},
-            {"pipeClient", pipeClient});
+        LOG_D("Received TEvReadingPartitionStartedRequest from unknown pipe", {"pipeClient", pipeClient});
         return;
     }
 
     auto consumer = GetConsumer(r.GetConsumer());
     if (!consumer) {
-        YDB_LOG_DEBUG("Received TEvReadingPartitionStartedRequest from unknown consumer",
-            {LogPrefix()},
-            {"consumer", r.GetConsumer()});
+        LOG_D("Received TEvReadingPartitionStartedRequest from unknown consumer", {"consumer", r.GetConsumer()});
         return;
     }
 
@@ -2064,17 +1965,13 @@ void TBalancer::Handle(TEvPersQueue::TEvReadingPartitionFinishedRequest::TPtr& e
     auto pipeClient = ActorIdFromProto(r.GetPipeClient());
 
     if (pipeClient && !Sessions.contains(pipeClient)) {
-        YDB_LOG_DEBUG("Received TEvReadingPartitionFinishedRequest from unknown pipe",
-            {LogPrefix()},
-            {"pipeClient", pipeClient});
+        LOG_D("Received TEvReadingPartitionFinishedRequest from unknown pipe", {"pipeClient", pipeClient});
         return;
     }
 
     auto consumer = GetConsumer(r.GetConsumer());
     if (!consumer) {
-        YDB_LOG_DEBUG("Received TEvReadingPartitionFinishedRequest from unknown consumer",
-            {LogPrefix()},
-            {"consumer", r.GetConsumer()});
+        LOG_D("Received TEvReadingPartitionFinishedRequest from unknown consumer", {"consumer", r.GetConsumer()});
         return;
     }
 
@@ -2089,26 +1986,20 @@ void TBalancer::Handle(TEvPersQueue::TEvPartitionReleased::TPtr& ev, const TActo
 
     auto* partitionInfo = GetPartitionInfo(partitionId);
     if (!partitionInfo) {
-        YDB_LOG_CRIT("Client pipe got deleted partition",
-            {LogPrefix()},
-            {"clientId", r.GetClientId()},
+        LOG_C("Client pipe got deleted partition", {"clientId", r.GetClientId()},
             {"sender", sender},
             {"r", r});
         return;
     }
 
-    YDB_LOG_INFO("Client released partition from pipe session partition",
-        {LogPrefix()},
-        {"clientId", r.GetClientId()},
+    LOG_I("Client released partition from pipe session partition", {"clientId", r.GetClientId()},
         {"sender", sender},
         {"session", r.GetSession()},
         {"partitionId", partitionId});
 
     auto* consumer = GetConsumer(consumerName);
     if (!consumer) {
-        YDB_LOG_CRIT("Client pipe is not connected and got release partitions request for session",
-            {LogPrefix()},
-            {"clientId", r.GetClientId()},
+        LOG_C("Client pipe is not connected and got release partitions request for session", {"clientId", r.GetClientId()},
             {"sender", sender},
             {"session", r.GetSession()});
         return;
@@ -2132,16 +2023,12 @@ void TBalancer::Handle(TEvPQ::TEvWakeupReleasePartition::TPtr &ev, const TActorC
     }
 
     if (partition->Commited) {
-        YDB_LOG_DEBUG("Skip releasing partition of consumer by reading finished timeout because offset is commited",
-            {LogPrefix()},
-            {"partitionId", msg->PartitionId},
+        LOG_D("Skip releasing partition of consumer by reading finished timeout because offset is commited", {"partitionId", msg->PartitionId},
             {"consumer", msg->Consumer});
         return;
     }
 
-    YDB_LOG_INFO("Releasing partition of consumer by reading finished timeout",
-        {LogPrefix()},
-        {"partitionId", msg->PartitionId},
+    LOG_I("Releasing partition of consumer by reading finished timeout", {"partitionId", msg->PartitionId},
         {"consumer", msg->Consumer});
 
     consumer->Release(msg->PartitionId, ctx);
@@ -2158,30 +2045,22 @@ void TBalancer::Handle(TEvTabletPipe::TEvServerConnected::TPtr& ev, const TActor
     auto& session = it->second;
     ++session->ServerActors;
 
-    YDB_LOG_INFO("Pipe connected; active server",
-        {LogPrefix()},
-        {"sender", sender},
+    LOG_I("Pipe connected; active server", {"sender", sender},
         {"actors", session->ServerActors});
 }
 
 void TBalancer::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TActorContext& ctx) {
-    YDB_LOG_DEBUG("Pipe disconnected",
-        {LogPrefix()},
-        {"clientId", ev->Get()->ClientId});
+    LOG_D("Pipe disconnected", {"clientId", ev->Get()->ClientId});
     Subscriptions.erase(ev->Get()->ClientId);
 
     auto it = Sessions.find(ev->Get()->ClientId);
 
     if (it == Sessions.end()) {
-        YDB_LOG_DEBUG("Pipe disconnected but there aren't sessions exists",
-            {LogPrefix()},
-            {"clientId", ev->Get()->ClientId});
+        LOG_D("Pipe disconnected but there aren't sessions exists", {"clientId", ev->Get()->ClientId});
         return;
     }
 
-    YDB_LOG_INFO("Pipe disconnected; active server",
-        {LogPrefix()},
-        {"clientId", ev->Get()->ClientId},
+    LOG_I("Pipe disconnected; active server", {"clientId", ev->Get()->ClientId},
         {"actors", (it != Sessions.end() ? it->second->ServerActors : -1)});
 
     auto& session = it->second;
@@ -2190,9 +2069,7 @@ void TBalancer::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TAc
     }
 
     if (!session->SessionName.empty()) {
-        YDB_LOG_NOTICE("Pipe client disconnected session",
-            {LogPrefix()},
-            {"eventClientId", ev->Get()->ClientId},
+        LOG_N("Pipe client disconnected session", {"eventClientId", ev->Get()->ClientId},
             {"sessionClientId", session->ClientId},
             {"sessionName", session->SessionName});
 
@@ -2210,9 +2087,7 @@ void TBalancer::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TAc
 
         Sessions.erase(it);
     } else {
-        YDB_LOG_INFO("Pipe disconnected no session",
-            {LogPrefix()},
-            {"clientId", ev->Get()->ClientId});
+        LOG_I("Pipe disconnected no session", {"clientId", ev->Get()->ClientId});
 
         Sessions.erase(it);
     }
@@ -2223,35 +2098,28 @@ void TBalancer::Handle(TEvPersQueue::TEvRegisterReadSession::TPtr& ev, const TAc
     auto& consumerName = r.GetClientId();
 
     TActorId pipe = ActorIdFromProto(r.GetPipeClient());
-    YDB_LOG_NOTICE("Consumer register session for pipe session",
-        {LogPrefix()},
-        {"consumerName", consumerName},
+    LOG_N("Consumer register session for pipe session", {"consumerName", consumerName},
         {"pipe", pipe},
         {"session", r.GetSession()});
 
     if (consumerName.empty()) {
-        YDB_LOG_CRIT("Ignored the session registration with empty consumer name",
-            {LogPrefix()});
+        LOG_C("Ignored the session registration with empty consumer name");
         return;
     }
 
     if (r.GetSession().empty()) {
-        YDB_LOG_CRIT("Ignored the session registration with empty session name",
-            {LogPrefix()});
+        LOG_C("Ignored the session registration with empty session name");
         return;
     }
 
     if (!pipe) {
-        YDB_LOG_CRIT("Ignored the session registration with empty Pipe",
-            {LogPrefix()});
+        LOG_C("Ignored the session registration with empty Pipe");
         return;
     }
 
     auto jt = Sessions.find(pipe);
     if (jt == Sessions.end()) {
-        YDB_LOG_CRIT("Client pipe is not connected and got register session request for session",
-            {LogPrefix()},
-            {"consumerName", consumerName},
+        LOG_C("Client pipe is not connected and got register session request for session", {"consumerName", consumerName},
             {"pipe", pipe},
             {"session", r.GetSession()});
         return;
@@ -2368,9 +2236,7 @@ void TBalancer::Handle(TEvPersQueue::TEvStatusResponse::TPtr& ev, const TActorCo
 }
 
 void TBalancer::ProcessPendingStats(const TActorContext& ctx) {
-    YDB_LOG_DEBUG("ProcessPendingStats. PendingUpdates size",
-        {LogPrefix()},
-        {"pendingUpdatesSize", PendingUpdates.size()});
+    LOG_D("ProcessPendingStats. PendingUpdates size", {"pendingUpdatesSize", PendingUpdates.size()});
 
     GetPartitionGraph().Travers([&](ui32 id) {
         for (auto& d : PendingUpdates[id]) {
@@ -2386,9 +2252,7 @@ void TBalancer::ProcessPendingStats(const TActorContext& ctx) {
 
 void TBalancer::Handle(TEvPersQueue::TEvBalancingSubscribe::TPtr& ev, const TActorContext& ctx) {
     auto& record = ev->Get()->Record;
-    YDB_LOG_DEBUG("Handle TEvPersQueue::TEvBalancingSubscribe",
-        {LogPrefix()},
-        {"ev", record.ShortDebugString()});
+    LOG_D("Handle TEvPersQueue::TEvBalancingSubscribe", {"ev", record.ShortDebugString()});
 
     auto sender = ActorIdFromProto(record.GetSourceActor());
     auto status = Consumers.contains(record.GetConsumer()) ?
@@ -2400,9 +2264,7 @@ void TBalancer::Handle(TEvPersQueue::TEvBalancingSubscribe::TPtr& ev, const TAct
 
 void TBalancer::Handle(TEvPersQueue::TEvBalancingUnsubscribe::TPtr& ev, const TActorContext&) {
     auto& record = ev->Get()->Record;
-    YDB_LOG_DEBUG("Handle TEvPersQueue::TEvBalancingUnsubscribe",
-        {LogPrefix()},
-        {"ev", record.ShortDebugString()});
+    LOG_D("Handle TEvPersQueue::TEvBalancingUnsubscribe", {"ev", record.ShortDebugString()});
 
     auto sender = ActorIdFromProto(record.GetSourceActor());
     auto& consumer = record.GetConsumer();
@@ -2441,7 +2303,7 @@ void TBalancer::Notify(const TActorId subscriber, const TString& consumer, NKiki
     ctx.Send(subscriber, new TEvPersQueue::TEvBalancingSubscribeNotify(TabletGeneration(), ++NotifyCookie, TopicPath(), consumer, status));
 }
 
-NActors::NStructuredLog::TStructuredMessage TBalancer::LogPrefix() const {
+TStructuredLogPrefix TBalancer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"tabletId", TopicActor.TabletID()},
         {"topic", Topic()});

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -175,7 +175,7 @@ ui32 TPartitionFamily::NextStep() {
     return Consumer.NextStep();
 }
 
-TStructuredLogPrefix TPartitionFamily::LogPrefix() const {
+TStructuredMessage TPartitionFamily::LogPrefix() const {
     if (Session) {
         return YDB_LOG_CREATE_MESSAGE(
             Consumer.LogPrefix(),
@@ -1287,7 +1287,7 @@ bool TConsumer::ScalingSupport() const {
     return Balancer.ScalingSupport();
 }
 
-TStructuredLogPrefix TConsumer::LogPrefix() const {
+TStructuredMessage TConsumer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         Balancer.LogPrefix(),
         {"consumer", ConsumerName});
@@ -2303,7 +2303,7 @@ void TBalancer::Notify(const TActorId subscriber, const TString& consumer, NKiki
     ctx.Send(subscriber, new TEvPersQueue::TEvBalancingSubscribeNotify(TabletGeneration(), ++NotifyCookie, TopicPath(), consumer, status));
 }
 
-TStructuredLogPrefix TBalancer::LogPrefix() const {
+TStructuredMessage TBalancer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"tabletId", TopicActor.TabletID()},
         {"topic", Topic()});

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -15,6 +15,18 @@
 
 namespace NKikimr::NPQ::NBalancing {
 
+namespace {
+
+const char* FamilyStatusName(TPartitionFamily::EStatus status) {
+    switch (status) {
+        case TPartitionFamily::EStatus::Active: return "Active";
+        case TPartitionFamily::EStatus::Releasing: return "Releasing";
+        case TPartitionFamily::EStatus::Free: return "Free";
+    }
+    return "Unknown";
+}
+
+}
 
 struct LowLoadSessionComparator {
     bool operator()(const TSession* lhs, const TSession* rhs) const;
@@ -162,14 +174,21 @@ ui32 TPartitionFamily::NextStep() {
     return Consumer.NextStep();
 }
 
-TString TPartitionFamily::LogPrefix() const {
-    TStringBuilder sb;
-    sb << Consumer.LogPrefix() << "family " << Id << " status " << Status
-        << " partitions [" << JoinRange(", ", Partitions.begin(), Partitions.end()) << "] ";
+NActors::NStructuredLog::TStructuredMessage TPartitionFamily::LogPrefix() const {
     if (Session) {
-        sb << "session \"" << Session->SessionName << "\" sender " << Session->Sender << " ";
+        return YDB_LOG_CREATE_MESSAGE(
+            Consumer.LogPrefix(),
+            {"familyId", Id},
+            {"status", FamilyStatusName(Status)},
+            {"partitions", Partitions},
+            {"session", Session->SessionName},
+            {"sender", Session->Sender});
     }
-    return sb;
+    return YDB_LOG_CREATE_MESSAGE(
+        Consumer.LogPrefix(),
+        {"familyId", Id},
+            {"status", FamilyStatusName(Status)},
+        {"partitions", Partitions});
 }
 
 
@@ -178,20 +197,20 @@ void TPartitionFamily::Release(const TActorContext& ctx, ETargetStatus targetSta
     Y_DEBUG_ABORT_UNLESS(Session, "Releasing a family without a session, family %lu", Id);
     if (Status != EStatus::Active) {
         YDB_LOG_CRIT("Releasing the family that isn't active",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"debugStr", DebugStr()});
         return;
     }
 
     if (!Session) {
         YDB_LOG_CRIT("Releasing the family that does not have a session",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"debugStr", DebugStr()});
         return;
     }
 
     YDB_LOG_INFO("Release partitions. Target status",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"lockedPartitions", JoinRange(", ", LockedPartitions.begin(), LockedPartitions.end())},
         {"targetStatus", targetStatus});
 
@@ -213,14 +232,14 @@ void TPartitionFamily::Release(const TActorContext& ctx, ETargetStatus targetSta
 bool TPartitionFamily::Unlock(const TActorId& sender, ui32 partitionId, const TActorContext& ctx) {
     if (!Session || Session->Pipe != sender) {
         YDB_LOG_DEBUG("Try unlock the partition from other sender",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId});
         return false;
     }
 
     if (Status != EStatus::Releasing) {
         YDB_LOG_CRIT("Try unlock partition but family status is",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"status", Status});
         return false;
@@ -228,7 +247,7 @@ bool TPartitionFamily::Unlock(const TActorId& sender, ui32 partitionId, const TA
 
     if (!LockedPartitions.erase(partitionId)) {
         YDB_LOG_CRIT("Try unlock partition but partition isn't locked. Locked partitions are",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"lockedPartitions", JoinRange(", ", LockedPartitions.begin(), LockedPartitions.end())});
         return false;
@@ -238,7 +257,7 @@ bool TPartitionFamily::Unlock(const TActorId& sender, ui32 partitionId, const TA
 
     if (!LockedPartitions.empty()) {
         YDB_LOG_DEBUG("Partition was unlocked, but wait",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"lockedPartitions", JoinRange(", ", LockedPartitions.begin(), LockedPartitions.end())});
         return false;
@@ -270,7 +289,7 @@ bool TPartitionFamily::Reset(ETargetStatus targetStatus, const TActorContext& ct
 
         case ETargetStatus::Free:
             YDB_LOG_TRACE("Is free",
-                {"logPrefix", LogPrefix()});
+                {LogPrefix()});
 
             Status = EStatus::Free;
             AfterRelease();
@@ -285,7 +304,7 @@ bool TPartitionFamily::Reset(ETargetStatus targetStatus, const TActorContext& ct
             auto it = Consumer.Families.find(MergeTo);
             if (it == Consumer.Families.end()) {
                 YDB_LOG_DEBUG("Has been released for merge but target family is not exists",
-                    {"logPrefix", LogPrefix()});
+                    {LogPrefix()});
                 return true;
             }
             auto* targetFamily = it->second.get();
@@ -303,7 +322,7 @@ bool TPartitionFamily::Reset(ETargetStatus targetStatus, const TActorContext& ct
 
 void TPartitionFamily::Destroy(const TActorContext&) {
     YDB_LOG_DEBUG("Destroyed",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     if (Session) {
         Session->Families.erase(Id);
@@ -347,13 +366,13 @@ void TPartitionFamily::StartReading(TSession& session, const TActorContext& ctx)
         "StartReading session is not registered, family %lu", Id);
     if (Status != EStatus::Free) {
         YDB_LOG_CRIT("Try start reading but the family status is",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"status", Status});
         return;
     }
 
     YDB_LOG_TRACE("Start reading",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     Y_DEBUG_ABORT_UNLESS(IsCommon() || IsLonely(),
         "StartReading special-session family %zu has %zu partitions", Id, Partitions.size());
@@ -363,7 +382,7 @@ void TPartitionFamily::StartReading(TSession& session, const TActorContext& ctx)
         for (auto partitionId : Partitions) {
             if (!IsReadable(partitionId)) {
                 YDB_LOG_DEBUG("Skip start reading because the family has an unreadable partition",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"partitionId", partitionId});
                 return;
             }
@@ -392,7 +411,7 @@ void TPartitionFamily::StartReading(TSession& session, const TActorContext& ctx)
 
 void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, const TActorContext& ctx) {
     YDB_LOG_DEBUG("Attaching partitions",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"partitions", JoinRange(", ", partitions.begin(), partitions.end())});
 
     absl::flat_hash_set<ui32> existedPartitions;
@@ -422,7 +441,7 @@ void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, co
             "Attaching partitions to an active family without a session, family %zu", Id);
         if (!Session) {
             YDB_LOG_CRIT("Attaching partitions to an active family without a session",
-                {"logPrefix", LogPrefix()});
+                {LogPrefix()});
             return;
         }
         if (!Session->AllPartitionsReadable(newPartitions)) {
@@ -471,7 +490,7 @@ void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, co
 
 void TPartitionFamily::ActivatePartition(ui32 partitionId) {
     YDB_LOG_DEBUG("Activating partition",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"partitionId", partitionId});
 
     ChangePartitionCounters(1, -1);
@@ -479,7 +498,7 @@ void TPartitionFamily::ActivatePartition(ui32 partitionId) {
 
 void TPartitionFamily::InactivatePartition(ui32 partitionId) {
     YDB_LOG_DEBUG("Inactivating partition",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"partitionId", partitionId});
 
     ChangePartitionCounters(-1, 1);
@@ -502,7 +521,7 @@ void TPartitionFamily::ChangePartitionCounters(ssize_t active, ssize_t inactive)
 
 void TPartitionFamily::Merge(TPartitionFamily* other) {
     YDB_LOG_DEBUG("Merge family with",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"debug", other->DebugStr()});
 
     Y_DEBUG_ABORT_UNLESS(!HasSpecialSession(),
@@ -744,7 +763,7 @@ void TPartitionFamily::LockPartition(ui32 partitionId, const TActorContext& ctx)
         "Lock unreadable partition %u, family %lu", partitionId, Id);
     if (!Session) {
         YDB_LOG_CRIT("Lock partition without a session",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId});
         return;
     }
@@ -752,7 +771,7 @@ void TPartitionFamily::LockPartition(ui32 partitionId, const TActorContext& ctx)
     auto step = NextStep();
 
     YDB_LOG_INFO("Lock partition for generation step",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"partitionId", partitionId},
         {"debug", Session->DebugStr()},
         {"tabletGeneration", TabletGeneration()},
@@ -847,7 +866,7 @@ void TConsumer::RegisterPartition(ui32 partitionId, const TActorContext& ctx) {
     auto [_, inserted] = Partitions.try_emplace(partitionId, TPartition());
     if (inserted && IsReadable(partitionId)) {
         YDB_LOG_DEBUG("Register readable partition",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId});
 
         CreateFamily({partitionId}, ctx);
@@ -881,7 +900,7 @@ TPartitionFamily* TConsumer::CreateFamily(std::vector<ui32>&& partitions, TParti
     }
 
     YDB_LOG_DEBUG("Family created",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"family", family->DebugStr()});
 
     return family;
@@ -927,7 +946,7 @@ bool TConsumer::BreakUpFamily(TPartitionFamily* family, ui32 partitionId, bool d
 
     if (!family->IsLonely()) {
         YDB_LOG_DEBUG("Break up",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"family", family->DebugStr()},
             {"partition", partitionId});
 
@@ -1015,7 +1034,7 @@ bool TConsumer::BreakUpFamily(TPartitionFamily* family, ui32 partitionId, bool d
             }
         } else {
             YDB_LOG_DEBUG("Can't break up because is not root of family",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"family", family->DebugStr()},
                 {"partition", partitionId});
         }
@@ -1154,7 +1173,7 @@ TPartitionFamily* TConsumer::FindFamily(ui32 partitionId) {
 
 void TConsumer::RegisterReadingSession(TSession* session, const TActorContext& ctx) {
     YDB_LOG_INFO("Register reading session",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"debug", session->DebugStr()});
 
     Sessions[session->Pipe] = session;
@@ -1219,7 +1238,7 @@ void TConsumer::UnregisterReadingSession(TSession* session, const TActorContext&
             }
             if (partition->StopReading()) {
                 YDB_LOG_DEBUG("Finish was reset because the reading session disconnected",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"partitionId", partitionId},
                     {"session", session->SessionName});
                 parentsToReleaseChildren.push_back(partitionId);
@@ -1273,7 +1292,7 @@ bool TConsumer::Unlock(const TActorId& sender, ui32 partitionId, const TActorCon
     auto* family = FindFamily(partitionId);
     if (!family) {
         YDB_LOG_CRIT("Unlocking the partition from unknown family",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId});
         return false;
     }
@@ -1316,8 +1335,10 @@ bool TConsumer::ScalingSupport() const {
     return Balancer.ScalingSupport();
 }
 
-TString TConsumer::LogPrefix() const {
-    return TStringBuilder() << Balancer.LogPrefix() << "consumer " << ConsumerName << " ";
+NActors::NStructuredLog::TStructuredMessage TConsumer::LogPrefix() const {
+    return YDB_LOG_CREATE_MESSAGE(
+        Balancer.LogPrefix(),
+        {"consumer", ConsumerName});
 }
 
 bool TConsumer::SetCommittedState(ui32 partitionId, ui32 generation, ui64 cookie) {
@@ -1359,7 +1380,7 @@ bool TConsumer::ProccessReadingFinished(ui32 partitionId, bool wasInactive, cons
 
     if (partition.NeedReleaseChildren()) {
         YDB_LOG_DEBUG("Attache partitions",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"newPartitions", JoinRange(", ", newPartitions.begin(), newPartitions.end())},
             {"family", family->DebugStr()});
         for (auto id : newPartitions) {
@@ -1415,7 +1436,7 @@ bool TConsumer::ProccessReadingFinished(ui32 partitionId, bool wasInactive, cons
                 }
             } else {
                 YDB_LOG_DEBUG("Can't attache partition",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"id", id},
                     {"family", family->DebugStr()});
                 TPartitionFamily* commonParent = nullptr;
@@ -1462,7 +1483,7 @@ bool TConsumer::ProccessReadingFinished(ui32 partitionId, bool wasInactive, cons
 void TConsumer::StartReading(ui32 partitionId, const TActorContext& ctx) {
     if (!GetPartitionInfo(partitionId)) {
         YDB_LOG_NOTICE("Reading of the partition was started by but partition has been deleted",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"consumerName", ConsumerName});
         return;
@@ -1471,7 +1492,7 @@ void TConsumer::StartReading(ui32 partitionId, const TActorContext& ctx) {
     auto* partition = GetPartition(partitionId);
     if (!partition) {
         YDB_LOG_NOTICE("Reading of the partition was started by but partition does not exist",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"consumerName", ConsumerName});
         return;
@@ -1480,7 +1501,7 @@ void TConsumer::StartReading(ui32 partitionId, const TActorContext& ctx) {
     auto wasInactive = partition->IsInactive();
     if (partition->StartReading()) {
         YDB_LOG_DEBUG("Reading of the partition was started by We stop reading from child partitions",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"consumerName", ConsumerName});
 
@@ -1528,7 +1549,7 @@ void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::
 
     if (!IsReadable(partitionId)) {
         YDB_LOG_DEBUG("Reading of the partition was finished by but the partition isn't readable",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"consumerName", ConsumerName});
         return;
@@ -1537,7 +1558,7 @@ void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::
     auto* family = FindFamily(partitionId);
     if (!family) {
         YDB_LOG_DEBUG("Reading of the partition was finished by but the partition hasn't family",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"consumerName", ConsumerName});
         return;
@@ -1545,7 +1566,7 @@ void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::
 
     if (!family->Session) {
         YDB_LOG_DEBUG("Reading of the partition was finished by but the partition hasn't reading session",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"consumerName", ConsumerName});
         return;
@@ -1559,7 +1580,7 @@ void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::
     const bool wasInactive = partition.IsInactive();
     if (partition.SetFinishedState(r.GetScaleAwareSDK(), r.GetStartedReadingFromEndOffset()) || wasInactive) {
         YDB_LOG_DEBUG("Reading of the partition was finished by",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"consumer", r.GetConsumer()},
             {"firstMessage", r.GetStartedReadingFromEndOffset()},
@@ -1572,7 +1593,7 @@ void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::
         auto delay = std::min<size_t>(1ul << partition.Iteration, Balancer.GetLifetimeSeconds()); // TODO use split/merge time
 
         YDB_LOG_DEBUG("Reading of the partition was finished by Scheduled release of the partition for re-reading. seconds",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"consumer", r.GetConsumer()},
             {"delay", delay},
@@ -1586,14 +1607,14 @@ void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::
 void TConsumer::ScheduleBalance(const TActorContext& ctx) {
     if (BalanceScheduled) {
         YDB_LOG_TRACE("Rebalancing already was scheduled",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         return;
     }
 
     BalanceScheduled = true;
 
     YDB_LOG_DEBUG("Rebalancing was scheduled",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     ctx.Send(Balancer.TopicActor.SelfId(), new TEvPQ::TEvBalanceConsumer(ConsumerName));
 }
@@ -1650,7 +1671,7 @@ size_t GetStatistics(const TFamilies& values, TPredicate predicate) {
 
 void TConsumer::Balance(const TActorContext& ctx) {
     YDB_LOG_DEBUG("Balancing",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"sessions", Sessions.size()},
         {"families", Families.size()},
         {"unreadableFamilies", UnreadableFamilies.size()},
@@ -1675,7 +1696,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
         }
         if (!family->Session || !family->SpecialSessions.contains(family->Session->Pipe)) {
             YDB_LOG_DEBUG("Rebalance because exists the special session for it",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"family", family->DebugStr()});
             family->Release(ctx);
         }
@@ -1694,7 +1715,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
             const bool hasUnreadable = AnyOf(family->Partitions, [&](ui32 id) { return !IsReadable(id); });
             if (hasUnreadable && (family->IsCommon() || !family->IsLonely())) {
                 YDB_LOG_DEBUG("Skip balancing because the family has an unreadable partition",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"family", family->DebugStr()});
                 continue;
             }
@@ -1709,7 +1730,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
 
             if (sit == sessions.end()) {
                 YDB_LOG_DEBUG("Balancing of the failed because there are no suitable reading sessions",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"family", family->DebugStr()});
 
                 continue;
@@ -1721,7 +1742,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
             sessions.erase(sit);
 
             YDB_LOG_DEBUG("Balancing",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"family", family->DebugStr()},
                 {"debug", session->DebugStr()});
             family->StartReading(*session, ctx);
@@ -1745,7 +1766,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
         auto allowPlusOne = familyCount % commonSessions.size();
 
         YDB_LOG_DEBUG("Start rebalancing",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"familyCount", familyCount},
             {"sessionCount", commonSessions.size()},
             {"desiredFamilyCount", desiredFamilyCount},
@@ -1787,7 +1808,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
 
             if (!family->IsActive() || !family->Session) {
                 YDB_LOG_DEBUG("Skip balancing because it is not active",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"family", family->DebugStr()});
 
                 FamiliesRequireBalancing.erase(family->Id);
@@ -1802,7 +1823,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
 
             if (family->Session->ActiveFamilyCount == 1) {
                 YDB_LOG_DEBUG("Skip balancing because it is considered a session that does not read anything else",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"family", family->DebugStr()});
 
                 FamiliesRequireBalancing.erase(family->Id);
@@ -1811,7 +1832,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
 
             if (family->SpecialSessions.size() <= 1) {
                 YDB_LOG_DEBUG("Skip balancing because there are no other suitable reading sessions",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"family", family->DebugStr()});
 
                 FamiliesRequireBalancing.erase(family->Id);
@@ -1835,7 +1856,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
                 FamiliesRequireBalancing.erase(family->Id);
             } else {
                 YDB_LOG_DEBUG("Skip balancing because it is already being read by the best session",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"family", family->DebugStr()});
             }
         }
@@ -1843,7 +1864,7 @@ void TConsumer::Balance(const TActorContext& ctx) {
 
     auto duration = TAppData::TimeProvider->Now() - startTime;
     YDB_LOG_DEBUG("Balancing",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"duration", duration});
 }
 
@@ -1961,7 +1982,7 @@ const absl::flat_hash_map<TActorId, std::unique_ptr<TSession>, THash<TActorId>>&
 
 void TBalancer::UpdateConfig(const std::vector<ui32>& addedPartitions, const std::vector<ui32>& deletedPartitions, const TActorContext& ctx) {
     YDB_LOG_DEBUG("Updating configuration. Deleted partitions Added partitions",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"deletedPartitions", JoinRange(", ", deletedPartitions.begin(), deletedPartitions.end())},
         {"addedPartitions", JoinRange(", ", addedPartitions.begin(), addedPartitions.end())});
 
@@ -1990,7 +2011,7 @@ bool TBalancer::SetCommittedState(const TString& consumerName, ui32 partitionId,
 
     if (!consumer->IsReadable(partitionId)) {
         YDB_LOG_DEBUG("The offset of the partition was commited by but the partition isn't readable",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"consumerName", consumerName});
         return false;
@@ -1999,7 +2020,7 @@ bool TBalancer::SetCommittedState(const TString& consumerName, ui32 partitionId,
     auto wasInactive = consumer->IsInactive(partitionId);
     if (consumer->SetCommittedState(partitionId, generation, cookie)) {
         YDB_LOG_DEBUG("The offset of the partition was commited by",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"consumerName", consumerName});
 
@@ -2026,7 +2047,7 @@ void TBalancer::Handle(TEvPersQueue::TEvReadingPartitionStartedRequest::TPtr& ev
 
     if (pipeClient && !Sessions.contains(pipeClient)) {
         YDB_LOG_DEBUG("Received TEvReadingPartitionStartedRequest from unknown pipe",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"pipeClient", pipeClient});
         return;
     }
@@ -2034,7 +2055,7 @@ void TBalancer::Handle(TEvPersQueue::TEvReadingPartitionStartedRequest::TPtr& ev
     auto consumer = GetConsumer(r.GetConsumer());
     if (!consumer) {
         YDB_LOG_DEBUG("Received TEvReadingPartitionStartedRequest from unknown consumer",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"consumer", r.GetConsumer()});
         return;
     }
@@ -2048,7 +2069,7 @@ void TBalancer::Handle(TEvPersQueue::TEvReadingPartitionFinishedRequest::TPtr& e
 
     if (pipeClient && !Sessions.contains(pipeClient)) {
         YDB_LOG_DEBUG("Received TEvReadingPartitionFinishedRequest from unknown pipe",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"pipeClient", pipeClient});
         return;
     }
@@ -2056,7 +2077,7 @@ void TBalancer::Handle(TEvPersQueue::TEvReadingPartitionFinishedRequest::TPtr& e
     auto consumer = GetConsumer(r.GetConsumer());
     if (!consumer) {
         YDB_LOG_DEBUG("Received TEvReadingPartitionFinishedRequest from unknown consumer",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"consumer", r.GetConsumer()});
         return;
     }
@@ -2073,7 +2094,7 @@ void TBalancer::Handle(TEvPersQueue::TEvPartitionReleased::TPtr& ev, const TActo
     auto* partitionInfo = GetPartitionInfo(partitionId);
     if (!partitionInfo) {
         YDB_LOG_CRIT("Client pipe got deleted partition",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"clientId", r.GetClientId()},
             {"sender", sender},
             {"r", r});
@@ -2081,7 +2102,7 @@ void TBalancer::Handle(TEvPersQueue::TEvPartitionReleased::TPtr& ev, const TActo
     }
 
     YDB_LOG_INFO("Client released partition from pipe session partition",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"clientId", r.GetClientId()},
         {"sender", sender},
         {"session", r.GetSession()},
@@ -2090,7 +2111,7 @@ void TBalancer::Handle(TEvPersQueue::TEvPartitionReleased::TPtr& ev, const TActo
     auto* consumer = GetConsumer(consumerName);
     if (!consumer) {
         YDB_LOG_CRIT("Client pipe is not connected and got release partitions request for session",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"clientId", r.GetClientId()},
             {"sender", sender},
             {"session", r.GetSession()});
@@ -2116,14 +2137,14 @@ void TBalancer::Handle(TEvPQ::TEvWakeupReleasePartition::TPtr &ev, const TActorC
 
     if (partition->Commited) {
         YDB_LOG_DEBUG("Skip releasing partition of consumer by reading finished timeout because offset is commited",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", msg->PartitionId},
             {"consumer", msg->Consumer});
         return;
     }
 
     YDB_LOG_INFO("Releasing partition of consumer by reading finished timeout",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"partitionId", msg->PartitionId},
         {"consumer", msg->Consumer});
 
@@ -2142,14 +2163,14 @@ void TBalancer::Handle(TEvTabletPipe::TEvServerConnected::TPtr& ev, const TActor
     ++session->ServerActors;
 
     YDB_LOG_INFO("Pipe connected; active server",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"sender", sender},
         {"actors", session->ServerActors});
 }
 
 void TBalancer::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TActorContext& ctx) {
     YDB_LOG_DEBUG("Pipe disconnected",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"clientId", ev->Get()->ClientId});
     Subscriptions.erase(ev->Get()->ClientId);
 
@@ -2157,13 +2178,13 @@ void TBalancer::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TAc
 
     if (it == Sessions.end()) {
         YDB_LOG_DEBUG("Pipe disconnected but there aren't sessions exists",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"clientId", ev->Get()->ClientId});
         return;
     }
 
     YDB_LOG_INFO("Pipe disconnected; active server",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"clientId", ev->Get()->ClientId},
         {"actors", (it != Sessions.end() ? it->second->ServerActors : -1)});
 
@@ -2174,7 +2195,7 @@ void TBalancer::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TAc
 
     if (!session->SessionName.empty()) {
         YDB_LOG_NOTICE("Pipe client disconnected session",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"eventClientId", ev->Get()->ClientId},
             {"sessionClientId", session->ClientId},
             {"sessionName", session->SessionName});
@@ -2194,7 +2215,7 @@ void TBalancer::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TAc
         Sessions.erase(it);
     } else {
         YDB_LOG_INFO("Pipe disconnected no session",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"clientId", ev->Get()->ClientId});
 
         Sessions.erase(it);
@@ -2207,33 +2228,33 @@ void TBalancer::Handle(TEvPersQueue::TEvRegisterReadSession::TPtr& ev, const TAc
 
     TActorId pipe = ActorIdFromProto(r.GetPipeClient());
     YDB_LOG_NOTICE("Consumer register session for pipe session",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"consumerName", consumerName},
         {"pipe", pipe},
         {"session", r.GetSession()});
 
     if (consumerName.empty()) {
         YDB_LOG_CRIT("Ignored the session registration with empty consumer name",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         return;
     }
 
     if (r.GetSession().empty()) {
         YDB_LOG_CRIT("Ignored the session registration with empty session name",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         return;
     }
 
     if (!pipe) {
         YDB_LOG_CRIT("Ignored the session registration with empty Pipe",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         return;
     }
 
     auto jt = Sessions.find(pipe);
     if (jt == Sessions.end()) {
         YDB_LOG_CRIT("Client pipe is not connected and got register session request for session",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"consumerName", consumerName},
             {"pipe", pipe},
             {"session", r.GetSession()});
@@ -2352,7 +2373,7 @@ void TBalancer::Handle(TEvPersQueue::TEvStatusResponse::TPtr& ev, const TActorCo
 
 void TBalancer::ProcessPendingStats(const TActorContext& ctx) {
     YDB_LOG_DEBUG("ProcessPendingStats. PendingUpdates size",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"pendingUpdatesSize", PendingUpdates.size()});
 
     GetPartitionGraph().Travers([&](ui32 id) {
@@ -2370,7 +2391,7 @@ void TBalancer::ProcessPendingStats(const TActorContext& ctx) {
 void TBalancer::Handle(TEvPersQueue::TEvBalancingSubscribe::TPtr& ev, const TActorContext& ctx) {
     auto& record = ev->Get()->Record;
     YDB_LOG_DEBUG("Handle TEvPersQueue::TEvBalancingSubscribe",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"ev", record.ShortDebugString()});
 
     auto sender = ActorIdFromProto(record.GetSourceActor());
@@ -2384,7 +2405,7 @@ void TBalancer::Handle(TEvPersQueue::TEvBalancingSubscribe::TPtr& ev, const TAct
 void TBalancer::Handle(TEvPersQueue::TEvBalancingUnsubscribe::TPtr& ev, const TActorContext&) {
     auto& record = ev->Get()->Record;
     YDB_LOG_DEBUG("Handle TEvPersQueue::TEvBalancingUnsubscribe",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"ev", record.ShortDebugString()});
 
     auto sender = ActorIdFromProto(record.GetSourceActor());
@@ -2424,8 +2445,10 @@ void TBalancer::Notify(const TActorId subscriber, const TString& consumer, NKiki
     ctx.Send(subscriber, new TEvPersQueue::TEvBalancingSubscribeNotify(TabletGeneration(), ++NotifyCookie, TopicPath(), consumer, status));
 }
 
-TString TBalancer::LogPrefix() const {
-    return TStringBuilder() << "[" << TopicActor.TabletID() << "][" << Topic() << "] ";
+NActors::NStructuredLog::TStructuredMessage TBalancer::LogPrefix() const {
+    return YDB_LOG_CREATE_MESSAGE(
+        {"tabletId", TopicActor.TabletID()},
+        {"topic", Topic()});
 }
 
 ui32 TBalancer::NextStep() {

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.h
@@ -164,7 +164,7 @@ private:
     void LockPartition(ui32 partitionId, const TActorContext& ctx);
     std::unique_ptr<TEvPersQueue::TEvReleasePartition> MakeEvReleasePartition(ui32 partitionId) const;
     std::unique_ptr<TEvPersQueue::TEvLockPartition> MakeEvLockPartition(ui32 partitionId, ui32 step) const;
-    TStructuredLogPrefix LogPrefix() const override;
+    TStructuredMessage LogPrefix() const override;
     void AssertInvariants() const;
 };
 
@@ -250,7 +250,7 @@ struct TConsumer : TLogPrefix {
     bool ScalingSupport() const;
 
 private:
-    TStructuredLogPrefix LogPrefix() const override;
+    TStructuredMessage LogPrefix() const override;
 };
 
 struct TSession {
@@ -349,7 +349,7 @@ public:
     void RenderApp(NApp::TNavigationBar&) const;
 
 private:
-    TStructuredLogPrefix LogPrefix() const override;
+    TStructuredMessage LogPrefix() const override;
     ui32 NextStep();
 
 private:

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.h
@@ -60,7 +60,7 @@ struct TPartition {
 };
 
 // Multiple partitions balancing together always in one reading session
-struct TPartitionFamily {
+struct TPartitionFamily : TLogPrefix {
     friend struct TConsumer;
 
     enum class EStatus {
@@ -164,7 +164,7 @@ private:
     void LockPartition(ui32 partitionId, const TActorContext& ctx);
     std::unique_ptr<TEvPersQueue::TEvReleasePartition> MakeEvReleasePartition(ui32 partitionId) const;
     std::unique_ptr<TEvPersQueue::TEvLockPartition> MakeEvLockPartition(ui32 partitionId, ui32 step) const;
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
+    TStructuredLogPrefix LogPrefix() const override;
     void AssertInvariants() const;
 };
 
@@ -180,7 +180,7 @@ using TOrderedSessions = absl::btree_set<TSession*, SessionComparator>;
 
 // It contains all the logic of balancing the reading sessions of a single consumer: the distribution of partitions
 // across reading sessions, the uniformity of the load.
-struct TConsumer {
+struct TConsumer : TLogPrefix {
     friend struct TPartitionFamily;
 
     TBalancer& Balancer;
@@ -250,7 +250,7 @@ struct TConsumer {
     bool ScalingSupport() const;
 
 private:
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
+    TStructuredLogPrefix LogPrefix() const override;
 };
 
 struct TSession {
@@ -299,7 +299,7 @@ struct TSession {
 };
 
 
-class TBalancer {
+class TBalancer : public TLogPrefix {
     friend struct TConsumer;
 public:
     TBalancer(TPersQueueReadBalancer& topicActor);
@@ -349,7 +349,7 @@ public:
     void RenderApp(NApp::TNavigationBar&) const;
 
 private:
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
+    TStructuredLogPrefix LogPrefix() const override;
     ui32 NextStep();
 
 private:

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.h
@@ -164,7 +164,7 @@ private:
     void LockPartition(ui32 partitionId, const TActorContext& ctx);
     std::unique_ptr<TEvPersQueue::TEvReleasePartition> MakeEvReleasePartition(ui32 partitionId) const;
     std::unique_ptr<TEvPersQueue::TEvLockPartition> MakeEvLockPartition(ui32 partitionId, ui32 step) const;
-    TString LogPrefix() const;
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
     void AssertInvariants() const;
 };
 
@@ -250,7 +250,7 @@ struct TConsumer {
     bool ScalingSupport() const;
 
 private:
-    TString LogPrefix() const;
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
 };
 
 struct TSession {
@@ -349,7 +349,7 @@ public:
     void RenderApp(NApp::TNavigationBar&) const;
 
 private:
-    TString LogPrefix() const;
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
     ui32 NextStep();
 
 private:

--- a/ydb/core/persqueue/pqrb/read_balancer__mlp_balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__mlp_balancing.cpp
@@ -16,7 +16,8 @@ ui64 ReceiveAttemptExpiryToSeconds(TInstant expiry) {
 } // namespace
 
 TMLPConsumer::TMLPConsumer(TMLPBalancer& balancer, const TString& consumerName)
-    : Balancer(balancer)
+    : TLogPrefix(NKikimrServices::PERSQUEUE_READ_BALANCER)
+    , Balancer(balancer)
     , ConsumerName(consumerName) {
 }
 
@@ -44,7 +45,7 @@ const TPartitionGraph& TMLPConsumer::GetPartitionGraph() const {
     return Balancer.GetPartitionGraph();
 }
 
-NActors::NStructuredLog::TStructuredMessage TMLPConsumer::LogPrefix() const {
+TStructuredLogPrefix TMLPConsumer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         Balancer.LogPrefix(),
         {"consumer", ConsumerName});
@@ -211,9 +212,7 @@ void TMLPConsumer::Rebuild() {
         }
     }
 
-    YDB_LOG_DEBUG("Rebuild partitions for balancing",
-        {LogPrefix()},
-        {"partitionsForBalancing", JoinSeq(",", PartitionsForBalancing)});
+    LOG_D("Rebuild partitions for balancing", {"partitionsForBalancing", JoinSeq(",", PartitionsForBalancing)});
 }
 
 const TMLPConsumer::TMetrics& TMLPConsumer::GetMetrics() const {
@@ -221,10 +220,11 @@ const TMLPConsumer::TMetrics& TMLPConsumer::GetMetrics() const {
 }
 
 TMLPBalancer::TMLPBalancer(TPersQueueReadBalancer& topicActor)
-    : TopicActor(topicActor) {
+    : TLogPrefix(NKikimrServices::PERSQUEUE_READ_BALANCER)
+    , TopicActor(topicActor) {
 }
 
-NActors::NStructuredLog::TStructuredMessage TMLPBalancer::LogPrefix() const {
+TStructuredLogPrefix TMLPBalancer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"tabletId", TopicActor.TabletID()},
         {"topic", TopicActor.Topic});
@@ -239,9 +239,7 @@ TPrepareGetPartitionResponse TMLPBalancer::PrepareGetPartitionResponse(
 
     auto* consumerConfig = NPQ::GetConsumer(GetConfig(), consumerName);
     if (!consumerConfig) {
-        YDB_LOG_DEBUG("Consumer does not exist",
-            {LogPrefix()},
-            {"consumerName", consumerName});
+        LOG_D("Consumer does not exist", {"consumerName", consumerName});
         result.IsError = true;
         result.ErrorStatus = Ydb::StatusIds::SCHEME_ERROR;
         result.ErrorMessage = TStringBuilder() << "Consumer '" << consumerName << "' does not exist";
@@ -249,9 +247,7 @@ TPrepareGetPartitionResponse TMLPBalancer::PrepareGetPartitionResponse(
     }
 
     if (consumerConfig->GetType() != NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP) {
-        YDB_LOG_DEBUG("Consumer is not MLP consumer",
-            {LogPrefix()},
-            {"consumerName", consumerName});
+        LOG_D("Consumer is not MLP consumer", {"consumerName", consumerName});
         result.IsError = true;
         result.ErrorStatus = Ydb::StatusIds::SCHEME_ERROR;
         result.ErrorMessage = TStringBuilder() << "Consumer '" << consumerName << "' is not MLP consumer";
@@ -301,18 +297,14 @@ void TMLPBalancer::Handle(TEvPQ::TEvMLPGetRuntimeAttributesRequest::TPtr& ev) {
 
     const auto* consumerConfig = NPQ::GetConsumer(GetConfig(), consumerName);
     if (!consumerConfig) {
-        YDB_LOG_DEBUG("Consumer does not exist",
-            {LogPrefix()},
-            {"consumerName", consumerName});
+        LOG_D("Consumer does not exist", {"consumerName", consumerName});
         TopicActor.Send(ev->Sender, new TEvPQ::TEvMLPErrorResponse(Ydb::StatusIds::SCHEME_ERROR,
             TStringBuilder() << "Consumer '" << consumerName << "' does not exist"), 0, ev->Cookie);
         return;
     }
 
     if (consumerConfig->GetType() != NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP) {
-        YDB_LOG_DEBUG("Consumer is not MLP consumer",
-            {LogPrefix()},
-            {"consumerName", consumerName});
+        LOG_D("Consumer is not MLP consumer", {"consumerName", consumerName});
         TopicActor.Send(ev->Sender, new TEvPQ::TEvMLPErrorResponse(Ydb::StatusIds::SCHEME_ERROR,
             TStringBuilder() << "Consumer '" << consumerName << "' is not MLP consumer"), 0, ev->Cookie);
         return;
@@ -320,9 +312,7 @@ void TMLPBalancer::Handle(TEvPQ::TEvMLPGetRuntimeAttributesRequest::TPtr& ev) {
 
     auto it = Consumers.find(consumerName);
     if (it == Consumers.end()) {
-        YDB_LOG_DEBUG("Consumer is not initialized",
-            {LogPrefix()},
-            {"consumerName", consumerName});
+        LOG_D("Consumer is not initialized", {"consumerName", consumerName});
         TopicActor.Send(ev->Sender, new TEvPQ::TEvMLPGetRuntimeAttributesResponse(0, 0, 0), 0, ev->Cookie);
         return;
     }
@@ -339,9 +329,7 @@ void TMLPBalancer::Handle(TEvPQ::TEvMLPGetRuntimeAttributesRequest::TPtr& ev) {
 }
 
 void TMLPBalancer::Handle(TEvPersQueue::TEvStatusResponse::TPtr& ev, const TActorContext&) {
-    YDB_LOG_DEBUG("Handle TEvPersQueue::TEvStatusResponse",
-        {LogPrefix()},
-        {"ev", ev->Get()->Record.ShortDebugString()});
+    LOG_D("Handle TEvPersQueue::TEvStatusResponse", {"ev", ev->Get()->Record.ShortDebugString()});
 
     absl::flat_hash_map<TString, bool> mlpConsumers;
     for (const auto& consumer : GetConfig().GetConsumers()) {
@@ -386,9 +374,7 @@ void TMLPBalancer::Handle(TEvPersQueue::TEvStatusResponse::TPtr& ev, const TActo
 
 void TMLPBalancer::Handle(TEvPQ::TEvReadingPartitionStatusRequest::TPtr& ev, const TActorContext&) {
     auto& record = ev->Get()->Record;
-    YDB_LOG_DEBUG("Handle TEvPQ::TEvReadingPartitionStatusRequest",
-        {LogPrefix()},
-        {"ev", record.ShortDebugString()});
+    LOG_D("Handle TEvPQ::TEvReadingPartitionStatusRequest", {"ev", record.ShortDebugString()});
     SetUseForReading(record.GetConsumer(),
                      record.GetPartitionId(),
                      true, // reading is finished
@@ -404,9 +390,7 @@ void TMLPBalancer::Handle(TEvPQ::TEvReadingPartitionStatusRequest::TPtr& ev, con
 
 void TMLPBalancer::Handle(TEvPQ::TEvMLPConsumerStatus::TPtr& ev) {
     auto& record = ev->Get()->Record;
-    YDB_LOG_DEBUG("Handle TEvPQ::TEvMLPConsumerStatus",
-        {LogPrefix()},
-        {"ev", record.ShortDebugString()});
+    LOG_D("Handle TEvPQ::TEvMLPConsumerStatus", {"ev", record.ShortDebugString()});
     SetUseForReading(record.GetConsumer(),
                      record.GetPartitionId(),
                      std::nullopt, // reading is finished
@@ -466,16 +450,12 @@ void TMLPBalancer::SetUseForReading(const TString& consumerName,
                                     ui64 cookie) {
     auto* consumerConfig = NPQ::GetConsumer(GetConfig(), consumerName);
     if (!consumerConfig) {
-        YDB_LOG_DEBUG("Consumer does not exist",
-            {LogPrefix()},
-            {"consumerName", consumerName});
+        LOG_D("Consumer does not exist", {"consumerName", consumerName});
         return;
     }
 
     if (consumerConfig->GetType() != NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP) {
-        YDB_LOG_DEBUG("Consumer is not MLP consumer",
-            {LogPrefix()},
-            {"consumerName", consumerName});
+        LOG_D("Consumer is not MLP consumer", {"consumerName", consumerName});
         return;
     }
 

--- a/ydb/core/persqueue/pqrb/read_balancer__mlp_balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__mlp_balancing.cpp
@@ -44,6 +44,12 @@ const TPartitionGraph& TMLPConsumer::GetPartitionGraph() const {
     return Balancer.GetPartitionGraph();
 }
 
+NActors::NStructuredLog::TStructuredMessage TMLPConsumer::LogPrefix() const {
+    return YDB_LOG_CREATE_MESSAGE(
+        Balancer.LogPrefix(),
+        {"consumer", ConsumerName});
+}
+
 const TPartitionGraph::Node* TMLPConsumer::PickNextPartition() {
     if (PartitionsForBalancing.empty()) {
         const auto& activePartitions = Balancer.GetActivePartitions();
@@ -206,7 +212,7 @@ void TMLPConsumer::Rebuild() {
     }
 
     YDB_LOG_DEBUG("Rebuild partitions for balancing",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"partitionsForBalancing", JoinSeq(",", PartitionsForBalancing)});
 }
 
@@ -216,6 +222,12 @@ const TMLPConsumer::TMetrics& TMLPConsumer::GetMetrics() const {
 
 TMLPBalancer::TMLPBalancer(TPersQueueReadBalancer& topicActor)
     : TopicActor(topicActor) {
+}
+
+NActors::NStructuredLog::TStructuredMessage TMLPBalancer::LogPrefix() const {
+    return YDB_LOG_CREATE_MESSAGE(
+        {"tabletId", TopicActor.TabletID()},
+        {"topic", TopicActor.Topic});
 }
 
 TPrepareGetPartitionResponse TMLPBalancer::PrepareGetPartitionResponse(
@@ -228,7 +240,7 @@ TPrepareGetPartitionResponse TMLPBalancer::PrepareGetPartitionResponse(
     auto* consumerConfig = NPQ::GetConsumer(GetConfig(), consumerName);
     if (!consumerConfig) {
         YDB_LOG_DEBUG("Consumer does not exist",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"consumerName", consumerName});
         result.IsError = true;
         result.ErrorStatus = Ydb::StatusIds::SCHEME_ERROR;
@@ -238,7 +250,7 @@ TPrepareGetPartitionResponse TMLPBalancer::PrepareGetPartitionResponse(
 
     if (consumerConfig->GetType() != NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP) {
         YDB_LOG_DEBUG("Consumer is not MLP consumer",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"consumerName", consumerName});
         result.IsError = true;
         result.ErrorStatus = Ydb::StatusIds::SCHEME_ERROR;
@@ -290,7 +302,7 @@ void TMLPBalancer::Handle(TEvPQ::TEvMLPGetRuntimeAttributesRequest::TPtr& ev) {
     const auto* consumerConfig = NPQ::GetConsumer(GetConfig(), consumerName);
     if (!consumerConfig) {
         YDB_LOG_DEBUG("Consumer does not exist",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"consumerName", consumerName});
         TopicActor.Send(ev->Sender, new TEvPQ::TEvMLPErrorResponse(Ydb::StatusIds::SCHEME_ERROR,
             TStringBuilder() << "Consumer '" << consumerName << "' does not exist"), 0, ev->Cookie);
@@ -299,7 +311,7 @@ void TMLPBalancer::Handle(TEvPQ::TEvMLPGetRuntimeAttributesRequest::TPtr& ev) {
 
     if (consumerConfig->GetType() != NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP) {
         YDB_LOG_DEBUG("Consumer is not MLP consumer",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"consumerName", consumerName});
         TopicActor.Send(ev->Sender, new TEvPQ::TEvMLPErrorResponse(Ydb::StatusIds::SCHEME_ERROR,
             TStringBuilder() << "Consumer '" << consumerName << "' is not MLP consumer"), 0, ev->Cookie);
@@ -309,7 +321,7 @@ void TMLPBalancer::Handle(TEvPQ::TEvMLPGetRuntimeAttributesRequest::TPtr& ev) {
     auto it = Consumers.find(consumerName);
     if (it == Consumers.end()) {
         YDB_LOG_DEBUG("Consumer is not initialized",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"consumerName", consumerName});
         TopicActor.Send(ev->Sender, new TEvPQ::TEvMLPGetRuntimeAttributesResponse(0, 0, 0), 0, ev->Cookie);
         return;
@@ -328,7 +340,7 @@ void TMLPBalancer::Handle(TEvPQ::TEvMLPGetRuntimeAttributesRequest::TPtr& ev) {
 
 void TMLPBalancer::Handle(TEvPersQueue::TEvStatusResponse::TPtr& ev, const TActorContext&) {
     YDB_LOG_DEBUG("Handle TEvPersQueue::TEvStatusResponse",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     absl::flat_hash_map<TString, bool> mlpConsumers;
@@ -375,7 +387,7 @@ void TMLPBalancer::Handle(TEvPersQueue::TEvStatusResponse::TPtr& ev, const TActo
 void TMLPBalancer::Handle(TEvPQ::TEvReadingPartitionStatusRequest::TPtr& ev, const TActorContext&) {
     auto& record = ev->Get()->Record;
     YDB_LOG_DEBUG("Handle TEvPQ::TEvReadingPartitionStatusRequest",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"ev", record.ShortDebugString()});
     SetUseForReading(record.GetConsumer(),
                      record.GetPartitionId(),
@@ -393,7 +405,7 @@ void TMLPBalancer::Handle(TEvPQ::TEvReadingPartitionStatusRequest::TPtr& ev, con
 void TMLPBalancer::Handle(TEvPQ::TEvMLPConsumerStatus::TPtr& ev) {
     auto& record = ev->Get()->Record;
     YDB_LOG_DEBUG("Handle TEvPQ::TEvMLPConsumerStatus",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"ev", record.ShortDebugString()});
     SetUseForReading(record.GetConsumer(),
                      record.GetPartitionId(),
@@ -455,14 +467,14 @@ void TMLPBalancer::SetUseForReading(const TString& consumerName,
     auto* consumerConfig = NPQ::GetConsumer(GetConfig(), consumerName);
     if (!consumerConfig) {
         YDB_LOG_DEBUG("Consumer does not exist",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"consumerName", consumerName});
         return;
     }
 
     if (consumerConfig->GetType() != NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP) {
         YDB_LOG_DEBUG("Consumer is not MLP consumer",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"consumerName", consumerName});
         return;
     }

--- a/ydb/core/persqueue/pqrb/read_balancer__mlp_balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__mlp_balancing.cpp
@@ -45,7 +45,7 @@ const TPartitionGraph& TMLPConsumer::GetPartitionGraph() const {
     return Balancer.GetPartitionGraph();
 }
 
-TStructuredLogPrefix TMLPConsumer::LogPrefix() const {
+TStructuredMessage TMLPConsumer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         Balancer.LogPrefix(),
         {"consumer", ConsumerName});
@@ -224,7 +224,7 @@ TMLPBalancer::TMLPBalancer(TPersQueueReadBalancer& topicActor)
     , TopicActor(topicActor) {
 }
 
-TStructuredLogPrefix TMLPBalancer::LogPrefix() const {
+TStructuredMessage TMLPBalancer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"tabletId", TopicActor.TabletID()},
         {"topic", TopicActor.Topic});

--- a/ydb/core/persqueue/pqrb/read_balancer__mlp_balancing.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__mlp_balancing.h
@@ -52,7 +52,7 @@ public:
 
     const NKikimrPQ::TPQTabletConfig& GetConfig() const;
     const TPartitionGraph& GetPartitionGraph() const;
-    TStructuredLogPrefix LogPrefix() const override;
+    TStructuredMessage LogPrefix() const override;
 
 private:
     TDuration GetReceiveAttemptIdPeriod() const;
@@ -121,7 +121,7 @@ public:
     const NKikimrPQ::TPQTabletConfig& GetConfig() const;
     const TPartitionGraph& GetPartitionGraph() const;
     const std::vector<ui32>& GetActivePartitions() const;
-    TStructuredLogPrefix LogPrefix() const override;
+    TStructuredMessage LogPrefix() const override;
 
 private:
     TPersQueueReadBalancer& TopicActor;

--- a/ydb/core/persqueue/pqrb/read_balancer__mlp_balancing.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__mlp_balancing.h
@@ -19,7 +19,7 @@ struct TPrepareGetPartitionResponse {
     TNextPartitionPersistChanges PersistChanges;
 };
 
-class TMLPConsumer {
+class TMLPConsumer : public TLogPrefix {
 public:
     struct TMetrics {
         ui64 Messages = 0;
@@ -52,7 +52,7 @@ public:
 
     const NKikimrPQ::TPQTabletConfig& GetConfig() const;
     const TPartitionGraph& GetPartitionGraph() const;
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
+    TStructuredLogPrefix LogPrefix() const override;
 
 private:
     TDuration GetReceiveAttemptIdPeriod() const;
@@ -85,7 +85,7 @@ private:
     TMetrics Metrics;
 };
 
-class TMLPBalancer {
+class TMLPBalancer : public TLogPrefix {
 public:
     explicit TMLPBalancer(TPersQueueReadBalancer& topicActor);
 
@@ -121,7 +121,7 @@ public:
     const NKikimrPQ::TPQTabletConfig& GetConfig() const;
     const TPartitionGraph& GetPartitionGraph() const;
     const std::vector<ui32>& GetActivePartitions() const;
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
+    TStructuredLogPrefix LogPrefix() const override;
 
 private:
     TPersQueueReadBalancer& TopicActor;

--- a/ydb/core/persqueue/pqrb/read_balancer__mlp_balancing.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__mlp_balancing.h
@@ -52,6 +52,7 @@ public:
 
     const NKikimrPQ::TPQTabletConfig& GetConfig() const;
     const TPartitionGraph& GetPartitionGraph() const;
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
 
 private:
     TDuration GetReceiveAttemptIdPeriod() const;
@@ -120,6 +121,7 @@ public:
     const NKikimrPQ::TPQTabletConfig& GetConfig() const;
     const TPartitionGraph& GetPartitionGraph() const;
     const std::vector<ui32>& GetActivePartitions() const;
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
 
 private:
     TPersQueueReadBalancer& TopicActor;

--- a/ydb/core/persqueue/pqrb/read_balancer_log.h
+++ b/ydb/core/persqueue/pqrb/read_balancer_log.h
@@ -1,11 +1,9 @@
 #pragma once
 
 #include <ydb/library/actors/core/log.h>
-#include <util/generic/string.h>
 
 namespace NKikimr::NPQ {
 
-inline TString LogPrefix() { return {}; }
-
+inline NActors::NStructuredLog::TStructuredMessage LogPrefix() { return {}; }
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqrb/read_balancer_log.h
+++ b/ydb/core/persqueue/pqrb/read_balancer_log.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <ydb/library/actors/core/log.h>
+#include <ydb/core/persqueue/common/logging.h>
 
 namespace NKikimr::NPQ {
 
-inline NActors::NStructuredLog::TStructuredMessage LogPrefix() { return {}; }
+inline TStructuredLogPrefix LogPrefix() { return {}; }
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqrb/read_balancer_log.h
+++ b/ydb/core/persqueue/pqrb/read_balancer_log.h
@@ -4,6 +4,6 @@
 
 namespace NKikimr::NPQ {
 
-inline TStructuredLogPrefix LogPrefix() { return {}; }
+inline TStructuredMessage LogPrefix() { return {}; }
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqrb/read_balancer_partition_location.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer_partition_location.cpp
@@ -50,9 +50,7 @@ void TPersQueueReadBalancer::EnqueuePartitionsLocationRequest(
         .Cookie = ev->Cookie,
     });
 
-    YDB_LOG_DEBUG("Enqueue GetPartitionsLocation request",
-        {LogPrefix()},
-        {"queueSize", PartitionsLocationQueue.size()},
+    LOG_D("Enqueue GetPartitionsLocation request", {"queueSize", PartitionsLocationQueue.size()},
         {"timeout", timeout},
         {"deadline", PartitionsLocationQueue.back().Deadline});
 
@@ -72,9 +70,7 @@ void TPersQueueReadBalancer::ProcessPartitionsLocationQueue(const TActorContext&
         }
 
         if (request.Deadline <= now) {
-            YDB_LOG_DEBUG("GetPartitionsLocation request expired",
-                {LogPrefix()},
-                {"sender", request.Sender});
+            LOG_D("GetPartitionsLocation request expired", {"sender", request.Sender});
             SendPartitionsLocationError(request.Sender, ctx, request.Cookie);
             continue;
         }
@@ -146,9 +142,7 @@ bool TPersQueueReadBalancer::TryRespondPartitionsLocation(
         pResponse->SetNodeId(*iter->second.NodeId);
         pResponse->SetGeneration(*iter->second.Generation);
 
-        YDB_LOG_DEBUG("The partition location was added to response",
-            {LogPrefix()},
-            {"partitionTabletId", tabletId},
+        LOG_D("The partition location was added to response", {"partitionTabletId", tabletId},
             {"partitionId", partitionId},
             {"nodeId", pResponse->GetNodeId()},
             {"generation", pResponse->GetGeneration()});

--- a/ydb/core/persqueue/pqrb/read_balancer_partition_location.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer_partition_location.cpp
@@ -51,7 +51,7 @@ void TPersQueueReadBalancer::EnqueuePartitionsLocationRequest(
     });
 
     YDB_LOG_DEBUG("Enqueue GetPartitionsLocation request",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"queueSize", PartitionsLocationQueue.size()},
         {"timeout", timeout},
         {"deadline", PartitionsLocationQueue.back().Deadline});
@@ -73,7 +73,7 @@ void TPersQueueReadBalancer::ProcessPartitionsLocationQueue(const TActorContext&
 
         if (request.Deadline <= now) {
             YDB_LOG_DEBUG("GetPartitionsLocation request expired",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"sender", request.Sender});
             SendPartitionsLocationError(request.Sender, ctx, request.Cookie);
             continue;
@@ -147,7 +147,7 @@ bool TPersQueueReadBalancer::TryRespondPartitionsLocation(
         pResponse->SetGeneration(*iter->second.Generation);
 
         YDB_LOG_DEBUG("The partition location was added to response",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"tabletId", tabletId},
             {"partitionId", partitionId},
             {"nodeId", pResponse->GetNodeId()},

--- a/ydb/core/persqueue/pqrb/read_balancer_partition_location.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer_partition_location.cpp
@@ -148,7 +148,7 @@ bool TPersQueueReadBalancer::TryRespondPartitionsLocation(
 
         YDB_LOG_DEBUG("The partition location was added to response",
             {LogPrefix()},
-            {"tabletId", tabletId},
+            {"partitionTabletId", tabletId},
             {"partitionId", partitionId},
             {"nodeId", pResponse->GetNodeId()},
             {"generation", pResponse->GetGeneration()});

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
@@ -21,7 +21,7 @@ void TBatchProcessor::Bootstrap(const NActors::TActorContext&) {
     Become(&TThis::StateWork);
 }
 
-TLogPrefix TBatchProcessor::BuildLogPrefix() const {
+TStructuredLogPrefix TBatchProcessor::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "BatchProcessor"},
         {"selfId", SelfId()});

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
@@ -23,8 +23,7 @@ void TBatchProcessor::Bootstrap(const NActors::TActorContext&) {
 
 TStructuredLogPrefix TBatchProcessor::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "BatchProcessor"},
-        {"selfId", SelfId()});
+        {"actorClassName", "BatchProcessor"});
 }
 
 NActors::TActorId TBatchProcessor::GetOrCreateConsumerProcessor(const TString& user) {

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
@@ -21,7 +21,7 @@ void TBatchProcessor::Bootstrap(const NActors::TActorContext&) {
     Become(&TThis::StateWork);
 }
 
-TStructuredLogPrefix TBatchProcessor::BuildLogPrefix() const {
+TStructuredMessage TBatchProcessor::BuildLogPrefix() const {
     return {};
 }
 

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.cpp
@@ -22,8 +22,7 @@ void TBatchProcessor::Bootstrap(const NActors::TActorContext&) {
 }
 
 TStructuredLogPrefix TBatchProcessor::BuildLogPrefix() const {
-    return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "BatchProcessor"});
+    return {};
 }
 
 NActors::TActorId TBatchProcessor::GetOrCreateConsumerProcessor(const TString& user) {

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.h
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.h
@@ -69,7 +69,7 @@ public:
 
     void Bootstrap(const NActors::TActorContext& ctx);
 
-    TStructuredLogPrefix BuildLogPrefix() const override;
+    TStructuredMessage BuildLogPrefix() const override;
 
     void Handle(TEvProcessBatch::TPtr& ev, const NActors::TActorContext& ctx);
     void Handle(TEvProcessBatchKeys::TPtr& ev, const NActors::TActorContext& ctx);

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.h
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.h
@@ -69,7 +69,7 @@ public:
 
     void Bootstrap(const NActors::TActorContext& ctx);
 
-    TLogPrefix BuildLogPrefix() const override;
+    TStructuredLogPrefix BuildLogPrefix() const override;
 
     void Handle(TEvProcessBatch::TPtr& ev, const NActors::TActorContext& ctx);
     void Handle(TEvProcessBatchKeys::TPtr& ev, const NActors::TActorContext& ctx);

--- a/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
@@ -29,7 +29,7 @@ namespace {
 
     void LogKafkaBatchUserError(
         TStringBuf message,
-        const TLogPrefix& logPrefix,
+        const TStructuredLogPrefix& logPrefix,
         ui32 partition,
         ui64 offset,
         const TString& error,
@@ -48,7 +48,7 @@ namespace {
         const IBatchCutter& cutter,
         const TBatchCutterData& data,
         ui64 readStartOffset,
-        const TLogPrefix& logPrefix,
+        const TStructuredLogPrefix& logPrefix,
         const TString& user,
         ui32 partition)
     {
@@ -70,7 +70,7 @@ namespace {
         const IBatchCutter& cutter,
         const TBatchCutterData& data,
         ui64 readStartOffset,
-        const TLogPrefix& logPrefix,
+        const TStructuredLogPrefix& logPrefix,
         ui32 partition)
     {
         auto outcome = cutter.GetKeys(data, readStartOffset);
@@ -90,15 +90,15 @@ namespace {
 TConsumerBatchProcessor::TConsumerBatchProcessor(ui64 tabletId, const NActors::TActorId& tabletActorId, TString user)
     : TBaseTabletActor(tabletId, tabletActorId, NKikimrServices::PERSQUEUE)
     , User(std::move(user))
-    , LogPrefix(YDB_LOG_CREATE_MESSAGE(
+    , LogPrefix_(YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "ConsumerBatchProcessor"},
         {"consumer", User}))
 {
     BatchCutters.emplace(static_cast<int>(Ydb::Topic::CODEC_KAFKA_BATCH) - 1, MakeHolder<TKafkaBatchCutter>());
 }
 
-const TLogPrefix& TConsumerBatchProcessor::GetLogPrefix() const {
-    return LogPrefix;
+const TStructuredLogPrefix& TConsumerBatchProcessor::GetLogPrefix() const {
+    return LogPrefix_;
 }
 
 void TConsumerBatchProcessor::Bootstrap(const NActors::TActorContext& ctx) {

--- a/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
@@ -91,7 +91,6 @@ TConsumerBatchProcessor::TConsumerBatchProcessor(ui64 tabletId, const NActors::T
     : TBaseTabletActor(tabletId, tabletActorId, NKikimrServices::PERSQUEUE)
     , User(std::move(user))
     , LogPrefix_(YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "ConsumerBatchProcessor"},
         {"consumer", User}))
 {
     BatchCutters.emplace(static_cast<int>(Ydb::Topic::CODEC_KAFKA_BATCH) - 1, MakeHolder<TKafkaBatchCutter>());

--- a/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.cpp
@@ -29,7 +29,7 @@ namespace {
 
     void LogKafkaBatchUserError(
         TStringBuf message,
-        const TStructuredLogPrefix& logPrefix,
+        const TStructuredMessage& logPrefix,
         ui32 partition,
         ui64 offset,
         const TString& error,
@@ -48,7 +48,7 @@ namespace {
         const IBatchCutter& cutter,
         const TBatchCutterData& data,
         ui64 readStartOffset,
-        const TStructuredLogPrefix& logPrefix,
+        const TStructuredMessage& logPrefix,
         const TString& user,
         ui32 partition)
     {
@@ -70,7 +70,7 @@ namespace {
         const IBatchCutter& cutter,
         const TBatchCutterData& data,
         ui64 readStartOffset,
-        const TStructuredLogPrefix& logPrefix,
+        const TStructuredMessage& logPrefix,
         ui32 partition)
     {
         auto outcome = cutter.GetKeys(data, readStartOffset);
@@ -96,7 +96,7 @@ TConsumerBatchProcessor::TConsumerBatchProcessor(ui64 tabletId, const NActors::T
     BatchCutters.emplace(static_cast<int>(Ydb::Topic::CODEC_KAFKA_BATCH) - 1, MakeHolder<TKafkaBatchCutter>());
 }
 
-const TStructuredLogPrefix& TConsumerBatchProcessor::GetLogPrefix() const {
+const TStructuredMessage& TConsumerBatchProcessor::GetLogPrefix() const {
     return LogPrefix_;
 }
 

--- a/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.h
+++ b/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.h
@@ -16,7 +16,7 @@ public:
     void Handle(NActors::TEvents::TEvWakeup::TPtr& ev, const NActors::TActorContext& ctx);
     void Handle(NActors::TEvents::TEvPoisonPill::TPtr& ev, const NActors::TActorContext& ctx);
 
-    const TStructuredLogPrefix& GetLogPrefix() const override;
+    const TStructuredMessage& GetLogPrefix() const override;
 
 private:
     STFUNC(StateWork);
@@ -24,7 +24,7 @@ private:
 
 private:
     const TString User;
-    TStructuredLogPrefix LogPrefix_;
+    TStructuredMessage LogPrefix_;
 
     // codec -> batch cutter
     THashMap<int, THolder<IBatchCutter>> BatchCutters;

--- a/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.h
+++ b/ydb/core/persqueue/pqtablet/batching/consumer_batch_processor.h
@@ -16,7 +16,7 @@ public:
     void Handle(NActors::TEvents::TEvWakeup::TPtr& ev, const NActors::TActorContext& ctx);
     void Handle(NActors::TEvents::TEvPoisonPill::TPtr& ev, const NActors::TActorContext& ctx);
 
-    const TLogPrefix& GetLogPrefix() const override;
+    const TStructuredLogPrefix& GetLogPrefix() const override;
 
 private:
     STFUNC(StateWork);
@@ -24,7 +24,7 @@ private:
 
 private:
     const TString User;
-    TLogPrefix LogPrefix;
+    TStructuredLogPrefix LogPrefix_;
 
     // codec -> batch cutter
     THashMap<int, THolder<IBatchCutter>> BatchCutters;

--- a/ydb/core/persqueue/pqtablet/cache/cache_eviction.h
+++ b/ydb/core/persqueue/pqtablet/cache/cache_eviction.h
@@ -5,6 +5,7 @@
 
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/keyvalue/keyvalue_events.h>
+#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/persqueue/pqtablet/blob/blob.h>
 
@@ -185,7 +186,7 @@ namespace NKikimr::NPQ {
     };
 
     /// Intablet (L1) cache logic
-    class TIntabletCache {
+    class TIntabletCache : public TLogPrefix {
     public:
         struct TValueL1 {
             enum ESource : ui32 {
@@ -252,10 +253,18 @@ namespace NKikimr::NPQ {
         };
 
         explicit TIntabletCache(ui64 tabletId)
-            : TabletId(tabletId)
+            : TLogPrefix(NKikimrServices::PERSQUEUE)
+            , TabletId(tabletId)
             , L1Strategy(nullptr)
         {
         }
+
+        TStructuredLogPrefix LogPrefix() const override {
+            return YDB_LOG_CREATE_MESSAGE(
+                {"actorClassName", "IntabletCache"});
+        }
+
+        ui64 TabletId;
 
         const TMapType& CachedMap() const { return Cache; }
         ui64 GetSize() const { return Cache.size(); }
@@ -310,12 +319,11 @@ namespace NKikimr::NPQ {
 
                 reqData.StoredBlobs.emplace_back(kvReq.Partition, reqBlob.Offset, reqBlob.PartNo, blob.Count, blob.InternalPartsCount, blob.Suffix, cached);
 
-                YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PERSQUEUE, "Caching head blob in L1. Partition offset count size actorID",
+                LOG_D("Caching head blob in L1. Partition offset count size actorID",
                     {"blobPartition", blob.Partition},
                     {"blobOffset", blob.Offset},
                     {"blobCount", blob.Count},
-                    {"rawValueSize", reqBlob.RawValue.size()},
-                    {"selfId", ctx.SelfID});
+                    {"rawValueSize", reqBlob.RawValue.size()});
             }
         }
 
@@ -342,20 +350,20 @@ namespace NKikimr::NPQ {
                                                       std::make_tuple(oldBlob.Partition, oldBlob.Offset, oldBlob.PartNo, oldBlob.Count, oldBlob.InternalPartsCount, oldBlob.Suffix, nullptr),
                                                       std::make_tuple(newBlob.Partition, newBlob.Offset, newBlob.PartNo, newBlob.Count, newBlob.InternalPartsCount, newBlob.Suffix, nullptr));
 
-                    YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PERSQUEUE, "Renaming head blob in L1. Old partition old offset old count new partition new offset new count actorID",
+                    LOG_D("Renaming head blob in L1. Old partition old offset old count new partition new offset new count actorID",
                         {"partition", oldBlob.Partition},
                         {"offset", oldBlob.Offset},
                         {"count", oldBlob.Count},
                         {"newPartition", newBlob.Partition},
                         {"newOffset", newBlob.Offset},
-                        {"newCount", newBlob.Count},
-                        {"selfId", ctx.SelfID});
+                        {"newCount", newBlob.Count});
                 }
             }
         }
 
         void DeleteBlobs(const TKvRequest& kvReq, TCacheL2Request& reqData, const TActorContext& ctx)
         {
+            Y_UNUSED(ctx);
             for (const auto& range : kvReq.DeletedBlobs) {
                 auto [lowerBound, upperBound] = MapSubrange(Cache,
                                                             MakeBlobId(range.Begin), range.IncludeBegin,
@@ -367,11 +375,10 @@ namespace NKikimr::NPQ {
                     reqData.RemovedBlobs.emplace_back(blob.Partition, blob.Offset, blob.PartNo, blob.Count, blob.InternalPartsCount, blob.Suffix, nullptr);
                     Counters.Dec(value);
 
-                    YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PERSQUEUE, "Deleting head blob in L1. Partition offset count actorID",
+                    LOG_D("Deleting head blob in L1. Partition offset count actorID",
                         {"blobPartition", blob.Partition},
                         {"blobOffset", blob.Offset},
-                        {"blobCount", blob.Count},
-                        {"selfId", ctx.SelfID});
+                        {"blobCount", blob.Count});
                 }
 
                 Cache.erase(lowerBound, upperBound);
@@ -406,12 +413,11 @@ namespace NKikimr::NPQ {
 
                 reqData->StoredBlobs.emplace_back(kvReq.Partition, reqBlob.Offset, reqBlob.PartNo, reqBlob.Count, reqBlob.InternalPartsCount, reqBlob.Key.GetSuffix(), cached);
 
-                YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PERSQUEUE, "Prefetched blob in L1. Partition offset count size actorID",
+                LOG_D("Prefetched blob in L1. Partition offset count size actorID",
                     {"blobPartition", blob.Partition},
                     {"blobOffset", blob.Offset},
                     {"blobCount", blob.Count},
-                    {"rawValueSize", reqBlob.RawValue.size()},
-                    {"selfId", ctx.SelfID});
+                    {"rawValueSize", reqBlob.RawValue.size()});
                 haveSome = true;
             }
 
@@ -423,9 +429,10 @@ namespace NKikimr::NPQ {
 
         void RemoveEvictedBlob(const TActorContext& ctx, const TBlobId& blob, TCacheValue::TPtr value)
         {
+            Y_UNUSED(ctx);
             auto it = Cache.find(blob);
             if (it == Cache.end()) {
-                YDB_LOG_ERROR_CTX_COMP(ctx, NKikimrServices::PERSQUEUE, "Can't evict. No such blob in L1. Partition offset size cause it's been evicted from L2. Actual L1",
+                LOG_E("Can't evict. No such blob in L1. Partition offset size cause it's been evicted from L2. Actual L1",
                     {"blobPartition", blob.Partition},
                     {"blobOffset", blob.Offset},
                     {"dataSize", value->GetDataSize()},
@@ -435,7 +442,7 @@ namespace NKikimr::NPQ {
 
             auto sp = it->second.GetBlob();
             if (sp.get() != value.get()) {
-                YDB_LOG_CRIT_CTX_COMP(ctx, NKikimrServices::PERSQUEUE, "Evicting strange blob. Partition offset partNo size L1 ptr vs L2 ptr",
+                LOG_C("Evicting strange blob. Partition offset partNo size L1 ptr vs L2 ptr",
                     {"partitionInternalPartitionId", blob.Partition.InternalPartitionId},
                     {"blobOffset", blob.Offset},
                     {"partNo", blob.PartNo},
@@ -445,7 +452,7 @@ namespace NKikimr::NPQ {
             }
             RemoveBlob(it);
 
-            YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PERSQUEUE, "Erasing blob in L1. Partition offset size cause it's been evicted from L2. Actual L1",
+            LOG_D("Erasing blob in L1. Partition offset size cause it's been evicted from L2. Actual L1",
                 {"blobPartition", blob.Partition},
                 {"blobOffset", blob.Offset},
                 {"dataSize", value->GetDataSize()},
@@ -470,10 +477,11 @@ namespace NKikimr::NPQ {
     private:
         void PrepareTouch(const TActorContext& ctx, THolder<TCacheL2Request>& reqData, const TDeque<TBlobId>& used)
         {
+            Y_UNUSED(ctx);
             for (auto& blob : used) {
                 reqData->ExpectedBlobs.emplace_back(blob.Partition, blob.Offset, blob.PartNo, blob.Count, blob.InternalPartsCount, blob.Suffix, nullptr);
 
-                YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PERSQUEUE, "Touching blob. Partition offset count",
+                LOG_D("Touching blob. Partition offset count",
                     {"blobPartition", blob.Partition},
                     {"blobOffset", blob.Offset},
                     {"blobCount", blob.Count});
@@ -482,27 +490,26 @@ namespace NKikimr::NPQ {
 
         TCacheValue::TPtr GetValue(const TActorContext& ctx, const TBlobId& blobId)
         {
+            Y_UNUSED(ctx);
             const auto it = Cache.find(blobId);
             if (it == Cache.end()) {
-                YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PERSQUEUE, "No blob in L1. Partition offset partno count parts_count actorID",
+                LOG_D("No blob in L1. Partition offset partno count parts_count actorID",
                     {"partition", blobId.Partition},
                     {"offset", blobId.Offset},
                     {"partNo", blobId.PartNo},
                     {"count", blobId.Count},
-                    {"internalPartsCount", blobId.InternalPartsCount},
-                    {"selfId", ctx.SelfID});
+                    {"internalPartsCount", blobId.InternalPartsCount});
                 return nullptr;
             }
 
             TCacheValue::TPtr data = it->second.GetBlob();
             if (!data) {
-                YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PERSQUEUE, "Evicted blob in L1. Partition offset partno count parts_count actorID",
+                LOG_D("Evicted blob in L1. Partition offset partno count parts_count actorID",
                     {"partition", blobId.Partition},
                     {"offset", blobId.Offset},
                     {"partNo", blobId.PartNo},
                     {"count", blobId.Count},
-                    {"internalPartsCount", blobId.InternalPartsCount},
-                    {"selfId", ctx.SelfID});
+                    {"internalPartsCount", blobId.InternalPartsCount});
                 RemoveBlob(it);
                 return nullptr;
             }
@@ -512,7 +519,7 @@ namespace NKikimr::NPQ {
                 ("it->second.DataSize", it->second.DataSize);
 
             const TBlobId& blob = it->first;
-            YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PERSQUEUE, "Got data from cache. Partition offset partno count parts_count source size accessed times before, last time",
+            LOG_D("Got data from cache. Partition offset partno count parts_count source size accessed times before, last time",
                 {"blobPartition", blob.Partition},
                 {"blobOffset", blob.Offset},
                 {"partNo", blob.PartNo},
@@ -561,7 +568,6 @@ namespace NKikimr::NPQ {
         }
 
     private:
-        ui64 TabletId;
         TMapType Cache;
         TCounters Counters;
         THolder<TCacheEvictionStrategy> L1Strategy;
@@ -574,16 +580,16 @@ namespace NKikimr::NPQ {
 
         bool CheckExists(const TActorContext& ctx, const TBlobId& blob, TValueL1& out, bool remove = false)
         {
+            Y_UNUSED(ctx);
             auto it = Cache.find(blob);
             if (it != Cache.end()) {
                 out = it->second;
                 AFL_ENSURE(out.GetBlob())("d", "Duplicate blob in L1 with no data");
-                YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PERSQUEUE, "Duplicate blob in L1. Partition offset count size actorID is actual",
+                LOG_D("Duplicate blob in L1. Partition offset count size actorID is actual",
                     {"blobPartition", blob.Partition},
                     {"blobOffset", blob.Offset},
                     {"blobCount", blob.Count},
                     {"dataSize", out.DataSize},
-                    {"selfId", ctx.SelfID},
                     {"hasBlob", (bool)out.GetBlob()});
                 if (remove)
                     RemoveBlob(it);

--- a/ydb/core/persqueue/pqtablet/cache/cache_eviction.h
+++ b/ydb/core/persqueue/pqtablet/cache/cache_eviction.h
@@ -260,8 +260,7 @@ namespace NKikimr::NPQ {
         }
 
         TStructuredLogPrefix LogPrefix() const override {
-            return YDB_LOG_CREATE_MESSAGE(
-                {"actorClassName", "IntabletCache"});
+            return {};
         }
 
         ui64 TabletId;

--- a/ydb/core/persqueue/pqtablet/cache/cache_eviction.h
+++ b/ydb/core/persqueue/pqtablet/cache/cache_eviction.h
@@ -259,7 +259,7 @@ namespace NKikimr::NPQ {
         {
         }
 
-        TStructuredLogPrefix LogPrefix() const override {
+        TStructuredMessage LogPrefix() const override {
             return {};
         }
 

--- a/ydb/core/persqueue/pqtablet/cache/pq_l2_cache.cpp
+++ b/ydb/core/persqueue/pqtablet/cache/pq_l2_cache.cpp
@@ -1,8 +1,6 @@
 #include "pq_l2_cache.h"
 #include <ydb/core/mon/mon.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PERSQUEUE
-
 namespace NKikimr {
 namespace NPQ {
 
@@ -86,6 +84,7 @@ void TPersQueueCacheL2::Handle(TEvPqCache::TEvCacheKeysRequest::TPtr& ev, const 
 void TPersQueueCacheL2::AddBlobs(const TActorContext& ctx, ui64 tabletId, const TVector<TCacheBlobL2>& blobs,
                                  THashMap<TKey, TCacheValue::TPtr>& outEvicted)
 {
+    Y_UNUSED(ctx);
     ui32 numUnused = 0;
     for (const TCacheBlobL2& blob : blobs) {
         AFL_ENSURE(blob.Value->GetDataSize())("d", "Trying to place empty blob into L2 cache");
@@ -93,7 +92,7 @@ void TPersQueueCacheL2::AddBlobs(const TActorContext& ctx, ui64 tabletId, const 
         TKey key(tabletId, blob);
         // PQ tablet could send some data twice (if it's restored after die)
         if (Cache.FindWithoutPromote(key) != Cache.End()) {
-            YDB_LOG_WARN_CTX(ctx, "PQ Cache (L2). Same blob insertion. size",
+            LOG_W("PQ Cache (L2). Same blob insertion. size",
                 {"key", key},
                 {"valueDataSize", blob.Value->GetDataSize()});
             continue;
@@ -124,7 +123,7 @@ void TPersQueueCacheL2::AddBlobs(const TActorContext& ctx, ui64 tabletId, const 
             if (value->GetAccessCount() == 0)
                 ++numUnused;
 
-            YDB_LOG_DEBUG_CTX(ctx, "PQ Cache (L2). Evicting blob. size",
+            LOG_D("PQ Cache (L2). Evicting blob. size",
                 {"key", oldest.Key()},
                 {"dataSize", value->GetDataSize()});
 
@@ -132,7 +131,7 @@ void TPersQueueCacheL2::AddBlobs(const TActorContext& ctx, ui64 tabletId, const 
             Cache.Erase(oldest);
         }
 
-        YDB_LOG_DEBUG_CTX(ctx, "PQ Cache (L2). Adding blob. size",
+        LOG_D("PQ Cache (L2). Adding blob. size",
             {"key", key},
             {"valueDataSize", blob.Value->GetDataSize()});
 
@@ -150,6 +149,7 @@ void TPersQueueCacheL2::AddBlobs(const TActorContext& ctx, ui64 tabletId, const 
 
 void TPersQueueCacheL2::RemoveBlobs(const TActorContext& ctx, ui64 tabletId, const TVector<TCacheBlobL2>& blobs)
 {
+    Y_UNUSED(ctx);
     ui32 numEvicted = 0;
     ui32 numUnused = 0;
     for (const TCacheBlobL2& blob : blobs) {
@@ -160,12 +160,12 @@ void TPersQueueCacheL2::RemoveBlobs(const TActorContext& ctx, ui64 tabletId, con
             numEvicted++;
             if ((*it)->GetAccessCount() == 0)
                 ++numUnused;
-            YDB_LOG_DEBUG_CTX(ctx, "PQ Cache (L2). Removed. size",
+            LOG_D("PQ Cache (L2). Removed. size",
                 {"key", key},
                 {"dataSize", (*it)->GetDataSize()});
             Cache.Erase(it);
         } else {
-            YDB_LOG_DEBUG_CTX(ctx, "PQ Cache (L2). Miss in remove",
+            LOG_D("PQ Cache (L2). Miss in remove",
                 {"key", key});
         }
     }
@@ -182,6 +182,7 @@ void TPersQueueCacheL2::RemoveBlobs(const TActorContext& ctx, ui64 tabletId, con
 void TPersQueueCacheL2::RenameBlobs(const TActorContext& ctx, ui64 tabletId,
                                     const TVector<std::pair<TCacheBlobL2, TCacheBlobL2>>& blobs)
 {
+    Y_UNUSED(ctx);
     RenamedKeys += blobs.size();
 
     for (const auto& [oldBlob, newBlob] : blobs) {
@@ -196,7 +197,7 @@ void TPersQueueCacheL2::RenameBlobs(const TActorContext& ctx, ui64 tabletId,
         Cache.Insert(newKey, *it);
         Cache.Erase(it);
 
-        YDB_LOG_DEBUG_CTX(ctx, "PQ Cache (L2). Renamed. old new",
+        LOG_D("PQ Cache (L2). Renamed. old new",
             {"oldKey", oldKey},
             {"newKey", newKey});
     }
@@ -204,6 +205,7 @@ void TPersQueueCacheL2::RenameBlobs(const TActorContext& ctx, ui64 tabletId,
 
 void TPersQueueCacheL2::TouchBlobs(const TActorContext& ctx, ui64 tabletId, const TVector<TCacheBlobL2>& blobs, bool isHit)
 {
+    Y_UNUSED(ctx);
     TInstant now = TAppData::TimeProvider->Now();
 
     for (const TCacheBlobL2& blob : blobs) {
@@ -211,10 +213,10 @@ void TPersQueueCacheL2::TouchBlobs(const TActorContext& ctx, ui64 tabletId, cons
         auto it = Cache.Find(key);
         if (it != Cache.End()) {
             (*it)->Touch(now);
-            YDB_LOG_DEBUG_CTX(ctx, "PQ Cache (L2). Touched",
+            LOG_D("PQ Cache (L2). Touched",
                 {"key", key});
         } else {
-            YDB_LOG_DEBUG_CTX(ctx, "PQ Cache (L2). Miss in touch",
+            LOG_D("PQ Cache (L2). Miss in touch",
                 {"key", key});
         }
     }
@@ -232,8 +234,9 @@ void TPersQueueCacheL2::TouchBlobs(const TActorContext& ctx, ui64 tabletId, cons
 
 void TPersQueueCacheL2::RegretBlobs(const TActorContext& ctx, ui64 tabletId, const TVector<TCacheBlobL2>& blobs)
 {
+    Y_UNUSED(ctx);
     for (const TCacheBlobL2& blob : blobs) {
-        YDB_LOG_DEBUG_CTX(ctx, "PQ Cache (L2). Missed blob. tabletId partition offset partno count parts_count",
+        LOG_D("PQ Cache (L2). Missed blob. tabletId partition offset partno count parts_count",
             {"tabletId", tabletId},
             {"blobPartition", blob.Partition},
             {"blobOffset", blob.Offset},

--- a/ydb/core/persqueue/pqtablet/cache/pq_l2_cache.h
+++ b/ydb/core/persqueue/pqtablet/cache/pq_l2_cache.h
@@ -111,8 +111,7 @@ public:
     {}
 
     TStructuredLogPrefix BuildLogPrefix() const override {
-        return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "PersQueueCacheL2"});
+        return {};
     }
 
     void Bootstrap(const TActorContext& ctx);

--- a/ydb/core/persqueue/pqtablet/cache/pq_l2_cache.h
+++ b/ydb/core/persqueue/pqtablet/cache/pq_l2_cache.h
@@ -38,7 +38,8 @@ struct TL2Counters {
 };
 
 /// PersQueue shared (L2) cache
-class TPersQueueCacheL2 : public TActorBootstrapped<TPersQueueCacheL2> {
+class TPersQueueCacheL2 : public TBaseActor<TPersQueueCacheL2>
+                         , public TConstantLogPrefix {
 public:
     struct TKey {
         ui64 TabletId;
@@ -100,13 +101,19 @@ public:
     }
 
     TPersQueueCacheL2(const TCacheL2Parameters& params, TIntrusivePtr<::NMonitoring::TDynamicCounters> countersGroup)
-        : Cache(1_TB / MAX_BLOB_SIZE) // It's some "much bigger then we need" size here.
+        : TBaseActor(NKikimrServices::PERSQUEUE)
+        , Cache(1_TB / MAX_BLOB_SIZE) // It's some "much bigger then we need" size here.
         , MaxSize(ClampMinSize(params.MaxSizeMB * 1_MB))
         , CurrentSize(0)
         , KeepTime(params.KeepTime)
         , RetentionTime(TDuration::Zero())
         , Counters(countersGroup)
     {}
+
+    TStructuredLogPrefix BuildLogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"actorClassName", "PersQueueCacheL2"});
+    }
 
     void Bootstrap(const TActorContext& ctx);
 

--- a/ydb/core/persqueue/pqtablet/cache/pq_l2_cache.h
+++ b/ydb/core/persqueue/pqtablet/cache/pq_l2_cache.h
@@ -110,7 +110,7 @@ public:
         , Counters(countersGroup)
     {}
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return {};
     }
 

--- a/ydb/core/persqueue/pqtablet/cache/read.h
+++ b/ydb/core/persqueue/pqtablet/cache/read.h
@@ -35,9 +35,9 @@ namespace NPQ {
             Become(&TThis::StateFunc);
         }
 
-        const TLogPrefix& GetLogPrefix() const
+        const TStructuredLogPrefix& GetLogPrefix() const
         {
-            static const TLogPrefix LogPrefix = YDB_LOG_CREATE_MESSAGE(
+            static const TStructuredLogPrefix LogPrefix = YDB_LOG_CREATE_MESSAGE(
                 {"actorClassName", "PQCacheProxy"});
             return LogPrefix;
         }

--- a/ydb/core/persqueue/pqtablet/cache/read.h
+++ b/ydb/core/persqueue/pqtablet/cache/read.h
@@ -37,8 +37,7 @@ namespace NPQ {
 
         const TStructuredLogPrefix& GetLogPrefix() const
         {
-            static const TStructuredLogPrefix LogPrefix = YDB_LOG_CREATE_MESSAGE(
-                {"actorClassName", "PQCacheProxy"});
+            static const TStructuredLogPrefix LogPrefix;
             return LogPrefix;
         }
 

--- a/ydb/core/persqueue/pqtablet/cache/read.h
+++ b/ydb/core/persqueue/pqtablet/cache/read.h
@@ -35,9 +35,9 @@ namespace NPQ {
             Become(&TThis::StateFunc);
         }
 
-        const TStructuredLogPrefix& GetLogPrefix() const
+        const TStructuredMessage& GetLogPrefix() const
         {
-            static const TStructuredLogPrefix LogPrefix;
+            static const TStructuredMessage LogPrefix;
             return LogPrefix;
         }
 

--- a/ydb/core/persqueue/pqtablet/cache/ya.make
+++ b/ydb/core/persqueue/pqtablet/cache/ya.make
@@ -8,6 +8,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/keyvalue
+    ydb/core/persqueue/common
     ydb/core/persqueue/pqtablet/blob
     ydb/core/persqueue/events
     ydb/public/api/grpc/draft

--- a/ydb/core/persqueue/pqtablet/common/logging.h
+++ b/ydb/core/persqueue/pqtablet/common/logging.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include <ydb/library/actors/core/log.h>
-#include <util/generic/string.h>
 
 namespace NKikimr::NPQ {
 
-inline TString LogPrefix() { return {}; }
+inline NActors::NStructuredLog::TStructuredMessage LogPrefix() { return {}; }
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/common/logging.h
+++ b/ydb/core/persqueue/pqtablet/common/logging.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <ydb/library/actors/core/log.h>
+#include <ydb/core/persqueue/common/logging.h>
 
 namespace NKikimr::NPQ {
 
-inline NActors::NStructuredLog::TStructuredMessage LogPrefix() { return {}; }
+inline TStructuredLogPrefix LogPrefix() { return {}; }
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/common/logging.h
+++ b/ydb/core/persqueue/pqtablet/common/logging.h
@@ -4,6 +4,6 @@
 
 namespace NKikimr::NPQ {
 
-inline TStructuredLogPrefix LogPrefix() { return {}; }
+inline TStructuredMessage LogPrefix() { return {}; }
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
@@ -95,7 +95,7 @@ public:
 
     NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "TAutopartitioningManager"},
+            {"className", "TAutopartitioningManager"},
             {"partition", PartitionId});
     }
 

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
@@ -93,10 +93,16 @@ public:
         RecreateSumMetric();
     }
 
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"actorClassName", "TAutopartitioningManager"},
+            {"partition", PartitionId});
+    }
+
 protected:
     void OnWriteImpl(const TString& sourceId, ui64 delta, const TString& key = "") {
         YDB_LOG_DEBUG("TAutopartitioningManager::OnWrite",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"sourceId", sourceId},
             {"delta", delta},
             {"key", key},
@@ -175,7 +181,7 @@ protected:
             const auto& keyRange = partition->GetKeyRange();
 
             YDB_LOG_DEBUG("TAutopartitioningManager::SplitBoundary KLL sketch enabled, no median key found, will split by middle of key range",
-                {"logPrefix", LogPrefix()});
+                {LogPrefix()});
             return MiddleOf(keyRange.GetFromBound(), keyRange.GetToBound());
         }
 
@@ -201,7 +207,7 @@ protected:
         auto mergeEnabled = Config.GetPartitionStrategy().GetPartitionStrategyType() == ::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT_AND_MERGE;
 
         YDB_LOG_DEBUG("TPartition::CheckScaleStatus",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"splitMergeAvgWriteBytes", SumMetric->GetValue()},
             {"usagePercent", usagePercent},
             {"scaleThresholdSeconds", Config.GetPartitionStrategy().GetScaleThresholdSeconds()},
@@ -216,11 +222,11 @@ protected:
 
         if (splitEnabled && canSplit && shouldSplit) {
             YDB_LOG_DEBUG("TPartition::CheckScaleStatus NEED_SPLIT",
-                {"logPrefix", LogPrefix()});
+                {LogPrefix()});
             return NKikimrPQ::EScaleStatus::NEED_SPLIT;
         } else if (mergeEnabled && usagePercent <= Config.GetPartitionStrategy().GetScaleDownPartitionWriteSpeedThresholdPercent()) {
             YDB_LOG_DEBUG("TPartition::CheckScaleStatus NEED_MERGE",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"usagePercent", usagePercent});
             return NKikimrPQ::EScaleStatus::NEED_MERGE;
         }

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
@@ -78,7 +78,7 @@ public:
     }
 };
 
-class TWindowedAutopartitioningManager : public IAutopartitioningManager {
+class TWindowedAutopartitioningManager : public IAutopartitioningManager, public TLogPrefix {
     static constexpr size_t Precision = 100;
 public:
     TWindowedAutopartitioningManager(const NKikimrPQ::TPQTabletConfig& config, ui32 partitionId, ui64 maxUsagePerSec, const ETag tag = ETag::BYTES)
@@ -93,7 +93,7 @@ public:
         RecreateSumMetric();
     }
 
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+    TStructuredLogPrefix LogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"className", "TAutopartitioningManager"},
             {"partition", PartitionId});
@@ -101,9 +101,7 @@ public:
 
 protected:
     void OnWriteImpl(const TString& sourceId, ui64 delta, const TString& key = "") {
-        YDB_LOG_DEBUG("TAutopartitioningManager::OnWrite",
-            {LogPrefix()},
-            {"sourceId", sourceId},
+        LOG_D("TAutopartitioningManager::OnWrite", {"sourceId", sourceId},
             {"delta", delta},
             {"key", key},
             {"isEnabled", IsEnabled()},
@@ -180,8 +178,7 @@ protected:
             auto* partition = GetPartition();
             const auto& keyRange = partition->GetKeyRange();
 
-            YDB_LOG_DEBUG("TAutopartitioningManager::SplitBoundary KLL sketch enabled, no median key found, will split by middle of key range",
-                {LogPrefix()});
+            LOG_D("TAutopartitioningManager::SplitBoundary KLL sketch enabled, no median key found, will split by middle of key range");
             return MiddleOf(keyRange.GetFromBound(), keyRange.GetToBound());
         }
 
@@ -206,9 +203,7 @@ protected:
             || Config.GetPartitionStrategy().GetPartitionStrategyType() == ::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT_AND_MERGE;
         auto mergeEnabled = Config.GetPartitionStrategy().GetPartitionStrategyType() == ::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT_AND_MERGE;
 
-        YDB_LOG_DEBUG("TPartition::CheckScaleStatus",
-            {LogPrefix()},
-            {"splitMergeAvgWriteBytes", SumMetric->GetValue()},
+        LOG_D("TPartition::CheckScaleStatus", {"splitMergeAvgWriteBytes", SumMetric->GetValue()},
             {"usagePercent", usagePercent},
             {"scaleThresholdSeconds", Config.GetPartitionStrategy().GetScaleThresholdSeconds()},
             {"totalPartitionWriteSpeed", MaxUsagePerSec},
@@ -221,13 +216,10 @@ protected:
                 >= Config.GetPartitionStrategy().GetScaleUpPartitionWriteSpeedThresholdPercent();
 
         if (splitEnabled && canSplit && shouldSplit) {
-            YDB_LOG_DEBUG("TPartition::CheckScaleStatus NEED_SPLIT",
-                {LogPrefix()});
+            LOG_D("TPartition::CheckScaleStatus NEED_SPLIT");
             return NKikimrPQ::EScaleStatus::NEED_SPLIT;
         } else if (mergeEnabled && usagePercent <= Config.GetPartitionStrategy().GetScaleDownPartitionWriteSpeedThresholdPercent()) {
-            YDB_LOG_DEBUG("TPartition::CheckScaleStatus NEED_MERGE",
-                {LogPrefix()},
-                {"usagePercent", usagePercent});
+            LOG_D("TPartition::CheckScaleStatus NEED_MERGE", {"usagePercent", usagePercent});
             return NKikimrPQ::EScaleStatus::NEED_MERGE;
         }
         return NKikimrPQ::EScaleStatus::NORMAL;

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
@@ -93,7 +93,7 @@ public:
         RecreateSumMetric();
     }
 
-    TStructuredLogPrefix LogPrefix() const override {
+    TStructuredMessage LogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"className", "TAutopartitioningManager"},
             {"partition", PartitionId});

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
@@ -73,7 +73,6 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "DeduplicationQueue"},
             {"topic", TopicName},
             {"partition", PartitionId});
     }

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
@@ -71,7 +71,7 @@ public:
         Become(&TThis::StateWork);
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "DeduplicationQueue"},
             {"topic", TopicName},
@@ -253,8 +253,8 @@ private:
                 TConstArrayRef(&messageDeduplicationId, 1));
             LOG_D(
                 "Send TEvCheckMessageDeduplicationRequest",
-                {"partition", parentPartition.PartitionId},
-                {"tabletId", tabletId},
+                {"parentPartitionId", parentPartition.PartitionId},
+                {"partitionTabletId", tabletId},
                 {"messageDeduplicationId", messageDeduplicationId}
             );
             auto forward = std::make_unique<TEvPipeCache::TEvForward>(

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
@@ -71,7 +71,7 @@ public:
         Become(&TThis::StateWork);
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"topic", TopicName},
             {"partition", PartitionId});

--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
@@ -5,9 +5,10 @@
 #include <ydb/core/persqueue/public/write_meta/write_meta.h>
 #include <ydb/core/persqueue/writer/source_id_encoding.h>
 #include <ydb/core/protos/grpc_pq_old.pb.h>
-#include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
+#include <ydb/library/actors/struct_log/text_writer.h>
 #include <ydb/library/persqueue/topic_parser/counters.h>
 #include <ydb/public/lib/base/msgbus.h>
+#include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT Service
 
@@ -28,6 +29,13 @@ static constexpr TDuration DEFAULT_REWIND_COMMIT_OFFSET_DELAY = TDuration::Minut
 static constexpr TDuration REWIND_COMMIT_INTERVAL = TDuration::Minutes(4);
 
 namespace {
+
+TString StructuredLogPrefixText(const TStructuredMessage& prefix) {
+    TStringBuilder out;
+    NActors::NStructuredLog::TTextWriter writer;
+    writer.Write(out, prefix);
+    return out;
+}
 
 struct TBatchInfo {
     ui32 LogicalMessageCount = 1;

--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
@@ -722,7 +722,7 @@ void TMirrorer::ScheduleConsumerCreation(const TActorContext& ctx) {
     ScheduleWithIncreasingTimeout<TEvPQ::TEvCreateConsumer>(SelfId(), ConsumerInitInterval, CONSUMER_INIT_INTERVAL_MAX, ctx);
 }
 
-TStructuredLogPrefix TMirrorer::BuildLogPrefix() const {
+TStructuredMessage TMirrorer::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"topic", TopicConverter->GetPrintableString()},
         {"partition", Partition});

--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
@@ -724,7 +724,6 @@ void TMirrorer::ScheduleConsumerCreation(const TActorContext& ctx) {
 
 TStructuredLogPrefix TMirrorer::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "Mirrorer"},
         {"topic", TopicConverter->GetPrintableString()},
         {"partition", Partition});
 }

--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
@@ -722,7 +722,7 @@ void TMirrorer::ScheduleConsumerCreation(const TActorContext& ctx) {
     ScheduleWithIncreasingTimeout<TEvPQ::TEvCreateConsumer>(SelfId(), ConsumerInitInterval, CONSUMER_INIT_INTERVAL_MAX, ctx);
 }
 
-TLogPrefix TMirrorer::BuildLogPrefix() const {
+TStructuredLogPrefix TMirrorer::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "Mirrorer"},
         {"topic", TopicConverter->GetPrintableString()},

--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.h
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.h
@@ -112,7 +112,7 @@ private:
 
     bool TryRewindCommittedOffset(const TActorContext& ctx);
 
-    TLogPrefix BuildLogPrefix() const override;
+    TStructuredLogPrefix BuildLogPrefix() const override;
 
     TString GetCurrentState() const;
 

--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.h
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.h
@@ -112,7 +112,7 @@ private:
 
     bool TryRewindCommittedOffset(const TActorContext& ctx);
 
-    TStructuredLogPrefix BuildLogPrefix() const override;
+    TStructuredMessage BuildLogPrefix() const override;
 
     TString GetCurrentState() const;
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
@@ -220,7 +220,7 @@ void TConsumerActor::PassAway() {
     TBase::PassAway();
 }
 
-TStructuredLogPrefix TConsumerActor::BuildLogPrefix() const {
+TStructuredMessage TConsumerActor::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"partition", PartitionId},
         {"consumer", Config.GetName()});

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
@@ -222,7 +222,6 @@ void TConsumerActor::PassAway() {
 
 TStructuredLogPrefix TConsumerActor::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "MLPConsumer"},
         {"partition", PartitionId},
         {"consumer", Config.GetName()});
 }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
@@ -220,7 +220,7 @@ void TConsumerActor::PassAway() {
     TBase::PassAway();
 }
 
-TLogPrefix TConsumerActor::BuildLogPrefix() const {
+TStructuredLogPrefix TConsumerActor::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "MLPConsumer"},
         {"partition", PartitionId},

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.h
@@ -35,7 +35,7 @@ public:
     void PassAway() override;
 
 protected:
-    TStructuredLogPrefix BuildLogPrefix() const override;
+    TStructuredMessage BuildLogPrefix() const override;
 
 private:
     void Queue(TEvPQ::TEvMLPReadRequest::TPtr&);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.h
@@ -35,7 +35,7 @@ public:
     void PassAway() override;
 
 protected:
-    TLogPrefix BuildLogPrefix() const override;
+    TStructuredLogPrefix BuildLogPrefix() const override;
 
 private:
     void Queue(TEvPQ::TEvMLPReadRequest::TPtr&);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_dlq_mover.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_dlq_mover.cpp
@@ -67,7 +67,6 @@ void TDLQMoverActor::PassAway() {
 
 TStructuredLogPrefix TDLQMoverActor::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "MLPDLQMover"},
         {"tabletId", Settings.TabletId},
         {"partition", Settings.PartitionId},
         {"consumer", Settings.ConsumerName});

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_dlq_mover.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_dlq_mover.cpp
@@ -65,7 +65,7 @@ void TDLQMoverActor::PassAway() {
     TActor::PassAway();
 }
 
-TStructuredLogPrefix TDLQMoverActor::BuildLogPrefix() const {
+TStructuredMessage TDLQMoverActor::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"tabletId", Settings.TabletId},
         {"partition", Settings.PartitionId},

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_dlq_mover.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_dlq_mover.cpp
@@ -65,7 +65,7 @@ void TDLQMoverActor::PassAway() {
     TActor::PassAway();
 }
 
-TLogPrefix TDLQMoverActor::BuildLogPrefix() const {
+TStructuredLogPrefix TDLQMoverActor::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "MLPDLQMover"},
         {"tabletId", Settings.TabletId},

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_dlq_mover.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_dlq_mover.h
@@ -21,7 +21,7 @@ public:
 
     void Bootstrap();
     void PassAway() override;
-    TLogPrefix BuildLogPrefix() const override;
+    TStructuredLogPrefix BuildLogPrefix() const override;
 
 private:
     void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr&);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_dlq_mover.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_dlq_mover.h
@@ -21,7 +21,7 @@ public:
 
     void Bootstrap();
     void PassAway() override;
-    TStructuredLogPrefix BuildLogPrefix() const override;
+    TStructuredMessage BuildLogPrefix() const override;
 
 private:
     void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr&);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
@@ -22,16 +22,18 @@ public:
     void Bootstrap();
     void PassAway() override;
 
-protected:
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "MLPMessageEnricher"},
-            {"tabletId", TabletId},
             {"partition", PartitionId},
             {"consumer", ConsumerName});
     }
 
+    const ui64 TabletId;
+
 private:
+    const ui32 PartitionId;
+    const TString ConsumerName;
     struct TOffsetEntry {
         ui64 Offset;
         size_t ReplyIndex;
@@ -59,10 +61,6 @@ private:
     void ProcessQueue();
     void SendToPQTablet(std::unique_ptr<IEventBase> ev);
 
-private:
-    const ui64 TabletId;
-    const ui32 PartitionId;
-    const TString ConsumerName;
     std::deque<TReadResult> Replies;
     std::vector<TPendingResponse> PendingResponses;
     std::vector<TOffsetEntry> SortedEntries;

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
@@ -24,7 +24,6 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "MLPMessageEnricher"},
             {"partition", PartitionId},
             {"consumer", ConsumerName});
     }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
@@ -22,7 +22,7 @@ public:
     void Bootstrap();
     void PassAway() override;
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"partition", PartitionId},
             {"consumer", ConsumerName});

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
@@ -23,7 +23,7 @@ public:
     void PassAway() override;
 
 protected:
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "MLPMessageEnricher"},
             {"tabletId", TabletId},

--- a/ydb/core/persqueue/pqtablet/partition/offload_actor.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/offload_actor.cpp
@@ -40,7 +40,6 @@ private:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "OffloadActor"},
             {"partition", Partition});
     }
 

--- a/ydb/core/persqueue/pqtablet/partition/offload_actor.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/offload_actor.cpp
@@ -38,7 +38,7 @@ private:
     TActorId Worker;
     TActorId SchemeShardPipe;
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "OffloadActor"},
             {"partition", Partition},

--- a/ydb/core/persqueue/pqtablet/partition/offload_actor.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/offload_actor.cpp
@@ -38,7 +38,7 @@ private:
     TActorId Worker;
     TActorId SchemeShardPipe;
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"partition", Partition});
     }

--- a/ydb/core/persqueue/pqtablet/partition/offload_actor.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/offload_actor.cpp
@@ -41,8 +41,7 @@ private:
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "OffloadActor"},
-            {"partition", Partition},
-            {"selfId", SelfId()});
+            {"partition", Partition});
     }
 
 public:

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -206,7 +206,6 @@ TStructuredLogPrefix TPartition::BuildLogPrefix() const {
         state = "Unknown";
     }
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "Partition"},
         {"partition", Partition.ToString()},
         {"actorState", state});
 }

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -196,7 +196,7 @@ const TString& TPartition::TopicName() const {
     return TopicConverter->GetClientsideName();
 }
 
-TStructuredLogPrefix TPartition::BuildLogPrefix() const {
+TStructuredMessage TPartition::BuildLogPrefix() const {
     TString state;
     if (CurrentStateFunc() == &TThis::StateInit) {
         state = "StateInit";
@@ -210,8 +210,8 @@ TStructuredLogPrefix TPartition::BuildLogPrefix() const {
         {"actorState", state});
 }
 
-const TStructuredLogPrefix& TPartition::GetLogPrefix() const {
-    TMaybe<TStructuredLogPrefix>* logPrefix = &UnknownLogPrefix;
+const TStructuredMessage& TPartition::GetLogPrefix() const {
+    TMaybe<TStructuredMessage>* logPrefix = &UnknownLogPrefix;
     if (CurrentStateFunc() == &TThis::StateInit) {
         logPrefix = &InitLogPrefix;
     } else if (CurrentStateFunc() == &TThis::StateIdle) {

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1011,8 +1011,7 @@ void TPartition::InitComplete(const TActorContext& ctx) {
     LOG_I(
         "Init complete for topic partition generation",
         {"topicName", TopicName()},
-        {"tabletGeneration", TabletGeneration},
-        {"selfId", ctx.SelfID}
+        {"tabletGeneration", TabletGeneration}
     );
 
     TStringBuilder ss;

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -196,7 +196,7 @@ const TString& TPartition::TopicName() const {
     return TopicConverter->GetClientsideName();
 }
 
-TLogPrefix TPartition::LogPrefix() const {
+TStructuredLogPrefix TPartition::BuildLogPrefix() const {
     TString state;
     if (CurrentStateFunc() == &TThis::StateInit) {
         state = "StateInit";
@@ -211,8 +211,8 @@ TLogPrefix TPartition::LogPrefix() const {
         {"actorState", state});
 }
 
-const TLogPrefix& TPartition::GetLogPrefix() const {
-    TMaybe<TLogPrefix>* logPrefix = &UnknownLogPrefix;
+const TStructuredLogPrefix& TPartition::GetLogPrefix() const {
+    TMaybe<TStructuredLogPrefix>* logPrefix = &UnknownLogPrefix;
     if (CurrentStateFunc() == &TThis::StateInit) {
         logPrefix = &InitLogPrefix;
     } else if (CurrentStateFunc() == &TThis::StateIdle) {
@@ -220,7 +220,7 @@ const TLogPrefix& TPartition::GetLogPrefix() const {
     }
 
     if (!logPrefix->Defined()) {
-        *logPrefix = LogPrefix();
+        *logPrefix = BuildLogPrefix();
     }
 
     return *(*logPrefix);
@@ -1011,7 +1011,6 @@ void TPartition::InitComplete(const TActorContext& ctx) {
     LOG_I(
         "Init complete for topic partition generation",
         {"topicName", TopicName()},
-        {"partition", Partition},
         {"tabletGeneration", TabletGeneration},
         {"selfId", ctx.SelfID}
     );
@@ -1061,7 +1060,6 @@ void TPartition::InitComplete(const TActorContext& ctx) {
         LOG_D(
             "Init complete for topic",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"sourceId", s.first},
             {"seqNo", s.second.SeqNo},
             {"offset", s.second.Offset},
@@ -2372,7 +2370,6 @@ void TPartition::Handle(TEvPQ::TEvError::TPtr& ev, const TActorContext& ctx) {
     LOG_E(
         "Topic partition user readTimeStamp",
         {"topicName", TopicName()},
-        {"partition", Partition},
         {"readingForUser", ReadingForUser},
         {"error", ev->Get()->Error}
     );
@@ -2768,10 +2765,7 @@ void TPartition::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
         CompacterKvRequestInflight = false;
         LOG_D(
             "Topic partition Got compacter KV response, release RW lock",
-            {"clientSideName", TopicConverter->GetClientsideName()},
-                    {"partition",
-            Partition}
-        );
+            {"clientSideName", TopicConverter->GetClientsideName()});
         Send(ReadQuotaTrackerActor, new TEvPQ::TEvReleaseExclusiveLock());
         if (Compacter) {
             Compacter->ProcessResponse(ev);
@@ -2787,7 +2781,6 @@ void TPartition::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
         LOG_E(
             "OnWrite topic partition commands are not processed at all",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"reason", response.DebugString()}
         );
         ctx.Send(TabletActorId, new TEvents::TEvPoisonPill());
@@ -2799,9 +2792,7 @@ void TPartition::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
             if (response.GetDeleteRangeResult(i).GetStatus() != NKikimrProto::OK) {
                 LOG_E(
                     "OnWrite topic partition delete range error",
-                    {"topicName", TopicName()},
-                    {"partition", Partition}
-                );
+                    {"topicName", TopicName()});
                 //TODO: if disk is full, could this be ok? delete must be ok, of course
                 ctx.Send(TabletActorId, new TEvents::TEvPoisonPill());
                 return;
@@ -2815,9 +2806,7 @@ void TPartition::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
             if (response.GetWriteResult(i).GetStatus() != NKikimrProto::OK) {
                 LOG_E(
                     "OnWrite topic partition write error",
-                    {"topicName", TopicName()},
-                    {"partition", Partition}
-                );
+                    {"topicName", TopicName()});
                 ctx.Send(TabletActorId, new TEvents::TEvPoisonPill());
                 return;
             }
@@ -2832,7 +2821,6 @@ void TPartition::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
             LOG_E(
                 "OnWrite topic partition are not processed at all, got KV error in CmdGetStatus",
                 {"topicName", TopicName()},
-                {"partition", Partition},
                 {"status", res.GetStatus()}
             );
             ctx.Send(TabletActorId, new TEvents::TEvPoisonPill());
@@ -3760,7 +3748,6 @@ TPartition::EProcessResult TPartition::BeginTransactionData(TTransaction& t,
         if (AffectedUsers.contains(consumer) && !GetPendingUserIfExists(consumer)) {
             LOG_W(
                 "Partition Consumer has been removed",
-                {"partition", Partition},
                 {"consumer", consumer}
             );
             issueMsg = (MakeTxReadErrorMessage(tx.TxId, TopicName(), Partition, consumer) << "Consumer has been removed");
@@ -3771,7 +3758,6 @@ TPartition::EProcessResult TPartition::BeginTransactionData(TTransaction& t,
         if (!UsersInfoStorage->GetIfExists(consumer)) {
             LOG_W(
                 "Partition Unknown consumer",
-                {"partition", Partition},
                 {"consumer", consumer}
             );
             issueMsg = (MakeTxReadErrorMessage(tx.TxId, TopicName(), Partition, consumer) << "Unknown consumer");
@@ -3790,7 +3776,6 @@ TPartition::EProcessResult TPartition::BeginTransactionData(TTransaction& t,
             if (IsActive() || operation.GetCommitOffsetsEnd() < GetEndOffset() || userInfo.Offset != i64(GetEndOffset())) {
                 LOG_W(
                     "Partition Consumer Bad request (session already dead) RequestSessionId CurrentSessionId",
-                    {"partition", Partition},
                     {"consumer", consumer},
                     {"operationReadSessionId", operation.GetReadSessionId()},
                     {"userInfoSession", userInfo.Session}
@@ -3804,7 +3789,6 @@ TPartition::EProcessResult TPartition::BeginTransactionData(TTransaction& t,
             if (!operation.GetForceCommit() && operation.GetCommitOffsetsBegin() > operation.GetCommitOffsetsEnd()) {
                 LOG_W(
                     "Partition Consumer Bad request (invalid range) Begin End",
-                    {"partition", Partition},
                     {"consumer", consumer},
                     {"operationCommitOffsetsBegin", operation.GetCommitOffsetsBegin()},
                     {"operationCommitOffsetsEnd", operation.GetCommitOffsetsEnd()}
@@ -3816,7 +3800,6 @@ TPartition::EProcessResult TPartition::BeginTransactionData(TTransaction& t,
             } else if (!operation.GetForceCommit() && userInfo.Offset != (i64)operation.GetCommitOffsetsBegin()) {
                 LOG_W(
                     "Partition Consumer Bad request (gap) Offset Begin",
-                    {"partition", Partition},
                     {"consumer", consumer},
                     {"userInfoOffset", userInfo.Offset},
                     {"operationCommitOffsetsBegin", operation.GetCommitOffsetsBegin()}
@@ -3828,7 +3811,6 @@ TPartition::EProcessResult TPartition::BeginTransactionData(TTransaction& t,
             } else if (!operation.GetForceCommit() && operation.GetCommitOffsetsEnd() > GetEndOffset()) {
                 LOG_W(
                     "Partition Consumer Bad request (behind the last offset) EndOffset End",
-                    {"partition", Partition},
                     {"consumer", consumer},
                     {"endOffset", GetEndOffset()},
                     {"operationCommitOffsetsEnd", operation.GetCommitOffsetsEnd()}
@@ -3840,7 +3822,6 @@ TPartition::EProcessResult TPartition::BeginTransactionData(TTransaction& t,
             } else if (IsCommitOffsetForbiddenForMLPConsumer(consumer, false)) {
                 LOG_W(
                     "Partition Consumer Bad request (changing commit offset for MLP consumer) EndOffset End",
-                    {"partition", Partition},
                     {"consumer", consumer},
                     {"endOffset", GetEndOffset()},
                     {"operationCommitOffsetsEnd", operation.GetCommitOffsetsEnd()}
@@ -4567,7 +4548,6 @@ void TPartition::CommitUserAct(TEvPQ::TEvSetClientInfo& act) {
         LOG_D(
             "Topic partition user drop request",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"user", user}
         );
 
@@ -4634,7 +4614,6 @@ void TPartition::CommitUserAct(TEvPQ::TEvSetClientInfo& act) {
         LOG_D(
             "Topic partition user reinit request with generation",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"actClientId", act.ClientId},
             {"readRuleGeneration", readRuleGeneration}
         );
@@ -4654,7 +4633,6 @@ void TPartition::CommitUserAct(TEvPQ::TEvSetClientInfo& act) {
         LOG_W(
             "Commit to future - topic partition client EndOffset offset",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"actClientId", act.ClientId},
             {"endOffset", GetEndOffset()},
             {"offset", offset}
@@ -4709,7 +4687,6 @@ void TPartition::EmulatePostProcessUserAct(const TEvPQ::TEvSetClientInfo& act,
         LOG_D(
             "Topic partition user drop done",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"user", user}
         );
         PendingUsersInfo.erase(user);
@@ -4717,7 +4694,6 @@ void TPartition::EmulatePostProcessUserAct(const TEvPQ::TEvSetClientInfo& act,
         LOG_D(
             "Topic partition user reinit with generation done",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"user", user},
             {"readRuleGeneration", readRuleGeneration}
         );
@@ -4765,7 +4741,6 @@ void TPartition::EmulatePostProcessUserAct(const TEvPQ::TEvSetClientInfo& act,
         LOG_D(
             "Topic partition user is set to (startOffset session",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"user", user},
             {"operationType", (createSession || dropSession ? " session" : " offset")},
             {"offset", offset},
@@ -5163,7 +5138,6 @@ void TPartition::Handle(TEvPQ::TEvApproveWriteQuota::TPtr& ev, const TActorConte
     LOG_D(
         "Got quota. Topic",
         {"topicName", TopicName()},
-        {"partition", Partition},
         {"cookie", cookie},
         {"accountWaitTime", ev->Get()->AccountQuotaWaitTime},
             {"partitionWaitTime", ev->Get()->PartitionQuotaWaitTime}
@@ -5238,7 +5212,6 @@ void TPartition::Handle(TEvPQ::TEvSubDomainStatus::TPtr& ev, const TActorContext
         LOG_I(
             "SubDomainOutOfSpace was changed. Topic",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"subDomainOutOfSpace", SubDomainOutOfSpace}
         );
 
@@ -5255,7 +5228,6 @@ void TPartition::Handle(TEvPQ::TEvCheckPartitionStatusRequest::TPtr& ev, const T
     if (Partition.InternalPartitionId != record.GetPartition()) {
         LOG_I(
             "TEvCheckPartitionStatusRequest for wrong partition Topic",
-            {"partition", record.GetPartition()},
             {"topicName", TopicName()},
             {"internalPartition", Partition}
         );
@@ -5432,10 +5404,7 @@ void TPartition::SendCompacterWriteRequest(THolder<TEvKeyValue::TEvRequest>&& re
         ("tablet_id", TabletId)("partition_id", Partition)("topic", TopicName());
     LOG_D(
         "Topic partition Acquire RW Lock",
-        {"clientSideName", TopicConverter->GetClientsideName()},
-            {"partition",
-        Partition}
-    );
+        {"clientSideName", TopicConverter->GetClientsideName()});
     Send(ReadQuotaTrackerActor, new TEvPQ::TEvAcquireExclusiveLock());
     CompacterKvRequestInflight = true;
     CompacterKvRequest = std::move(request);
@@ -5444,10 +5413,7 @@ void TPartition::SendCompacterWriteRequest(THolder<TEvKeyValue::TEvRequest>&& re
 void TPartition::Handle(TEvPQ::TEvExclusiveLockAcquired::TPtr&) {
     LOG_D(
         "Topic partition Acquired RW Lock, send compacter KV request",
-        {"clientSideName", TopicConverter->GetClientsideName()},
-            {"partition",
-        Partition}
-    );
+        {"clientSideName", TopicConverter->GetClientsideName()});
     Send(BlobCache, CompacterKvRequest.Release(), 0, 0, PersistRequestSpan.GetTraceId());
 }
 
@@ -5552,16 +5518,12 @@ void TPartition::Handle(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationReque
         "TEvCheckMessageDeduplicationRequest for partition deduplication IDs Topic",
         {"partitionId", partitionId},
         {"count", record.MessageDeduplicationIdSize()},
-        {"topicName", TopicName()},
-        {"partition", Partition}
-    );
+        {"topicName", TopicName()});
    if (Partition.InternalPartitionId != partitionId) {
         LOG_W(
             "TEvCheckMessageDeduplicationRequest for wrong partition Topic",
             {"partitionId", partitionId},
-            {"topicName", TopicName()},
-            {"partition", Partition}
-        );
+            {"topicName", TopicName()});
         return;
     }
     auto response = MakeHolder<NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationResponse>();

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -539,8 +539,8 @@ private:
     void ChangeScaleStatusIfNeeded(NKikimrPQ::EScaleStatus scaleStatus);
     void Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr& ev, const TActorContext& ctx);
 
-    TStructuredLogPrefix BuildLogPrefix() const;
-    const TStructuredLogPrefix& GetLogPrefix() const override;
+    TStructuredMessage BuildLogPrefix() const;
+    const TStructuredMessage& GetLogPrefix() const override;
 
     void Handle(TEvPQ::TEvProcessChangeOwnerRequests::TPtr& ev, const TActorContext& ctx);
     void StartProcessChangeOwnerRequests(const TActorContext& ctx);
@@ -869,9 +869,9 @@ private:
 
     TMaybe<TUsersInfoStorage> UsersInfoStorage;
 
-    mutable TMaybe<TStructuredLogPrefix> IdleLogPrefix;
-    mutable TMaybe<TStructuredLogPrefix> InitLogPrefix;
-    mutable TMaybe<TStructuredLogPrefix> UnknownLogPrefix;
+    mutable TMaybe<TStructuredMessage> IdleLogPrefix;
+    mutable TMaybe<TStructuredMessage> InitLogPrefix;
+    mutable TMaybe<TStructuredMessage> UnknownLogPrefix;
 
     struct TAffectedSourceIdsAndConsumers {
         TVector<TString> TxWriteSourcesIds;

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -539,8 +539,8 @@ private:
     void ChangeScaleStatusIfNeeded(NKikimrPQ::EScaleStatus scaleStatus);
     void Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr& ev, const TActorContext& ctx);
 
-    TLogPrefix LogPrefix() const;
-    const TLogPrefix& GetLogPrefix() const override;
+    TStructuredLogPrefix BuildLogPrefix() const;
+    const TStructuredLogPrefix& GetLogPrefix() const override;
 
     void Handle(TEvPQ::TEvProcessChangeOwnerRequests::TPtr& ev, const TActorContext& ctx);
     void StartProcessChangeOwnerRequests(const TActorContext& ctx);
@@ -625,7 +625,6 @@ private:
         NPersQueue::TCounterTimeKeeper keeper(TabletCounters.Cumulative()[COUNTER_PQ_TABLET_CPU_USAGE]);
 
         LOG_T("Handle event",
-            {"actorState", "StateInit"},
             {"event", EventStr("StateIdle", ev)});
 
         TRACE_EVENT(NKikimrServices::PERSQUEUE);
@@ -685,7 +684,6 @@ private:
         NPersQueue::TCounterTimeKeeper keeper(TabletCounters.Cumulative()[COUNTER_PQ_TABLET_CPU_USAGE]);
 
         LOG_T("Handle event",
-            {"actorState", "StateIdle"},
             {"event", EventStr("StateIdle", ev)});
 
         TRACE_EVENT(NKikimrServices::PERSQUEUE);
@@ -871,9 +869,9 @@ private:
 
     TMaybe<TUsersInfoStorage> UsersInfoStorage;
 
-    mutable TMaybe<TLogPrefix> IdleLogPrefix;
-    mutable TMaybe<TLogPrefix> InitLogPrefix;
-    mutable TMaybe<TLogPrefix> UnknownLogPrefix;
+    mutable TMaybe<TStructuredLogPrefix> IdleLogPrefix;
+    mutable TMaybe<TStructuredLogPrefix> InitLogPrefix;
+    mutable TMaybe<TStructuredLogPrefix> UnknownLogPrefix;
 
     struct TAffectedSourceIdsAndConsumers {
         TVector<TString> TxWriteSourcesIds;

--- a/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
@@ -3,28 +3,6 @@
 #include "partition_util.h"
 #include <ydb/library/actors/core/log.h>
 
-#undef NPQ_LOG_PREFIX
-#undef LOG
-#undef LOG_T
-#undef LOG_D
-#undef LOG_I
-#undef LOG_N
-#undef LOG_W
-#undef LOG_E
-#undef LOG_C
-#undef LOG_A
-
-#define NPQ_LOG_PREFIX this->LogPrefix()
-#define LOG(level, T, ...) YDB_LOG_COMP(level, NKikimrServices::PERSQUEUE, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_T(T, ...) YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_D(T, ...) YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_I(T, ...) YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_N(T, ...) YDB_LOG_NOTICE_COMP(NKikimrServices::PERSQUEUE, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_W(T, ...) YDB_LOG_WARN_COMP(NKikimrServices::PERSQUEUE, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_E(T, ...) YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_C(T, ...) YDB_LOG_CRIT_COMP(NKikimrServices::PERSQUEUE, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-#define LOG_A(T, ...) YDB_LOG_ALERT_COMP(NKikimrServices::PERSQUEUE, T, NPQ_LOG_PREFIX, ##__VA_ARGS__)
-
 namespace NKikimr::NPQ {
 std::unique_ptr<TEvPQ::TEvRead> MakeEvRead(const TActorId& selfId, ui64 nextRequestCookie, ui64 startOffset, ui64 lastOffset, TMaybe<ui64> nextPartNo = Nothing()) {
     auto evRead = std::make_unique<TEvPQ::TEvRead>(
@@ -64,21 +42,21 @@ const char* CompactionStepName(TPartitionCompaction::EStep step) {
 
 } // namespace
 
-TLogPrefix TPartitionCompaction::MakeLogPrefix(const TPartition* actor, const char* compactionStep) {
-    TLogPrefix prefix = MakeNpqLogPrefix(actor->LogBuilder(), actor->GetLogPrefix());
+TStructuredLogPrefix TPartitionCompaction::MakeLogPrefix(const TPartition* actor, const char* compactionStep) {
+    TStructuredLogPrefix prefix = MakeNpqLogPrefix(actor->LogBuilder(), actor->GetLogPrefix());
     prefix.AppendMessage(YDB_LOG_CREATE_MESSAGE({"compactionStep", compactionStep}));
     return prefix;
 }
 
-TLogPrefix TPartitionCompaction::LogPrefix() const {
+TStructuredLogPrefix TPartitionCompaction::LogPrefix() const {
     return MakeLogPrefix(PartitionActor, CompactionStepName(Step));
 }
 
-TLogPrefix TPartitionCompaction::TReadState::LogPrefix() const {
+TStructuredLogPrefix TPartitionCompaction::TReadState::LogPrefix() const {
     return MakeLogPrefix(PartitionActor, "reading");
 }
 
-TLogPrefix TPartitionCompaction::TCompactState::LogPrefix() const {
+TStructuredLogPrefix TPartitionCompaction::TCompactState::LogPrefix() const {
     return MakeLogPrefix(PartitionActor, "compacting");
 }
 
@@ -145,8 +123,7 @@ void TPartitionCompaction::ProcessResponse(TEvPQ::TEvError::TPtr& ev) {
     LOG_E(
         "Compaction for topic proxy ERROR",
         {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()},
-            {"partition", PartitionActor->Partition},
-            {"response", ev->Get()->Error}
+        {"response", ev->Get()->Error}
     );
     PartitionActor->Send(PartitionActor->TabletActorId, new TEvents::TEvPoison());
     Step = EStep::PENDING;
@@ -157,8 +134,7 @@ void TPartitionCompaction::ProcessResponse(TEvPQ::TEvProxyResponse::TPtr& ev) {
     LOG_D(
         "Compaction for topic proxy response",
         {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()},
-            {"partition", PartitionActor->Partition},
-            {"cookie", ev->Get()->Cookie}
+        {"cookie", ev->Get()->Cookie}
     );
     if (ev->Get()->Cookie != PartRequestCookie) {
         return;
@@ -217,16 +193,12 @@ void TPartitionCompaction::ProcessResponse(TEvKeyValue::TEvResponse::TPtr& ev) {
     AFL_ENSURE(!PartitionActor->CompacterKvRequestInflight);
     LOG_D(
         "Compaction for topic Process KV response",
-        {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()},
-            {"partition", PartitionActor->Partition}
-    );
+        {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()});
     if (CompactState) {
         if (!CompactState->ProcessKVResponse(ev)) {
             LOG_E(
                 "Compaction for topic Process KV response: BAD Status",
-                {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()},
-                            {"partition", PartitionActor->Partition}
-            );
+                {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()});
 
             PartitionActor->Send(PartitionActor->TabletActorId, new TEvents::TEvPoison());
             return;
@@ -411,7 +383,6 @@ TPartitionCompaction::EStep TPartitionCompaction::TReadState::ContinueIfPossible
     LOG_D(
         "Compaction for topic Send EvRead (Read state)",
         {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()},
-            {"partition", PartitionActor->Partition},
             {"fromOffset", OffsetToRead},
             {"nextPartNo", NextPartNo}
     );
@@ -475,7 +446,6 @@ TPartitionCompaction::TCompactState::TCompactState(
     LOG_D(
         "Compaction for topic Created compact state. first head",
         {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()},
-            {"partition", PartitionActor->Partition},
             {"startOffset", partitionActor->CompactionBlobEncoder.StartOffset},
             {"offset", FirstHeadOffset},
             {"endOffset", partitionActor->BlobEncoder.EndOffset}
@@ -511,7 +481,6 @@ TPartitionCompaction::EStep TPartitionCompaction::TCompactState::ContinueIfPossi
         LOG_D(
             "Compaction for topic Send EvRead (Compact state)",
             {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()},
-                    {"partition", PartitionActor->Partition},
                     {"fromOffset", currKey.GetOffset()},
                     {"currKeyPartNo", currKey.GetPartNo()}
         );
@@ -657,7 +626,6 @@ bool TPartitionCompaction::TCompactState::ProcessReadResult(NKikimrClient::TCmdR
     LOG_D(
         "Compaction for topic process read result in CompState starting isTruncatedBlob",
         {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()},
-            {"partition", PartitionActor->Partition},
             {"from", readResult.GetResult(0).GetOffset()},
             {"readResultResult0PartNo", readResult.GetResult(0).GetPartNo()},
             {"isTruncatedBlob", isTruncatedBlob}
@@ -804,7 +772,6 @@ bool TPartitionCompaction::TCompactState::ProcessReadResult(NKikimrClient::TCmdR
             LOG_D(
                 "Compaction for topic LastPart processed read result in CompState starting res.GetOffset() isTruncatedBlob hasNonZeroParts keepMessage LastBatch",
                 {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()},
-                            {"partition", PartitionActor->Partition},
                             {"from", readResult.GetResult(0).GetOffset()},
                             {"readResultResult0PartNo", readResult.GetResult(0).GetPartNo()},
                             {"offset", res.GetOffset()},
@@ -845,7 +812,6 @@ bool TPartitionCompaction::TCompactState::ProcessReadResult(NKikimrClient::TCmdR
     LOG_D(
         "Compaction for topic processed read result in CompState starting isTruncatedBlob hasNonZeroParts isMiddlePartOfMessage",
         {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()},
-            {"partition", PartitionActor->Partition},
             {"from", readResult.GetResult(0).GetOffset()},
             {"readResultResult0PartNo", readResult.GetResult(0).GetPartNo()},
             {"isTruncatedBlob", isTruncatedBlob},
@@ -904,7 +870,6 @@ void TPartitionCompaction::TCompactState::AddDeleteRange(const TKey& key) {
     LOG_D(
         "Compaction for topic add CmdDeleteRange for key",
         {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()},
-            {"partition", PartitionActor->Partition},
             {"key", key}
     );
 
@@ -971,7 +936,6 @@ void TPartitionCompaction::TCompactState::SendCommit(ui64 cookie) {
     LOG_D(
         "Compaction for topic commit",
         {"clientSideName", PartitionActor->TopicConverter->GetClientsideName()},
-            {"partition", PartitionActor->Partition},
             {"offset", MaxOffset}
     );
     PartitionActor->CompacterPartitionRequestInflight = true;

--- a/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
@@ -43,7 +43,7 @@ const char* CompactionStepName(TPartitionCompaction::EStep step) {
 } // namespace
 
 TStructuredLogPrefix TPartitionCompaction::MakeLogPrefix(const TPartition* actor, const char* compactionStep) {
-    TStructuredLogPrefix prefix = MakeNpqLogPrefix(actor->LogBuilder(), actor->GetLogPrefix());
+    TStructuredLogPrefix prefix = MakeRuntimeLogPrefix(*actor);
     prefix.AppendMessage(YDB_LOG_CREATE_MESSAGE({"compactionStep", compactionStep}));
     return prefix;
 }

--- a/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
@@ -42,21 +42,21 @@ const char* CompactionStepName(TPartitionCompaction::EStep step) {
 
 } // namespace
 
-TStructuredLogPrefix TPartitionCompaction::MakeLogPrefix(const TPartition* actor, const char* compactionStep) {
-    TStructuredLogPrefix prefix = MakeRuntimeLogPrefix(*actor);
+TStructuredMessage TPartitionCompaction::MakeLogPrefix(const TPartition* actor, const char* compactionStep) {
+    TStructuredMessage prefix = MakeRuntimeLogPrefix(*actor);
     prefix.AppendMessage(YDB_LOG_CREATE_MESSAGE({"compactionStep", compactionStep}));
     return prefix;
 }
 
-TStructuredLogPrefix TPartitionCompaction::LogPrefix() const {
+TStructuredMessage TPartitionCompaction::LogPrefix() const {
     return MakeLogPrefix(PartitionActor, CompactionStepName(Step));
 }
 
-TStructuredLogPrefix TPartitionCompaction::TReadState::LogPrefix() const {
+TStructuredMessage TPartitionCompaction::TReadState::LogPrefix() const {
     return MakeLogPrefix(PartitionActor, "reading");
 }
 
-TStructuredLogPrefix TPartitionCompaction::TCompactState::LogPrefix() const {
+TStructuredMessage TPartitionCompaction::TCompactState::LogPrefix() const {
     return MakeLogPrefix(PartitionActor, "compacting");
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_compactification.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compactification.h
@@ -47,11 +47,11 @@ struct TKeyCompactionCounters {
 };
 
 class TPartitionCompaction : public TLogPrefix {
-    static TStructuredLogPrefix MakeLogPrefix(const TPartition* actor, const char* compactionStep);
+    static TStructuredMessage MakeLogPrefix(const TPartition* actor, const char* compactionStep);
 
 public:
     TPartitionCompaction(ui64 lastCompactedOffset, ui64 partReqestCookie, TPartition* partitionActor);
-    TStructuredLogPrefix LogPrefix() const override;
+    TStructuredMessage LogPrefix() const override;
 
     enum class EStep {
         PENDING,
@@ -77,7 +77,7 @@ public:
 
     public:
         TReadState(ui64 firstOffset, TPartition* partitionActor);
-        TStructuredLogPrefix LogPrefix() const override;
+        TStructuredMessage LogPrefix() const override;
 
         bool ProcessResponse(TEvPQ::TEvProxyResponse::TPtr& ev);
         void ProcessResponse(NBatching::TEvProcessBatchKeysResult::TPtr& ev);
@@ -129,7 +129,7 @@ public:
         TKeyCompactionCounters* Counters;
 
         TCompactState(THashMap<TString, ui64>&& data, ui64 firstUncompactedOffset, ui64 maxOffset, TPartition* partitionActor, TKeyCompactionCounters* counters);
-        TStructuredLogPrefix LogPrefix() const override;
+        TStructuredMessage LogPrefix() const override;
 
         bool ProcessKVResponse(TEvKeyValue::TEvResponse::TPtr& ev);
         bool ProcessResponse(TEvPQ::TEvProxyResponse::TPtr& ev);

--- a/ydb/core/persqueue/pqtablet/partition/partition_compactification.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compactification.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/core/persqueue/common/key.h>
+#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/core/persqueue/pqtablet/batching/batch_processor.h>
 #include <ydb/core/persqueue/pqtablet/blob/blob.h>
 
@@ -45,12 +46,12 @@ struct TKeyCompactionCounters {
     ui64 WriteCyclesCount = 0;
 };
 
-class TPartitionCompaction {
-    static TLogPrefix MakeLogPrefix(const TPartition* actor, const char* compactionStep);
+class TPartitionCompaction : public TLogPrefix {
+    static TStructuredLogPrefix MakeLogPrefix(const TPartition* actor, const char* compactionStep);
 
 public:
     TPartitionCompaction(ui64 lastCompactedOffset, ui64 partReqestCookie, TPartition* partitionActor);
-    TLogPrefix LogPrefix() const;
+    TStructuredLogPrefix LogPrefix() const override;
 
     enum class EStep {
         PENDING,
@@ -59,7 +60,7 @@ public:
     };
 
 
-    struct TReadState {
+    struct TReadState : TLogPrefix {
         friend TPartitionCompaction;
         constexpr static const ui64 MAX_DATA_KEYS = 5000;
 
@@ -76,7 +77,7 @@ public:
 
     public:
         TReadState(ui64 firstOffset, TPartition* partitionActor);
-        TLogPrefix LogPrefix() const;
+        TStructuredLogPrefix LogPrefix() const override;
 
         bool ProcessResponse(TEvPQ::TEvProxyResponse::TPtr& ev);
         void ProcessResponse(NBatching::TEvProcessBatchKeysResult::TPtr& ev);
@@ -86,7 +87,7 @@ public:
         void UpdateConfig(ui64 maxBurst, ui64 readQuota); //ToDo;
     };
 
-    struct TCompactState {
+    struct TCompactState : TLogPrefix {
         friend TPartitionCompaction;
         using TKeysIter = std::deque<TDataKey>::iterator;
 
@@ -128,7 +129,7 @@ public:
         TKeyCompactionCounters* Counters;
 
         TCompactState(THashMap<TString, ui64>&& data, ui64 firstUncompactedOffset, ui64 maxOffset, TPartition* partitionActor, TKeyCompactionCounters* counters);
-        TLogPrefix LogPrefix() const;
+        TStructuredLogPrefix LogPrefix() const override;
 
         bool ProcessKVResponse(TEvKeyValue::TEvResponse::TPtr& ev);
         bool ProcessResponse(TEvPQ::TEvProxyResponse::TPtr& ev);

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -16,7 +16,6 @@ bool TPartition::ExecRequestForCompaction(TWriteMsg& p, TProcessParametersBase& 
     LOG_T(
         "Topic partition process write",
         {"topicName", TopicName()},
-        {"partition", Partition},
         {"sourceId", EscapeC(p.Msg.SourceId)},
         {"disableDeduplication", p.Msg.DisableDeduplication},
         {"seqNo", p.Msg.SeqNo},
@@ -57,7 +56,6 @@ bool TPartition::ExecRequestForCompaction(TWriteMsg& p, TProcessParametersBase& 
     LOG_D(
         "Topic partition part blob processing sourceId seqNo partNo",
         {"topicName", TopicName()},
-        {"partition", Partition},
         {"sourceId", EscapeC(p.Msg.SourceId)},
         {"seqNo", p.Msg.SeqNo},
         {"partNo", p.Msg.PartNo}
@@ -97,7 +95,6 @@ bool TPartition::ExecRequestForCompaction(TWriteMsg& p, TProcessParametersBase& 
         LOG_D(
             "Topic partition part blob sourceId seqNo partNo result is size",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"sourceId", EscapeC(p.Msg.SourceId)},
             {"seqNo", p.Msg.SeqNo},
             {"partNo", p.Msg.PartNo},
@@ -146,7 +143,6 @@ bool TPartition::ExecRequestForCompaction(TWriteMsg& p, TProcessParametersBase& 
         LOG_D(
             "Topic partition part blob complete sourceId seqNo partNo FormedBlobsCount",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"sourceId", EscapeC(p.Msg.SourceId)},
             {"seqNo", p.Msg.SeqNo},
             {"partNo", p.Msg.PartNo},
@@ -764,7 +760,6 @@ void TPartition::EndProcessWritesForCompaction(TEvKeyValue::TEvRequest* request,
     LOG_D(
         "Add new write blob: topic partition compactOffset HeadOffset endOffset curOffset size WTime",
         {"topicName", TopicName()},
-        {"partition", Partition},
         {"offset", key.GetOffset()},
         {"count", key.GetCount()},
         {"compactionBlobEncoderHeadOffset", CompactionBlobEncoder.Head.Offset},

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -64,8 +64,7 @@ void TInitializer::Next(const TActorContext& ctx) {
 }
 
 void TInitializer::Done(const TActorContext& ctx) {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Initializing completed",
-        {LogPrefix()});
+    LOG_D("Initializing completed");
     InProgress = false;
     Partition->InitComplete(ctx);
 }
@@ -85,13 +84,12 @@ void TInitializer::DoNext(const TActorContext& ctx) {
         }
     }
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Start initializing step",
-        {LogPrefix()},
+    LOG_D("Start initializing step", 
         {"currentStepGetName", CurrentStep->Get()->Name});
     CurrentStep->Get()->Execute(ctx);
 }
 
-NActors::NStructuredLog::TStructuredMessage TInitializer::LogPrefix() const {
+TStructuredLogPrefix TInitializer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"className", "Initializer"},
         {"topic", Partition->TopicName()},
@@ -115,8 +113,7 @@ void TInitializerStep::Done(const TActorContext& ctx) {
 
 void TInitializerStep::RestartTablet(const std::string_view message) const {
     if (NActors::TlsActivationContext) {
-        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Restarting tablet",
-            {LogPrefix()},
+        LOG_E("Restarting tablet", 
             {"partitionTabletId", Partition()->TabletId},
             {"message", message});
     }
@@ -145,7 +142,7 @@ TInitializionContext& TInitializerStep::GetContext() {
     return Initializer->Ctx;
 }
 
-NActors::NStructuredLog::TStructuredMessage TInitializerStep::LogPrefix() const {
+TStructuredLogPrefix TInitializerStep::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"className", Name},
         {"topic", Partition()->TopicName()},
@@ -547,7 +544,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
 
     for (size_t i = 0; i < keys.size(); ++i) {
         if (NActors::TlsActivationContext) {
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Dump key[index]",
+            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Dump key[index]", 
                 {LogPrefix()},
                 {"index", i},
                 {"value", keys[i]});
@@ -560,7 +557,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
     for (auto& k : keys) {
         if (filtered.empty()) {
             if (NActors::TlsActivationContext) {
-                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key",
+                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key", 
                     {LogPrefix()},
                     {"k", k});
             }
@@ -574,7 +571,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                     if (lastKey.GetCount() < candidate.GetCount()) {
                         // candidate содержит lastKey
                         if (NActors::TlsActivationContext) {
-                            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Replace key",
+                            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Replace key", 
                                 {LogPrefix()},
                                 {"filteredBack", filtered.back()},
                                 {"k", k});
@@ -585,7 +582,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                         if (lastKey.GetInternalPartsCount() < candidate.GetInternalPartsCount()) {
                             // candidate содержит lastKey
                             if (NActors::TlsActivationContext) {
-                                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Replace key",
+                                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Replace key", 
                                     {LogPrefix()},
                                     {"filteredBack", filtered.back()},
                                     {"k", k});
@@ -595,7 +592,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                         } else {
                             // lastKey содержит candidate
                             if (NActors::TlsActivationContext) {
-                                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key",
+                                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key", 
                                     {LogPrefix()},
                                     {"k", k});
                             }
@@ -603,7 +600,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                     } else {
                         // lastKey содержит candidate
                         if (NActors::TlsActivationContext) {
-                            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key",
+                            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key", 
                                 {LogPrefix()},
                                 {"k", k});
                         }
@@ -611,14 +608,14 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                 } else if (lastKey.GetPartNo() > candidate.GetPartNo()) {
                     // lastKey содержит candidate
                     if (NActors::TlsActivationContext) {
-                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key",
+                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key", 
                             {LogPrefix()},
                             {"k", k});
                     }
                 } else {
                     // candidate после lastKey
                     if (NActors::TlsActivationContext) {
-                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key",
+                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key", 
                             {LogPrefix()},
                             {"k", k});
                     }
@@ -629,14 +626,14 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                 if (const ui64 nextOffset = lastKey.GetOffset() + lastKey.GetCount(); nextOffset > candidate.GetOffset()) {
                     // lastKey содержит candidate
                     if (NActors::TlsActivationContext) {
-                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key",
+                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key", 
                             {LogPrefix()},
                             {"k", k});
                     }
                 } else {
                     // candidate после lastKey или пропуск между lastKey и candidate
                     if (NActors::TlsActivationContext) {
-                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key",
+                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key", 
                             {LogPrefix()},
                             {"k", k});
                     }
@@ -673,7 +670,7 @@ static void CheckKeysTimestampOrder(const std::deque<TDataKey>& keys) {
         prev = curr++;
     }
     if (disorderPairCount > 0) {
-        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Data keys have misarranged timestamps;",
+        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Data keys have misarranged timestamps;", 
             {LogPrefix()},
             {"disorderPairCount", disorderPairCount},
             {"sample", sample});
@@ -698,13 +695,11 @@ void TInitDataRangeStep::FillBlobsMetaData(const TActorContext&) {
         for (ui32 i = 0; i < range.PairSize(); ++i) {
             const auto& pair = range.GetPair(i);
             PQ_INIT_ENSURE(pair.GetStatus() == NKikimrProto::OK); //this is readrange without keys, only OK could be here
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Check key",
-                {LogPrefix()},
+            LOG_D("Check key", 
                 {"key", pair.GetKey()});
             const auto k = TKey::FromString(pair.GetKey(), PartitionId());
             if (!actualKeys.contains(pair.GetKey())) {
-                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Unknown key will be deleted",
-                    {LogPrefix()},
+                LOG_D("Unknown key will be deleted", 
                     {"key", pair.GetKey()});
                 GetContext().DeletedKeys.emplace_back(k.ToString());
                 continue;
@@ -730,8 +725,7 @@ void TInitDataRangeStep::FillBlobsMetaData(const TActorContext&) {
                 bodySize += pair.GetValueSize();
             }
 
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Got data offset count size so eo",
-                {LogPrefix()},
+            LOG_D("Got data offset count size so eo", 
                 {"kOffset", k.GetOffset()},
                 {"kCount", k.GetCount()},
                 {"valueSize", pair.GetValueSize()},
@@ -804,19 +798,13 @@ void TInitDataRangeStep::NormalizeOffsetsForEmptyData() {
     // WARN when meta claims a non-empty range while keys are gone: partition would stay
     // inconsistent (offset range without blobs) until we collapse to endOffset (#49507).
     if (startOffset < endOffset) {
-        YDB_LOG_WARN_COMP(NKikimrServices::PERSQUEUE,
-            "No data keys during partition init; normalizing empty partition offsets",
-            {LogPrefix()},
+        LOG_W("No data keys during partition init; normalizing empty partition offsets", 
             {"tablet_id", Partition()->TabletId},
-            {"partition", Partition()->Partition},
             {"metaStartOffset", startOffset},
             {"metaEndOffset", endOffset});
     } else {
-        YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE,
-            "No data keys during partition init; normalizing empty partition offsets",
-            {LogPrefix()},
+        LOG_I("No data keys during partition init; normalizing empty partition offsets", 
             {"tablet_id", Partition()->TabletId},
-            {"partition", Partition()->Partition},
             {"metaStartOffset", startOffset},
             {"metaEndOffset", endOffset});
     }
@@ -1116,8 +1104,7 @@ void TInitDataStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActorConte
                 PQ_INIT_ENSURE(!dataKeysHead[currentLevel].NeedCompaction())
                     ("c", currentLevel);
 
-                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Read res partition offset endOffset key valuesize expected",
-                    {LogPrefix()},
+                LOG_D("Read res partition offset endOffset key valuesize expected", 
                     {"offset", offset},
                     {"partitionBlobEncoderEndOffset", Partition()->BlobEncoder.EndOffset},
                     {"keyOffset", key.GetOffset()},
@@ -1131,8 +1118,7 @@ void TInitDataStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActorConte
                 PQ_INIT_ENSURE(size == read.GetValue().size())("size", size)("read.GetValue().size()", read.GetValue().size());
 
                 for (TBlobIterator it(key, read.GetValue()); it.IsValid(); it.Next()) {
-                    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add batch",
-                        {LogPrefix()});
+                    LOG_D("Add batch");
                     head.AddBatch(it.GetBatch());
                 }
                 head.PackedSize += size;
@@ -1165,8 +1151,7 @@ TInitEndWriteTimestampStep::TInitEndWriteTimestampStep(TInitializer* initializer
 void TInitEndWriteTimestampStep::Execute(const TActorContext &ctx) {
     if (Partition()->EndWriteTimestamp != TInstant::Zero() ||
         (Partition()->BlobEncoder.IsEmpty() && Partition()->CompactionBlobEncoder.IsEmpty())) {
-        YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Initializing EndWriteTimestamp skipped because already initialized",
-            {LogPrefix()});
+        LOG_I("Initializing EndWriteTimestamp skipped because already initialized");
         return Done(ctx);
     }
 
@@ -1182,8 +1167,7 @@ void TInitEndWriteTimestampStep::Execute(const TActorContext &ctx) {
         Partition()->PendingWriteTimestamp = Partition()->EndWriteTimestamp;
     }
 
-    YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Initializing EndWriteTimestamp from keys completed. Value",
-        {LogPrefix()},
+    LOG_I("Initializing EndWriteTimestamp from keys completed. Value", 
         {"partitionEndWriteTimestamp", Partition()->EndWriteTimestamp});
 
     return Done(ctx);
@@ -1318,7 +1302,6 @@ void TPartition::Initialize(const TActorContext& ctx) {
 
     LOG_I(
         "Bootstrapping",
-        {"partition", Partition},
         {"selfId", ctx.SelfID}
     );
 
@@ -1661,7 +1644,7 @@ static void RequestRange(const TActorContext& ctx, const TActorId& dst, const TP
         AddCmdDeleteRange(*request, TKeyPrefix::TypeTmpData, partition);
     }
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Read range request. From",
+    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Read range request. From", 
         {LogPrefix()},
         {"from", from},
         {"to", to});

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -65,7 +65,7 @@ void TInitializer::Next(const TActorContext& ctx) {
 
 void TInitializer::Done(const TActorContext& ctx) {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Initializing completed",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
     InProgress = false;
     Partition->InitComplete(ctx);
 }
@@ -86,13 +86,16 @@ void TInitializer::DoNext(const TActorContext& ctx) {
     }
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Start initializing step",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"currentStepGetName", CurrentStep->Get()->Name});
     CurrentStep->Get()->Execute(ctx);
 }
 
-TString TInitializer::LogPrefix() const {
-    return TStringBuilder() << "[" << Partition->TopicName() << ":" << Partition->Partition << ":Initializer] ";
+NActors::NStructuredLog::TStructuredMessage TInitializer::LogPrefix() const {
+    return YDB_LOG_CREATE_MESSAGE(
+        {"actorClassName", "Initializer"},
+        {"topic", Partition->TopicName()},
+        {"partition", Partition->Partition.ToString()});
 }
 
 
@@ -113,7 +116,7 @@ void TInitializerStep::Done(const TActorContext& ctx) {
 void TInitializerStep::RestartTablet(const std::string_view message) const {
     if (NActors::TlsActivationContext) {
         YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Restarting tablet",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionTabletId", Partition()->TabletId},
             {"message", message});
     }
@@ -142,8 +145,11 @@ TInitializionContext& TInitializerStep::GetContext() {
     return Initializer->Ctx;
 }
 
-TString TInitializerStep::LogPrefix() const {
-    return TStringBuilder() << "[" << Partition()->TopicName() << ":" << Partition()->Partition << ":" << Name << "] ";
+NActors::NStructuredLog::TStructuredMessage TInitializerStep::LogPrefix() const {
+    return YDB_LOG_CREATE_MESSAGE(
+        {"actorClassName", Name},
+        {"topic", Partition()->TopicName()},
+        {"partition", PartitionId().ToString()});
 }
 
 
@@ -542,7 +548,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
     for (size_t i = 0; i < keys.size(); ++i) {
         if (NActors::TlsActivationContext) {
             YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Dump key[index]",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"index", i},
                 {"value", keys[i]});
         }
@@ -555,7 +561,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
         if (filtered.empty()) {
             if (NActors::TlsActivationContext) {
                 YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"k", k});
             }
             filtered.push_back(std::move(k));
@@ -569,7 +575,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                         // candidate содержит lastKey
                         if (NActors::TlsActivationContext) {
                             YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Replace key",
-                                {"logPrefix", LogPrefix()},
+                                {LogPrefix()},
                                 {"filteredBack", filtered.back()},
                                 {"k", k});
                         }
@@ -580,7 +586,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                             // candidate содержит lastKey
                             if (NActors::TlsActivationContext) {
                                 YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Replace key",
-                                    {"logPrefix", LogPrefix()},
+                                    {LogPrefix()},
                                     {"filteredBack", filtered.back()},
                                     {"k", k});
                             }
@@ -590,7 +596,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                             // lastKey содержит candidate
                             if (NActors::TlsActivationContext) {
                                 YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key",
-                                    {"logPrefix", LogPrefix()},
+                                    {LogPrefix()},
                                     {"k", k});
                             }
                         }
@@ -598,7 +604,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                         // lastKey содержит candidate
                         if (NActors::TlsActivationContext) {
                             YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key",
-                                {"logPrefix", LogPrefix()},
+                                {LogPrefix()},
                                 {"k", k});
                         }
                     }
@@ -606,14 +612,14 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                     // lastKey содержит candidate
                     if (NActors::TlsActivationContext) {
                         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key",
-                            {"logPrefix", LogPrefix()},
+                            {LogPrefix()},
                             {"k", k});
                     }
                 } else {
                     // candidate после lastKey
                     if (NActors::TlsActivationContext) {
                         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key",
-                            {"logPrefix", LogPrefix()},
+                            {LogPrefix()},
                             {"k", k});
                     }
                     filtered.push_back(std::move(k));
@@ -624,14 +630,14 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                     // lastKey содержит candidate
                     if (NActors::TlsActivationContext) {
                         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key",
-                            {"logPrefix", LogPrefix()},
+                            {LogPrefix()},
                             {"k", k});
                     }
                 } else {
                     // candidate после lastKey или пропуск между lastKey и candidate
                     if (NActors::TlsActivationContext) {
                         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key",
-                            {"logPrefix", LogPrefix()},
+                            {LogPrefix()},
                             {"k", k});
                     }
                     filtered.push_back(std::move(k));
@@ -668,7 +674,7 @@ static void CheckKeysTimestampOrder(const std::deque<TDataKey>& keys) {
     }
     if (disorderPairCount > 0) {
         YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Data keys have misarranged timestamps;",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"disorderPairCount", disorderPairCount},
             {"sample", sample});
     }
@@ -693,12 +699,12 @@ void TInitDataRangeStep::FillBlobsMetaData(const TActorContext&) {
             const auto& pair = range.GetPair(i);
             PQ_INIT_ENSURE(pair.GetStatus() == NKikimrProto::OK); //this is readrange without keys, only OK could be here
             YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Check key",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"key", pair.GetKey()});
             const auto k = TKey::FromString(pair.GetKey(), PartitionId());
             if (!actualKeys.contains(pair.GetKey())) {
                 YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Unknown key will be deleted",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"key", pair.GetKey()});
                 GetContext().DeletedKeys.emplace_back(k.ToString());
                 continue;
@@ -725,7 +731,7 @@ void TInitDataRangeStep::FillBlobsMetaData(const TActorContext&) {
             }
 
             YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Got data offset count size so eo",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"kOffset", k.GetOffset()},
                 {"kCount", k.GetCount()},
                 {"valueSize", pair.GetValueSize()},
@@ -800,7 +806,7 @@ void TInitDataRangeStep::NormalizeOffsetsForEmptyData() {
     if (startOffset < endOffset) {
         YDB_LOG_WARN_COMP(NKikimrServices::PERSQUEUE,
             "No data keys during partition init; normalizing empty partition offsets",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"tablet_id", Partition()->TabletId},
             {"partition", Partition()->Partition},
             {"metaStartOffset", startOffset},
@@ -808,7 +814,7 @@ void TInitDataRangeStep::NormalizeOffsetsForEmptyData() {
     } else {
         YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE,
             "No data keys during partition init; normalizing empty partition offsets",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"tablet_id", Partition()->TabletId},
             {"partition", Partition()->Partition},
             {"metaStartOffset", startOffset},
@@ -1111,7 +1117,7 @@ void TInitDataStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActorConte
                     ("c", currentLevel);
 
                 YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Read res partition offset endOffset key valuesize expected",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"offset", offset},
                     {"partitionBlobEncoderEndOffset", Partition()->BlobEncoder.EndOffset},
                     {"keyOffset", key.GetOffset()},
@@ -1126,7 +1132,7 @@ void TInitDataStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActorConte
 
                 for (TBlobIterator it(key, read.GetValue()); it.IsValid(); it.Next()) {
                     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add batch",
-                        {"logPrefix", LogPrefix()});
+                        {LogPrefix()});
                     head.AddBatch(it.GetBatch());
                 }
                 head.PackedSize += size;
@@ -1160,7 +1166,7 @@ void TInitEndWriteTimestampStep::Execute(const TActorContext &ctx) {
     if (Partition()->EndWriteTimestamp != TInstant::Zero() ||
         (Partition()->BlobEncoder.IsEmpty() && Partition()->CompactionBlobEncoder.IsEmpty())) {
         YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Initializing EndWriteTimestamp skipped because already initialized",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         return Done(ctx);
     }
 
@@ -1177,7 +1183,7 @@ void TInitEndWriteTimestampStep::Execute(const TActorContext &ctx) {
     }
 
     YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Initializing EndWriteTimestamp from keys completed. Value",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"partitionEndWriteTimestamp", Partition()->EndWriteTimestamp});
 
     return Done(ctx);
@@ -1656,7 +1662,7 @@ static void RequestRange(const TActorContext& ctx, const TActorId& dst, const TP
     }
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Read range request. From",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"from", from},
         {"to", to});
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -93,7 +93,7 @@ void TInitializer::DoNext(const TActorContext& ctx) {
 
 NActors::NStructuredLog::TStructuredMessage TInitializer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "Initializer"},
+        {"className", "Initializer"},
         {"topic", Partition->TopicName()},
         {"partition", Partition->Partition.ToString()});
 }
@@ -147,7 +147,7 @@ TInitializionContext& TInitializerStep::GetContext() {
 
 NActors::NStructuredLog::TStructuredMessage TInitializerStep::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", Name},
+        {"className", Name},
         {"topic", Partition()->TopicName()},
         {"partition", PartitionId().ToString()});
 }

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -84,7 +84,7 @@ void TInitializer::DoNext(const TActorContext& ctx) {
         }
     }
 
-    LOG_D("Start initializing step", 
+    LOG_D("Start initializing step",
         {"currentStepGetName", CurrentStep->Get()->Name});
     CurrentStep->Get()->Execute(ctx);
 }
@@ -113,7 +113,7 @@ void TInitializerStep::Done(const TActorContext& ctx) {
 
 void TInitializerStep::RestartTablet(const std::string_view message) const {
     if (NActors::TlsActivationContext) {
-        LOG_E("Restarting tablet", 
+        LOG_E("Restarting tablet",
             {"partitionTabletId", Partition()->TabletId},
             {"message", message});
     }
@@ -544,7 +544,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
 
     for (size_t i = 0; i < keys.size(); ++i) {
         if (NActors::TlsActivationContext) {
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Dump key[index]", 
+            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Dump key[index]",
                 {LogPrefix()},
                 {"index", i},
                 {"value", keys[i]});
@@ -557,7 +557,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
     for (auto& k : keys) {
         if (filtered.empty()) {
             if (NActors::TlsActivationContext) {
-                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key", 
+                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key",
                     {LogPrefix()},
                     {"k", k});
             }
@@ -571,7 +571,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                     if (lastKey.GetCount() < candidate.GetCount()) {
                         // candidate содержит lastKey
                         if (NActors::TlsActivationContext) {
-                            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Replace key", 
+                            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Replace key",
                                 {LogPrefix()},
                                 {"filteredBack", filtered.back()},
                                 {"k", k});
@@ -582,7 +582,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                         if (lastKey.GetInternalPartsCount() < candidate.GetInternalPartsCount()) {
                             // candidate содержит lastKey
                             if (NActors::TlsActivationContext) {
-                                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Replace key", 
+                                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Replace key",
                                     {LogPrefix()},
                                     {"filteredBack", filtered.back()},
                                     {"k", k});
@@ -592,7 +592,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                         } else {
                             // lastKey содержит candidate
                             if (NActors::TlsActivationContext) {
-                                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key", 
+                                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key",
                                     {LogPrefix()},
                                     {"k", k});
                             }
@@ -600,7 +600,7 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                     } else {
                         // lastKey содержит candidate
                         if (NActors::TlsActivationContext) {
-                            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key", 
+                            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key",
                                 {LogPrefix()},
                                 {"k", k});
                         }
@@ -608,14 +608,14 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                 } else if (lastKey.GetPartNo() > candidate.GetPartNo()) {
                     // lastKey содержит candidate
                     if (NActors::TlsActivationContext) {
-                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key", 
+                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key",
                             {LogPrefix()},
                             {"k", k});
                     }
                 } else {
                     // candidate после lastKey
                     if (NActors::TlsActivationContext) {
-                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key", 
+                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key",
                             {LogPrefix()},
                             {"k", k});
                     }
@@ -626,14 +626,14 @@ THashSet<TString> FilterBlobsMetaData(const TVector<NKikimrClient::TKeyValueResp
                 if (const ui64 nextOffset = lastKey.GetOffset() + lastKey.GetCount(); nextOffset > candidate.GetOffset()) {
                     // lastKey содержит candidate
                     if (NActors::TlsActivationContext) {
-                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key", 
+                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Ignore key",
                             {LogPrefix()},
                             {"k", k});
                     }
                 } else {
                     // candidate после lastKey или пропуск между lastKey и candidate
                     if (NActors::TlsActivationContext) {
-                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key", 
+                        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Add key",
                             {LogPrefix()},
                             {"k", k});
                     }
@@ -670,7 +670,7 @@ static void CheckKeysTimestampOrder(const std::deque<TDataKey>& keys) {
         prev = curr++;
     }
     if (disorderPairCount > 0) {
-        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Data keys have misarranged timestamps;", 
+        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Data keys have misarranged timestamps;",
             {LogPrefix()},
             {"disorderPairCount", disorderPairCount},
             {"sample", sample});
@@ -695,11 +695,11 @@ void TInitDataRangeStep::FillBlobsMetaData(const TActorContext&) {
         for (ui32 i = 0; i < range.PairSize(); ++i) {
             const auto& pair = range.GetPair(i);
             PQ_INIT_ENSURE(pair.GetStatus() == NKikimrProto::OK); //this is readrange without keys, only OK could be here
-            LOG_D("Check key", 
+            LOG_D("Check key",
                 {"key", pair.GetKey()});
             const auto k = TKey::FromString(pair.GetKey(), PartitionId());
             if (!actualKeys.contains(pair.GetKey())) {
-                LOG_D("Unknown key will be deleted", 
+                LOG_D("Unknown key will be deleted",
                     {"key", pair.GetKey()});
                 GetContext().DeletedKeys.emplace_back(k.ToString());
                 continue;
@@ -725,7 +725,7 @@ void TInitDataRangeStep::FillBlobsMetaData(const TActorContext&) {
                 bodySize += pair.GetValueSize();
             }
 
-            LOG_D("Got data offset count size so eo", 
+            LOG_D("Got data offset count size so eo",
                 {"kOffset", k.GetOffset()},
                 {"kCount", k.GetCount()},
                 {"valueSize", pair.GetValueSize()},
@@ -798,12 +798,12 @@ void TInitDataRangeStep::NormalizeOffsetsForEmptyData() {
     // WARN when meta claims a non-empty range while keys are gone: partition would stay
     // inconsistent (offset range without blobs) until we collapse to endOffset (#49507).
     if (startOffset < endOffset) {
-        LOG_W("No data keys during partition init; normalizing empty partition offsets", 
+        LOG_W("No data keys during partition init; normalizing empty partition offsets",
             {"tablet_id", Partition()->TabletId},
             {"metaStartOffset", startOffset},
             {"metaEndOffset", endOffset});
     } else {
-        LOG_I("No data keys during partition init; normalizing empty partition offsets", 
+        LOG_I("No data keys during partition init; normalizing empty partition offsets",
             {"tablet_id", Partition()->TabletId},
             {"metaStartOffset", startOffset},
             {"metaEndOffset", endOffset});
@@ -1104,7 +1104,7 @@ void TInitDataStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActorConte
                 PQ_INIT_ENSURE(!dataKeysHead[currentLevel].NeedCompaction())
                     ("c", currentLevel);
 
-                LOG_D("Read res partition offset endOffset key valuesize expected", 
+                LOG_D("Read res partition offset endOffset key valuesize expected",
                     {"offset", offset},
                     {"partitionBlobEncoderEndOffset", Partition()->BlobEncoder.EndOffset},
                     {"keyOffset", key.GetOffset()},
@@ -1167,7 +1167,7 @@ void TInitEndWriteTimestampStep::Execute(const TActorContext &ctx) {
         Partition()->PendingWriteTimestamp = Partition()->EndWriteTimestamp;
     }
 
-    LOG_I("Initializing EndWriteTimestamp from keys completed. Value", 
+    LOG_I("Initializing EndWriteTimestamp from keys completed. Value",
         {"partitionEndWriteTimestamp", Partition()->EndWriteTimestamp});
 
     return Done(ctx);
@@ -1641,7 +1641,7 @@ static void RequestRange(const TActorContext& ctx, const TActorId& dst, const TP
         AddCmdDeleteRange(*request, TKeyPrefix::TypeTmpData, partition);
     }
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Read range request. From", 
+    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Read range request. From",
         {LogPrefix()},
         {"from", from},
         {"to", to});

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -1300,10 +1300,7 @@ void TPartition::Initialize(const TActorContext& ctx) {
             Config.GetYdbDatabasePath(), Config.GetOffloadConfig()));
     }
 
-    LOG_I(
-        "Bootstrapping",
-        {"selfId", ctx.SelfID}
-    );
+    LOG_I("Bootstrapping");
 
     if (AppData(ctx)->Counters) {
         if (AppData()->PQConfig.GetTopicsAreFirstClassCitizen()) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -89,7 +89,7 @@ void TInitializer::DoNext(const TActorContext& ctx) {
     CurrentStep->Get()->Execute(ctx);
 }
 
-TStructuredLogPrefix TInitializer::LogPrefix() const {
+TStructuredMessage TInitializer::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"className", "Initializer"},
         {"topic", Partition->TopicName()},
@@ -142,7 +142,7 @@ TInitializionContext& TInitializerStep::GetContext() {
     return Initializer->Ctx;
 }
 
-TStructuredLogPrefix TInitializerStep::LogPrefix() const {
+TStructuredMessage TInitializerStep::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"className", Name},
         {"topic", Partition()->TopicName()},

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.h
@@ -1,15 +1,13 @@
 #pragma once
 
+#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/core/persqueue/pqtablet/blob/header.h>
 #include <ydb/core/persqueue/public/utils.h>
 
 #include <ydb/core/keyvalue/keyvalue_events.h>
-#include <ydb/library/persqueue/counter_time_keeper/counter_time_keeper.h>
-
-#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/hfunc.h>
-#include <ydb/library/actors/core/log.h>
+#include <ydb/library/persqueue/counter_time_keeper/counter_time_keeper.h>
 
 #include <util/generic/set.h>
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.h
@@ -46,7 +46,7 @@ protected:
 private:
     void DoNext(const TActorContext& ctx);
 
-    TStructuredLogPrefix LogPrefix() const override;
+    TStructuredMessage LogPrefix() const override;
 
     TPartition* Partition;
 
@@ -82,7 +82,7 @@ public:
 protected:
     void Done(const TActorContext& ctx);
 
-    TStructuredLogPrefix LogPrefix() const override;
+    TStructuredMessage LogPrefix() const override;
 
 private:
     TInitializer* Initializer;

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.h
@@ -47,7 +47,7 @@ protected:
 private:
     void DoNext(const TActorContext& ctx);
 
-    TString LogPrefix() const;
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
 
     TPartition* Partition;
 
@@ -83,7 +83,7 @@ public:
 protected:
     void Done(const TActorContext& ctx);
 
-    TString LogPrefix() const;
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
 
 private:
     TInitializer* Initializer;

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.h
@@ -6,6 +6,7 @@
 #include <ydb/core/keyvalue/keyvalue_events.h>
 #include <ydb/library/persqueue/counter_time_keeper/counter_time_keeper.h>
 
+#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
@@ -30,7 +31,7 @@ struct TInitializionContext {
  * This class execute independent steps of parttition actor initialization.
  * Each initialization step makes its own decision whether to perform it or not.
  */
-class TInitializer {
+class TInitializer : public TLogPrefix {
     friend TInitializerStep;
 
 public:
@@ -47,7 +48,7 @@ protected:
 private:
     void DoNext(const TActorContext& ctx);
 
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
+    TStructuredLogPrefix LogPrefix() const override;
 
     TPartition* Partition;
 
@@ -62,7 +63,7 @@ private:
  * Its is independent initialization step.
  * Step begin a execution when method Execute called and ends it after metheod Done called.
  */
-class TInitializerStep {
+class TInitializerStep : public TLogPrefix {
 public:
     TInitializerStep(TInitializer* initializer, TString name, bool skipNewPartition);
     virtual ~TInitializerStep() = default;
@@ -83,7 +84,7 @@ public:
 protected:
     void Done(const TActorContext& ctx);
 
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
+    TStructuredLogPrefix LogPrefix() const override;
 
 private:
     TInitializer* Initializer;

--- a/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
@@ -556,7 +556,7 @@ TMaybe<TReadAnswer> TReadInfo::AddBlobsFromBody(const TVector<NPQ::TRequestedBlo
                 continue;
             }
 
-            LOG_D("FormAnswer processing batch offset totakecount count size from batchStartIdx cbcount", 
+            LOG_D("FormAnswer processing batch offset totakecount count size from batchStartIdx cbcount",
                 {"offsetHeaderCount", (offset - header.GetCount())},
                 {"count", count},
                 {"headerCount", header.GetCount()},
@@ -643,7 +643,7 @@ TReadAnswer TReadInfo::FormAnswer(
     readResult->SetReadFromTimestampMs(ReadTimestampMs);
 
     AFL_ENSURE(endOffset <= (ui64)Max<i64>())("Max offset is too big", endOffset);
-    LOG_D("FormAnswer for blobs", 
+    LOG_D("FormAnswer for blobs",
         {"blobsSize", Blobs.size()});
 
     if (!isActive && response->GetBlobs().empty()) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
@@ -488,8 +488,7 @@ TMaybe<TReadAnswer> TReadInfo::AddBlobsFromBody(const TVector<NPQ::TRequestedBlo
         const ui16 partNo = blobs[blobIdx].PartNo;
 
         if (blobs[blobIdx].Empty()) { // this is ok. Means that someone requested too much data or retention race
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Not full answer here!",
-                {LogPrefix()});
+            LOG_D("Not full answer here!");
             const ui64 answerSize = answer->Response->ByteSize();
             if (userInfo && Destination != 0) {
                 userInfo->ReadDone(ctx, ctx.Now(), answerSize, cnt, ClientDC,
@@ -557,8 +556,7 @@ TMaybe<TReadAnswer> TReadInfo::AddBlobsFromBody(const TVector<NPQ::TRequestedBlo
                 continue;
             }
 
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "FormAnswer processing batch offset totakecount count size from batchStartIdx cbcount",
-                {LogPrefix()},
+            LOG_D("FormAnswer processing batch offset totakecount count size from batchStartIdx cbcount", 
                 {"offsetHeaderCount", (offset - header.GetCount())},
                 {"count", count},
                 {"headerCount", header.GetCount()},
@@ -645,8 +643,7 @@ TReadAnswer TReadInfo::FormAnswer(
     readResult->SetReadFromTimestampMs(ReadTimestampMs);
 
     AFL_ENSURE(endOffset <= (ui64)Max<i64>())("Max offset is too big", endOffset);
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "FormAnswer for blobs",
-        {LogPrefix()},
+    LOG_D("FormAnswer for blobs", 
         {"blobsSize", Blobs.size()});
 
     if (!isActive && response->GetBlobs().empty()) {
@@ -800,7 +797,6 @@ void TPartition::Handle(TEvPQ::TEvReadTimeout::TPtr& ev, const TActorContext& ct
     LOG_D(
         "Waiting read cookie partition read timeout for offset",
         {"cookie", ev->Get()->Cookie},
-            {"partition", Partition},
             {"user", res->User},
             {"offset", res->Offset}
     );
@@ -893,8 +889,6 @@ void TPartition::Handle(TEvPQ::TEvRead::TPtr& ev, const TActorContext& ctx) {
         LOG_E(
             "I was right, there could be rewinds and deletions at once! Topic partition readOffset readPartNo startOffset",
             {"clientSideName", TopicConverter->GetClientsideName()},
-                    {"partition",
-            Partition},
                     {"offset",
             read->Offset},
                     {"partNo", read->PartNo},
@@ -914,8 +908,6 @@ void TPartition::Handle(TEvPQ::TEvRead::TPtr& ev, const TActorContext& ctx) {
         LOG_E(
             "Reading from too big offset - topic partition client EndOffset offset",
             {"clientSideName", TopicConverter->GetClientsideName()},
-                    {"partition",
-            Partition},
                     {"clientId",
             read->ClientId},
                     {"endOffset", GetEndOffset()},
@@ -984,8 +976,6 @@ void TPartition::DoRead(TEvPQ::TEvRead::TPtr&& readEvent, TDuration waitQuotaTim
         "Read cookie Topic partition user offset partno count size endOffset max time lag ms effective offset",
         {"cookie", cookie},
         {"clientSideName", TopicConverter->GetClientsideName()},
-            {"partition",
-        Partition},
             {"user",
         user},
             {"offset",
@@ -1005,8 +995,6 @@ void TPartition::DoRead(TEvPQ::TEvRead::TPtr&& readEvent, TDuration waitQuotaTim
                 LOG_D(
                     "Too big read timeout Topic partition user offset count size endOffset max time lag ms effective offset",
                     {"clientSideName", TopicConverter->GetClientsideName()},
-                                    {"partition",
-                    Partition},
                                     {"clientId",
                     read->ClientId},
                                     {"offset", read->Offset},
@@ -1051,8 +1039,6 @@ void TPartition::ReadTimestampForOffset(const TString& user, TUserInfo& userInfo
     LOG_D(
         "Topic partition user readTimeStamp for offset initiated queuesize startOffset ReadingTimestamp rrg",
         {"clientSideName", TopicConverter->GetClientsideName()},
-            {"partition",
-        Partition},
             {"user",
         user},
             {"userInfoOffset",
@@ -1106,8 +1092,6 @@ void TPartition::ReadTimestampForOffset(const TString& user, TUserInfo& userInfo
     LOG_D(
         "Topic partition user send read request for offset initiated queuesize startOffset ReadingTimestamp rrg",
         {"clientSideName", TopicConverter->GetClientsideName()},
-            {"partition",
-        Partition},
             {"user",
         user},
             {"userInfoOffset",
@@ -1142,10 +1126,7 @@ void TPartition::Handle(TEvPQ::TEvProxyResponse::TPtr& ev, const TActorContext& 
     if (ev->Get()->IsInternal) {
         LOG_D(
             "Topic partition Got internal ProxyResponse",
-            {"clientSideName", TopicConverter->GetClientsideName()},
-                    {"partition",
-            Partition}
-        );
+            {"clientSideName", TopicConverter->GetClientsideName()});
         CompacterPartitionRequestInflight = false;
         if (Compacter) {
             Compacter->ProcessResponse(ev);
@@ -1159,8 +1140,6 @@ void TPartition::Handle(TEvPQ::TEvProxyResponse::TPtr& ev, const TActorContext& 
         LOG_I(
             "Topic partition user readTimeStamp for other generation or no client info at all",
             {"clientSideName", TopicConverter->GetClientsideName()},
-                    {"partition",
-            Partition},
                     {"readingForUser",
             ReadingForUser}
         );
@@ -1172,8 +1151,6 @@ void TPartition::Handle(TEvPQ::TEvProxyResponse::TPtr& ev, const TActorContext& 
     LOG_D(
         "Topic partition user readTimeStamp done, result queuesize startOffset",
         {"clientSideName", TopicConverter->GetClientsideName()},
-            {"partition",
-        Partition},
             {"readingForUser",
         ReadingForUser},
             {"userInfoWriteTimestampMilliSeconds",

--- a/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
@@ -489,7 +489,7 @@ TMaybe<TReadAnswer> TReadInfo::AddBlobsFromBody(const TVector<NPQ::TRequestedBlo
 
         if (blobs[blobIdx].Empty()) { // this is ok. Means that someone requested too much data or retention race
             YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Not full answer here!",
-                {"logPrefix", LogPrefix()});
+                {LogPrefix()});
             const ui64 answerSize = answer->Response->ByteSize();
             if (userInfo && Destination != 0) {
                 userInfo->ReadDone(ctx, ctx.Now(), answerSize, cnt, ClientDC,
@@ -558,7 +558,7 @@ TMaybe<TReadAnswer> TReadInfo::AddBlobsFromBody(const TVector<NPQ::TRequestedBlo
             }
 
             YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "FormAnswer processing batch offset totakecount count size from batchStartIdx cbcount",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"offsetHeaderCount", (offset - header.GetCount())},
                 {"count", count},
                 {"headerCount", header.GetCount()},
@@ -646,7 +646,7 @@ TReadAnswer TReadInfo::FormAnswer(
 
     AFL_ENSURE(endOffset <= (ui64)Max<i64>())("Max offset is too big", endOffset);
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "FormAnswer for blobs",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"blobsSize", Blobs.size()});
 
     if (!isActive && response->GetBlobs().empty()) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -39,9 +39,7 @@ static constexpr NPersQueue::NErrorCode::EErrorCode InactivePartitionErrorCode =
 
 void TPartition::ReplyOwnerOk(const TActorContext& ctx, const ui64 dst, const TString& cookie, ui64 seqNo, NWilson::TSpan& span) {
     LOG_D(
-        "TPartition::ReplyOwnerOk",
-        {"partition", Partition}
-    );
+        "TPartition::ReplyOwnerOk");
 
     THolder<TEvPQ::TEvProxyResponse> response = MakeHolder<TEvPQ::TEvProxyResponse>(dst, false);
     NKikimrClient::TResponse& resp = *response->Response;
@@ -65,9 +63,7 @@ void TPartition::ReplyWrite(
     const TDuration partitionQuotedTime, const TDuration topicQuotedTime, const TDuration queueTime, const TDuration writeTime, NWilson::TSpan& span) {
 
     LOG_D(
-        "TPartition::ReplyWrite",
-        {"partition", Partition}
-    );
+        "TPartition::ReplyWrite");
 
     PQ_ENSURE(offset <= (ui64)Max<i64>())("Offset is too big", offset);
     PQ_ENSURE(seqNo <= (ui64)Max<i64>())("SeqNo is too big", seqNo);
@@ -204,17 +200,13 @@ void TPartition::ProcessReserveRequests(const TActorContext& ctx) {
         const ui64 currentSize = ReservedSize + WriteInflightSize + WriteCycleSize;
         if (currentSize != 0 && currentSize + size > maxWriteInflightSize) {
             LOG_D(
-                "Reserve processing: maxWriteInflightSize riched",
-                {"partition", Partition}
-            );
+                "Reserve processing: maxWriteInflightSize riched");
             break;
         }
 
         if (WaitingForSubDomainQuota(currentSize)) {
             LOG_D(
-                "Reserve processing: SubDomainOutOfSpace",
-                {"partition", Partition}
-            );
+                "Reserve processing: SubDomainOutOfSpace");
             break;
         }
 
@@ -467,7 +459,6 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
                 "Answering for message sourceid: Topic: is",
                 {"escapeCS", EscapeC(s)},
                 {"topicName", TopicName()},
-                {"partition", Partition},
                 {"seqNo", seqNo},
                 {"partNo", partNo},
                 {"offset", offset},
@@ -852,7 +843,6 @@ void TPartition::HandleOnWrite(TEvPQ::TEvWrite::TPtr& ev, const TActorContext& c
         if (msg.SeqNo > (ui64)Max<i64>()) {
             LOG_E(
                 "Request to write wrong SeqNo. Partition sourceId seqno",
-                {"partition", Partition},
                 {"escapeCMsgSourceId", EscapeC(msg.SourceId)},
                 {"seqNo", msg.SeqNo}
             );
@@ -1246,7 +1236,6 @@ void TPartition::RenameFormedBlobs(const std::deque<TPartitionedBlob::TRenameFor
         LOG_D(
             "Writing blob: topic partition old key new key size WTime",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"oldKey", x.OldKey},
             {"newKey", x.NewKey},
             {"size", x.Size},
@@ -1356,7 +1345,6 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
     LOG_T(
         "Topic partition process write",
         {"topicName", TopicName()},
-        {"partition", Partition},
         {"sourceId", EscapeC(p.Msg.SourceId)},
         {"disableDeduplication", p.Msg.DisableDeduplication},
         {"seqNo", p.Msg.SeqNo},
@@ -1421,7 +1409,6 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
             LOG_D(
                 "Already written message. Topic: SourceId: Message Committed Writing",
                 {"topicName", TopicName()},
-                {"partition", Partition},
                 {"sourceId", EscapeC(p.Msg.SourceId)},
                 {"seqNo", p.Msg.SeqNo},
                 {"initialSeqNo", p.InitialSeqNo},
@@ -1466,7 +1453,6 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
         LOG_D(
             "Topic partition process heartbeat sourceId version",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"sourceId", EscapeC(p.Msg.SourceId)},
             {"hbVersion", *hbVersion}
         );
@@ -1495,7 +1481,6 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
         LOG_D(
             "Topic partition process schema change sourceId version",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"sourceId", EscapeC(p.Msg.SourceId)},
             {"scVersion", *scVersion}
         );
@@ -1596,7 +1581,6 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
     LOG_D(
         "Topic partition part blob processing sourceId seqNo partNo",
         {"topicName", TopicName()},
-        {"partition", Partition},
         {"sourceId", EscapeC(p.Msg.SourceId)},
         {"seqNo", p.Msg.SeqNo},
         {"partNo", p.Msg.PartNo}
@@ -1659,7 +1643,6 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
         LOG_D(
             "Topic partition part blob sourceId seqNo partNo result is size",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"sourceId", EscapeC(p.Msg.SourceId)},
             {"seqNo", p.Msg.SeqNo},
             {"partNo", p.Msg.PartNo},
@@ -1708,7 +1691,6 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
         LOG_D(
             "Topic partition part blob complete sourceId seqNo partNo FormedBlobsCount",
             {"topicName", TopicName()},
-            {"partition", Partition},
             {"sourceId", EscapeC(p.Msg.SourceId)},
             {"seqNo", p.Msg.SeqNo},
             {"partNo", p.Msg.PartNo},
@@ -1972,7 +1954,6 @@ void TPartition::EndProcessWrites(TEvKeyValue::TEvRequest* request, const TActor
     LOG_D(
         "Add new write blob: topic partition compactOffset HeadOffset endOffset curOffset size WTime",
         {"topicName", TopicName()},
-        {"partition", Partition},
         {"offset", key.GetOffset()},
         {"count", key.GetCount()},
         {"blobEncoderHeadOffset", BlobEncoder.Head.Offset},
@@ -2018,7 +1999,6 @@ void TPartition::EndAppendHeadWithNewWrites(const TActorContext& ctx)
             LOG_I(
                 "Topic partition emit heartbeat",
                 {"topicName", TopicName()},
-                {"partition", Partition},
                 {"version", heartbeat->Version}
             );
 
@@ -2054,7 +2034,6 @@ void TPartition::EndAppendHeadWithNewWrites(const TActorContext& ctx)
             LOG_I(
                 "Topic partition emit schema change",
                 {"topicName", TopicName()},
-                {"partition", Partition},
                 {"version", schemaChange->Version}
             );
 
@@ -2102,7 +2081,6 @@ void TPartition::RequestQuotaForWriteBlobRequest(size_t dataSize, ui64 cookie) {
     LOG_D(
         "Send write quota request. Topic",
         {"topicName", TopicName()},
-        {"partition", Partition},
         {"amount", dataSize},
         {"cookie", cookie}
     );

--- a/ydb/core/persqueue/pqtablet/partition/subscriber.h
+++ b/ydb/core/persqueue/pqtablet/partition/subscriber.h
@@ -10,7 +10,6 @@
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/persqueue/common/blob_refcounter.h>
 #include <ydb/core/persqueue/common/logging.h>
-#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr {
 namespace NPQ {

--- a/ydb/core/persqueue/pqtablet/partition/subscriber.h
+++ b/ydb/core/persqueue/pqtablet/partition/subscriber.h
@@ -9,6 +9,7 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/persqueue/common/blob_refcounter.h>
+#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/library/actors/core/log.h>
 
 namespace NKikimr {
@@ -24,7 +25,7 @@ struct TReadAnswer {
     TActorId ReplyTo;
 };
 
-struct TReadInfo {
+struct TReadInfo : TLogPrefix {
     TString User;
     TString ClientDC;
     ui64 Offset;
@@ -97,7 +98,7 @@ struct TReadInfo {
         return LastOffset != 0 && Offset >= LastOffset;
     }
 
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+    TStructuredLogPrefix LogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"className", "TReadInfo"},
             {"user", User},

--- a/ydb/core/persqueue/pqtablet/partition/subscriber.h
+++ b/ydb/core/persqueue/pqtablet/partition/subscriber.h
@@ -9,6 +9,7 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/persqueue/common/blob_refcounter.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr {
 namespace NPQ {
@@ -94,6 +95,14 @@ struct TReadInfo {
 
     bool ReachedLastOffset() const {
         return LastOffset != 0 && Offset >= LastOffset;
+    }
+
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"actorClassName", "TReadInfo"},
+            {"user", User},
+            {"offset", Offset},
+            {"destination", Destination});
     }
 
     TReadAnswer FormAnswer(

--- a/ydb/core/persqueue/pqtablet/partition/subscriber.h
+++ b/ydb/core/persqueue/pqtablet/partition/subscriber.h
@@ -99,7 +99,7 @@ struct TReadInfo {
 
     NActors::NStructuredLog::TStructuredMessage LogPrefix() const {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "TReadInfo"},
+            {"className", "TReadInfo"},
             {"user", User},
             {"offset", Offset},
             {"destination", Destination});

--- a/ydb/core/persqueue/pqtablet/partition/subscriber.h
+++ b/ydb/core/persqueue/pqtablet/partition/subscriber.h
@@ -97,7 +97,7 @@ struct TReadInfo : TLogPrefix {
         return LastOffset != 0 && Offset >= LastOffset;
     }
 
-    TStructuredLogPrefix LogPrefix() const override {
+    TStructuredMessage LogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"className", "TReadInfo"},
             {"user", User},

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -270,8 +270,7 @@ public:
     }
 
     const TStructuredLogPrefix& GetLogPrefix() const {
-        static const TStructuredLogPrefix LogPrefix = YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "BuilderProxy"});
+        static const TStructuredLogPrefix LogPrefix;
         return LogPrefix;
     }
 
@@ -5576,8 +5575,7 @@ void TPersQueue::BeginDeletePartitions(const TDistributedTransaction& tx)
 }
 
 TStructuredLogPrefix TPersQueue::LogPrefix() const {
-    return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "PQ"});
+    return {};
 }
 
 ui64 TPersQueue::GetGeneration() {

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -364,7 +364,7 @@ void TPersQueue::ApplyNewConfig(const NKikimrPQ::TPQTabletConfig& newConfig,
 {
     Config = newConfig;
 
-    LOG_D("Apply new config", 
+    LOG_D("Apply new config",
         {"config", Config.ShortDebugString()});
 
     ui32 cacheSize = CACHE_SIZE;
@@ -502,7 +502,7 @@ void TPersQueue::ReadTxInfo(const NKikimrClient::TKeyValueResponse::TReadResult&
         return;
     }
 
-    LOG_I("PlanStep PlanTxId ExecStep ExecTxId", 
+    LOG_I("PlanStep PlanTxId ExecStep ExecTxId",
         {"planStep", PlanStep},
         {"planTxId", PlanTxId},
         {"execStep", ExecStep},
@@ -578,7 +578,7 @@ void TPersQueue::MoveTopTxToCalculating(TDistributedTransaction& tx,
     PQ_ENSURE(!TxQueue.empty());
 
     std::tie(ExecStep, ExecTxId) = TxQueue.front();
-    LOG_I("New ExecStep ExecTxId", 
+    LOG_I("New ExecStep ExecTxId",
         {"execStep", ExecStep},
         {"execTxId", ExecTxId});
 
@@ -721,20 +721,20 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
             if (tx.GetStep() > PlanStep) {
                 PlanStep = tx.GetStep();
                 PlanTxId = tx.GetTxId();
-                LOG_D("PlanStep PlanTxId", 
+                LOG_D("PlanStep PlanTxId",
                     {"planStep", PlanStep},
                     {"planTxId", PlanTxId});
             } else if (tx.GetStep() == PlanStep) {
                 if (tx.GetTxId() > PlanTxId) {
                     PlanTxId = tx.GetTxId();
-                    LOG_D("PlanStep PlanTxId", 
+                    LOG_D("PlanStep PlanTxId",
                         {"planStep", PlanStep},
                         {"planTxId", PlanTxId});
                 }
             }
         }
 
-        LOG_I("Restore Tx", 
+        LOG_I("Restore Tx",
             {"txId", tx.GetTxId()},
             {"step", tx.GetStep()},
             {"state", NKikimrPQ::TTransaction_EState_Name(tx.GetState())},
@@ -745,7 +745,7 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
         Txs.emplace(tx.GetTxId(), tx);
 
         if (tx.HasWriteId()) {
-            LOG_I("Link TxId with WriteId", 
+            LOG_I("Link TxId with WriteId",
                 {"txId", tx.GetTxId()},
                 {"writeId", GetWriteId(tx)});
             TxWrites[GetWriteId(tx)].TxId = tx.GetTxId();
@@ -753,7 +753,7 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
     }
 
     for (const auto& [txId, tx] : Txs) {
-        LOG_D("Dump logPrefix, txId, step, state, decision", 
+        LOG_D("Dump logPrefix, txId, step, state, decision",
             {"txId", txId},
             {"step", tx.Step},
             {"state", NKikimrPQ::TTransaction_EState_Name(tx.State)},
@@ -848,7 +848,7 @@ void TPersQueue::InitializeMeteringSink(const TActorContext& ctx) {
 
     auto& pqConfig = AppData(ctx)->PQConfig;
     if (!pqConfig.GetBillingMeteringConfig().GetEnabled()) {
-        LOG_N("Disable metering is not enabled in BillingMeteringConfig", 
+        LOG_N("Disable metering is not enabled in BillingMeteringConfig",
             {"reason", "billing"});
         return;
     }
@@ -1012,7 +1012,7 @@ TPartitionInfo& TPersQueue::GetPartitionInfo(const TPartitionId& partitionId)
 
 void TPersQueue::Handle(TEvPQ::TEvPartitionCounters::TPtr& ev, const TActorContext& ctx)
 {
-    LOG_T("Handle TEvPQ::TEvPartitionCounters PartitionId", 
+    LOG_T("Handle TEvPQ::TEvPartitionCounters PartitionId",
         {"partition", ev->Get()->Partition});
 
     auto& partitionId = ev->Get()->Partition;
@@ -1136,7 +1136,7 @@ void TPersQueue::Handle(TEvPQ::TEvTabletCacheCounters::TPtr& ev, const TActorCon
     CacheCounters = ev->Get()->Counters;
     SetCacheCounters(CacheCounters);
 
-    LOG_D("Topic counters. CacheSize CachedBlobs", 
+    LOG_D("Topic counters. CacheSize CachedBlobs",
         {"topic", (TopicConverter ? TopicConverter->GetClientsideName() : "Undefined")},
         {"cacheSizeBytes", CacheCounters.CacheSizeBytes},
         {"cacheSizeBlobs", CacheCounters.CacheSizeBlobs});
@@ -1188,7 +1188,7 @@ void TPersQueue::Handle(TEvPQ::TEvInitComplete::TPtr& ev, const TActorContext& c
 
 void TPersQueue::Handle(TEvPQ::TEvError::TPtr& ev, const TActorContext& ctx)
 {
-    LOG_D("Handle TEvPQ::TEvError Cookie Error", 
+    LOG_D("Handle TEvPQ::TEvError Cookie Error",
         {"cookie", ev->Get()->Cookie},
         {"error", ev->Get()->Error});
 
@@ -1386,7 +1386,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvStatus::TPtr& ev, const TActorContext& 
     LOG_T("Handle TEvPersQueue::TEvStatus");
 
     if (!ConfigInited || !AllOriginalPartitionsInited()) {
-        LOG_D("Postpone the request. ConfigInited PartitionsInited OriginalPartitionsCount", 
+        LOG_D("Postpone the request. ConfigInited PartitionsInited OriginalPartitionsCount",
             {"configInited", static_cast<int>(ConfigInited)},
             {"partitionsInited", PartitionsInited},
             {"originalPartitionsCount", OriginalPartitionsCount});
@@ -1457,7 +1457,7 @@ void TPersQueue::HandleDeleteSessionRequest(
     InitResponseBuilder(responseCookie, 1, COUNTER_LATENCY_PQ_DELETE_SESSION);
     const auto& cmd = req.GetCmdDeleteSession();
     //To do : priority
-    LOG_I("Got cmd delete", 
+    LOG_I("Got cmd delete",
         {"session", cmd.DebugString()});
 
     if (!cmd.HasClientId()){
@@ -1516,7 +1516,7 @@ void TPersQueue::HandleCreateSessionRequest(const ui64 responseCookie, NWilson::
 
             pipeIter->second.SessionId = cmd.GetSessionId();
             pipeIter->second.PartitionSessionId = cmd.GetPartitionSessionId();
-            LOG_D("Created session", 
+            LOG_D("Created session",
                 {"sessionId", cmd.GetSessionId()},
                 {"onPipe", pipeIter->first});
             ctx.Send(MakePQDReadCacheServiceActorId(),
@@ -1651,7 +1651,7 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
     }
 
     if (req.HasWriteId()) {
-        LOG_D("Write in transaction", 
+        LOG_D("Write in transaction",
             {"partition", req.GetPartition()},
             {"writeId", req.GetWriteId()},
             {"needSupportivePartition", req.GetNeedSupportivePartition()});
@@ -1829,7 +1829,7 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
 
                 partNo++;
                 uncompressedSize = 0;
-                LOG_D("Got client PART message", 
+                LOG_D("Got client PART message",
                     {"topic", (TopicConverter ? TopicConverter->GetClientsideName() : "Undefined")},
                     {"partition", req.GetPartition()},
                     {"sourceId", EscapeC(msgs.back().SourceId)},
@@ -1891,7 +1891,7 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
             });
             FillBatchInfo(cmd, msgs.back());
         }
-        LOG_D("Got client message", 
+        LOG_D("Got client message",
             {"topic", (TopicConverter ? TopicConverter->GetClientsideName() : "Undefined")},
             {"partition", req.GetPartition()},
             {"sourceId", EscapeC(msgs.back().SourceId)},
@@ -1944,7 +1944,7 @@ void TPersQueue::HandleReserveBytesRequest(const ui64 responseCookie, NWilson::T
     }
 
     if (req.HasWriteId()) {
-        LOG_D("Reserve bytes in transaction", 
+        LOG_D("Reserve bytes in transaction",
             {"partition", req.GetPartition()},
             {"writeId", req.GetWriteId()},
             {"needSupportivePartition", req.GetNeedSupportivePartition()});
@@ -2115,7 +2115,7 @@ void TPersQueue::HandlePublishReadRequest(
     publishRes->SetDirectReadId(key.ReadId);
     ctx.Send(SelfId(), publishDoneEvent.Release());
 
-    LOG_D("Publish direct read id for session", 
+    LOG_D("Publish direct read id for session",
         {"readId", key.ReadId},
         {"sessionId", key.SessionId});
     ctx.Send(
@@ -2145,7 +2145,7 @@ void TPersQueue::HandleForgetReadRequest(
     forgetDoneEvent->Response->MutablePartitionResponse()->MutableCmdForgetReadResult()->SetDirectReadId(key.ReadId);
     ctx.Send(SelfId(), forgetDoneEvent.Release());
 
-    LOG_D("Forget direct read id for session", 
+    LOG_D("Forget direct read id for session",
         {"readId", key.ReadId},
         {"sessionId", key.SessionId});
     ctx.Send(
@@ -2157,7 +2157,7 @@ void TPersQueue::HandleForgetReadRequest(
 }
 
 void TPersQueue::DestroySession(TPipeInfo& pipeInfo) {
-    LOG_D("Destroy direct read session", 
+    LOG_D("Destroy direct read session",
         {"sessionId", pipeInfo.SessionId});
     if (pipeInfo.SessionId.empty())
         return;
@@ -2376,7 +2376,7 @@ void TPersQueue::HandleAbortDeferredStagingRequest(const ui64 responseCookie,
     if (TxWrites.contains(writeId)) {
         TTxWriteInfo& writeInfo = TxWrites.at(writeId);
         if (writeInfo.Partitions.contains(originalPartitionId) && !writeInfo.Deleting) {
-            LOG_D("Abort deferred staging", 
+            LOG_D("Abort deferred staging",
                 {"writeId", writeId},
                 {"partition", originalPartitionId},
             );
@@ -2515,7 +2515,7 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
         //
         TTxWriteInfo& writeInfo = TxWrites[writeId];
         TPartitionId partitionId(originalPartitionId, writeId, NextSupportivePartitionId++);
-        LOG_I("Partition for WriteId", 
+        LOG_I("Partition for WriteId",
             {"partitionId", partitionId},
             {"writeId", writeId});
 
@@ -2599,7 +2599,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvRequest::TPtr& ev, const TActorContext&
     TPartitionId partition(req.GetPartition());
     auto it = Partitions.find(partition);
 
-    LOG_D("Got client message batch for topic partition", 
+    LOG_D("Got client message batch for topic partition",
         {"topic", (TopicConverter ? TopicConverter->GetClientsideName() : "Undefined")},
         {"partition", partition});
 
@@ -2689,7 +2689,7 @@ void TPersQueue::Handle(TEvTabletPipe::TEvServerConnected::TPtr& ev, const TActo
 
     auto it = PipesInfo.insert({ev->Get()->ClientId, {}}).first;
     it->second.ServerActors++;
-    LOG_D("Server connected, pipe now have active actors on pipe", 
+    LOG_D("Server connected, pipe now have active actors on pipe",
         {"clientId", ev->Get()->ClientId},
         {"serverActors", it->second.ServerActors});
 
@@ -2715,7 +2715,7 @@ void TPersQueue::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TA
         if (!it->second.SessionId.empty()) {
             DestroySession(it->second);
         }
-        LOG_D("Server disconnected, pipe destroyed", 
+        LOG_D("Server disconnected, pipe destroyed",
             {"clientId", ev->Get()->ClientId});
         PipesInfo.erase(it);
         Counters->Simple()[COUNTER_PQ_TABLET_OPENED_PIPES] = PipesInfo.size();
@@ -2729,7 +2729,7 @@ void TPersQueue::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const TActo
     PQ_ENSURE(ev->Get()->Leader)("description", TStringBuilder() << "Unexpectedly connected to follower of tablet " << ev->Get()->TabletId);
 
     if (PipeClientCache->OnConnect(ev)) {
-        LOG_D("Connected to tablet", 
+        LOG_D("Connected to tablet",
             {"peerTabletId", ev->Get()->TabletId});
         return;
     }
@@ -2750,7 +2750,7 @@ void TPersQueue::AckReadSetsToTablet(ui64 tabletId, const TActorContext& ctx)
 
 
     for (ui64 txId : GetBindedTxs(tabletId)) {
-        LOG_I("Assume tablet dead, sending read set acks for tx", 
+        LOG_I("Assume tablet dead, sending read set acks for tx",
             {"peerTabletId", tabletId},
             {"txId", txId});
 
@@ -2785,7 +2785,7 @@ void TPersQueue::AckReadSetsToTablet(ui64 tabletId, const TActorContext& ctx)
 void TPersQueue::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev, const TActorContext& ctx)
 {
     LOG_D("Handle TEvTabletPipe::TEvClientDestroyed");
-    LOG_D("Client pipe to tablet is reset", 
+    LOG_D("Client pipe to tablet is reset",
         {"peerTabletId", ev->Get()->TabletId});
 
     PipeClientCache->OnDisconnect(ev);
@@ -2966,7 +2966,7 @@ void TPersQueue::AddCmdReadTransactionRange(TEvKeyValue::TEvRequest& request,
     cmd->MutableRange()->SetIncludeTo(true);
     cmd->SetIncludeData(true);
 
-    LOG_D("Transactions request. From To", 
+    LOG_D("Transactions request. From To",
         {"rangeFrom", cmd->MutableRange()->GetFrom()},
         {"rangeTo", cmd->MutableRange()->GetTo()});
 }
@@ -3016,7 +3016,7 @@ void TPersQueue::ScheduleDeleteExpiredKafkaTransactions() {
 
     for (auto& pair : TxWrites) {
         if (txnExpired(pair.second)) {
-            LOG_D("Transaction for Kafka producer is expired", 
+            LOG_D("Transaction for Kafka producer is expired",
                 {"kafkaProducerInstanceId", pair.first.GetKafkaProducerInstanceId()});
             BeginDeletePartitions(pair.first, pair.second);
         }
@@ -3081,7 +3081,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvCancelTransactionProposal::TPtr& ev, co
     NKikimrPQ::TEvCancelTransactionProposal& event = ev->Get()->Record;
     PQ_ENSURE(event.HasTxId());
 
-    LOG_W("Handle TEvPersQueue::TEvCancelTransactionProposal for TxId", 
+    LOG_W("Handle TEvPersQueue::TEvCancelTransactionProposal for TxId",
         {"txId", event.GetTxId()});
 
     if (auto tx = GetTransaction(ctx, event.GetTxId()); tx) {
@@ -3101,7 +3101,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvProposeTransaction::TPtr& ev, const TAc
     }
 
     const NKikimrPQ::TEvProposeTransaction& event = ev->Get()->GetRecord();
-    LOG_D("Handle TEvPersQueue::TEvProposeTransaction", 
+    LOG_D("Handle TEvPersQueue::TEvProposeTransaction",
         {"event", event.ShortDebugString()});
 
     auto span = GenerateSpan("Topic.Transaction", *SamplingControl, std::move(ev->TraceId));
@@ -3151,7 +3151,7 @@ bool TPersQueue::CheckTxWriteOperation(const NKikimrPQ::TPartitionOperation& ope
                                  writeId,
                                  GetSupportivePartition(operation)};
     }
-    LOG_D("PartitionId for WriteId", 
+    LOG_D("PartitionId for WriteId",
         {"partitionId", partitionId},
         {"writeId", writeId});
     return Partitions.contains(partitionId);
@@ -3250,7 +3250,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
     NKikimrPQ::TDataTransaction& txBody = *event.MutableData();
 
     if (TabletState != NKikimrPQ::ENormal) {
-        LOG_W("TxId invalid PQ tablet state", 
+        LOG_W("TxId invalid PQ tablet state",
             {"txId", event.GetTxId()},
             {"tabletState", NKikimrPQ::ETabletState_Name(TabletState)});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3262,7 +3262,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
     }
 
     if (txBody.OperationsSize() <= 0) {
-        LOG_W("TxId empty list of operations", 
+        LOG_W("TxId empty list of operations",
             {"txId", event.GetTxId()});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                     event.GetTxId(),
@@ -3351,7 +3351,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
     }
 
     if (!CheckTxWriteOperations(txBody)) {
-        LOG_W("TxId invalid WriteId", 
+        LOG_W("TxId invalid WriteId",
             {"txId", event.GetTxId()},
             {"writeId", txBody.GetWriteId()});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3366,7 +3366,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
         const TWriteId writeId = GetWriteId(txBody);
         if (!TxWrites.contains(writeId)) {
             if (!writeId.IsKafkaApiTransaction()) {
-                LOG_W("TxId unknown WriteId", 
+                LOG_W("TxId unknown WriteId",
                     {"txId", event.GetTxId()},
                     {"writeId", writeId});
                 SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3376,13 +3376,13 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
                                             ctx);
                 return;
             }
-            LOG_D("TxId Kafka commit with no writes for WriteId", 
+            LOG_D("TxId Kafka commit with no writes for WriteId",
                 {"txId", event.GetTxId()},
                 {"writeId", writeId});
         } else {
             TTxWriteInfo& writeInfo = TxWrites.at(writeId);
             if (writeInfo.Deleting) {
-                LOG_W("TxId WriteId will be deleted", 
+                LOG_W("TxId WriteId will be deleted",
                     {"txId", event.GetTxId()},
                     {"writeId", writeId});
                 SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3394,7 +3394,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
             }
 
             writeInfo.TxId = event.GetTxId();
-            LOG_I("TxId has WriteId", 
+            LOG_I("TxId has WriteId",
                 {"txId", event.GetTxId()},
                 {"writeId", writeId});
         }
@@ -3402,7 +3402,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
 
     TMaybe<TPartitionId> partitionId = FindPartitionId(txBody);
     if (!partitionId.Defined()) {
-        LOG_W("TxId unknown partition for WriteId", 
+        LOG_W("TxId unknown partition for WriteId",
             {"txId", event.GetTxId()},
             {"writeId", txBody.GetWriteId()});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3414,7 +3414,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
     }
 
     if (!Partitions.contains(*partitionId)) {
-        LOG_W("Unknown partition", 
+        LOG_W("Unknown partition",
             {"partitionId", *partitionId});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                     event.GetTxId(),
@@ -3472,7 +3472,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvPlanStep::TPtr& ev, const TActorCont
         return;
     }
 
-    LOG_D("Handle TEvTxProcessing::TEvPlanStep", 
+    LOG_D("Handle TEvTxProcessing::TEvPlanStep",
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     const TActorId sender = ev->Sender;
@@ -3488,7 +3488,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
         return;
     }
 
-    LOG_D("Handle TEvTxProcessing::TEvReadSet", 
+    LOG_D("Handle TEvTxProcessing::TEvReadSet",
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     NKikimrTx::TEvReadSet& event = ev->Get()->Record;
@@ -3499,7 +3499,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
         ack = std::make_unique<TEvTxProcessing::TEvReadSetAck>(*ev->Get(), TabletID());
     }
 
-    LOG_I("Handle TEvTxProcessing::TEvReadSet tx tabletProducer", 
+    LOG_I("Handle TEvTxProcessing::TEvReadSet tx tabletProducer",
         {"txId", event.GetTxId()},
         {"tabletProducer", event.GetTabletProducer()});
 
@@ -3509,7 +3509,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
         if ((tx->State > NKikimrPQ::TTransaction::EXECUTED) ||
             ((tx->State == NKikimrPQ::TTransaction::EXECUTED) && !tx->WriteInProgress)) {
             if (ack) {
-                LOG_I("Send TEvReadSetAck to for TxId", 
+                LOG_I("Send TEvReadSetAck to for TxId",
                     {"tabletProducer", event.GetTabletProducer()},
                     {"txId", event.GetTxId()});
                 ctx.Send(ev->Sender, ack.release());
@@ -3529,7 +3529,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
             TryWriteTxs(ctx);
         }
     } else if (ack) {
-        LOG_I("A TEvReadSetAck message to for TxId will be sent later", 
+        LOG_I("A TEvReadSetAck message to for TxId will be sent later",
             {"tabletProducer", event.GetTabletProducer()},
             {"txId", event.GetTxId()});
 
@@ -3553,7 +3553,7 @@ void TPersQueue::AddPendingDeferredReadSetAck(TDeferredReadSetAck&& ack)
 void TPersQueue::SendDeferredReadSetAcks(const TActorContext& ctx)
 {
     for (auto& e : DeferredReadSetAcks) {
-        LOG_I("Send TEvReadSetAck to for TxId", 
+        LOG_I("Send TEvReadSetAck to for TxId",
             {"ackRecordTabletSource", e.Ack->Record.GetTabletSource()},
             {"ackRecordTxId", e.Ack->Record.GetTxId()});
         ctx.Send(e.Sender, e.Ack.release());
@@ -3564,7 +3564,7 @@ void TPersQueue::SendDeferredReadSetAcks(const TActorContext& ctx)
 
 void TPersQueue::Handle(TEvTxProcessing::TEvReadSetAck::TPtr& ev, const TActorContext& ctx)
 {
-    LOG_I("Handle TEvTxProcessing::TEvReadSetAck", 
+    LOG_I("Handle TEvTxProcessing::TEvReadSetAck",
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     NKikimrTx::TEvReadSetAck& event = ev->Get()->Record;
@@ -3590,7 +3590,7 @@ void TPersQueue::Handle(TEvPQ::TEvTxCalcPredicateResult::TPtr& ev, const TActorC
 {
     const TEvPQ::TEvTxCalcPredicateResult& event = *ev->Get();
 
-    LOG_D("Handle TEvPQ::TEvTxCalcPredicateResult Step TxId Partition Predicate", 
+    LOG_D("Handle TEvPQ::TEvTxCalcPredicateResult Step TxId Partition Predicate",
         {"step", event.Step},
         {"txId", event.TxId},
         {"partition", event.Partition},
@@ -3614,7 +3614,7 @@ void TPersQueue::Handle(TEvPQ::TEvProposePartitionConfigResult::TPtr& ev, const 
 {
     TEvPQ::TEvProposePartitionConfigResult& event = *ev->Get();
 
-    LOG_D("Handle TEvPQ::TEvProposePartitionConfigResult Step TxId Partition", 
+    LOG_D("Handle TEvPQ::TEvProposePartitionConfigResult Step TxId Partition",
         {"step", event.Step},
         {"txId", event.TxId},
         {"partition", event.Partition});
@@ -3637,7 +3637,7 @@ void TPersQueue::Handle(TEvPQ::TEvTxDone::TPtr& ev, const TActorContext& ctx)
 {
     const TEvPQ::TEvTxDone& event = *ev->Get();
 
-    LOG_I("Handle TEvPQ::TEvTxDone Step TxId Partition", 
+    LOG_I("Handle TEvPQ::TEvTxDone Step TxId Partition",
         {"step", event.Step},
         {"txId", event.TxId},
         {"partition", event.Partition});
@@ -3677,7 +3677,7 @@ bool TPersQueue::CanProcessTxWrites() const
 void TPersQueue::SubscribeWriteId(const TWriteId& writeId,
                                   const TActorContext& ctx)
 {
-    LOG_D("Send TEvSubscribeLock for WriteId", 
+    LOG_D("Send TEvSubscribeLock for WriteId",
         {"writeId", writeId});
     ctx.Send(NLongTxService::MakeLongTxServiceID(ctx.SelfID.NodeId()),
              new NLongTxService::TEvLongTxService::TEvSubscribeLock(writeId.GetKeyId(), writeId.GetNodeId()));
@@ -3686,7 +3686,7 @@ void TPersQueue::SubscribeWriteId(const TWriteId& writeId,
 void TPersQueue::UnsubscribeWriteId(const TWriteId& writeId,
                                     const TActorContext& ctx)
 {
-    LOG_D("Send TEvUnsubscribeLock for WriteId", 
+    LOG_D("Send TEvUnsubscribeLock for WriteId",
         {"writeId", writeId});
     ctx.Send(NLongTxService::MakeLongTxServiceID(ctx.SelfID.NodeId()),
              new NLongTxService::TEvLongTxService::TEvUnsubscribeLock(writeId.GetKeyId(), writeId.GetNodeId()));
@@ -3808,7 +3808,7 @@ void TPersQueue::ProcessProposeTransactionQueue(const TActorContext& ctx,
         case NKikimrPQ::TTransaction::UNKNOWN:
             tx.OnProposeTransaction(event, GetAllowedStep(),
                                     TabletID());
-            LOG_I("Propose TxId WriteId", 
+            LOG_I("Propose TxId WriteId",
                 {"txId", tx.TxId},
                 {"txWriteId", tx.WriteId});
 
@@ -3820,14 +3820,14 @@ void TPersQueue::ProcessProposeTransactionQueue(const TActorContext& ctx,
                 const TWriteId& writeId = *tx.WriteId;
                 if (TxWrites.contains(writeId)) {
                     TTxWriteInfo& writeInfo = TxWrites.at(writeId);
-                    LOG_D("Link TxId with WriteId", 
+                    LOG_D("Link TxId with WriteId",
                         {"txId", tx.TxId},
                         {"writeId", writeId});
                     writeInfo.TxId = tx.TxId;
                 } else {
                     PQ_ENSURE(writeId.IsKafkaApiTransaction())
                         ("TxId", tx.TxId)("WriteId", writeId.ToString());
-                    LOG_D("Kafka commit with no writes; skip WriteId link", 
+                    LOG_D("Kafka commit with no writes; skip WriteId link",
                         {"txId", tx.TxId},
                         {"writeId", writeId});
                 }
@@ -3880,7 +3880,7 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
                 tx.OnPlanStep(step);
                 TryExecuteTxs(ctx, tx);
             } else {
-                LOG_W("Transaction already planned for step", 
+                LOG_W("Transaction already planned for step",
                     {"txStep", tx.Step},
                     {"step", step},
                     {"txId", txId});
@@ -3888,7 +3888,7 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
 
             lastPlannedTxId = txId;
         } else {
-            LOG_W("Unknown transaction TxId Step", 
+            LOG_W("Unknown transaction TxId Step",
                 {"txId", txId},
                 {"step", step});
         }
@@ -3919,7 +3919,7 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
         SendPlanStepAcks(ctx, sender, *ev);
     }
 
-    LOG_D("PlanStep PlanTxId", 
+    LOG_D("PlanStep PlanTxId",
         {"planStep", PlanStep},
         {"planTxId", PlanTxId});
 }
@@ -3996,7 +3996,7 @@ void TPersQueue::ProcessWriteTxs(const TActorContext& ctx,
             // таблетка PQ сохраняет только после TEvProposeTransaction
             PQ_ENSURE(state == NKikimrPQ::TTransaction::PREPARED)("TxId", txId)("State", NKikimrPQ::TTransaction_EState_Name(state));
 
-            LOG_D("Persist state for TxId", 
+            LOG_D("Persist state for TxId",
                 {"state", NKikimrPQ::TTransaction_EState_Name(state)},
                 {"txId", txId});
             tx->AddCmdWrite(request, state);
@@ -4020,7 +4020,7 @@ void TPersQueue::ProcessDeleteTxs(const TActorContext& ctx,
     }
 
     for (ui64 txId : DeleteTxs) {
-        LOG_D("Delete key for TxId", 
+        LOG_D("Delete key for TxId",
             {"txId", txId});
         AddCmdDeleteTx(request, txId);
 
@@ -4162,7 +4162,7 @@ void TPersQueue::SendEvReadSetToReceivers(const TActorContext& ctx,
     TString body;
     PQ_ENSURE(data.SerializeToString(&body));
 
-    LOG_I("Send TEvTxProcessing::TEvReadSet to receivers. Wait TEvTxProcessing::TEvReadSet from senders", 
+    LOG_I("Send TEvTxProcessing::TEvReadSet to receivers. Wait TEvTxProcessing::TEvReadSet from senders",
         {"txPredicateRecipientsSize", tx.PredicateRecipients.size()},
         {"txPredicatesReceivedSize", tx.PredicatesReceived.size()});
     for (auto& [receiverId, _] : tx.PredicateRecipients) {
@@ -4174,7 +4174,7 @@ void TPersQueue::SendEvReadSetToReceivers(const TActorContext& ctx,
                                                                        TabletID(),
                                                                        body,
                                                                        0);
-            LOG_I("Send TEvReadSet to tablet tx", 
+            LOG_I("Send TEvReadSet to tablet tx",
                 {"receiverId", receiverId},
                 {"txId", tx.TxId});
             SendToPipe(receiverId, tx, std::move(event), ctx);
@@ -4187,7 +4187,7 @@ void TPersQueue::SendEvReadSetAckToSenders(const TActorContext& ctx,
 {
     LOG_D("TPersQueue::SendEvReadSetAckToSenders");
     for (auto& [target, event] : tx.ReadSetAcks) {
-        LOG_I("Send TEvTxProcessing::TEvReadSetAck", 
+        LOG_I("Send TEvTxProcessing::TEvReadSetAck",
             {"toString", event->ToString()});
         ctx.Send(target, event.release());
     }
@@ -4212,7 +4212,7 @@ TMaybe<TPartitionId> TPersQueue::FindPartitionId(const NKikimrPQ::TDataTransacti
             if (writeId.IsKafkaApiTransaction()) {
                 return TPartitionId(partitionId);
             }
-            LOG_W("Unknown WriteId", 
+            LOG_W("Unknown WriteId",
                 {"writeId", writeId});
             return Nothing();
         }
@@ -4222,7 +4222,7 @@ TMaybe<TPartitionId> TPersQueue::FindPartitionId(const NKikimrPQ::TDataTransacti
             if (writeId.IsKafkaApiTransaction()) {
                 return TPartitionId(partitionId);
             }
-            LOG_W("Unknown partition for WriteId", 
+            LOG_W("Unknown partition for WriteId",
                 {"partitionId", partitionId},
                 {"writeId", writeId});
             return Nothing();
@@ -4284,7 +4284,7 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
 
             for (auto& [originalPartitionId, partitionId] : writeInfo.Partitions) {
                 if (!OriginalPartitionExists(originalPartitionId)) {
-                    LOG_W("Unknown partition for TxId", 
+                    LOG_W("Unknown partition for TxId",
                         {"originalPartitionId", originalPartitionId},
                         {"txId", tx.TxId});
                     forcePredicateFalse = true;
@@ -4297,7 +4297,7 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
                 }
 
                 if (!Partitions.contains(partitionId)) {
-                    LOG_W("Unknown partition for TxId", 
+                    LOG_W("Unknown partition for TxId",
                         {"partitionId", partitionId},
                         {"txId", tx.TxId});
                     forcePredicateFalse = true;
@@ -4310,12 +4310,12 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
                 event->SetSkipSrcIdInfo(tx.GetSkipSrcIdInfo());
             }
         } else if (!writeId.IsKafkaApiTransaction()) {
-            LOG_W("Unknown WriteId for TxId", 
+            LOG_W("Unknown WriteId for TxId",
                 {"writeId", writeId},
                 {"txId", tx.TxId});
             forcePredicateFalse = true;
         } else {
-            LOG_D("Kafka commit with no writes for TxId", 
+            LOG_D("Kafka commit with no writes for TxId",
                 {"writeId", writeId},
                 {"txId", tx.TxId});
         }
@@ -4339,7 +4339,7 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
 void TPersQueue::SendEvTxCommitToPartitions(const TActorContext& ctx,
                                             TDistributedTransaction& tx)
 {
-    LOG_T("Commit TxId", 
+    LOG_T("Commit TxId",
         {"txId", tx.TxId});
 
     const auto serializedTx = tx.Serialize(NKikimrPQ::TTransaction::EXECUTED);
@@ -4379,7 +4379,7 @@ void TPersQueue::SendEvTxCommitToPartitions(const TActorContext& ctx,
 void TPersQueue::SendEvTxRollbackToPartitions(const TActorContext& ctx,
                                               TDistributedTransaction& tx)
 {
-    LOG_T("Rollback TxId", 
+    LOG_T("Rollback TxId",
         {"txId", tx.TxId});
 
     TMaybe<NKikimrPQ::TTransaction> serializedTx = tx.Serialize(NKikimrPQ::TTransaction::EXECUTED);
@@ -4421,7 +4421,7 @@ void TPersQueue::SendEvProposeTransactionResult(const TActorContext& ctx,
         *error = *tx.Error;
     }
 
-    LOG_D("Send TEvPersQueue::TEvProposeTransactionResult", 
+    LOG_D("Send TEvPersQueue::TEvProposeTransactionResult",
         {"txId", tx.TxId},
         {"status", NKikimrPQ::TEvProposeTransactionResult_EStatus_Name(result->Record.GetStatus())});
     ctx.Send(tx.SourceActor, std::move(result));
@@ -4472,7 +4472,7 @@ TDistributedTransaction* TPersQueue::GetTransaction(const TActorContext& ctx,
     Y_UNUSED(ctx);
     auto p = Txs.find(txId);
     if (p == Txs.end()) {
-        LOG_W("Unknown transaction", 
+        LOG_W("Unknown transaction",
             {"txId", txId});
         return nullptr;
     }
@@ -4489,7 +4489,7 @@ void TPersQueue::PushTxInQueue(TDistributedTransaction& tx, TDistributedTransact
 void TPersQueue::ChangeTxState(TDistributedTransaction& tx,
                                TDistributedTransaction::EState newState)
 {
-    LOG_I("TxId moved", 
+    LOG_I("TxId moved",
         {"txId", tx.TxId},
         {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)},
         {"newState", NKikimrPQ::TTransaction_EState_Name(newState)});
@@ -4536,7 +4536,7 @@ bool TPersQueue::CanExecute(const TDistributedTransaction& tx)
     auto& txQueue = TxsOrder[tx.State];
     PQ_ENSURE(!txQueue.empty())("TxId", tx.TxId)("State", NKikimrPQ::TTransaction_EState_Name(tx.State));
 
-    LOG_D("TxId State FrontTxId", 
+    LOG_D("TxId State FrontTxId",
         {"txId", tx.TxId},
         {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)},
         {"txQueueFront", txQueue.front()});
@@ -4547,7 +4547,7 @@ bool TPersQueue::CanExecute(const TDistributedTransaction& tx)
 void TPersQueue::TryExecuteTxs(const TActorContext& ctx,
                                TDistributedTransaction& tx)
 {
-    LOG_D("Try execute txs with state", 
+    LOG_D("Try execute txs with state",
         {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)});
 
     TDistributedTransaction::EState oldState = tx.State;
@@ -4561,20 +4561,20 @@ void TPersQueue::TryExecuteTxs(const TActorContext& ctx,
 
     if (oldState == tx.State) {
         // The transaction status has not changed. There is no point in watching the transactions behind her.
-        LOG_D("TxId status has not changed", 
+        LOG_D("TxId status has not changed",
             {"txId", tx.TxId});
         return;
     }
 
     auto& txQueue = TxsOrder[oldState];
     while (!txQueue.empty()) {
-        LOG_D("There are txs in the queue", 
+        LOG_D("There are txs in the queue",
             {"txQueueSize", txQueue.size()},
             {"oldState", NKikimrPQ::TTransaction_EState_Name(oldState)});
         ui64 txId = txQueue.front();
         PQ_ENSURE(Txs.contains(txId))("unknown TxId", txId);
         auto& tx = Txs.at(txId);
-        LOG_D("Try execute TxId Pending", 
+        LOG_D("Try execute TxId Pending",
             {"txId", tx.TxId},
             {"txPending", tx.Pending});
 
@@ -4588,7 +4588,7 @@ void TPersQueue::TryExecuteTxs(const TActorContext& ctx,
 
         if (oldState == tx.State) {
             // The transaction status has not changed. There is no point in watching the transactions behind her.
-            LOG_D("TxId status has not changed", 
+            LOG_D("TxId status has not changed",
                 {"txId", tx.TxId});
             break;
         }
@@ -4598,22 +4598,22 @@ void TPersQueue::TryExecuteTxs(const TActorContext& ctx,
 void TPersQueue::CheckTxState(const TActorContext& ctx,
                               TDistributedTransaction& tx)
 {
-    LOG_D("TxId State", 
+    LOG_D("TxId State",
         {"txId", tx.TxId},
         {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)});
 
     if (!CanExecute(tx)) {
-        LOG_D("Can't execute TxId Pending", 
+        LOG_D("Can't execute TxId Pending",
             {"txId", tx.TxId},
             {"txPending", tx.Pending});
         tx.Pending = true;
-        LOG_D("Wait for TxId", 
+        LOG_D("Wait for TxId",
             {"txId", tx.TxId});
         return;
     }
     if (tx.WriteInProgress) {
         if (tx.State == NKikimrPQ::TTransaction::EXECUTED) {
-            LOG_I("You cannot send TEvReadSetAck for until the EXECUTED state is saved", 
+            LOG_I("You cannot send TEvReadSetAck for until the EXECUTED state is saved",
                 {"txId", tx.TxId});
         }
         return;
@@ -4661,7 +4661,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
 
     case NKikimrPQ::TTransaction::PLANNED:
         PQ_ENSURE(tx.TxId == TxsOrder[tx.State].front())("TxId", tx.TxId)("FrontTxId", TxsOrder[tx.State].front());
-        LOG_D("TxQueue.size", 
+        LOG_D("TxQueue.size",
             {"txQueueSize", TxQueue.size()});
 
         MoveTopTxToCalculating(tx, ctx);
@@ -4673,7 +4673,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         PQ_ENSURE(tx.PartitionRepliesCount <= tx.PartitionRepliesExpected)("TxId", tx.TxId)
             ("PartitionRepliesCount", tx.PartitionRepliesCount)("PartitionRepliesExpected", tx.PartitionRepliesExpected);
 
-        LOG_D("Responses received from the partitions ", 
+        LOG_D("Responses received from the partitions ",
             {"txPartitionRepliesCount", tx.PartitionRepliesCount},
             {"txPartitionRepliesExpected", tx.PartitionRepliesExpected});
 
@@ -4712,7 +4712,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
     case NKikimrPQ::TTransaction::WAIT_RS:
         PQ_ENSURE(tx.TxId == TxsOrder[tx.State].front())("TxId", tx.TxId)("FrontTxId", TxsOrder[tx.State].front());
 
-        LOG_D("HaveParticipantsDecision", 
+        LOG_D("HaveParticipantsDecision",
             {"txHaveParticipantsDecision", tx.HaveParticipantsDecision()});
 
         if (tx.HaveParticipantsDecision()) {
@@ -4740,7 +4740,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         PQ_ENSURE(tx.PartitionRepliesCount <= tx.PartitionRepliesExpected)("TxId", tx.TxId)
             ("PartitionRepliesCount", tx.PartitionRepliesCount)("PartitionRepliesExpected", tx.PartitionRepliesExpected);
 
-        LOG_D("Responses received from the partitions ", 
+        LOG_D("Responses received from the partitions ",
             {"txPartitionRepliesCount", tx.PartitionRepliesCount},
             {"txPartitionRepliesExpected", tx.PartitionRepliesExpected});
 
@@ -4751,7 +4751,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         tx.EndExecuteSpan();
 
         SendEvProposeTransactionResult(ctx, tx);
-        LOG_I("Complete TxId", 
+        LOG_I("Complete TxId",
             {"txId", tx.TxId});
 
         switch (tx.Kind) {
@@ -4780,7 +4780,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         SendEvReadSetAckToSenders(ctx, tx);
         TryReturnTabletStateAll(ctx);
 
-        LOG_I("Delete partitions for TxId", 
+        LOG_I("Delete partitions for TxId",
             {"txId", tx.TxId});
         BeginDeletePartitions(tx);
 
@@ -4789,7 +4789,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         [[fallthrough]];
 
     case NKikimrPQ::TTransaction::WAIT_RS_ACKS:
-        LOG_D("HaveAllRecipientsReceive AllSupportivePartitionsHaveBeenDeleted", 
+        LOG_D("HaveAllRecipientsReceive AllSupportivePartitionsHaveBeenDeleted",
             {"txHaveAllRecipientsReceive", tx.HaveAllRecipientsReceive()},
             {"allSupportivePartitionsDeleted", AllSupportivePartitionsHaveBeenDeleted(tx.WriteId)});
         if (tx.HaveAllRecipientsReceive() && AllSupportivePartitionsHaveBeenDeleted(tx.WriteId)) {
@@ -4803,7 +4803,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
 
     case NKikimrPQ::TTransaction::EXPIRED:
     case NKikimrPQ::TTransaction::CANCELED:
-        LOG_D("AllSupportivePartitionsHaveBeenDeleted", 
+        LOG_D("AllSupportivePartitionsHaveBeenDeleted",
             {"allSupportivePartitionsDeleted", AllSupportivePartitionsHaveBeenDeleted(tx.WriteId)});
         if (AllSupportivePartitionsHaveBeenDeleted(tx.WriteId)) {
             DeleteTx(tx);
@@ -4816,7 +4816,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         // The PQ tablet has persisted its state. Now she can delete the transaction and take the next one.
         TMaybe<TWriteId> writeId = tx.WriteId; // copy writeId to save for kafka transaction after erase
         DeleteWriteId(writeId);
-        LOG_I("Delete TxId", 
+        LOG_I("Delete TxId",
             {"txId", tx.TxId});
         Txs.erase(tx.TxId);
         SetTxInFlyCounter();
@@ -4838,7 +4838,7 @@ bool TPersQueue::AllSupportivePartitionsHaveBeenDeleted(const TMaybe<TWriteId>& 
 
     const TTxWriteInfo& writeInfo = TxWrites.at(*writeId);
 
-    LOG_D("WriteId", 
+    LOG_D("WriteId",
         {"writeId", *writeId},
         {"partitionsSize", writeInfo.Partitions.size()});
     bool deleted =
@@ -4854,7 +4854,7 @@ void TPersQueue::DeleteWriteId(const TMaybe<TWriteId>& writeId)
         return;
     }
 
-    LOG_I("Delete WriteId", 
+    LOG_I("Delete WriteId",
         {"writeId", *writeId});
     TxWrites.erase(*writeId);
 }
@@ -4873,7 +4873,7 @@ void TPersQueue::WriteTx(TDistributedTransaction& tx, NKikimrPQ::TTransaction::E
 
 void TPersQueue::DeleteTx(TDistributedTransaction& tx)
 {
-    LOG_D("Add an TxId to the list for deletion", 
+    LOG_D("Add an TxId to the list for deletion",
         {"txId", tx.TxId});
 
     DeleteTxs.insert(tx.TxId);
@@ -4995,7 +4995,7 @@ void TPersQueue::SendProposeTransactionResult(const TActorId& target,
         error->SetReason(reason);
     }
 
-    LOG_I("Send TEvPersQueue::TEvProposeTransactionResult", 
+    LOG_I("Send TEvPersQueue::TEvProposeTransactionResult",
         {"txId", txId},
         {"status", NKikimrPQ::TEvProposeTransactionResult_EStatus_Name(event->Record.GetStatus())});
     ctx.Send(target, std::move(event));
@@ -5174,7 +5174,7 @@ void TPersQueue::InitTxsOrder()
 
 void TPersQueue::EndInitTransactions()
 {
-    LOG_D("Transactions are initialized", 
+    LOG_D("Transactions are initialized",
         {"txsSize", Txs.size()},
         {"plannedTxsSize", PlannedTxs.size()});
 
@@ -5184,7 +5184,7 @@ void TPersQueue::EndInitTransactions()
     }
 
     if (!TxQueue.empty()) {
-        LOG_D("Top tx queue", 
+        LOG_D("Top tx queue",
             {"txQueueFrontStep", TxQueue.front().first},
             {"txQueueFrontTxId", TxQueue.front().second});
     }
@@ -5196,7 +5196,7 @@ void TPersQueue::EndInitTransactions()
         PQ_ENSURE(txId == tx.TxId);
 
         if (!TxsOrder.contains(tx.State)) {
-            LOG_D("Skip", 
+            LOG_D("Skip",
                 {"txStep", tx.Step},
                 {"txId", txId},
                 {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)});
@@ -5205,7 +5205,7 @@ void TPersQueue::EndInitTransactions()
 
         PushTxInQueue(tx, tx.State);
 
-        LOG_D("Put the transaction in the queue", 
+        LOG_D("Put the transaction in the queue",
             {"txsOrder", tx.Step},
             {"txId", txId},
             {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)},
@@ -5307,7 +5307,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvProposeTransactionAttach::TPtr &ev, con
         return;
     }
 
-    LOG_D("Handle TEvPersQueue::TEvProposeTransactionAttach", 
+    LOG_D("Handle TEvPersQueue::TEvProposeTransactionAttach",
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     const ui64 txId = ev->Get()->Record.GetTxId();
@@ -5337,7 +5337,7 @@ void TPersQueue::Handle(TEvPQ::TEvCheckPartitionStatusRequest::TPtr& ev, const T
     auto& record = ev->Get()->Record;
     auto it = Partitions.find(TPartitionId(TPartitionId(record.GetPartition())));
     if (InitCompleted && it == Partitions.end()) {
-        LOG_I("Unknown partition", 
+        LOG_I("Unknown partition",
             {"partition", record.GetPartition()});
 
         auto response = MakeHolder<TEvPQ::TEvCheckPartitionStatusResponse>();
@@ -5384,7 +5384,7 @@ void TPersQueue::ProcessCheckMessageDeduplicationRequests(const TPartitionId& pa
 
 void TPersQueue::Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& ev)
 {
-    LOG_D("Handle TEvLongTxService::TEvLockStatus", 
+    LOG_D("Handle TEvLongTxService::TEvLockStatus",
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     auto& record = ev->Get()->Record;
@@ -5392,33 +5392,33 @@ void TPersQueue::Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& e
 
     if (!TxWrites.contains(writeId)) {
         // the transaction has already been completed
-        LOG_W("Unknown WriteId", 
+        LOG_W("Unknown WriteId",
             {"writeId", writeId});
         return;
     }
 
     TTxWriteInfo& writeInfo = TxWrites.at(writeId);
-    LOG_D("TxWriteInfo: WriteId TxId Status", 
+    LOG_D("TxWriteInfo: WriteId TxId Status",
         {"writeId", writeId},
         {"txId", writeInfo.TxId},
         {"longTxSubscriptionStatusName", NKikimrLongTxService::TEvLockStatus_EStatus_Name(writeInfo.LongTxSubscriptionStatus)});
     writeInfo.LongTxSubscriptionStatus = record.GetStatus();
 
     if (writeInfo.LongTxSubscriptionStatus == NKikimrLongTxService::TEvLockStatus::STATUS_SUBSCRIBED) {
-        LOG_D("Subscribed WriteId", 
+        LOG_D("Subscribed WriteId",
             {"writeId", writeId});
         return;
     }
 
     if (writeInfo.TxId.Defined()) {
         // the message `TEvProposeTransaction` has already arrived
-        LOG_D("There is already a transaction TxId for WriteId", 
+        LOG_D("There is already a transaction TxId for WriteId",
             {"txId", writeInfo.TxId},
             {"writeId", writeId});
         return;
     }
 
-    LOG_I("Delete partitions for WriteId (longTxService lost tx)", 
+    LOG_I("Delete partitions for WriteId (longTxService lost tx)",
         {"writeId", writeId});
     BeginDeletePartitions(writeId, writeInfo);
 }
@@ -5434,7 +5434,7 @@ void TPersQueue::Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr& ev, const T
 {
     const NKikimrPQ::TEvPartitionScaleStatusChanged& record = ev->Get()->Record;
     if (MirroringEnabled(Config) && record.HasParticipatingPartitions()) {
-        LOG_I("Got mirrorer split merge request", 
+        LOG_I("Got mirrorer split merge request",
             {"toString", ev->ToString()});
     }
 
@@ -5467,14 +5467,14 @@ void TPersQueue::DeletePartition(const TPartitionId& partitionId, const TActorCo
 
     ReservedBytes = ReservedBytes > partition.ReservedBytes ? ReservedBytes - partition.ReservedBytes : 0;
 
-    LOG_D("DeletePartition", 
+    LOG_D("DeletePartition",
         {"partitionId", partitionId});
     Partitions.erase(partitionId);
 }
 
 void TPersQueue::Handle(TEvPQ::TEvDeletePartitionDone::TPtr& ev, const TActorContext& ctx)
 {
-    LOG_D("Handle TEvPQ::TEvDeletePartitionDone", 
+    LOG_D("Handle TEvPQ::TEvDeletePartitionDone",
         {"partitionId", ev->Get()->PartitionId});
 
     auto* event = ev->Get();
@@ -5523,7 +5523,7 @@ void TPersQueue::TryDeleteWriteId(const TWriteId& writeId, const TTxWriteInfo& w
 
 void TPersQueue::Handle(TEvPQ::TEvTransactionCompleted::TPtr& ev, const TActorContext&)
 {
-    LOG_I("Handle TEvPQ::TEvTransactionCompleted WriteId", 
+    LOG_I("Handle TEvPQ::TEvTransactionCompleted WriteId",
         {"writeId", ev->Get()->WriteId});
 
     auto* event = ev->Get();
@@ -5533,7 +5533,7 @@ void TPersQueue::Handle(TEvPQ::TEvTransactionCompleted::TPtr& ev, const TActorCo
 
     const TWriteId& writeId = *event->WriteId;
     if (!TxWrites.contains(writeId)) {
-        LOG_D("Ignore TEvTransactionCompleted for unknown WriteId", 
+        LOG_D("Ignore TEvTransactionCompleted for unknown WriteId",
             {"writeId", writeId});
         return;
     }
@@ -5557,7 +5557,7 @@ void TPersQueue::BeginDeletePartitions(const TWriteId& writeId, TTxWriteInfo& wr
         for (auto& [_, partitionId] : writeInfo.Partitions) {
             PQ_ENSURE(Partitions.contains(partitionId));
             const TPartitionInfo& partition = Partitions.at(partitionId);
-            LOG_D("Send TEvPQ::TEvDeletePartition to partition", 
+            LOG_D("Send TEvPQ::TEvDeletePartition to partition",
                 {"partitionId", partitionId});
             Send(partition.Actor, new TEvPQ::TEvDeletePartition);
         }
@@ -5608,7 +5608,7 @@ void TPersQueue::Handle(TEvPQ::TEvForceCompaction::TPtr& ev, const TActorContext
     const TPartitionId partitionId(event.PartitionId);
 
     if (!Partitions.contains(partitionId)) {
-        LOG_D("Unknown partition id", 
+        LOG_D("Unknown partition id",
             {"partitionId", event.PartitionId});
         return;
     }
@@ -5644,7 +5644,7 @@ void TPersQueue::Handle(TEvPQ::TEvGetMLPConsumerStateRequest::TPtr& ev) {
 
 void TPersQueue::Handle(TEvPQ::TEvMLPConsumerStatus::TPtr& ev) {
     auto& record = ev->Get()->Record;
-    LOG_D("Handle TEvPQ::TEvMLPConsumerStatus", 
+    LOG_D("Handle TEvPQ::TEvMLPConsumerStatus",
         {"ev", record.ShortDebugString()});
     if (!ReadBalancerActorId) {
         return;
@@ -5661,7 +5661,7 @@ void TPersQueue::Handle(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationReque
     auto partitionId = record.GetPartitionId();
     auto* p = Partitions.FindPtr(TPartitionId{partitionId});
     if (p == nullptr) [[unlikely]] {
-        LOG_I("TEvCheckMessageDeduplicationRequest: unknown partition", 
+        LOG_I("TEvCheckMessageDeduplicationRequest: unknown partition",
             {"partitionId", partitionId});
         auto response = MakeHolder<NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationResponse>();
         response->Record.SetPartitionId(partitionId);
@@ -5685,7 +5685,7 @@ bool TPersQueue::ForwardToPartition(ui32 partitionId, TAutoPtr<TEventHandle>& ev
     auto it = Partitions.find(TPartitionId{partitionId});
     if (it == Partitions.end()) {
         if (!ConfigInited) {
-            LOG_D("Queue MLP request until config is inited", 
+            LOG_D("Queue MLP request until config is inited",
                 {"partitionId", partitionId});
             MLPRequests.emplace_back(std::move(ev));
             return false;

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -144,7 +144,7 @@ public:
 
     }
 
-    TStructuredLogPrefix LogPrefix() const override {
+    TStructuredMessage LogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"topicName", TopicName},
             {"partition", Partition},
@@ -269,8 +269,8 @@ public:
         ctx.Schedule(TOTAL_TIMEOUT, new TEvents::TEvWakeup());
     }
 
-    const TStructuredLogPrefix& GetLogPrefix() const {
-        static const TStructuredLogPrefix LogPrefix;
+    const TStructuredMessage& GetLogPrefix() const {
+        static const TStructuredMessage LogPrefix;
         return LogPrefix;
     }
 
@@ -5574,7 +5574,7 @@ void TPersQueue::BeginDeletePartitions(const TDistributedTransaction& tx)
     BeginDeletePartitions(*tx.WriteId, writeInfo);
 }
 
-TStructuredLogPrefix TPersQueue::LogPrefix() const {
+TStructuredMessage TPersQueue::LogPrefix() const {
     return {};
 }
 

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -475,8 +475,7 @@ void TPersQueue::ReadTxInfo(const NKikimrClient::TKeyValueResponse::TReadResult&
 {
     PQ_ENSURE(read.HasStatus());
     if (read.GetStatus() != NKikimrProto::OK && read.GetStatus() != NKikimrProto::NODATA) {
-        LOG_E("Tx info read error", 
-            {"selfId", ctx.SelfID});
+        LOG_E("Tx info read error");
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
         return;
     }
@@ -525,8 +524,7 @@ void TPersQueue::ReadTxWrites(const NKikimrClient::TKeyValueResponse::TReadResul
 {
     PQ_ENSURE(read.HasStatus());
     if (read.GetStatus() != NKikimrProto::OK && read.GetStatus() != NKikimrProto::NODATA) {
-        LOG_E("Tx writes read error", 
-            {"selfId", ctx.SelfID});
+        LOG_E("Tx writes read error");
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
         return;
     }
@@ -681,8 +679,7 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
 {
     PQ_ENSURE(read.HasStatus());
     if (read.GetStatus() != NKikimrProto::OK && read.GetStatus() != NKikimrProto::NODATA) {
-        LOG_E("Config read error", 
-            {"selfId", ctx.SelfID},
+        LOG_E("Config read error",
             {"status", read.GetStatus()});
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
         return;
@@ -955,8 +952,7 @@ void TPersQueue::EndWriteTabletState(const NKikimrClient::TResponse& resp, const
             (resp.WriteResultSize() == 1) &&
             (resp.GetWriteResult(0).GetStatus() == NKikimrProto::OK);
     if (!ok) {
-        LOG_E("SelfId State write", 
-            {"selfId", ctx.SelfID},
+        LOG_E("SelfId State write",
             {"error", resp.DebugString()});
 
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
@@ -988,9 +984,8 @@ void TPersQueue::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
         EndWriteTxs(resp, ctx);
         break;
     default:
-        LOG_E("Unexpected KV", 
-            {"response", ev->Get()->ToString()},
-            {"selfId", ctx.SelfID});
+        LOG_E("Unexpected KV",
+            {"response", ev->Get()->ToString()});
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
     }
 }
@@ -3761,8 +3756,7 @@ void TPersQueue::EndWriteTxs(const NKikimrClient::TResponse& resp,
     }
 
     if (!ok) {
-        LOG_E("SelfId TxInfo write", 
-            {"selfId", ctx.SelfID},
+        LOG_E("SelfId TxInfo write",
             {"error", resp.DebugString()});
 
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
@@ -5583,8 +5577,7 @@ void TPersQueue::BeginDeletePartitions(const TDistributedTransaction& tx)
 
 TStructuredLogPrefix TPersQueue::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "PQ"},
-        {"tabletId", TabletID()});
+        {"actorClassName", "PQ"});
 }
 
 ui64 TPersQueue::GetGeneration() {

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -48,7 +48,7 @@
 
 #define PQ_LOG_ERROR_AND_DIE(expr)                       \
     YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, expr, \
-        {"logPrefix", LogPrefix()});                     \
+        {LogPrefix()});                     \
     ctx.Send(ctx.SelfID, new TEvents::TEvPoison())
 
 #define PQ_ENSURE(condition) AFL_ENSURE(condition)("tablet_id", TabletID())("path", TopicPath)("topic", TopicName)
@@ -141,7 +141,7 @@ public:
             Response->Record.MutablePartitionResponse()->SetCookie(*cookie);
 
         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvRequest topic",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"topicName", TopicName},
             {"requestId", ReqId});
 
@@ -178,7 +178,7 @@ public:
 
         if (!Waiting) {
             YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Answer ok topic",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"topicName", TopicName},
                 {"partition", Partition},
                 {"messageNo", MessageNo},
@@ -201,7 +201,7 @@ public:
         const auto errorCode = ev->ErrorCode;
         const auto priority = errorCode == NPersQueue::NErrorCode::OVERLOAD ? NActors::NLog::EPriority::PRI_INFO : NActors::NLog::EPriority::PRI_ERROR;
         YDB_LOG_COMP(priority, NKikimrServices::PERSQUEUE, "Answer error topic",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"topicName", TopicName},
             {"partition", Partition},
             {"messageNo", MessageNo},
@@ -369,7 +369,7 @@ void TPersQueue::ApplyNewConfig(const NKikimrPQ::TPQTabletConfig& newConfig,
     Config = newConfig;
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Apply new config",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"config", Config.ShortDebugString()});
 
     ui32 cacheSize = CACHE_SIZE;
@@ -480,7 +480,7 @@ void TPersQueue::ReadTxInfo(const NKikimrClient::TKeyValueResponse::TReadResult&
     PQ_ENSURE(read.HasStatus());
     if (read.GetStatus() != NKikimrProto::OK && read.GetStatus() != NKikimrProto::NODATA) {
         YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Tx info read error",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"selfId", ctx.SelfID});
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
         return;
@@ -489,7 +489,7 @@ void TPersQueue::ReadTxInfo(const NKikimrClient::TKeyValueResponse::TReadResult&
     switch (read.GetStatus()) {
     case NKikimrProto::OK: {
         YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Has a tx info",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
 
         NKikimrPQ::TTabletTxInfo info;
         PQ_ENSURE(info.ParseFromString(read.GetValue()));
@@ -500,7 +500,7 @@ void TPersQueue::ReadTxInfo(const NKikimrClient::TKeyValueResponse::TReadResult&
     }
     case NKikimrProto::NODATA: {
         YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Doesn't have tx info",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
 
         InitPlanStep();
 
@@ -512,7 +512,7 @@ void TPersQueue::ReadTxInfo(const NKikimrClient::TKeyValueResponse::TReadResult&
     }
 
     YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "PlanStep PlanTxId ExecStep ExecTxId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"planStep", PlanStep},
         {"planTxId", PlanTxId},
         {"execStep", ExecStep},
@@ -534,7 +534,7 @@ void TPersQueue::ReadTxWrites(const NKikimrClient::TKeyValueResponse::TReadResul
     PQ_ENSURE(read.HasStatus());
     if (read.GetStatus() != NKikimrProto::OK && read.GetStatus() != NKikimrProto::NODATA) {
         YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Tx writes read error",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"selfId", ctx.SelfID});
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
         return;
@@ -543,7 +543,7 @@ void TPersQueue::ReadTxWrites(const NKikimrClient::TKeyValueResponse::TReadResul
     switch (read.GetStatus()) {
     case NKikimrProto::OK: {
         YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Has a tx writes info",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
 
         NKikimrPQ::TTabletTxInfo info;
         if (!info.ParseFromString(read.GetValue())) {
@@ -557,7 +557,7 @@ void TPersQueue::ReadTxWrites(const NKikimrClient::TKeyValueResponse::TReadResul
     }
     case NKikimrProto::NODATA: {
         YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Doesn't have tx writes info",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
 
         InitTxWrites({}, ctx);
 
@@ -593,7 +593,7 @@ void TPersQueue::MoveTopTxToCalculating(TDistributedTransaction& tx,
 
     std::tie(ExecStep, ExecTxId) = TxQueue.front();
     YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "New ExecStep ExecTxId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"execStep", ExecStep},
         {"execTxId", ExecTxId});
 
@@ -694,7 +694,7 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
     PQ_ENSURE(read.HasStatus());
     if (read.GetStatus() != NKikimrProto::OK && read.GetStatus() != NKikimrProto::NODATA) {
         YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Config read error",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"selfId", ctx.SelfID},
             {"status", read.GetStatus()});
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
@@ -725,7 +725,7 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
         ctx.Send(CacheActor, new TEvPQ::TEvChangeCacheConfig(TopicName, cacheSize));
     } else if (read.GetStatus() == NKikimrProto::NODATA) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "No config, start with empty partitions and default config",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
     } else {
         PQ_LOG_ERROR_AND_DIE("Unexpected config read status: " << read.GetStatus());
         return;
@@ -740,14 +740,14 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
                 PlanStep = tx.GetStep();
                 PlanTxId = tx.GetTxId();
                 YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "PlanStep PlanTxId",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"planStep", PlanStep},
                     {"planTxId", PlanTxId});
             } else if (tx.GetStep() == PlanStep) {
                 if (tx.GetTxId() > PlanTxId) {
                     PlanTxId = tx.GetTxId();
                     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "PlanStep PlanTxId",
-                        {"logPrefix", LogPrefix()},
+                        {LogPrefix()},
                         {"planStep", PlanStep},
                         {"planTxId", PlanTxId});
                 }
@@ -755,7 +755,7 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
         }
 
         YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Restore Tx",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", tx.GetTxId()},
             {"step", tx.GetStep()},
             {"state", NKikimrPQ::TTransaction_EState_Name(tx.GetState())},
@@ -767,7 +767,7 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
 
         if (tx.HasWriteId()) {
             YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Link TxId with WriteId",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"txId", tx.GetTxId()},
                 {"writeId", GetWriteId(tx)});
             TxWrites[GetWriteId(tx)].TxId = tx.GetTxId();
@@ -776,7 +776,7 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
 
     for (const auto& [txId, tx] : Txs) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Dump logPrefix, txId, step, state, decision",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", txId},
             {"step", tx.Step},
             {"state", NKikimrPQ::TTransaction_EState_Name(tx.State)},
@@ -872,7 +872,7 @@ void TPersQueue::InitializeMeteringSink(const TActorContext& ctx) {
     auto& pqConfig = AppData(ctx)->PQConfig;
     if (!pqConfig.GetBillingMeteringConfig().GetEnabled()) {
         YDB_LOG_NOTICE_COMP(NKikimrServices::PERSQUEUE, "Disable metering is not enabled in BillingMeteringConfig",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"reason", "billing"});
         return;
     }
@@ -894,7 +894,7 @@ void TPersQueue::InitializeMeteringSink(const TActorContext& ctx) {
     switch (Config.GetMeteringMode()) {
     case NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS:
         YDB_LOG_NOTICE_COMP(NKikimrServices::PERSQUEUE, "Metering mode METERING_MODE_REQUEST_UNITS",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         whichToFlush = TSet<EMeteringJson>{EMeteringJson::UsedStorageV1};
         break;
 
@@ -977,7 +977,7 @@ void TPersQueue::EndWriteTabletState(const NKikimrClient::TResponse& resp, const
             (resp.GetWriteResult(0).GetStatus() == NKikimrProto::OK);
     if (!ok) {
         YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "SelfId State write",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"selfId", ctx.SelfID},
             {"error", resp.DebugString()});
 
@@ -1007,12 +1007,12 @@ void TPersQueue::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
         break;
     case WRITE_TX_COOKIE:
         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvKeyValue::TEvResponse (WRITE_TX_COOKIE)",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         EndWriteTxs(resp, ctx);
         break;
     default:
         YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Unexpected KV",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"response", ev->Get()->ToString()},
             {"selfId", ctx.SelfID});
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
@@ -1043,7 +1043,7 @@ TPartitionInfo& TPersQueue::GetPartitionInfo(const TPartitionId& partitionId)
 void TPersQueue::Handle(TEvPQ::TEvPartitionCounters::TPtr& ev, const TActorContext& ctx)
 {
     YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Handle TEvPQ::TEvPartitionCounters PartitionId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"partition", ev->Get()->Partition});
 
     auto& partitionId = ev->Get()->Partition;
@@ -1168,7 +1168,7 @@ void TPersQueue::Handle(TEvPQ::TEvTabletCacheCounters::TPtr& ev, const TActorCon
     SetCacheCounters(CacheCounters);
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Topic counters. CacheSize CachedBlobs",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"topic", (TopicConverter ? TopicConverter->GetClientsideName() : "Undefined")},
         {"cacheSizeBytes", CacheCounters.CacheSizeBytes},
         {"cacheSizeBlobs", CacheCounters.CacheSizeBlobs});
@@ -1221,7 +1221,7 @@ void TPersQueue::Handle(TEvPQ::TEvInitComplete::TPtr& ev, const TActorContext& c
 void TPersQueue::Handle(TEvPQ::TEvError::TPtr& ev, const TActorContext& ctx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvPQ::TEvError Cookie Error",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"cookie", ev->Get()->Cookie},
         {"error", ev->Get()->Error});
 
@@ -1294,7 +1294,7 @@ void TPersQueue::UpdateConsumers(NKikimrPQ::TPQTabletConfig& cfg)
 void TPersQueue::Handle(TEvPersQueue::TEvDropTablet::TPtr& ev, const TActorContext& ctx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvPersQueue::TEvDropTablet",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     const auto& record = ev->Get()->Record;
     ui64 txId = record.GetTxId();
@@ -1418,11 +1418,11 @@ void TPersQueue::ProcessStatusRequests(const TActorContext &ctx) {
 void TPersQueue::Handle(TEvPersQueue::TEvStatus::TPtr& ev, const TActorContext& ctx)
 {
     YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Handle TEvPersQueue::TEvStatus",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     if (!ConfigInited || !AllOriginalPartitionsInited()) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Postpone the request. ConfigInited PartitionsInited OriginalPartitionsCount",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"configInited", static_cast<int>(ConfigInited)},
             {"partitionsInited", PartitionsInited},
             {"originalPartitionsCount", OriginalPartitionsCount});
@@ -1494,7 +1494,7 @@ void TPersQueue::HandleDeleteSessionRequest(
     const auto& cmd = req.GetCmdDeleteSession();
     //To do : priority
     YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Got cmd delete",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"session", cmd.DebugString()});
 
     if (!cmd.HasClientId()){
@@ -1554,7 +1554,7 @@ void TPersQueue::HandleCreateSessionRequest(const ui64 responseCookie, NWilson::
             pipeIter->second.SessionId = cmd.GetSessionId();
             pipeIter->second.PartitionSessionId = cmd.GetPartitionSessionId();
             YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Created session",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"sessionId", cmd.GetSessionId()},
                 {"onPipe", pipeIter->first});
             ctx.Send(MakePQDReadCacheServiceActorId(),
@@ -1690,7 +1690,7 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
 
     if (req.HasWriteId()) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Write in transaction",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partition", req.GetPartition()},
             {"writeId", req.GetWriteId()},
             {"needSupportivePartition", req.GetNeedSupportivePartition()});
@@ -1869,7 +1869,7 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
                 partNo++;
                 uncompressedSize = 0;
                 YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Got client PART message",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"topic", (TopicConverter ? TopicConverter->GetClientsideName() : "Undefined")},
                     {"partition", req.GetPartition()},
                     {"sourceId", EscapeC(msgs.back().SourceId)},
@@ -1932,7 +1932,7 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
             FillBatchInfo(cmd, msgs.back());
         }
         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Got client message",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"topic", (TopicConverter ? TopicConverter->GetClientsideName() : "Undefined")},
             {"partition", req.GetPartition()},
             {"sourceId", EscapeC(msgs.back().SourceId)},
@@ -1986,7 +1986,7 @@ void TPersQueue::HandleReserveBytesRequest(const ui64 responseCookie, NWilson::T
 
     if (req.HasWriteId()) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Reserve bytes in transaction",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partition", req.GetPartition()},
             {"writeId", req.GetWriteId()},
             {"needSupportivePartition", req.GetNeedSupportivePartition()});
@@ -2158,7 +2158,7 @@ void TPersQueue::HandlePublishReadRequest(
     ctx.Send(SelfId(), publishDoneEvent.Release());
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Publish direct read id for session",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"readId", key.ReadId},
         {"sessionId", key.SessionId});
     ctx.Send(
@@ -2189,7 +2189,7 @@ void TPersQueue::HandleForgetReadRequest(
     ctx.Send(SelfId(), forgetDoneEvent.Release());
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Forget direct read id for session",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"readId", key.ReadId},
         {"sessionId", key.SessionId});
     ctx.Send(
@@ -2202,7 +2202,7 @@ void TPersQueue::HandleForgetReadRequest(
 
 void TPersQueue::DestroySession(TPipeInfo& pipeInfo) {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Destroy direct read session",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"sessionId", pipeInfo.SessionId});
     if (pipeInfo.SessionId.empty())
         return;
@@ -2422,7 +2422,7 @@ void TPersQueue::HandleAbortDeferredStagingRequest(const ui64 responseCookie,
         TTxWriteInfo& writeInfo = TxWrites.at(writeId);
         if (writeInfo.Partitions.contains(originalPartitionId) && !writeInfo.Deleting) {
             YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Abort deferred staging",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"writeId", writeId},
                 {"partition", originalPartitionId},
             );
@@ -2493,7 +2493,7 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
         // This branch happens when previous Kafka transaction has committed and we receive write for next one
         // after PQ has deleted supportive partition and before it has deleted writeId from TxWrites (tx has not transaitioned to DELETED state)
         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "GetOwnership request for the next Kafka transaction while previous is being deleted. Saving it till the complete delete of the previous tx.",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         KafkaNextTransactionRequests[writeId.GetKafkaProducerInstanceId()].push_back(event);
         return;
     } else if (TxWrites.contains(writeId) && TxWrites.at(writeId).Partitions.contains(originalPartitionId)) {
@@ -2515,7 +2515,7 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
             // This branch happens when previous Kafka transaction has committed and we receive write for next one
             // before PQ has deleted supportive partition for previous transaction
             YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "GetOwnership request for the next Kafka transaction while previous is being deleted. Saving it till the complete delete of the previous tx.",
-                {"logPrefix", LogPrefix()});
+                {LogPrefix()});
             KafkaNextTransactionRequests[writeId.GetKafkaProducerInstanceId()].push_back(event);
             return;
         }
@@ -2564,7 +2564,7 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
         TTxWriteInfo& writeInfo = TxWrites[writeId];
         TPartitionId partitionId(originalPartitionId, writeId, NextSupportivePartitionId++);
         YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Partition for WriteId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId},
             {"writeId", writeId});
 
@@ -2649,7 +2649,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvRequest::TPtr& ev, const TActorContext&
     auto it = Partitions.find(partition);
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Got client message batch for topic partition",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"topic", (TopicConverter ? TopicConverter->GetClientsideName() : "Undefined")},
         {"partition", partition});
 
@@ -2736,12 +2736,12 @@ void TPersQueue::Handle(TEvPersQueue::TEvRequest::TPtr& ev, const TActorContext&
 void TPersQueue::Handle(TEvTabletPipe::TEvServerConnected::TPtr& ev, const TActorContext&)
 {
     YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Handle TEvTabletPipe::TEvServerConnected",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     auto it = PipesInfo.insert({ev->Get()->ClientId, {}}).first;
     it->second.ServerActors++;
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Server connected, pipe now have active actors on pipe",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"clientId", ev->Get()->ClientId},
         {"serverActors", it->second.ServerActors});
 
@@ -2752,7 +2752,7 @@ void TPersQueue::Handle(TEvTabletPipe::TEvServerConnected::TPtr& ev, const TActo
 void TPersQueue::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TActorContext& ctx)
 {
     YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Handle TEvTabletPipe::TEvServerDisconnected",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     //inform partition if needed;
     auto it = PipesInfo.find(ev->Get()->ClientId);
@@ -2769,7 +2769,7 @@ void TPersQueue::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TA
             DestroySession(it->second);
         }
         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Server disconnected, pipe destroyed",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"clientId", ev->Get()->ClientId});
         PipesInfo.erase(it);
         Counters->Simple()[COUNTER_PQ_TABLET_OPENED_PIPES] = PipesInfo.size();
@@ -2779,13 +2779,13 @@ void TPersQueue::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TA
 void TPersQueue::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const TActorContext& ctx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvTabletPipe::TEvClientConnected",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     PQ_ENSURE(ev->Get()->Leader)("description", TStringBuilder() << "Unexpectedly connected to follower of tablet " << ev->Get()->TabletId);
 
     if (PipeClientCache->OnConnect(ev)) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Connected to tablet",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"tabletId", ev->Get()->TabletId});
         return;
     }
@@ -2807,7 +2807,7 @@ void TPersQueue::AckReadSetsToTablet(ui64 tabletId, const TActorContext& ctx)
 
     for (ui64 txId : GetBindedTxs(tabletId)) {
         YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Assume tablet dead, sending read set acks for tx",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"tabletId", tabletId},
             {"txId", txId});
 
@@ -2842,9 +2842,9 @@ void TPersQueue::AckReadSetsToTablet(ui64 tabletId, const TActorContext& ctx)
 void TPersQueue::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev, const TActorContext& ctx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvTabletPipe::TEvClientDestroyed",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Client pipe to tablet is reset",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"tabletId", ev->Get()->TabletId});
 
     PipeClientCache->OnDisconnect(ev);
@@ -2988,7 +2988,7 @@ void TPersQueue::Handle(TEvMediatorTimecast::TEvRegisterTabletResult::TPtr& ev, 
     PQ_ENSURE(MediatorTimeCastEntry);
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Registered with mediator time cast",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     TryWriteTxs(ctx);
 }
@@ -2996,7 +2996,7 @@ void TPersQueue::Handle(TEvMediatorTimecast::TEvRegisterTabletResult::TPtr& ev, 
 void TPersQueue::Handle(TEvInterconnect::TEvNodeInfo::TPtr& ev, const TActorContext& ctx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvInterconnect::TEvNodeInfo",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     PQ_ENSURE(ev->Get()->Node);
     DCId = ev->Get()->Node->Location.GetDataCenterId();
@@ -3027,7 +3027,7 @@ void TPersQueue::AddCmdReadTransactionRange(TEvKeyValue::TEvRequest& request,
     cmd->SetIncludeData(true);
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Transactions request. From To",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"rangeFrom", cmd->MutableRange()->GetFrom()},
         {"rangeTo", cmd->MutableRange()->GetTo()});
 }
@@ -3078,7 +3078,7 @@ void TPersQueue::ScheduleDeleteExpiredKafkaTransactions() {
     for (auto& pair : TxWrites) {
         if (txnExpired(pair.second)) {
             YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Transaction for Kafka producer is expired",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"kafkaProducerInstanceId", pair.first.GetKafkaProducerInstanceId()});
             BeginDeletePartitions(pair.first, pair.second);
         }
@@ -3144,7 +3144,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvCancelTransactionProposal::TPtr& ev, co
     PQ_ENSURE(event.HasTxId());
 
     YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Handle TEvPersQueue::TEvCancelTransactionProposal for TxId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txId", event.GetTxId()});
 
     if (auto tx = GetTransaction(ctx, event.GetTxId()); tx) {
@@ -3165,7 +3165,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvProposeTransaction::TPtr& ev, const TAc
 
     const NKikimrPQ::TEvProposeTransaction& event = ev->Get()->GetRecord();
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvPersQueue::TEvProposeTransaction",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"event", event.ShortDebugString()});
 
     auto span = GenerateSpan("Topic.Transaction", *SamplingControl, std::move(ev->TraceId));
@@ -3216,7 +3216,7 @@ bool TPersQueue::CheckTxWriteOperation(const NKikimrPQ::TPartitionOperation& ope
                                  GetSupportivePartition(operation)};
     }
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "PartitionId for WriteId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"partitionId", partitionId},
         {"writeId", writeId});
     return Partitions.contains(partitionId);
@@ -3316,7 +3316,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
 
     if (TabletState != NKikimrPQ::ENormal) {
         YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "TxId invalid PQ tablet state",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", event.GetTxId()},
             {"tabletState", NKikimrPQ::ETabletState_Name(TabletState)});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3329,7 +3329,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
 
     if (txBody.OperationsSize() <= 0) {
         YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "TxId empty list of operations",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", event.GetTxId()});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                     event.GetTxId(),
@@ -3345,7 +3345,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
     if (hasDeferredFinalize) {
         if (txBody.GetImmediate()) {
             YDB_LOG_WARN("TxId immediate transaction is not supported for deferred publication finalize",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"txId", event.GetTxId()});
             SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                         event.GetTxId(),
@@ -3357,7 +3357,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
 
         if (!txBody.HasWriteId() || !GetWriteId(txBody).IsDeferredPublicationApiTransaction()) {
             YDB_LOG_WARN("TxId invalid WriteId for deferred publication finalize",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"txId", event.GetTxId()});
             SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                         event.GetTxId(),
@@ -3369,7 +3369,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
 
         if (!AllOperationsAreDeferredPublicationFinalize(txBody)) {
             YDB_LOG_WARN("TxId deferred publication finalize allows only finalize operations",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"txId", event.GetTxId()});
             SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                         event.GetTxId(),
@@ -3382,7 +3382,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
         const auto finalizeOp = GetSingleDeferredPublicationFinalizeOp(txBody);
         if (!finalizeOp.Defined()) {
             YDB_LOG_WARN("TxId deferred publication finalize requires matching Publish or Cancel op",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"txId", event.GetTxId()});
             SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                         event.GetTxId(),
@@ -3396,7 +3396,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
         if (TxWrites.contains(writeId)
             && !DeferredPublicationFinalizePartitionsMatchStaged(txBody, TxWrites.at(writeId).Partitions)) {
             YDB_LOG_WARN("TxId deferred publication finalize partition set mismatch",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"txId", event.GetTxId()});
             SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                         event.GetTxId(),
@@ -3407,7 +3407,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
         }
     } else if (txBody.HasWriteId() && GetWriteId(txBody).IsDeferredPublicationApiTransaction()) {
         YDB_LOG_WARN("TxId deferred publication WriteId requires finalize operation",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", event.GetTxId()});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                     event.GetTxId(),
@@ -3419,7 +3419,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
         for (const auto& operation : txBody.GetOperations()) {
             if (IsDeferredPublicationFinalizeOperation(operation)) {
                 YDB_LOG_WARN("TxId deferred publication finalize requires deferred WriteId",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"txId", event.GetTxId()});
                 SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                             event.GetTxId(),
@@ -3433,7 +3433,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
 
     if (!CheckTxWriteOperations(txBody)) {
         YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "TxId invalid WriteId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", event.GetTxId()},
             {"writeId", txBody.GetWriteId()});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3449,7 +3449,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
         if (!TxWrites.contains(writeId)) {
             if (!writeId.IsKafkaApiTransaction()) {
                 YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "TxId unknown WriteId",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"txId", event.GetTxId()},
                     {"writeId", writeId});
                 SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3460,14 +3460,14 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
                 return;
             }
             YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxId Kafka commit with no writes for WriteId",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"txId", event.GetTxId()},
                 {"writeId", writeId});
         } else {
             TTxWriteInfo& writeInfo = TxWrites.at(writeId);
             if (writeInfo.Deleting) {
                 YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "TxId WriteId will be deleted",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"txId", event.GetTxId()},
                     {"writeId", writeId});
                 SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3480,7 +3480,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
 
             writeInfo.TxId = event.GetTxId();
             YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "TxId has WriteId",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"txId", event.GetTxId()},
                 {"writeId", writeId});
         }
@@ -3489,7 +3489,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
     TMaybe<TPartitionId> partitionId = FindPartitionId(txBody);
     if (!partitionId.Defined()) {
         YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "TxId unknown partition for WriteId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", event.GetTxId()},
             {"writeId", txBody.GetWriteId()});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3502,7 +3502,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
 
     if (!Partitions.contains(*partitionId)) {
         YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown partition",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", *partitionId});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                     event.GetTxId(),
@@ -3514,7 +3514,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
 
     if (txBody.GetImmediate()) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Immediate transaction",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         TPartitionId originalPartitionId(txBody.GetOperations(0).GetPartitionId());
         const TPartitionInfo& partition = Partitions.at(originalPartitionId);
 
@@ -3536,7 +3536,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
         }
 
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Distributed transaction",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         EvProposeTransactionQueue.emplace_back(ev.Release());
 
         TryWriteTxs(ctx);
@@ -3563,7 +3563,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvPlanStep::TPtr& ev, const TActorCont
     }
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvTxProcessing::TEvPlanStep",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     const TActorId sender = ev->Sender;
@@ -3580,7 +3580,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
     }
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvTxProcessing::TEvReadSet",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     NKikimrTx::TEvReadSet& event = ev->Get()->Record;
@@ -3592,7 +3592,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
     }
 
     YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Handle TEvTxProcessing::TEvReadSet tx tabletProducer",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txId", event.GetTxId()},
         {"tabletProducer", event.GetTabletProducer()});
 
@@ -3603,7 +3603,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
             ((tx->State == NKikimrPQ::TTransaction::EXECUTED) && !tx->WriteInProgress)) {
             if (ack) {
                 YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Send TEvReadSetAck to for TxId",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"tabletProducer", event.GetTabletProducer()},
                     {"txId", event.GetTxId()});
                 ctx.Send(ev->Sender, ack.release());
@@ -3624,7 +3624,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
         }
     } else if (ack) {
         YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "A TEvReadSetAck message to for TxId will be sent later",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"tabletProducer", event.GetTabletProducer()},
             {"txId", event.GetTxId()});
 
@@ -3649,7 +3649,7 @@ void TPersQueue::SendDeferredReadSetAcks(const TActorContext& ctx)
 {
     for (auto& e : DeferredReadSetAcks) {
         YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Send TEvReadSetAck to for TxId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"ackRecordTabletSource", e.Ack->Record.GetTabletSource()},
             {"ackRecordTxId", e.Ack->Record.GetTxId()});
         ctx.Send(e.Sender, e.Ack.release());
@@ -3661,7 +3661,7 @@ void TPersQueue::SendDeferredReadSetAcks(const TActorContext& ctx)
 void TPersQueue::Handle(TEvTxProcessing::TEvReadSetAck::TPtr& ev, const TActorContext& ctx)
 {
     YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Handle TEvTxProcessing::TEvReadSetAck",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     NKikimrTx::TEvReadSetAck& event = ev->Get()->Record;
@@ -3688,7 +3688,7 @@ void TPersQueue::Handle(TEvPQ::TEvTxCalcPredicateResult::TPtr& ev, const TActorC
     const TEvPQ::TEvTxCalcPredicateResult& event = *ev->Get();
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvPQ::TEvTxCalcPredicateResult Step TxId Partition Predicate",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"step", event.Step},
         {"txId", event.TxId},
         {"partition", event.Partition},
@@ -3713,7 +3713,7 @@ void TPersQueue::Handle(TEvPQ::TEvProposePartitionConfigResult::TPtr& ev, const 
     TEvPQ::TEvProposePartitionConfigResult& event = *ev->Get();
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvPQ::TEvProposePartitionConfigResult Step TxId Partition",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"step", event.Step},
         {"txId", event.TxId},
         {"partition", event.Partition});
@@ -3737,7 +3737,7 @@ void TPersQueue::Handle(TEvPQ::TEvTxDone::TPtr& ev, const TActorContext& ctx)
     const TEvPQ::TEvTxDone& event = *ev->Get();
 
     YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Handle TEvPQ::TEvTxDone Step TxId Partition",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"step", event.Step},
         {"txId", event.TxId},
         {"partition", event.Partition});
@@ -3778,7 +3778,7 @@ void TPersQueue::SubscribeWriteId(const TWriteId& writeId,
                                   const TActorContext& ctx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Send TEvSubscribeLock for WriteId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"writeId", writeId});
     ctx.Send(NLongTxService::MakeLongTxServiceID(ctx.SelfID.NodeId()),
              new NLongTxService::TEvLongTxService::TEvSubscribeLock(writeId.GetKeyId(), writeId.GetNodeId()));
@@ -3788,7 +3788,7 @@ void TPersQueue::UnsubscribeWriteId(const TWriteId& writeId,
                                     const TActorContext& ctx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Send TEvUnsubscribeLock for WriteId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"writeId", writeId});
     ctx.Send(NLongTxService::MakeLongTxServiceID(ctx.SelfID.NodeId()),
              new NLongTxService::TEvLongTxService::TEvUnsubscribeLock(writeId.GetKeyId(), writeId.GetNodeId()));
@@ -3834,7 +3834,7 @@ void TPersQueue::BeginWriteTxs(const TActorContext& ctx)
     NewSupportivePartitions.clear();
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Send TEvKeyValue::TEvRequest (WRITE_TX_COOKIE)",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
     ctx.Send(ctx.SelfID, request.Release(),
              0, 0,
              WriteTxsSpan.GetTraceId());
@@ -3859,7 +3859,7 @@ void TPersQueue::EndWriteTxs(const NKikimrClient::TResponse& resp,
 
     if (!ok) {
         YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "SelfId TxInfo write",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"selfId", ctx.SelfID},
             {"error", resp.DebugString()});
 
@@ -3914,7 +3914,7 @@ void TPersQueue::ProcessProposeTransactionQueue(const TActorContext& ctx,
             tx.OnProposeTransaction(event, GetAllowedStep(),
                                     TabletID());
             YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Propose TxId WriteId",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"txId", tx.TxId},
                 {"txWriteId", tx.WriteId});
 
@@ -3927,7 +3927,7 @@ void TPersQueue::ProcessProposeTransactionQueue(const TActorContext& ctx,
                 if (TxWrites.contains(writeId)) {
                     TTxWriteInfo& writeInfo = TxWrites.at(writeId);
                     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Link TxId with WriteId",
-                        {"logPrefix", LogPrefix()},
+                        {LogPrefix()},
                         {"txId", tx.TxId},
                         {"writeId", writeId});
                     writeInfo.TxId = tx.TxId;
@@ -3935,7 +3935,7 @@ void TPersQueue::ProcessProposeTransactionQueue(const TActorContext& ctx,
                     PQ_ENSURE(writeId.IsKafkaApiTransaction())
                         ("TxId", tx.TxId)("WriteId", writeId.ToString());
                     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Kafka commit with no writes; skip WriteId link",
-                        {"logPrefix", LogPrefix()},
+                        {LogPrefix()},
                         {"txId", tx.TxId},
                         {"writeId", writeId});
                 }
@@ -3989,7 +3989,7 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
                 TryExecuteTxs(ctx, tx);
             } else {
                 YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Transaction already planned for step",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"txStep", tx.Step},
                     {"step", step},
                     {"txId", txId});
@@ -3998,7 +3998,7 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
             lastPlannedTxId = txId;
         } else {
             YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown transaction TxId Step",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"txId", txId},
                 {"step", step});
         }
@@ -4030,7 +4030,7 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
     }
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "PlanStep PlanTxId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"planStep", PlanStep},
         {"planTxId", PlanTxId});
 }
@@ -4108,7 +4108,7 @@ void TPersQueue::ProcessWriteTxs(const TActorContext& ctx,
             PQ_ENSURE(state == NKikimrPQ::TTransaction::PREPARED)("TxId", txId)("State", NKikimrPQ::TTransaction_EState_Name(state));
 
             YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Persist state for TxId",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"state", NKikimrPQ::TTransaction_EState_Name(state)},
                 {"txId", txId});
             tx->AddCmdWrite(request, state);
@@ -4133,7 +4133,7 @@ void TPersQueue::ProcessDeleteTxs(const TActorContext& ctx,
 
     for (ui64 txId : DeleteTxs) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Delete key for TxId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", txId});
         AddCmdDeleteTx(request, txId);
 
@@ -4248,7 +4248,7 @@ void TPersQueue::SaveTxWrites(NKikimrPQ::TTabletTxInfo& info)
 void TPersQueue::ScheduleProposeTransactionResult(const TDistributedTransaction& tx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Schedule TEvProposeTransactionResult(PREPARED)",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
     auto event = std::make_unique<TEvPersQueue::TEvProposeTransactionResult>();
 
     event->Record.SetOrigin(TabletID());
@@ -4277,7 +4277,7 @@ void TPersQueue::SendEvReadSetToReceivers(const TActorContext& ctx,
     PQ_ENSURE(data.SerializeToString(&body));
 
     YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Send TEvTxProcessing::TEvReadSet to receivers. Wait TEvTxProcessing::TEvReadSet from senders",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txPredicateRecipientsSize", tx.PredicateRecipients.size()},
         {"txPredicatesReceivedSize", tx.PredicatesReceived.size()});
     for (auto& [receiverId, _] : tx.PredicateRecipients) {
@@ -4290,7 +4290,7 @@ void TPersQueue::SendEvReadSetToReceivers(const TActorContext& ctx,
                                                                        body,
                                                                        0);
             YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Send TEvReadSet to tablet tx",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"receiverId", receiverId},
                 {"txId", tx.TxId});
             SendToPipe(receiverId, tx, std::move(event), ctx);
@@ -4302,10 +4302,10 @@ void TPersQueue::SendEvReadSetAckToSenders(const TActorContext& ctx,
                                            TDistributedTransaction& tx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TPersQueue::SendEvReadSetAckToSenders",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
     for (auto& [target, event] : tx.ReadSetAcks) {
         YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Send TEvTxProcessing::TEvReadSetAck",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"toString", event->ToString()});
         ctx.Send(target, event.release());
     }
@@ -4331,7 +4331,7 @@ TMaybe<TPartitionId> TPersQueue::FindPartitionId(const NKikimrPQ::TDataTransacti
                 return TPartitionId(partitionId);
             }
             YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown WriteId",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"writeId", writeId});
             return Nothing();
         }
@@ -4342,7 +4342,7 @@ TMaybe<TPartitionId> TPersQueue::FindPartitionId(const NKikimrPQ::TDataTransacti
                 return TPartitionId(partitionId);
             }
             YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown partition for WriteId",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"partitionId", partitionId},
                 {"writeId", writeId});
             return Nothing();
@@ -4405,7 +4405,7 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
             for (auto& [originalPartitionId, partitionId] : writeInfo.Partitions) {
                 if (!OriginalPartitionExists(originalPartitionId)) {
                     YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown partition for TxId",
-                        {"logPrefix", LogPrefix()},
+                        {LogPrefix()},
                         {"originalPartitionId", originalPartitionId},
                         {"txId", tx.TxId});
                     forcePredicateFalse = true;
@@ -4419,7 +4419,7 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
 
                 if (!Partitions.contains(partitionId)) {
                     YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown partition for TxId",
-                        {"logPrefix", LogPrefix()},
+                        {LogPrefix()},
                         {"partitionId", partitionId},
                         {"txId", tx.TxId});
                     forcePredicateFalse = true;
@@ -4433,13 +4433,13 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
             }
         } else if (!writeId.IsKafkaApiTransaction()) {
             YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown WriteId for TxId",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"writeId", writeId},
                 {"txId", tx.TxId});
             forcePredicateFalse = true;
         } else {
             YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Kafka commit with no writes for TxId",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"writeId", writeId},
                 {"txId", tx.TxId});
         }
@@ -4464,7 +4464,7 @@ void TPersQueue::SendEvTxCommitToPartitions(const TActorContext& ctx,
                                             TDistributedTransaction& tx)
 {
     YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Commit TxId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txId", tx.TxId});
 
     const auto serializedTx = tx.Serialize(NKikimrPQ::TTransaction::EXECUTED);
@@ -4505,7 +4505,7 @@ void TPersQueue::SendEvTxRollbackToPartitions(const TActorContext& ctx,
                                               TDistributedTransaction& tx)
 {
     YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Rollback TxId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txId", tx.TxId});
 
     TMaybe<NKikimrPQ::TTransaction> serializedTx = tx.Serialize(NKikimrPQ::TTransaction::EXECUTED);
@@ -4548,7 +4548,7 @@ void TPersQueue::SendEvProposeTransactionResult(const TActorContext& ctx,
     }
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Send TEvPersQueue::TEvProposeTransactionResult",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txId", tx.TxId},
         {"status", NKikimrPQ::TEvProposeTransactionResult_EStatus_Name(result->Record.GetStatus())});
     ctx.Send(tx.SourceActor, std::move(result));
@@ -4600,7 +4600,7 @@ TDistributedTransaction* TPersQueue::GetTransaction(const TActorContext& ctx,
     auto p = Txs.find(txId);
     if (p == Txs.end()) {
         YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown transaction",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", txId});
         return nullptr;
     }
@@ -4618,7 +4618,7 @@ void TPersQueue::ChangeTxState(TDistributedTransaction& tx,
                                TDistributedTransaction::EState newState)
 {
     YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "TxId moved",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txId", tx.TxId},
         {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)},
         {"newState", NKikimrPQ::TTransaction_EState_Name(newState)});
@@ -4666,7 +4666,7 @@ bool TPersQueue::CanExecute(const TDistributedTransaction& tx)
     PQ_ENSURE(!txQueue.empty())("TxId", tx.TxId)("State", NKikimrPQ::TTransaction_EState_Name(tx.State));
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxId State FrontTxId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txId", tx.TxId},
         {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)},
         {"txQueueFront", txQueue.front()});
@@ -4678,7 +4678,7 @@ void TPersQueue::TryExecuteTxs(const TActorContext& ctx,
                                TDistributedTransaction& tx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Try execute txs with state",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)});
 
     TDistributedTransaction::EState oldState = tx.State;
@@ -4693,7 +4693,7 @@ void TPersQueue::TryExecuteTxs(const TActorContext& ctx,
     if (oldState == tx.State) {
         // The transaction status has not changed. There is no point in watching the transactions behind her.
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxId status has not changed",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", tx.TxId});
         return;
     }
@@ -4701,14 +4701,14 @@ void TPersQueue::TryExecuteTxs(const TActorContext& ctx,
     auto& txQueue = TxsOrder[oldState];
     while (!txQueue.empty()) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "There are txs in the queue",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txQueueSize", txQueue.size()},
             {"oldState", NKikimrPQ::TTransaction_EState_Name(oldState)});
         ui64 txId = txQueue.front();
         PQ_ENSURE(Txs.contains(txId))("unknown TxId", txId);
         auto& tx = Txs.at(txId);
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Try execute TxId Pending",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", tx.TxId},
             {"txPending", tx.Pending});
 
@@ -4723,7 +4723,7 @@ void TPersQueue::TryExecuteTxs(const TActorContext& ctx,
         if (oldState == tx.State) {
             // The transaction status has not changed. There is no point in watching the transactions behind her.
             YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxId status has not changed",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"txId", tx.TxId});
             break;
         }
@@ -4734,25 +4734,25 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
                               TDistributedTransaction& tx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxId State",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txId", tx.TxId},
         {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)});
 
     if (!CanExecute(tx)) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Can't execute TxId Pending",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", tx.TxId},
             {"txPending", tx.Pending});
         tx.Pending = true;
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Wait for TxId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", tx.TxId});
         return;
     }
     if (tx.WriteInProgress) {
         if (tx.State == NKikimrPQ::TTransaction::EXECUTED) {
             YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "You cannot send TEvReadSetAck for until the EXECUTED state is saved",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"txId", tx.TxId});
         }
         return;
@@ -4801,7 +4801,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
     case NKikimrPQ::TTransaction::PLANNED:
         PQ_ENSURE(tx.TxId == TxsOrder[tx.State].front())("TxId", tx.TxId)("FrontTxId", TxsOrder[tx.State].front());
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxQueue.size",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txQueueSize", TxQueue.size()});
 
         MoveTopTxToCalculating(tx, ctx);
@@ -4814,7 +4814,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
             ("PartitionRepliesCount", tx.PartitionRepliesCount)("PartitionRepliesExpected", tx.PartitionRepliesExpected);
 
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Responses received from the partitions ",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txPartitionRepliesCount", tx.PartitionRepliesCount},
             {"txPartitionRepliesExpected", tx.PartitionRepliesExpected});
 
@@ -4854,7 +4854,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         PQ_ENSURE(tx.TxId == TxsOrder[tx.State].front())("TxId", tx.TxId)("FrontTxId", TxsOrder[tx.State].front());
 
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "HaveParticipantsDecision",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txHaveParticipantsDecision", tx.HaveParticipantsDecision()});
 
         if (tx.HaveParticipantsDecision()) {
@@ -4883,7 +4883,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
             ("PartitionRepliesCount", tx.PartitionRepliesCount)("PartitionRepliesExpected", tx.PartitionRepliesExpected);
 
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Responses received from the partitions ",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txPartitionRepliesCount", tx.PartitionRepliesCount},
             {"txPartitionRepliesExpected", tx.PartitionRepliesExpected});
 
@@ -4895,7 +4895,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
 
         SendEvProposeTransactionResult(ctx, tx);
         YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Complete TxId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", tx.TxId});
 
         switch (tx.Kind) {
@@ -4925,7 +4925,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         TryReturnTabletStateAll(ctx);
 
         YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Delete partitions for TxId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", tx.TxId});
         BeginDeletePartitions(tx);
 
@@ -4935,7 +4935,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
 
     case NKikimrPQ::TTransaction::WAIT_RS_ACKS:
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "HaveAllRecipientsReceive AllSupportivePartitionsHaveBeenDeleted",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txHaveAllRecipientsReceive", tx.HaveAllRecipientsReceive()},
             {"allSupportivePartitionsDeleted", AllSupportivePartitionsHaveBeenDeleted(tx.WriteId)});
         if (tx.HaveAllRecipientsReceive() && AllSupportivePartitionsHaveBeenDeleted(tx.WriteId)) {
@@ -4950,7 +4950,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
     case NKikimrPQ::TTransaction::EXPIRED:
     case NKikimrPQ::TTransaction::CANCELED:
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "AllSupportivePartitionsHaveBeenDeleted",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"allSupportivePartitionsDeleted", AllSupportivePartitionsHaveBeenDeleted(tx.WriteId)});
         if (AllSupportivePartitionsHaveBeenDeleted(tx.WriteId)) {
             DeleteTx(tx);
@@ -4964,7 +4964,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         TMaybe<TWriteId> writeId = tx.WriteId; // copy writeId to save for kafka transaction after erase
         DeleteWriteId(writeId);
         YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Delete TxId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", tx.TxId});
         Txs.erase(tx.TxId);
         SetTxInFlyCounter();
@@ -4987,7 +4987,7 @@ bool TPersQueue::AllSupportivePartitionsHaveBeenDeleted(const TMaybe<TWriteId>& 
     const TTxWriteInfo& writeInfo = TxWrites.at(*writeId);
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "WriteId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"writeId", *writeId},
         {"partitionsSize", writeInfo.Partitions.size()});
     bool deleted =
@@ -5004,7 +5004,7 @@ void TPersQueue::DeleteWriteId(const TMaybe<TWriteId>& writeId)
     }
 
     YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Delete WriteId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"writeId", *writeId});
     TxWrites.erase(*writeId);
 }
@@ -5024,7 +5024,7 @@ void TPersQueue::WriteTx(TDistributedTransaction& tx, NKikimrPQ::TTransaction::E
 void TPersQueue::DeleteTx(TDistributedTransaction& tx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Add an TxId to the list for deletion",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txId", tx.TxId});
 
     DeleteTxs.insert(tx.TxId);
@@ -5147,7 +5147,7 @@ void TPersQueue::SendProposeTransactionResult(const TActorId& target,
     }
 
     YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Send TEvPersQueue::TEvProposeTransactionResult",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txId", txId},
         {"status", NKikimrPQ::TEvProposeTransactionResult_EStatus_Name(event->Record.GetStatus())});
     ctx.Send(target, std::move(event));
@@ -5327,7 +5327,7 @@ void TPersQueue::InitTxsOrder()
 void TPersQueue::EndInitTransactions()
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Transactions are initialized",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txsSize", Txs.size()},
         {"plannedTxsSize", PlannedTxs.size()});
 
@@ -5338,7 +5338,7 @@ void TPersQueue::EndInitTransactions()
 
     if (!TxQueue.empty()) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Top tx queue",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txQueueFrontStep", TxQueue.front().first},
             {"txQueueFrontTxId", TxQueue.front().second});
     }
@@ -5351,7 +5351,7 @@ void TPersQueue::EndInitTransactions()
 
         if (!TxsOrder.contains(tx.State)) {
             YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Skip",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"txStep", tx.Step},
                 {"txId", txId},
                 {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)});
@@ -5361,7 +5361,7 @@ void TPersQueue::EndInitTransactions()
         PushTxInQueue(tx, tx.State);
 
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Put the transaction in the queue",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txsOrder", tx.Step},
             {"txId", txId},
             {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)},
@@ -5464,7 +5464,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvProposeTransactionAttach::TPtr &ev, con
     }
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvPersQueue::TEvProposeTransactionAttach",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     const ui64 txId = ev->Get()->Record.GetTxId();
@@ -5495,7 +5495,7 @@ void TPersQueue::Handle(TEvPQ::TEvCheckPartitionStatusRequest::TPtr& ev, const T
     auto it = Partitions.find(TPartitionId(TPartitionId(record.GetPartition())));
     if (InitCompleted && it == Partitions.end()) {
         YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Unknown partition",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partition", record.GetPartition()});
 
         auto response = MakeHolder<TEvPQ::TEvCheckPartitionStatusResponse>();
@@ -5543,7 +5543,7 @@ void TPersQueue::ProcessCheckMessageDeduplicationRequests(const TPartitionId& pa
 void TPersQueue::Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& ev)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvLongTxService::TEvLockStatus",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     auto& record = ev->Get()->Record;
@@ -5552,14 +5552,14 @@ void TPersQueue::Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& e
     if (!TxWrites.contains(writeId)) {
         // the transaction has already been completed
         YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown WriteId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"writeId", writeId});
         return;
     }
 
     TTxWriteInfo& writeInfo = TxWrites.at(writeId);
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxWriteInfo: WriteId TxId Status",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"writeId", writeId},
         {"txId", writeInfo.TxId},
         {"longTxSubscriptionStatusName", NKikimrLongTxService::TEvLockStatus_EStatus_Name(writeInfo.LongTxSubscriptionStatus)});
@@ -5567,7 +5567,7 @@ void TPersQueue::Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& e
 
     if (writeInfo.LongTxSubscriptionStatus == NKikimrLongTxService::TEvLockStatus::STATUS_SUBSCRIBED) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Subscribed WriteId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"writeId", writeId});
         return;
     }
@@ -5575,14 +5575,14 @@ void TPersQueue::Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& e
     if (writeInfo.TxId.Defined()) {
         // the message `TEvProposeTransaction` has already arrived
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "There is already a transaction TxId for WriteId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"txId", writeInfo.TxId},
             {"writeId", writeId});
         return;
     }
 
     YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Delete partitions for WriteId (longTxService lost tx)",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"writeId", writeId});
     BeginDeletePartitions(writeId, writeInfo);
 }
@@ -5599,7 +5599,7 @@ void TPersQueue::Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr& ev, const T
     const NKikimrPQ::TEvPartitionScaleStatusChanged& record = ev->Get()->Record;
     if (MirroringEnabled(Config) && record.HasParticipatingPartitions()) {
         YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Got mirrorer split merge request",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"toString", ev->ToString()});
     }
 
@@ -5633,7 +5633,7 @@ void TPersQueue::DeletePartition(const TPartitionId& partitionId, const TActorCo
     ReservedBytes = ReservedBytes > partition.ReservedBytes ? ReservedBytes - partition.ReservedBytes : 0;
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "DeletePartition",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"partitionId", partitionId});
     Partitions.erase(partitionId);
 }
@@ -5641,7 +5641,7 @@ void TPersQueue::DeletePartition(const TPartitionId& partitionId, const TActorCo
 void TPersQueue::Handle(TEvPQ::TEvDeletePartitionDone::TPtr& ev, const TActorContext& ctx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvPQ::TEvDeletePartitionDone",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"partitionId", ev->Get()->PartitionId});
 
     auto* event = ev->Get();
@@ -5691,7 +5691,7 @@ void TPersQueue::TryDeleteWriteId(const TWriteId& writeId, const TTxWriteInfo& w
 void TPersQueue::Handle(TEvPQ::TEvTransactionCompleted::TPtr& ev, const TActorContext&)
 {
     YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Handle TEvPQ::TEvTransactionCompleted WriteId",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"writeId", ev->Get()->WriteId});
 
     auto* event = ev->Get();
@@ -5702,7 +5702,7 @@ void TPersQueue::Handle(TEvPQ::TEvTransactionCompleted::TPtr& ev, const TActorCo
     const TWriteId& writeId = *event->WriteId;
     if (!TxWrites.contains(writeId)) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Ignore TEvTransactionCompleted for unknown WriteId",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"writeId", writeId});
         return;
     }
@@ -5716,7 +5716,7 @@ void TPersQueue::BeginDeletePartitions(const TWriteId& writeId, TTxWriteInfo& wr
 {
     if (writeInfo.Deleting) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Already deleting WriteInfo",
-            {"logPrefix", LogPrefix()});
+            {LogPrefix()});
         return;
     }
     writeInfo.Deleting = true;
@@ -5728,7 +5728,7 @@ void TPersQueue::BeginDeletePartitions(const TWriteId& writeId, TTxWriteInfo& wr
             PQ_ENSURE(Partitions.contains(partitionId));
             const TPartitionInfo& partition = Partitions.at(partitionId);
             YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Send TEvPQ::TEvDeletePartition to partition",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"partitionId", partitionId});
             Send(partition.Actor, new TEvPQ::TEvDeletePartition);
         }
@@ -5745,8 +5745,10 @@ void TPersQueue::BeginDeletePartitions(const TDistributedTransaction& tx)
     BeginDeletePartitions(*tx.WriteId, writeInfo);
 }
 
-TString TPersQueue::LogPrefix() const {
-    return TStringBuilder() << "[PQ: " << TabletID() << "] ";
+NActors::NStructuredLog::TStructuredMessage TPersQueue::LogPrefix() const {
+    return YDB_LOG_CREATE_MESSAGE(
+        {"actorClassName", "PQ"},
+        {"tabletId", TabletID()});
 }
 
 ui64 TPersQueue::GetGeneration() {
@@ -5774,14 +5776,14 @@ void TPersQueue::ProcessPendingEvents()
 void TPersQueue::Handle(TEvPQ::TEvForceCompaction::TPtr& ev, const TActorContext& ctx)
 {
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "TPersQueue::Handle(TEvPQ::TEvForceCompaction)",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     const auto& event = *ev->Get();
     const TPartitionId partitionId(event.PartitionId);
 
     if (!Partitions.contains(partitionId)) {
         YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Unknown partition id",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", event.PartitionId});
         return;
     }
@@ -5818,7 +5820,7 @@ void TPersQueue::Handle(TEvPQ::TEvGetMLPConsumerStateRequest::TPtr& ev) {
 void TPersQueue::Handle(TEvPQ::TEvMLPConsumerStatus::TPtr& ev) {
     auto& record = ev->Get()->Record;
     YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvPQ::TEvMLPConsumerStatus",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"ev", record.ShortDebugString()});
     if (!ReadBalancerActorId) {
         return;
@@ -5836,7 +5838,7 @@ void TPersQueue::Handle(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationReque
     auto* p = Partitions.FindPtr(TPartitionId{partitionId});
     if (p == nullptr) [[unlikely]] {
         YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "TEvCheckMessageDeduplicationRequest: unknown partition",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"partitionId", partitionId});
         auto response = MakeHolder<NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationResponse>();
         response->Record.SetPartitionId(partitionId);
@@ -5861,7 +5863,7 @@ bool TPersQueue::ForwardToPartition(ui32 partitionId, TAutoPtr<TEventHandle>& ev
     if (it == Partitions.end()) {
         if (!ConfigInited) {
             YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Queue MLP request until config is inited",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"partitionId", partitionId});
             MLPRequests.emplace_back(std::move(ev));
             return false;

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -46,9 +46,8 @@
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_TX
 
-#define PQ_LOG_ERROR_AND_DIE(expr)                       \
-    YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, expr, \
-        {LogPrefix()});                     \
+#define PQ_LOG_ERROR_AND_DIE(expr) \
+    LOG_E(expr); \
     ctx.Send(ctx.SelfID, new TEvents::TEvPoison())
 
 #define PQ_ENSURE(condition) AFL_ENSURE(condition)("tablet_id", TabletID())("path", TopicPath)("topic", TopicName)
@@ -118,13 +117,14 @@ TEvPQ::TMessageGroupsPtr CreateExplicitMessageGroups(const NKikimrPQ::TBootstrap
 }
 
 /******************************************************* AnswerBuilderProxy *********************************************************/
-class TResponseBuilder {
+class TResponseBuilder : public TLogPrefix {
 public:
 
     TResponseBuilder(const TActorId& sender, const TString& topicName, const ui32 partition, const ui64 messageNo,
                      const TString& reqId, const TMaybe<ui64> cookie, NMetrics::TResourceMetrics* resourceMetrics,
                      const TActorContext&)
-    : Sender(sender)
+    : TLogPrefix(NKikimrServices::PERSQUEUE)
+    , Sender(sender)
     , TopicName(topicName)
     , Partition(partition)
     , MessageNo(messageNo)
@@ -140,11 +140,15 @@ public:
         if (cookie)
             Response->Record.MutablePartitionResponse()->SetCookie(*cookie);
 
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvRequest topic",
-            {LogPrefix()},
-            {"topicName", TopicName},
-            {"requestId", ReqId});
+        LOG_D("Handle TEvRequest topic");
 
+    }
+
+    TStructuredLogPrefix LogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"topicName", TopicName},
+            {"partition", Partition},
+            {"requestId", ReqId});
     }
 
     void SetWasSplit()
@@ -177,12 +181,8 @@ public:
             Response->Record.MergeFrom(*ev->Get()->Response);
 
         if (!Waiting) {
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Answer ok topic",
-                {LogPrefix()},
-                {"topicName", TopicName},
-                {"partition", Partition},
+            LOG_D("Answer ok topic",
                 {"messageNo", MessageNo},
-                {"requestId", ReqId},
                 {"cookie", (Cookie ? *Cookie : 0)});
 
             if (ResourceMetrics) {
@@ -201,11 +201,8 @@ public:
         const auto errorCode = ev->ErrorCode;
         const auto priority = errorCode == NPersQueue::NErrorCode::OVERLOAD ? NActors::NLog::EPriority::PRI_INFO : NActors::NLog::EPriority::PRI_ERROR;
         YDB_LOG_COMP(priority, NKikimrServices::PERSQUEUE, "Answer error topic",
-            {LogPrefix()},
-            {"topicName", TopicName},
-            {"partition", Partition},
+            NPQ_LOG_PREFIX,
             {"messageNo", MessageNo},
-            {"requestId", ReqId},
             {"error", ev->Error});
 
         Response->Record.SetStatus(NMsgBusProxy::MSTATUS_ERROR);
@@ -272,8 +269,8 @@ public:
         ctx.Schedule(TOTAL_TIMEOUT, new TEvents::TEvWakeup());
     }
 
-    const TLogPrefix& GetLogPrefix() const {
-        static const TLogPrefix LogPrefix = YDB_LOG_CREATE_MESSAGE(
+    const TStructuredLogPrefix& GetLogPrefix() const {
+        static const TStructuredLogPrefix LogPrefix = YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "BuilderProxy"});
         return LogPrefix;
     }
@@ -368,8 +365,7 @@ void TPersQueue::ApplyNewConfig(const NKikimrPQ::TPQTabletConfig& newConfig,
 {
     Config = newConfig;
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Apply new config",
-        {LogPrefix()},
+    LOG_D("Apply new config", 
         {"config", Config.ShortDebugString()});
 
     ui32 cacheSize = CACHE_SIZE;
@@ -479,8 +475,7 @@ void TPersQueue::ReadTxInfo(const NKikimrClient::TKeyValueResponse::TReadResult&
 {
     PQ_ENSURE(read.HasStatus());
     if (read.GetStatus() != NKikimrProto::OK && read.GetStatus() != NKikimrProto::NODATA) {
-        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Tx info read error",
-            {LogPrefix()},
+        LOG_E("Tx info read error", 
             {"selfId", ctx.SelfID});
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
         return;
@@ -488,8 +483,7 @@ void TPersQueue::ReadTxInfo(const NKikimrClient::TKeyValueResponse::TReadResult&
 
     switch (read.GetStatus()) {
     case NKikimrProto::OK: {
-        YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Has a tx info",
-            {LogPrefix()});
+        LOG_I("Has a tx info");
 
         NKikimrPQ::TTabletTxInfo info;
         PQ_ENSURE(info.ParseFromString(read.GetValue()));
@@ -499,8 +493,7 @@ void TPersQueue::ReadTxInfo(const NKikimrClient::TKeyValueResponse::TReadResult&
         break;
     }
     case NKikimrProto::NODATA: {
-        YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Doesn't have tx info",
-            {LogPrefix()});
+        LOG_I("Doesn't have tx info");
 
         InitPlanStep();
 
@@ -511,8 +504,7 @@ void TPersQueue::ReadTxInfo(const NKikimrClient::TKeyValueResponse::TReadResult&
         return;
     }
 
-    YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "PlanStep PlanTxId ExecStep ExecTxId",
-        {LogPrefix()},
+    LOG_I("PlanStep PlanTxId ExecStep ExecTxId", 
         {"planStep", PlanStep},
         {"planTxId", PlanTxId},
         {"execStep", ExecStep},
@@ -533,8 +525,7 @@ void TPersQueue::ReadTxWrites(const NKikimrClient::TKeyValueResponse::TReadResul
 {
     PQ_ENSURE(read.HasStatus());
     if (read.GetStatus() != NKikimrProto::OK && read.GetStatus() != NKikimrProto::NODATA) {
-        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Tx writes read error",
-            {LogPrefix()},
+        LOG_E("Tx writes read error", 
             {"selfId", ctx.SelfID});
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
         return;
@@ -542,8 +533,7 @@ void TPersQueue::ReadTxWrites(const NKikimrClient::TKeyValueResponse::TReadResul
 
     switch (read.GetStatus()) {
     case NKikimrProto::OK: {
-        YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Has a tx writes info",
-            {LogPrefix()});
+        LOG_I("Has a tx writes info");
 
         NKikimrPQ::TTabletTxInfo info;
         if (!info.ParseFromString(read.GetValue())) {
@@ -556,8 +546,7 @@ void TPersQueue::ReadTxWrites(const NKikimrClient::TKeyValueResponse::TReadResul
         break;
     }
     case NKikimrProto::NODATA: {
-        YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Doesn't have tx writes info",
-            {LogPrefix()});
+        LOG_I("Doesn't have tx writes info");
 
         InitTxWrites({}, ctx);
 
@@ -592,8 +581,7 @@ void TPersQueue::MoveTopTxToCalculating(TDistributedTransaction& tx,
     PQ_ENSURE(!TxQueue.empty());
 
     std::tie(ExecStep, ExecTxId) = TxQueue.front();
-    YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "New ExecStep ExecTxId",
-        {LogPrefix()},
+    LOG_I("New ExecStep ExecTxId", 
         {"execStep", ExecStep},
         {"execTxId", ExecTxId});
 
@@ -693,8 +681,7 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
 {
     PQ_ENSURE(read.HasStatus());
     if (read.GetStatus() != NKikimrProto::OK && read.GetStatus() != NKikimrProto::NODATA) {
-        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Config read error",
-            {LogPrefix()},
+        LOG_E("Config read error", 
             {"selfId", ctx.SelfID},
             {"status", read.GetStatus()});
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
@@ -724,8 +711,7 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
         PQ_ENSURE(TopicName.size())("description", "Need topic name here");
         ctx.Send(CacheActor, new TEvPQ::TEvChangeCacheConfig(TopicName, cacheSize));
     } else if (read.GetStatus() == NKikimrProto::NODATA) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "No config, start with empty partitions and default config",
-            {LogPrefix()});
+        LOG_D("No config, start with empty partitions and default config");
     } else {
         PQ_LOG_ERROR_AND_DIE("Unexpected config read status: " << read.GetStatus());
         return;
@@ -739,23 +725,20 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
             if (tx.GetStep() > PlanStep) {
                 PlanStep = tx.GetStep();
                 PlanTxId = tx.GetTxId();
-                YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "PlanStep PlanTxId",
-                    {LogPrefix()},
+                LOG_D("PlanStep PlanTxId", 
                     {"planStep", PlanStep},
                     {"planTxId", PlanTxId});
             } else if (tx.GetStep() == PlanStep) {
                 if (tx.GetTxId() > PlanTxId) {
                     PlanTxId = tx.GetTxId();
-                    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "PlanStep PlanTxId",
-                        {LogPrefix()},
+                    LOG_D("PlanStep PlanTxId", 
                         {"planStep", PlanStep},
                         {"planTxId", PlanTxId});
                 }
             }
         }
 
-        YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Restore Tx",
-            {LogPrefix()},
+        LOG_I("Restore Tx", 
             {"txId", tx.GetTxId()},
             {"step", tx.GetStep()},
             {"state", NKikimrPQ::TTransaction_EState_Name(tx.GetState())},
@@ -766,8 +749,7 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
         Txs.emplace(tx.GetTxId(), tx);
 
         if (tx.HasWriteId()) {
-            YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Link TxId with WriteId",
-                {LogPrefix()},
+            LOG_I("Link TxId with WriteId", 
                 {"txId", tx.GetTxId()},
                 {"writeId", GetWriteId(tx)});
             TxWrites[GetWriteId(tx)].TxId = tx.GetTxId();
@@ -775,8 +757,7 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
     }
 
     for (const auto& [txId, tx] : Txs) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Dump logPrefix, txId, step, state, decision",
-            {LogPrefix()},
+        LOG_D("Dump logPrefix, txId, step, state, decision", 
             {"txId", txId},
             {"step", tx.Step},
             {"state", NKikimrPQ::TTransaction_EState_Name(tx.State)},
@@ -871,8 +852,7 @@ void TPersQueue::InitializeMeteringSink(const TActorContext& ctx) {
 
     auto& pqConfig = AppData(ctx)->PQConfig;
     if (!pqConfig.GetBillingMeteringConfig().GetEnabled()) {
-        YDB_LOG_NOTICE_COMP(NKikimrServices::PERSQUEUE, "Disable metering is not enabled in BillingMeteringConfig",
-            {LogPrefix()},
+        LOG_N("Disable metering is not enabled in BillingMeteringConfig", 
             {"reason", "billing"});
         return;
     }
@@ -893,8 +873,7 @@ void TPersQueue::InitializeMeteringSink(const TActorContext& ctx) {
 
     switch (Config.GetMeteringMode()) {
     case NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS:
-        YDB_LOG_NOTICE_COMP(NKikimrServices::PERSQUEUE, "Metering mode METERING_MODE_REQUEST_UNITS",
-            {LogPrefix()});
+        LOG_N("Metering mode METERING_MODE_REQUEST_UNITS");
         whichToFlush = TSet<EMeteringJson>{EMeteringJson::UsedStorageV1};
         break;
 
@@ -976,8 +955,7 @@ void TPersQueue::EndWriteTabletState(const NKikimrClient::TResponse& resp, const
             (resp.WriteResultSize() == 1) &&
             (resp.GetWriteResult(0).GetStatus() == NKikimrProto::OK);
     if (!ok) {
-        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "SelfId State write",
-            {LogPrefix()},
+        LOG_E("SelfId State write", 
             {"selfId", ctx.SelfID},
             {"error", resp.DebugString()});
 
@@ -1006,13 +984,11 @@ void TPersQueue::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
         EndWriteTabletState(resp, ctx);
         break;
     case WRITE_TX_COOKIE:
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvKeyValue::TEvResponse (WRITE_TX_COOKIE)",
-            {LogPrefix()});
+        LOG_D("Handle TEvKeyValue::TEvResponse (WRITE_TX_COOKIE)");
         EndWriteTxs(resp, ctx);
         break;
     default:
-        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Unexpected KV",
-            {LogPrefix()},
+        LOG_E("Unexpected KV", 
             {"response", ev->Get()->ToString()},
             {"selfId", ctx.SelfID});
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
@@ -1042,8 +1018,7 @@ TPartitionInfo& TPersQueue::GetPartitionInfo(const TPartitionId& partitionId)
 
 void TPersQueue::Handle(TEvPQ::TEvPartitionCounters::TPtr& ev, const TActorContext& ctx)
 {
-    YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Handle TEvPQ::TEvPartitionCounters PartitionId",
-        {LogPrefix()},
+    LOG_T("Handle TEvPQ::TEvPartitionCounters PartitionId", 
         {"partition", ev->Get()->Partition});
 
     auto& partitionId = ev->Get()->Partition;
@@ -1167,8 +1142,7 @@ void TPersQueue::Handle(TEvPQ::TEvTabletCacheCounters::TPtr& ev, const TActorCon
     CacheCounters = ev->Get()->Counters;
     SetCacheCounters(CacheCounters);
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Topic counters. CacheSize CachedBlobs",
-        {LogPrefix()},
+    LOG_D("Topic counters. CacheSize CachedBlobs", 
         {"topic", (TopicConverter ? TopicConverter->GetClientsideName() : "Undefined")},
         {"cacheSizeBytes", CacheCounters.CacheSizeBytes},
         {"cacheSizeBlobs", CacheCounters.CacheSizeBlobs});
@@ -1220,8 +1194,7 @@ void TPersQueue::Handle(TEvPQ::TEvInitComplete::TPtr& ev, const TActorContext& c
 
 void TPersQueue::Handle(TEvPQ::TEvError::TPtr& ev, const TActorContext& ctx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvPQ::TEvError Cookie Error",
-        {LogPrefix()},
+    LOG_D("Handle TEvPQ::TEvError Cookie Error", 
         {"cookie", ev->Get()->Cookie},
         {"error", ev->Get()->Error});
 
@@ -1293,8 +1266,7 @@ void TPersQueue::UpdateConsumers(NKikimrPQ::TPQTabletConfig& cfg)
 
 void TPersQueue::Handle(TEvPersQueue::TEvDropTablet::TPtr& ev, const TActorContext& ctx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvPersQueue::TEvDropTablet",
-        {LogPrefix()});
+    LOG_D("Handle TEvPersQueue::TEvDropTablet");
 
     const auto& record = ev->Get()->Record;
     ui64 txId = record.GetTxId();
@@ -1417,12 +1389,10 @@ void TPersQueue::ProcessStatusRequests(const TActorContext &ctx) {
 
 void TPersQueue::Handle(TEvPersQueue::TEvStatus::TPtr& ev, const TActorContext& ctx)
 {
-    YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Handle TEvPersQueue::TEvStatus",
-        {LogPrefix()});
+    LOG_T("Handle TEvPersQueue::TEvStatus");
 
     if (!ConfigInited || !AllOriginalPartitionsInited()) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Postpone the request. ConfigInited PartitionsInited OriginalPartitionsCount",
-            {LogPrefix()},
+        LOG_D("Postpone the request. ConfigInited PartitionsInited OriginalPartitionsCount", 
             {"configInited", static_cast<int>(ConfigInited)},
             {"partitionsInited", PartitionsInited},
             {"originalPartitionsCount", OriginalPartitionsCount});
@@ -1493,8 +1463,7 @@ void TPersQueue::HandleDeleteSessionRequest(
     InitResponseBuilder(responseCookie, 1, COUNTER_LATENCY_PQ_DELETE_SESSION);
     const auto& cmd = req.GetCmdDeleteSession();
     //To do : priority
-    YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Got cmd delete",
-        {LogPrefix()},
+    LOG_I("Got cmd delete", 
         {"session", cmd.DebugString()});
 
     if (!cmd.HasClientId()){
@@ -1553,8 +1522,7 @@ void TPersQueue::HandleCreateSessionRequest(const ui64 responseCookie, NWilson::
 
             pipeIter->second.SessionId = cmd.GetSessionId();
             pipeIter->second.PartitionSessionId = cmd.GetPartitionSessionId();
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Created session",
-                {LogPrefix()},
+            LOG_D("Created session", 
                 {"sessionId", cmd.GetSessionId()},
                 {"onPipe", pipeIter->first});
             ctx.Send(MakePQDReadCacheServiceActorId(),
@@ -1689,8 +1657,7 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
     }
 
     if (req.HasWriteId()) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Write in transaction",
-            {LogPrefix()},
+        LOG_D("Write in transaction", 
             {"partition", req.GetPartition()},
             {"writeId", req.GetWriteId()},
             {"needSupportivePartition", req.GetNeedSupportivePartition()});
@@ -1868,8 +1835,7 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
 
                 partNo++;
                 uncompressedSize = 0;
-                YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Got client PART message",
-                    {LogPrefix()},
+                LOG_D("Got client PART message", 
                     {"topic", (TopicConverter ? TopicConverter->GetClientsideName() : "Undefined")},
                     {"partition", req.GetPartition()},
                     {"sourceId", EscapeC(msgs.back().SourceId)},
@@ -1931,8 +1897,7 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
             });
             FillBatchInfo(cmd, msgs.back());
         }
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Got client message",
-            {LogPrefix()},
+        LOG_D("Got client message", 
             {"topic", (TopicConverter ? TopicConverter->GetClientsideName() : "Undefined")},
             {"partition", req.GetPartition()},
             {"sourceId", EscapeC(msgs.back().SourceId)},
@@ -1985,8 +1950,7 @@ void TPersQueue::HandleReserveBytesRequest(const ui64 responseCookie, NWilson::T
     }
 
     if (req.HasWriteId()) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Reserve bytes in transaction",
-            {LogPrefix()},
+        LOG_D("Reserve bytes in transaction", 
             {"partition", req.GetPartition()},
             {"writeId", req.GetWriteId()},
             {"needSupportivePartition", req.GetNeedSupportivePartition()});
@@ -2157,8 +2121,7 @@ void TPersQueue::HandlePublishReadRequest(
     publishRes->SetDirectReadId(key.ReadId);
     ctx.Send(SelfId(), publishDoneEvent.Release());
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Publish direct read id for session",
-        {LogPrefix()},
+    LOG_D("Publish direct read id for session", 
         {"readId", key.ReadId},
         {"sessionId", key.SessionId});
     ctx.Send(
@@ -2188,8 +2151,7 @@ void TPersQueue::HandleForgetReadRequest(
     forgetDoneEvent->Response->MutablePartitionResponse()->MutableCmdForgetReadResult()->SetDirectReadId(key.ReadId);
     ctx.Send(SelfId(), forgetDoneEvent.Release());
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Forget direct read id for session",
-        {LogPrefix()},
+    LOG_D("Forget direct read id for session", 
         {"readId", key.ReadId},
         {"sessionId", key.SessionId});
     ctx.Send(
@@ -2201,8 +2163,7 @@ void TPersQueue::HandleForgetReadRequest(
 }
 
 void TPersQueue::DestroySession(TPipeInfo& pipeInfo) {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Destroy direct read session",
-        {LogPrefix()},
+    LOG_D("Destroy direct read session", 
         {"sessionId", pipeInfo.SessionId});
     if (pipeInfo.SessionId.empty())
         return;
@@ -2421,8 +2382,7 @@ void TPersQueue::HandleAbortDeferredStagingRequest(const ui64 responseCookie,
     if (TxWrites.contains(writeId)) {
         TTxWriteInfo& writeInfo = TxWrites.at(writeId);
         if (writeInfo.Partitions.contains(originalPartitionId) && !writeInfo.Deleting) {
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Abort deferred staging",
-                {LogPrefix()},
+            LOG_D("Abort deferred staging", 
                 {"writeId", writeId},
                 {"partition", originalPartitionId},
             );
@@ -2492,8 +2452,7 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
     if (writeId.IsKafkaApiTransaction() && TxWrites.contains(writeId) && TxWrites.at(writeId).Deleting) {
         // This branch happens when previous Kafka transaction has committed and we receive write for next one
         // after PQ has deleted supportive partition and before it has deleted writeId from TxWrites (tx has not transaitioned to DELETED state)
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "GetOwnership request for the next Kafka transaction while previous is being deleted. Saving it till the complete delete of the previous tx.",
-            {LogPrefix()});
+        LOG_D("GetOwnership request for the next Kafka transaction while previous is being deleted. Saving it till the complete delete of the previous tx.");
         KafkaNextTransactionRequests[writeId.GetKafkaProducerInstanceId()].push_back(event);
         return;
     } else if (TxWrites.contains(writeId) && TxWrites.at(writeId).Partitions.contains(originalPartitionId)) {
@@ -2514,8 +2473,7 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
         } else if (writeInfo.TxId.Defined() && writeId.IsKafkaApiTransaction()) {
             // This branch happens when previous Kafka transaction has committed and we receive write for next one
             // before PQ has deleted supportive partition for previous transaction
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "GetOwnership request for the next Kafka transaction while previous is being deleted. Saving it till the complete delete of the previous tx.",
-                {LogPrefix()});
+            LOG_D("GetOwnership request for the next Kafka transaction while previous is being deleted. Saving it till the complete delete of the previous tx.");
             KafkaNextTransactionRequests[writeId.GetKafkaProducerInstanceId()].push_back(event);
             return;
         }
@@ -2563,8 +2521,7 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
         //
         TTxWriteInfo& writeInfo = TxWrites[writeId];
         TPartitionId partitionId(originalPartitionId, writeId, NextSupportivePartitionId++);
-        YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Partition for WriteId",
-            {LogPrefix()},
+        LOG_I("Partition for WriteId", 
             {"partitionId", partitionId},
             {"writeId", writeId});
 
@@ -2648,8 +2605,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvRequest::TPtr& ev, const TActorContext&
     TPartitionId partition(req.GetPartition());
     auto it = Partitions.find(partition);
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Got client message batch for topic partition",
-        {LogPrefix()},
+    LOG_D("Got client message batch for topic partition", 
         {"topic", (TopicConverter ? TopicConverter->GetClientsideName() : "Undefined")},
         {"partition", partition});
 
@@ -2735,13 +2691,11 @@ void TPersQueue::Handle(TEvPersQueue::TEvRequest::TPtr& ev, const TActorContext&
 
 void TPersQueue::Handle(TEvTabletPipe::TEvServerConnected::TPtr& ev, const TActorContext&)
 {
-    YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Handle TEvTabletPipe::TEvServerConnected",
-        {LogPrefix()});
+    LOG_T("Handle TEvTabletPipe::TEvServerConnected");
 
     auto it = PipesInfo.insert({ev->Get()->ClientId, {}}).first;
     it->second.ServerActors++;
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Server connected, pipe now have active actors on pipe",
-        {LogPrefix()},
+    LOG_D("Server connected, pipe now have active actors on pipe", 
         {"clientId", ev->Get()->ClientId},
         {"serverActors", it->second.ServerActors});
 
@@ -2751,8 +2705,7 @@ void TPersQueue::Handle(TEvTabletPipe::TEvServerConnected::TPtr& ev, const TActo
 
 void TPersQueue::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TActorContext& ctx)
 {
-    YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Handle TEvTabletPipe::TEvServerDisconnected",
-        {LogPrefix()});
+    LOG_T("Handle TEvTabletPipe::TEvServerDisconnected");
 
     //inform partition if needed;
     auto it = PipesInfo.find(ev->Get()->ClientId);
@@ -2768,8 +2721,7 @@ void TPersQueue::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TA
         if (!it->second.SessionId.empty()) {
             DestroySession(it->second);
         }
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Server disconnected, pipe destroyed",
-            {LogPrefix()},
+        LOG_D("Server disconnected, pipe destroyed", 
             {"clientId", ev->Get()->ClientId});
         PipesInfo.erase(it);
         Counters->Simple()[COUNTER_PQ_TABLET_OPENED_PIPES] = PipesInfo.size();
@@ -2778,15 +2730,13 @@ void TPersQueue::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TA
 
 void TPersQueue::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const TActorContext& ctx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvTabletPipe::TEvClientConnected",
-        {LogPrefix()});
+    LOG_D("Handle TEvTabletPipe::TEvClientConnected");
 
     PQ_ENSURE(ev->Get()->Leader)("description", TStringBuilder() << "Unexpectedly connected to follower of tablet " << ev->Get()->TabletId);
 
     if (PipeClientCache->OnConnect(ev)) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Connected to tablet",
-            {LogPrefix()},
-            {"tabletId", ev->Get()->TabletId});
+        LOG_D("Connected to tablet", 
+            {"peerTabletId", ev->Get()->TabletId});
         return;
     }
 
@@ -2806,9 +2756,8 @@ void TPersQueue::AckReadSetsToTablet(ui64 tabletId, const TActorContext& ctx)
 
 
     for (ui64 txId : GetBindedTxs(tabletId)) {
-        YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Assume tablet dead, sending read set acks for tx",
-            {LogPrefix()},
-            {"tabletId", tabletId},
+        LOG_I("Assume tablet dead, sending read set acks for tx", 
+            {"peerTabletId", tabletId},
             {"txId", txId});
 
         auto* tx = GetTransaction(ctx, txId);
@@ -2841,11 +2790,9 @@ void TPersQueue::AckReadSetsToTablet(ui64 tabletId, const TActorContext& ctx)
 
 void TPersQueue::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev, const TActorContext& ctx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvTabletPipe::TEvClientDestroyed",
-        {LogPrefix()});
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Client pipe to tablet is reset",
-        {LogPrefix()},
-        {"tabletId", ev->Get()->TabletId});
+    LOG_D("Handle TEvTabletPipe::TEvClientDestroyed");
+    LOG_D("Client pipe to tablet is reset", 
+        {"peerTabletId", ev->Get()->TabletId});
 
     PipeClientCache->OnDisconnect(ev);
 
@@ -2906,6 +2853,7 @@ void TPersQueue::InitPipeClientCache()
 
 TPersQueue::TPersQueue(const TActorId& tablet, TTabletStorageInfo *info)
     : TKeyValueFlat(tablet, info)
+    , TLogPrefix(NKikimrServices::PQ_TX)
     , ConfigInited(false)
     , PartitionsInited(0)
     , OriginalPartitionsCount(0)
@@ -2987,16 +2935,14 @@ void TPersQueue::Handle(TEvMediatorTimecast::TEvRegisterTabletResult::TPtr& ev, 
     MediatorTimeCastEntry = message->Entry;
     PQ_ENSURE(MediatorTimeCastEntry);
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Registered with mediator time cast",
-        {LogPrefix()});
+    LOG_D("Registered with mediator time cast");
 
     TryWriteTxs(ctx);
 }
 
 void TPersQueue::Handle(TEvInterconnect::TEvNodeInfo::TPtr& ev, const TActorContext& ctx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvInterconnect::TEvNodeInfo",
-        {LogPrefix()});
+    LOG_D("Handle TEvInterconnect::TEvNodeInfo");
 
     PQ_ENSURE(ev->Get()->Node);
     DCId = ev->Get()->Node->Location.GetDataCenterId();
@@ -3026,8 +2972,7 @@ void TPersQueue::AddCmdReadTransactionRange(TEvKeyValue::TEvRequest& request,
     cmd->MutableRange()->SetIncludeTo(true);
     cmd->SetIncludeData(true);
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Transactions request. From To",
-        {LogPrefix()},
+    LOG_D("Transactions request. From To", 
         {"rangeFrom", cmd->MutableRange()->GetFrom()},
         {"rangeTo", cmd->MutableRange()->GetTo()});
 }
@@ -3077,8 +3022,7 @@ void TPersQueue::ScheduleDeleteExpiredKafkaTransactions() {
 
     for (auto& pair : TxWrites) {
         if (txnExpired(pair.second)) {
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Transaction for Kafka producer is expired",
-                {LogPrefix()},
+            LOG_D("Transaction for Kafka producer is expired", 
                 {"kafkaProducerInstanceId", pair.first.GetKafkaProducerInstanceId()});
             BeginDeletePartitions(pair.first, pair.second);
         }
@@ -3143,8 +3087,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvCancelTransactionProposal::TPtr& ev, co
     NKikimrPQ::TEvCancelTransactionProposal& event = ev->Get()->Record;
     PQ_ENSURE(event.HasTxId());
 
-    YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Handle TEvPersQueue::TEvCancelTransactionProposal for TxId",
-        {LogPrefix()},
+    LOG_W("Handle TEvPersQueue::TEvCancelTransactionProposal for TxId", 
         {"txId", event.GetTxId()});
 
     if (auto tx = GetTransaction(ctx, event.GetTxId()); tx) {
@@ -3164,8 +3107,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvProposeTransaction::TPtr& ev, const TAc
     }
 
     const NKikimrPQ::TEvProposeTransaction& event = ev->Get()->GetRecord();
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvPersQueue::TEvProposeTransaction",
-        {LogPrefix()},
+    LOG_D("Handle TEvPersQueue::TEvProposeTransaction", 
         {"event", event.ShortDebugString()});
 
     auto span = GenerateSpan("Topic.Transaction", *SamplingControl, std::move(ev->TraceId));
@@ -3215,8 +3157,7 @@ bool TPersQueue::CheckTxWriteOperation(const NKikimrPQ::TPartitionOperation& ope
                                  writeId,
                                  GetSupportivePartition(operation)};
     }
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "PartitionId for WriteId",
-        {LogPrefix()},
+    LOG_D("PartitionId for WriteId", 
         {"partitionId", partitionId},
         {"writeId", writeId});
     return Partitions.contains(partitionId);
@@ -3315,8 +3256,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
     NKikimrPQ::TDataTransaction& txBody = *event.MutableData();
 
     if (TabletState != NKikimrPQ::ENormal) {
-        YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "TxId invalid PQ tablet state",
-            {LogPrefix()},
+        LOG_W("TxId invalid PQ tablet state", 
             {"txId", event.GetTxId()},
             {"tabletState", NKikimrPQ::ETabletState_Name(TabletState)});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3328,8 +3268,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
     }
 
     if (txBody.OperationsSize() <= 0) {
-        YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "TxId empty list of operations",
-            {LogPrefix()},
+        LOG_W("TxId empty list of operations", 
             {"txId", event.GetTxId()});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                     event.GetTxId(),
@@ -3344,9 +3283,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
     const bool hasDeferredFinalize = HasDeferredPublicationFinalizeOperation(txBody);
     if (hasDeferredFinalize) {
         if (txBody.GetImmediate()) {
-            YDB_LOG_WARN("TxId immediate transaction is not supported for deferred publication finalize",
-                {LogPrefix()},
-                {"txId", event.GetTxId()});
+            LOG_W("TxId immediate transaction is not supported for deferred publication finalize", {"txId", event.GetTxId()});
             SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                         event.GetTxId(),
                                         NKikimrPQ::TError::BAD_REQUEST,
@@ -3356,9 +3293,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
         }
 
         if (!txBody.HasWriteId() || !GetWriteId(txBody).IsDeferredPublicationApiTransaction()) {
-            YDB_LOG_WARN("TxId invalid WriteId for deferred publication finalize",
-                {LogPrefix()},
-                {"txId", event.GetTxId()});
+            LOG_W("TxId invalid WriteId for deferred publication finalize", {"txId", event.GetTxId()});
             SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                         event.GetTxId(),
                                         NKikimrPQ::TError::BAD_REQUEST,
@@ -3368,9 +3303,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
         }
 
         if (!AllOperationsAreDeferredPublicationFinalize(txBody)) {
-            YDB_LOG_WARN("TxId deferred publication finalize allows only finalize operations",
-                {LogPrefix()},
-                {"txId", event.GetTxId()});
+            LOG_W("TxId deferred publication finalize allows only finalize operations", {"txId", event.GetTxId()});
             SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                         event.GetTxId(),
                                         NKikimrPQ::TError::BAD_REQUEST,
@@ -3381,9 +3314,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
 
         const auto finalizeOp = GetSingleDeferredPublicationFinalizeOp(txBody);
         if (!finalizeOp.Defined()) {
-            YDB_LOG_WARN("TxId deferred publication finalize requires matching Publish or Cancel op",
-                {LogPrefix()},
-                {"txId", event.GetTxId()});
+            LOG_W("TxId deferred publication finalize requires matching Publish or Cancel op", {"txId", event.GetTxId()});
             SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                         event.GetTxId(),
                                         NKikimrPQ::TError::BAD_REQUEST,
@@ -3395,9 +3326,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
         const TWriteId writeId = GetWriteId(txBody);
         if (TxWrites.contains(writeId)
             && !DeferredPublicationFinalizePartitionsMatchStaged(txBody, TxWrites.at(writeId).Partitions)) {
-            YDB_LOG_WARN("TxId deferred publication finalize partition set mismatch",
-                {LogPrefix()},
-                {"txId", event.GetTxId()});
+            LOG_W("TxId deferred publication finalize partition set mismatch", {"txId", event.GetTxId()});
             SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                         event.GetTxId(),
                                         NKikimrPQ::TError::BAD_REQUEST,
@@ -3406,9 +3335,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
             return;
         }
     } else if (txBody.HasWriteId() && GetWriteId(txBody).IsDeferredPublicationApiTransaction()) {
-        YDB_LOG_WARN("TxId deferred publication WriteId requires finalize operation",
-            {LogPrefix()},
-            {"txId", event.GetTxId()});
+        LOG_W("TxId deferred publication WriteId requires finalize operation", {"txId", event.GetTxId()});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                     event.GetTxId(),
                                     NKikimrPQ::TError::BAD_REQUEST,
@@ -3418,9 +3345,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
     } else {
         for (const auto& operation : txBody.GetOperations()) {
             if (IsDeferredPublicationFinalizeOperation(operation)) {
-                YDB_LOG_WARN("TxId deferred publication finalize requires deferred WriteId",
-                    {LogPrefix()},
-                    {"txId", event.GetTxId()});
+                LOG_W("TxId deferred publication finalize requires deferred WriteId", {"txId", event.GetTxId()});
                 SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                             event.GetTxId(),
                                             NKikimrPQ::TError::BAD_REQUEST,
@@ -3432,8 +3357,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
     }
 
     if (!CheckTxWriteOperations(txBody)) {
-        YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "TxId invalid WriteId",
-            {LogPrefix()},
+        LOG_W("TxId invalid WriteId", 
             {"txId", event.GetTxId()},
             {"writeId", txBody.GetWriteId()});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3448,8 +3372,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
         const TWriteId writeId = GetWriteId(txBody);
         if (!TxWrites.contains(writeId)) {
             if (!writeId.IsKafkaApiTransaction()) {
-                YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "TxId unknown WriteId",
-                    {LogPrefix()},
+                LOG_W("TxId unknown WriteId", 
                     {"txId", event.GetTxId()},
                     {"writeId", writeId});
                 SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3459,15 +3382,13 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
                                             ctx);
                 return;
             }
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxId Kafka commit with no writes for WriteId",
-                {LogPrefix()},
+            LOG_D("TxId Kafka commit with no writes for WriteId", 
                 {"txId", event.GetTxId()},
                 {"writeId", writeId});
         } else {
             TTxWriteInfo& writeInfo = TxWrites.at(writeId);
             if (writeInfo.Deleting) {
-                YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "TxId WriteId will be deleted",
-                    {LogPrefix()},
+                LOG_W("TxId WriteId will be deleted", 
                     {"txId", event.GetTxId()},
                     {"writeId", writeId});
                 SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3479,8 +3400,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
             }
 
             writeInfo.TxId = event.GetTxId();
-            YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "TxId has WriteId",
-                {LogPrefix()},
+            LOG_I("TxId has WriteId", 
                 {"txId", event.GetTxId()},
                 {"writeId", writeId});
         }
@@ -3488,8 +3408,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
 
     TMaybe<TPartitionId> partitionId = FindPartitionId(txBody);
     if (!partitionId.Defined()) {
-        YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "TxId unknown partition for WriteId",
-            {LogPrefix()},
+        LOG_W("TxId unknown partition for WriteId", 
             {"txId", event.GetTxId()},
             {"writeId", txBody.GetWriteId()});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
@@ -3501,8 +3420,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
     }
 
     if (!Partitions.contains(*partitionId)) {
-        YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown partition",
-            {LogPrefix()},
+        LOG_W("Unknown partition", 
             {"partitionId", *partitionId});
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
                                     event.GetTxId(),
@@ -3513,8 +3431,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
     }
 
     if (txBody.GetImmediate()) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Immediate transaction",
-            {LogPrefix()});
+        LOG_D("Immediate transaction");
         TPartitionId originalPartitionId(txBody.GetOperations(0).GetPartitionId());
         const TPartitionInfo& partition = Partitions.at(originalPartitionId);
 
@@ -3535,8 +3452,7 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
             return;
         }
 
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Distributed transaction",
-            {LogPrefix()});
+        LOG_D("Distributed transaction");
         EvProposeTransactionQueue.emplace_back(ev.Release());
 
         TryWriteTxs(ctx);
@@ -3562,8 +3478,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvPlanStep::TPtr& ev, const TActorCont
         return;
     }
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvTxProcessing::TEvPlanStep",
-        {LogPrefix()},
+    LOG_D("Handle TEvTxProcessing::TEvPlanStep", 
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     const TActorId sender = ev->Sender;
@@ -3579,8 +3494,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
         return;
     }
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvTxProcessing::TEvReadSet",
-        {LogPrefix()},
+    LOG_D("Handle TEvTxProcessing::TEvReadSet", 
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     NKikimrTx::TEvReadSet& event = ev->Get()->Record;
@@ -3591,8 +3505,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
         ack = std::make_unique<TEvTxProcessing::TEvReadSetAck>(*ev->Get(), TabletID());
     }
 
-    YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Handle TEvTxProcessing::TEvReadSet tx tabletProducer",
-        {LogPrefix()},
+    LOG_I("Handle TEvTxProcessing::TEvReadSet tx tabletProducer", 
         {"txId", event.GetTxId()},
         {"tabletProducer", event.GetTabletProducer()});
 
@@ -3602,8 +3515,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
         if ((tx->State > NKikimrPQ::TTransaction::EXECUTED) ||
             ((tx->State == NKikimrPQ::TTransaction::EXECUTED) && !tx->WriteInProgress)) {
             if (ack) {
-                YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Send TEvReadSetAck to for TxId",
-                    {LogPrefix()},
+                LOG_I("Send TEvReadSetAck to for TxId", 
                     {"tabletProducer", event.GetTabletProducer()},
                     {"txId", event.GetTxId()});
                 ctx.Send(ev->Sender, ack.release());
@@ -3623,8 +3535,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
             TryWriteTxs(ctx);
         }
     } else if (ack) {
-        YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "A TEvReadSetAck message to for TxId will be sent later",
-            {LogPrefix()},
+        LOG_I("A TEvReadSetAck message to for TxId will be sent later", 
             {"tabletProducer", event.GetTabletProducer()},
             {"txId", event.GetTxId()});
 
@@ -3648,8 +3559,7 @@ void TPersQueue::AddPendingDeferredReadSetAck(TDeferredReadSetAck&& ack)
 void TPersQueue::SendDeferredReadSetAcks(const TActorContext& ctx)
 {
     for (auto& e : DeferredReadSetAcks) {
-        YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Send TEvReadSetAck to for TxId",
-            {LogPrefix()},
+        LOG_I("Send TEvReadSetAck to for TxId", 
             {"ackRecordTabletSource", e.Ack->Record.GetTabletSource()},
             {"ackRecordTxId", e.Ack->Record.GetTxId()});
         ctx.Send(e.Sender, e.Ack.release());
@@ -3660,8 +3570,7 @@ void TPersQueue::SendDeferredReadSetAcks(const TActorContext& ctx)
 
 void TPersQueue::Handle(TEvTxProcessing::TEvReadSetAck::TPtr& ev, const TActorContext& ctx)
 {
-    YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Handle TEvTxProcessing::TEvReadSetAck",
-        {LogPrefix()},
+    LOG_I("Handle TEvTxProcessing::TEvReadSetAck", 
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     NKikimrTx::TEvReadSetAck& event = ev->Get()->Record;
@@ -3687,8 +3596,7 @@ void TPersQueue::Handle(TEvPQ::TEvTxCalcPredicateResult::TPtr& ev, const TActorC
 {
     const TEvPQ::TEvTxCalcPredicateResult& event = *ev->Get();
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvPQ::TEvTxCalcPredicateResult Step TxId Partition Predicate",
-        {LogPrefix()},
+    LOG_D("Handle TEvPQ::TEvTxCalcPredicateResult Step TxId Partition Predicate", 
         {"step", event.Step},
         {"txId", event.TxId},
         {"partition", event.Partition},
@@ -3712,8 +3620,7 @@ void TPersQueue::Handle(TEvPQ::TEvProposePartitionConfigResult::TPtr& ev, const 
 {
     TEvPQ::TEvProposePartitionConfigResult& event = *ev->Get();
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvPQ::TEvProposePartitionConfigResult Step TxId Partition",
-        {LogPrefix()},
+    LOG_D("Handle TEvPQ::TEvProposePartitionConfigResult Step TxId Partition", 
         {"step", event.Step},
         {"txId", event.TxId},
         {"partition", event.Partition});
@@ -3736,8 +3643,7 @@ void TPersQueue::Handle(TEvPQ::TEvTxDone::TPtr& ev, const TActorContext& ctx)
 {
     const TEvPQ::TEvTxDone& event = *ev->Get();
 
-    YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Handle TEvPQ::TEvTxDone Step TxId Partition",
-        {LogPrefix()},
+    LOG_I("Handle TEvPQ::TEvTxDone Step TxId Partition", 
         {"step", event.Step},
         {"txId", event.TxId},
         {"partition", event.Partition});
@@ -3777,8 +3683,7 @@ bool TPersQueue::CanProcessTxWrites() const
 void TPersQueue::SubscribeWriteId(const TWriteId& writeId,
                                   const TActorContext& ctx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Send TEvSubscribeLock for WriteId",
-        {LogPrefix()},
+    LOG_D("Send TEvSubscribeLock for WriteId", 
         {"writeId", writeId});
     ctx.Send(NLongTxService::MakeLongTxServiceID(ctx.SelfID.NodeId()),
              new NLongTxService::TEvLongTxService::TEvSubscribeLock(writeId.GetKeyId(), writeId.GetNodeId()));
@@ -3787,8 +3692,7 @@ void TPersQueue::SubscribeWriteId(const TWriteId& writeId,
 void TPersQueue::UnsubscribeWriteId(const TWriteId& writeId,
                                     const TActorContext& ctx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Send TEvUnsubscribeLock for WriteId",
-        {LogPrefix()},
+    LOG_D("Send TEvUnsubscribeLock for WriteId", 
         {"writeId", writeId});
     ctx.Send(NLongTxService::MakeLongTxServiceID(ctx.SelfID.NodeId()),
              new NLongTxService::TEvLongTxService::TEvUnsubscribeLock(writeId.GetKeyId(), writeId.GetNodeId()));
@@ -3833,8 +3737,7 @@ void TPersQueue::BeginWriteTxs(const TActorContext& ctx)
     PendingSupportivePartitions = std::move(NewSupportivePartitions);
     NewSupportivePartitions.clear();
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Send TEvKeyValue::TEvRequest (WRITE_TX_COOKIE)",
-        {LogPrefix()});
+    LOG_D("Send TEvKeyValue::TEvRequest (WRITE_TX_COOKIE)");
     ctx.Send(ctx.SelfID, request.Release(),
              0, 0,
              WriteTxsSpan.GetTraceId());
@@ -3858,8 +3761,7 @@ void TPersQueue::EndWriteTxs(const NKikimrClient::TResponse& resp,
     }
 
     if (!ok) {
-        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "SelfId TxInfo write",
-            {LogPrefix()},
+        LOG_E("SelfId TxInfo write", 
             {"selfId", ctx.SelfID},
             {"error", resp.DebugString()});
 
@@ -3913,8 +3815,7 @@ void TPersQueue::ProcessProposeTransactionQueue(const TActorContext& ctx,
         case NKikimrPQ::TTransaction::UNKNOWN:
             tx.OnProposeTransaction(event, GetAllowedStep(),
                                     TabletID());
-            YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Propose TxId WriteId",
-                {LogPrefix()},
+            LOG_I("Propose TxId WriteId", 
                 {"txId", tx.TxId},
                 {"txWriteId", tx.WriteId});
 
@@ -3926,16 +3827,14 @@ void TPersQueue::ProcessProposeTransactionQueue(const TActorContext& ctx,
                 const TWriteId& writeId = *tx.WriteId;
                 if (TxWrites.contains(writeId)) {
                     TTxWriteInfo& writeInfo = TxWrites.at(writeId);
-                    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Link TxId with WriteId",
-                        {LogPrefix()},
+                    LOG_D("Link TxId with WriteId", 
                         {"txId", tx.TxId},
                         {"writeId", writeId});
                     writeInfo.TxId = tx.TxId;
                 } else {
                     PQ_ENSURE(writeId.IsKafkaApiTransaction())
                         ("TxId", tx.TxId)("WriteId", writeId.ToString());
-                    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Kafka commit with no writes; skip WriteId link",
-                        {LogPrefix()},
+                    LOG_D("Kafka commit with no writes; skip WriteId link", 
                         {"txId", tx.TxId},
                         {"writeId", writeId});
                 }
@@ -3988,8 +3887,7 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
                 tx.OnPlanStep(step);
                 TryExecuteTxs(ctx, tx);
             } else {
-                YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Transaction already planned for step",
-                    {LogPrefix()},
+                LOG_W("Transaction already planned for step", 
                     {"txStep", tx.Step},
                     {"step", step},
                     {"txId", txId});
@@ -3997,8 +3895,7 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
 
             lastPlannedTxId = txId;
         } else {
-            YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown transaction TxId Step",
-                {LogPrefix()},
+            LOG_W("Unknown transaction TxId Step", 
                 {"txId", txId},
                 {"step", step});
         }
@@ -4029,8 +3926,7 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
         SendPlanStepAcks(ctx, sender, *ev);
     }
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "PlanStep PlanTxId",
-        {LogPrefix()},
+    LOG_D("PlanStep PlanTxId", 
         {"planStep", PlanStep},
         {"planTxId", PlanTxId});
 }
@@ -4107,8 +4003,7 @@ void TPersQueue::ProcessWriteTxs(const TActorContext& ctx,
             // таблетка PQ сохраняет только после TEvProposeTransaction
             PQ_ENSURE(state == NKikimrPQ::TTransaction::PREPARED)("TxId", txId)("State", NKikimrPQ::TTransaction_EState_Name(state));
 
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Persist state for TxId",
-                {LogPrefix()},
+            LOG_D("Persist state for TxId", 
                 {"state", NKikimrPQ::TTransaction_EState_Name(state)},
                 {"txId", txId});
             tx->AddCmdWrite(request, state);
@@ -4132,8 +4027,7 @@ void TPersQueue::ProcessDeleteTxs(const TActorContext& ctx,
     }
 
     for (ui64 txId : DeleteTxs) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Delete key for TxId",
-            {LogPrefix()},
+        LOG_D("Delete key for TxId", 
             {"txId", txId});
         AddCmdDeleteTx(request, txId);
 
@@ -4247,8 +4141,7 @@ void TPersQueue::SaveTxWrites(NKikimrPQ::TTabletTxInfo& info)
 
 void TPersQueue::ScheduleProposeTransactionResult(const TDistributedTransaction& tx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Schedule TEvProposeTransactionResult(PREPARED)",
-        {LogPrefix()});
+    LOG_D("Schedule TEvProposeTransactionResult(PREPARED)");
     auto event = std::make_unique<TEvPersQueue::TEvProposeTransactionResult>();
 
     event->Record.SetOrigin(TabletID());
@@ -4276,8 +4169,7 @@ void TPersQueue::SendEvReadSetToReceivers(const TActorContext& ctx,
     TString body;
     PQ_ENSURE(data.SerializeToString(&body));
 
-    YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Send TEvTxProcessing::TEvReadSet to receivers. Wait TEvTxProcessing::TEvReadSet from senders",
-        {LogPrefix()},
+    LOG_I("Send TEvTxProcessing::TEvReadSet to receivers. Wait TEvTxProcessing::TEvReadSet from senders", 
         {"txPredicateRecipientsSize", tx.PredicateRecipients.size()},
         {"txPredicatesReceivedSize", tx.PredicatesReceived.size()});
     for (auto& [receiverId, _] : tx.PredicateRecipients) {
@@ -4289,8 +4181,7 @@ void TPersQueue::SendEvReadSetToReceivers(const TActorContext& ctx,
                                                                        TabletID(),
                                                                        body,
                                                                        0);
-            YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Send TEvReadSet to tablet tx",
-                {LogPrefix()},
+            LOG_I("Send TEvReadSet to tablet tx", 
                 {"receiverId", receiverId},
                 {"txId", tx.TxId});
             SendToPipe(receiverId, tx, std::move(event), ctx);
@@ -4301,11 +4192,9 @@ void TPersQueue::SendEvReadSetToReceivers(const TActorContext& ctx,
 void TPersQueue::SendEvReadSetAckToSenders(const TActorContext& ctx,
                                            TDistributedTransaction& tx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TPersQueue::SendEvReadSetAckToSenders",
-        {LogPrefix()});
+    LOG_D("TPersQueue::SendEvReadSetAckToSenders");
     for (auto& [target, event] : tx.ReadSetAcks) {
-        YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Send TEvTxProcessing::TEvReadSetAck",
-            {LogPrefix()},
+        LOG_I("Send TEvTxProcessing::TEvReadSetAck", 
             {"toString", event->ToString()});
         ctx.Send(target, event.release());
     }
@@ -4330,8 +4219,7 @@ TMaybe<TPartitionId> TPersQueue::FindPartitionId(const NKikimrPQ::TDataTransacti
             if (writeId.IsKafkaApiTransaction()) {
                 return TPartitionId(partitionId);
             }
-            YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown WriteId",
-                {LogPrefix()},
+            LOG_W("Unknown WriteId", 
                 {"writeId", writeId});
             return Nothing();
         }
@@ -4341,8 +4229,7 @@ TMaybe<TPartitionId> TPersQueue::FindPartitionId(const NKikimrPQ::TDataTransacti
             if (writeId.IsKafkaApiTransaction()) {
                 return TPartitionId(partitionId);
             }
-            YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown partition for WriteId",
-                {LogPrefix()},
+            LOG_W("Unknown partition for WriteId", 
                 {"partitionId", partitionId},
                 {"writeId", writeId});
             return Nothing();
@@ -4404,8 +4291,7 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
 
             for (auto& [originalPartitionId, partitionId] : writeInfo.Partitions) {
                 if (!OriginalPartitionExists(originalPartitionId)) {
-                    YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown partition for TxId",
-                        {LogPrefix()},
+                    LOG_W("Unknown partition for TxId", 
                         {"originalPartitionId", originalPartitionId},
                         {"txId", tx.TxId});
                     forcePredicateFalse = true;
@@ -4418,8 +4304,7 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
                 }
 
                 if (!Partitions.contains(partitionId)) {
-                    YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown partition for TxId",
-                        {LogPrefix()},
+                    LOG_W("Unknown partition for TxId", 
                         {"partitionId", partitionId},
                         {"txId", tx.TxId});
                     forcePredicateFalse = true;
@@ -4432,14 +4317,12 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
                 event->SetSkipSrcIdInfo(tx.GetSkipSrcIdInfo());
             }
         } else if (!writeId.IsKafkaApiTransaction()) {
-            YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown WriteId for TxId",
-                {LogPrefix()},
+            LOG_W("Unknown WriteId for TxId", 
                 {"writeId", writeId},
                 {"txId", tx.TxId});
             forcePredicateFalse = true;
         } else {
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Kafka commit with no writes for TxId",
-                {LogPrefix()},
+            LOG_D("Kafka commit with no writes for TxId", 
                 {"writeId", writeId},
                 {"txId", tx.TxId});
         }
@@ -4463,8 +4346,7 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
 void TPersQueue::SendEvTxCommitToPartitions(const TActorContext& ctx,
                                             TDistributedTransaction& tx)
 {
-    YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Commit TxId",
-        {LogPrefix()},
+    LOG_T("Commit TxId", 
         {"txId", tx.TxId});
 
     const auto serializedTx = tx.Serialize(NKikimrPQ::TTransaction::EXECUTED);
@@ -4504,8 +4386,7 @@ void TPersQueue::SendEvTxCommitToPartitions(const TActorContext& ctx,
 void TPersQueue::SendEvTxRollbackToPartitions(const TActorContext& ctx,
                                               TDistributedTransaction& tx)
 {
-    YDB_LOG_TRACE_COMP(NKikimrServices::PERSQUEUE, "Rollback TxId",
-        {LogPrefix()},
+    LOG_T("Rollback TxId", 
         {"txId", tx.TxId});
 
     TMaybe<NKikimrPQ::TTransaction> serializedTx = tx.Serialize(NKikimrPQ::TTransaction::EXECUTED);
@@ -4547,8 +4428,7 @@ void TPersQueue::SendEvProposeTransactionResult(const TActorContext& ctx,
         *error = *tx.Error;
     }
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Send TEvPersQueue::TEvProposeTransactionResult",
-        {LogPrefix()},
+    LOG_D("Send TEvPersQueue::TEvProposeTransactionResult", 
         {"txId", tx.TxId},
         {"status", NKikimrPQ::TEvProposeTransactionResult_EStatus_Name(result->Record.GetStatus())});
     ctx.Send(tx.SourceActor, std::move(result));
@@ -4599,8 +4479,7 @@ TDistributedTransaction* TPersQueue::GetTransaction(const TActorContext& ctx,
     Y_UNUSED(ctx);
     auto p = Txs.find(txId);
     if (p == Txs.end()) {
-        YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown transaction",
-            {LogPrefix()},
+        LOG_W("Unknown transaction", 
             {"txId", txId});
         return nullptr;
     }
@@ -4617,8 +4496,7 @@ void TPersQueue::PushTxInQueue(TDistributedTransaction& tx, TDistributedTransact
 void TPersQueue::ChangeTxState(TDistributedTransaction& tx,
                                TDistributedTransaction::EState newState)
 {
-    YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "TxId moved",
-        {LogPrefix()},
+    LOG_I("TxId moved", 
         {"txId", tx.TxId},
         {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)},
         {"newState", NKikimrPQ::TTransaction_EState_Name(newState)});
@@ -4665,8 +4543,7 @@ bool TPersQueue::CanExecute(const TDistributedTransaction& tx)
     auto& txQueue = TxsOrder[tx.State];
     PQ_ENSURE(!txQueue.empty())("TxId", tx.TxId)("State", NKikimrPQ::TTransaction_EState_Name(tx.State));
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxId State FrontTxId",
-        {LogPrefix()},
+    LOG_D("TxId State FrontTxId", 
         {"txId", tx.TxId},
         {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)},
         {"txQueueFront", txQueue.front()});
@@ -4677,8 +4554,7 @@ bool TPersQueue::CanExecute(const TDistributedTransaction& tx)
 void TPersQueue::TryExecuteTxs(const TActorContext& ctx,
                                TDistributedTransaction& tx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Try execute txs with state",
-        {LogPrefix()},
+    LOG_D("Try execute txs with state", 
         {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)});
 
     TDistributedTransaction::EState oldState = tx.State;
@@ -4692,23 +4568,20 @@ void TPersQueue::TryExecuteTxs(const TActorContext& ctx,
 
     if (oldState == tx.State) {
         // The transaction status has not changed. There is no point in watching the transactions behind her.
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxId status has not changed",
-            {LogPrefix()},
+        LOG_D("TxId status has not changed", 
             {"txId", tx.TxId});
         return;
     }
 
     auto& txQueue = TxsOrder[oldState];
     while (!txQueue.empty()) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "There are txs in the queue",
-            {LogPrefix()},
+        LOG_D("There are txs in the queue", 
             {"txQueueSize", txQueue.size()},
             {"oldState", NKikimrPQ::TTransaction_EState_Name(oldState)});
         ui64 txId = txQueue.front();
         PQ_ENSURE(Txs.contains(txId))("unknown TxId", txId);
         auto& tx = Txs.at(txId);
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Try execute TxId Pending",
-            {LogPrefix()},
+        LOG_D("Try execute TxId Pending", 
             {"txId", tx.TxId},
             {"txPending", tx.Pending});
 
@@ -4722,8 +4595,7 @@ void TPersQueue::TryExecuteTxs(const TActorContext& ctx,
 
         if (oldState == tx.State) {
             // The transaction status has not changed. There is no point in watching the transactions behind her.
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxId status has not changed",
-                {LogPrefix()},
+            LOG_D("TxId status has not changed", 
                 {"txId", tx.TxId});
             break;
         }
@@ -4733,26 +4605,22 @@ void TPersQueue::TryExecuteTxs(const TActorContext& ctx,
 void TPersQueue::CheckTxState(const TActorContext& ctx,
                               TDistributedTransaction& tx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxId State",
-        {LogPrefix()},
+    LOG_D("TxId State", 
         {"txId", tx.TxId},
         {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)});
 
     if (!CanExecute(tx)) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Can't execute TxId Pending",
-            {LogPrefix()},
+        LOG_D("Can't execute TxId Pending", 
             {"txId", tx.TxId},
             {"txPending", tx.Pending});
         tx.Pending = true;
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Wait for TxId",
-            {LogPrefix()},
+        LOG_D("Wait for TxId", 
             {"txId", tx.TxId});
         return;
     }
     if (tx.WriteInProgress) {
         if (tx.State == NKikimrPQ::TTransaction::EXECUTED) {
-            YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "You cannot send TEvReadSetAck for until the EXECUTED state is saved",
-                {LogPrefix()},
+            LOG_I("You cannot send TEvReadSetAck for until the EXECUTED state is saved", 
                 {"txId", tx.TxId});
         }
         return;
@@ -4800,8 +4668,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
 
     case NKikimrPQ::TTransaction::PLANNED:
         PQ_ENSURE(tx.TxId == TxsOrder[tx.State].front())("TxId", tx.TxId)("FrontTxId", TxsOrder[tx.State].front());
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxQueue.size",
-            {LogPrefix()},
+        LOG_D("TxQueue.size", 
             {"txQueueSize", TxQueue.size()});
 
         MoveTopTxToCalculating(tx, ctx);
@@ -4813,8 +4680,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         PQ_ENSURE(tx.PartitionRepliesCount <= tx.PartitionRepliesExpected)("TxId", tx.TxId)
             ("PartitionRepliesCount", tx.PartitionRepliesCount)("PartitionRepliesExpected", tx.PartitionRepliesExpected);
 
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Responses received from the partitions ",
-            {LogPrefix()},
+        LOG_D("Responses received from the partitions ", 
             {"txPartitionRepliesCount", tx.PartitionRepliesCount},
             {"txPartitionRepliesExpected", tx.PartitionRepliesExpected});
 
@@ -4853,8 +4719,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
     case NKikimrPQ::TTransaction::WAIT_RS:
         PQ_ENSURE(tx.TxId == TxsOrder[tx.State].front())("TxId", tx.TxId)("FrontTxId", TxsOrder[tx.State].front());
 
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "HaveParticipantsDecision",
-            {LogPrefix()},
+        LOG_D("HaveParticipantsDecision", 
             {"txHaveParticipantsDecision", tx.HaveParticipantsDecision()});
 
         if (tx.HaveParticipantsDecision()) {
@@ -4882,8 +4747,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         PQ_ENSURE(tx.PartitionRepliesCount <= tx.PartitionRepliesExpected)("TxId", tx.TxId)
             ("PartitionRepliesCount", tx.PartitionRepliesCount)("PartitionRepliesExpected", tx.PartitionRepliesExpected);
 
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Responses received from the partitions ",
-            {LogPrefix()},
+        LOG_D("Responses received from the partitions ", 
             {"txPartitionRepliesCount", tx.PartitionRepliesCount},
             {"txPartitionRepliesExpected", tx.PartitionRepliesExpected});
 
@@ -4894,8 +4758,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         tx.EndExecuteSpan();
 
         SendEvProposeTransactionResult(ctx, tx);
-        YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Complete TxId",
-            {LogPrefix()},
+        LOG_I("Complete TxId", 
             {"txId", tx.TxId});
 
         switch (tx.Kind) {
@@ -4924,8 +4787,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         SendEvReadSetAckToSenders(ctx, tx);
         TryReturnTabletStateAll(ctx);
 
-        YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Delete partitions for TxId",
-            {LogPrefix()},
+        LOG_I("Delete partitions for TxId", 
             {"txId", tx.TxId});
         BeginDeletePartitions(tx);
 
@@ -4934,8 +4796,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         [[fallthrough]];
 
     case NKikimrPQ::TTransaction::WAIT_RS_ACKS:
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "HaveAllRecipientsReceive AllSupportivePartitionsHaveBeenDeleted",
-            {LogPrefix()},
+        LOG_D("HaveAllRecipientsReceive AllSupportivePartitionsHaveBeenDeleted", 
             {"txHaveAllRecipientsReceive", tx.HaveAllRecipientsReceive()},
             {"allSupportivePartitionsDeleted", AllSupportivePartitionsHaveBeenDeleted(tx.WriteId)});
         if (tx.HaveAllRecipientsReceive() && AllSupportivePartitionsHaveBeenDeleted(tx.WriteId)) {
@@ -4949,8 +4810,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
 
     case NKikimrPQ::TTransaction::EXPIRED:
     case NKikimrPQ::TTransaction::CANCELED:
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "AllSupportivePartitionsHaveBeenDeleted",
-            {LogPrefix()},
+        LOG_D("AllSupportivePartitionsHaveBeenDeleted", 
             {"allSupportivePartitionsDeleted", AllSupportivePartitionsHaveBeenDeleted(tx.WriteId)});
         if (AllSupportivePartitionsHaveBeenDeleted(tx.WriteId)) {
             DeleteTx(tx);
@@ -4963,8 +4823,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         // The PQ tablet has persisted its state. Now she can delete the transaction and take the next one.
         TMaybe<TWriteId> writeId = tx.WriteId; // copy writeId to save for kafka transaction after erase
         DeleteWriteId(writeId);
-        YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Delete TxId",
-            {LogPrefix()},
+        LOG_I("Delete TxId", 
             {"txId", tx.TxId});
         Txs.erase(tx.TxId);
         SetTxInFlyCounter();
@@ -4986,8 +4845,7 @@ bool TPersQueue::AllSupportivePartitionsHaveBeenDeleted(const TMaybe<TWriteId>& 
 
     const TTxWriteInfo& writeInfo = TxWrites.at(*writeId);
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "WriteId",
-        {LogPrefix()},
+    LOG_D("WriteId", 
         {"writeId", *writeId},
         {"partitionsSize", writeInfo.Partitions.size()});
     bool deleted =
@@ -5003,8 +4861,7 @@ void TPersQueue::DeleteWriteId(const TMaybe<TWriteId>& writeId)
         return;
     }
 
-    YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Delete WriteId",
-        {LogPrefix()},
+    LOG_I("Delete WriteId", 
         {"writeId", *writeId});
     TxWrites.erase(*writeId);
 }
@@ -5023,8 +4880,7 @@ void TPersQueue::WriteTx(TDistributedTransaction& tx, NKikimrPQ::TTransaction::E
 
 void TPersQueue::DeleteTx(TDistributedTransaction& tx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Add an TxId to the list for deletion",
-        {LogPrefix()},
+    LOG_D("Add an TxId to the list for deletion", 
         {"txId", tx.TxId});
 
     DeleteTxs.insert(tx.TxId);
@@ -5146,8 +5002,7 @@ void TPersQueue::SendProposeTransactionResult(const TActorId& target,
         error->SetReason(reason);
     }
 
-    YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Send TEvPersQueue::TEvProposeTransactionResult",
-        {LogPrefix()},
+    LOG_I("Send TEvPersQueue::TEvProposeTransactionResult", 
         {"txId", txId},
         {"status", NKikimrPQ::TEvProposeTransactionResult_EStatus_Name(event->Record.GetStatus())});
     ctx.Send(target, std::move(event));
@@ -5326,8 +5181,7 @@ void TPersQueue::InitTxsOrder()
 
 void TPersQueue::EndInitTransactions()
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Transactions are initialized",
-        {LogPrefix()},
+    LOG_D("Transactions are initialized", 
         {"txsSize", Txs.size()},
         {"plannedTxsSize", PlannedTxs.size()});
 
@@ -5337,8 +5191,7 @@ void TPersQueue::EndInitTransactions()
     }
 
     if (!TxQueue.empty()) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Top tx queue",
-            {LogPrefix()},
+        LOG_D("Top tx queue", 
             {"txQueueFrontStep", TxQueue.front().first},
             {"txQueueFrontTxId", TxQueue.front().second});
     }
@@ -5350,8 +5203,7 @@ void TPersQueue::EndInitTransactions()
         PQ_ENSURE(txId == tx.TxId);
 
         if (!TxsOrder.contains(tx.State)) {
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Skip",
-                {LogPrefix()},
+            LOG_D("Skip", 
                 {"txStep", tx.Step},
                 {"txId", txId},
                 {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)});
@@ -5360,8 +5212,7 @@ void TPersQueue::EndInitTransactions()
 
         PushTxInQueue(tx, tx.State);
 
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Put the transaction in the queue",
-            {LogPrefix()},
+        LOG_D("Put the transaction in the queue", 
             {"txsOrder", tx.Step},
             {"txId", txId},
             {"txState", NKikimrPQ::TTransaction_EState_Name(tx.State)},
@@ -5463,8 +5314,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvProposeTransactionAttach::TPtr &ev, con
         return;
     }
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvPersQueue::TEvProposeTransactionAttach",
-        {LogPrefix()},
+    LOG_D("Handle TEvPersQueue::TEvProposeTransactionAttach", 
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     const ui64 txId = ev->Get()->Record.GetTxId();
@@ -5494,8 +5344,7 @@ void TPersQueue::Handle(TEvPQ::TEvCheckPartitionStatusRequest::TPtr& ev, const T
     auto& record = ev->Get()->Record;
     auto it = Partitions.find(TPartitionId(TPartitionId(record.GetPartition())));
     if (InitCompleted && it == Partitions.end()) {
-        YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Unknown partition",
-            {LogPrefix()},
+        LOG_I("Unknown partition", 
             {"partition", record.GetPartition()});
 
         auto response = MakeHolder<TEvPQ::TEvCheckPartitionStatusResponse>();
@@ -5542,8 +5391,7 @@ void TPersQueue::ProcessCheckMessageDeduplicationRequests(const TPartitionId& pa
 
 void TPersQueue::Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& ev)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvLongTxService::TEvLockStatus",
-        {LogPrefix()},
+    LOG_D("Handle TEvLongTxService::TEvLockStatus", 
         {"ev", ev->Get()->Record.ShortDebugString()});
 
     auto& record = ev->Get()->Record;
@@ -5551,38 +5399,33 @@ void TPersQueue::Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& e
 
     if (!TxWrites.contains(writeId)) {
         // the transaction has already been completed
-        YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown WriteId",
-            {LogPrefix()},
+        LOG_W("Unknown WriteId", 
             {"writeId", writeId});
         return;
     }
 
     TTxWriteInfo& writeInfo = TxWrites.at(writeId);
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "TxWriteInfo: WriteId TxId Status",
-        {LogPrefix()},
+    LOG_D("TxWriteInfo: WriteId TxId Status", 
         {"writeId", writeId},
         {"txId", writeInfo.TxId},
         {"longTxSubscriptionStatusName", NKikimrLongTxService::TEvLockStatus_EStatus_Name(writeInfo.LongTxSubscriptionStatus)});
     writeInfo.LongTxSubscriptionStatus = record.GetStatus();
 
     if (writeInfo.LongTxSubscriptionStatus == NKikimrLongTxService::TEvLockStatus::STATUS_SUBSCRIBED) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Subscribed WriteId",
-            {LogPrefix()},
+        LOG_D("Subscribed WriteId", 
             {"writeId", writeId});
         return;
     }
 
     if (writeInfo.TxId.Defined()) {
         // the message `TEvProposeTransaction` has already arrived
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "There is already a transaction TxId for WriteId",
-            {LogPrefix()},
+        LOG_D("There is already a transaction TxId for WriteId", 
             {"txId", writeInfo.TxId},
             {"writeId", writeId});
         return;
     }
 
-    YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Delete partitions for WriteId (longTxService lost tx)",
-        {LogPrefix()},
+    LOG_I("Delete partitions for WriteId (longTxService lost tx)", 
         {"writeId", writeId});
     BeginDeletePartitions(writeId, writeInfo);
 }
@@ -5598,8 +5441,7 @@ void TPersQueue::Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr& ev, const T
 {
     const NKikimrPQ::TEvPartitionScaleStatusChanged& record = ev->Get()->Record;
     if (MirroringEnabled(Config) && record.HasParticipatingPartitions()) {
-        YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Got mirrorer split merge request",
-            {LogPrefix()},
+        LOG_I("Got mirrorer split merge request", 
             {"toString", ev->ToString()});
     }
 
@@ -5632,16 +5474,14 @@ void TPersQueue::DeletePartition(const TPartitionId& partitionId, const TActorCo
 
     ReservedBytes = ReservedBytes > partition.ReservedBytes ? ReservedBytes - partition.ReservedBytes : 0;
 
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "DeletePartition",
-        {LogPrefix()},
+    LOG_D("DeletePartition", 
         {"partitionId", partitionId});
     Partitions.erase(partitionId);
 }
 
 void TPersQueue::Handle(TEvPQ::TEvDeletePartitionDone::TPtr& ev, const TActorContext& ctx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Handle TEvPQ::TEvDeletePartitionDone",
-        {LogPrefix()},
+    LOG_D("Handle TEvPQ::TEvDeletePartitionDone", 
         {"partitionId", ev->Get()->PartitionId});
 
     auto* event = ev->Get();
@@ -5690,8 +5530,7 @@ void TPersQueue::TryDeleteWriteId(const TWriteId& writeId, const TTxWriteInfo& w
 
 void TPersQueue::Handle(TEvPQ::TEvTransactionCompleted::TPtr& ev, const TActorContext&)
 {
-    YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Handle TEvPQ::TEvTransactionCompleted WriteId",
-        {LogPrefix()},
+    LOG_I("Handle TEvPQ::TEvTransactionCompleted WriteId", 
         {"writeId", ev->Get()->WriteId});
 
     auto* event = ev->Get();
@@ -5701,8 +5540,7 @@ void TPersQueue::Handle(TEvPQ::TEvTransactionCompleted::TPtr& ev, const TActorCo
 
     const TWriteId& writeId = *event->WriteId;
     if (!TxWrites.contains(writeId)) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Ignore TEvTransactionCompleted for unknown WriteId",
-            {LogPrefix()},
+        LOG_D("Ignore TEvTransactionCompleted for unknown WriteId", 
             {"writeId", writeId});
         return;
     }
@@ -5715,8 +5553,7 @@ void TPersQueue::Handle(TEvPQ::TEvTransactionCompleted::TPtr& ev, const TActorCo
 void TPersQueue::BeginDeletePartitions(const TWriteId& writeId, TTxWriteInfo& writeInfo)
 {
     if (writeInfo.Deleting) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Already deleting WriteInfo",
-            {LogPrefix()});
+        LOG_D("Already deleting WriteInfo");
         return;
     }
     writeInfo.Deleting = true;
@@ -5727,8 +5564,7 @@ void TPersQueue::BeginDeletePartitions(const TWriteId& writeId, TTxWriteInfo& wr
         for (auto& [_, partitionId] : writeInfo.Partitions) {
             PQ_ENSURE(Partitions.contains(partitionId));
             const TPartitionInfo& partition = Partitions.at(partitionId);
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Send TEvPQ::TEvDeletePartition to partition",
-                {LogPrefix()},
+            LOG_D("Send TEvPQ::TEvDeletePartition to partition", 
                 {"partitionId", partitionId});
             Send(partition.Actor, new TEvPQ::TEvDeletePartition);
         }
@@ -5745,7 +5581,7 @@ void TPersQueue::BeginDeletePartitions(const TDistributedTransaction& tx)
     BeginDeletePartitions(*tx.WriteId, writeInfo);
 }
 
-NActors::NStructuredLog::TStructuredMessage TPersQueue::LogPrefix() const {
+TStructuredLogPrefix TPersQueue::LogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "PQ"},
         {"tabletId", TabletID()});
@@ -5775,15 +5611,13 @@ void TPersQueue::ProcessPendingEvents()
 
 void TPersQueue::Handle(TEvPQ::TEvForceCompaction::TPtr& ev, const TActorContext& ctx)
 {
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "TPersQueue::Handle(TEvPQ::TEvForceCompaction)",
-        {LogPrefix()});
+    LOG_D("TPersQueue::Handle(TEvPQ::TEvForceCompaction)");
 
     const auto& event = *ev->Get();
     const TPartitionId partitionId(event.PartitionId);
 
     if (!Partitions.contains(partitionId)) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Unknown partition id",
-            {LogPrefix()},
+        LOG_D("Unknown partition id", 
             {"partitionId", event.PartitionId});
         return;
     }
@@ -5819,8 +5653,7 @@ void TPersQueue::Handle(TEvPQ::TEvGetMLPConsumerStateRequest::TPtr& ev) {
 
 void TPersQueue::Handle(TEvPQ::TEvMLPConsumerStatus::TPtr& ev) {
     auto& record = ev->Get()->Record;
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvPQ::TEvMLPConsumerStatus",
-        {LogPrefix()},
+    LOG_D("Handle TEvPQ::TEvMLPConsumerStatus", 
         {"ev", record.ShortDebugString()});
     if (!ReadBalancerActorId) {
         return;
@@ -5837,8 +5670,7 @@ void TPersQueue::Handle(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationReque
     auto partitionId = record.GetPartitionId();
     auto* p = Partitions.FindPtr(TPartitionId{partitionId});
     if (p == nullptr) [[unlikely]] {
-        YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "TEvCheckMessageDeduplicationRequest: unknown partition",
-            {LogPrefix()},
+        LOG_I("TEvCheckMessageDeduplicationRequest: unknown partition", 
             {"partitionId", partitionId});
         auto response = MakeHolder<NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationResponse>();
         response->Record.SetPartitionId(partitionId);
@@ -5862,8 +5694,7 @@ bool TPersQueue::ForwardToPartition(ui32 partitionId, TAutoPtr<TEventHandle>& ev
     auto it = Partitions.find(TPartitionId{partitionId});
     if (it == Partitions.end()) {
         if (!ConfigInited) {
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Queue MLP request until config is inited",
-                {LogPrefix()},
+            LOG_D("Queue MLP request until config is inited", 
                 {"partitionId", partitionId});
             MLPRequests.emplace_back(std::move(ev));
             return false;

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -9,15 +9,13 @@
 #include <ydb/core/tablet/tablet_pipe_client_cache.h>
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/jaeger_tracing/sampling_throttling_control.h>
+#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/core/tx/time_cast/time_cast.h>
 #include <ydb/core/tx/tx_processing.h>
 #include <ydb/core/tx/long_tx_service/public/events.h>
-
-#include <ydb/core/persqueue/common/logging.h>
-#include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/interconnect/interconnect.h>
 
 namespace NKikimr {

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -16,6 +16,7 @@
 #include <ydb/core/tx/tx_processing.h>
 #include <ydb/core/tx/long_tx_service/public/events.h>
 
+#include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/interconnect/interconnect.h>
 
 namespace NKikimr {
@@ -203,7 +204,7 @@ class TPersQueue : public NKeyValue::TKeyValueFlat {
     void Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPQ::TBroadcastPartitionError::TPtr& ev, const TActorContext& ctx);
 
-    TString LogPrefix() const;
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
 
     static constexpr const char * KeyConfig() { return "_config"; }
     static constexpr const char * KeyState() { return "_state"; }

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -203,7 +203,7 @@ class TPersQueue : public NKeyValue::TKeyValueFlat, public TLogPrefix {
     void Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPQ::TBroadcastPartitionError::TPtr& ev, const TActorContext& ctx);
 
-    TStructuredLogPrefix LogPrefix() const override;
+    TStructuredMessage LogPrefix() const override;
 
     static constexpr const char * KeyConfig() { return "_config"; }
     static constexpr const char * KeyState() { return "_state"; }

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -16,6 +16,7 @@
 #include <ydb/core/tx/tx_processing.h>
 #include <ydb/core/tx/long_tx_service/public/events.h>
 
+#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/interconnect/interconnect.h>
 
@@ -32,7 +33,7 @@ struct TTransaction;
 
 //USES MAIN chanel for big blobs, INLINE or EXTRA for ZK-like load, EXTRA2 for small blob for logging (VDISK of type LOG is ok with EXTRA2)
 
-class TPersQueue : public NKeyValue::TKeyValueFlat {
+class TPersQueue : public NKeyValue::TKeyValueFlat, public TLogPrefix {
     enum ECookie : ui64 {
         WRITE_CONFIG_COOKIE = 2, // reserved: former TEvUpdateConfig persist cookie
         READ_CONFIG_COOKIE  = 3,
@@ -204,7 +205,7 @@ class TPersQueue : public NKeyValue::TKeyValueFlat {
     void Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPQ::TBroadcastPartitionError::TPtr& ev, const TActorContext& ctx);
 
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
+    TStructuredLogPrefix LogPrefix() const override;
 
     static constexpr const char * KeyConfig() { return "_config"; }
     static constexpr const char * KeyState() { return "_state"; }

--- a/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
@@ -184,8 +184,7 @@ private:
 
         LOG_D(
             "Answer TEvRemoteHttpInfoRes: to self",
-            {"sender", Sender},
-            {"selfId", ctx.SelfID}
+            {"sender", Sender}
         );
         ctx.Send(Sender, new NMon::TEvRemoteHttpInfoRes(str.Str()));
         Die(ctx);

--- a/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
@@ -101,8 +101,8 @@ public:
         ctx.Schedule(TDuration::Seconds(10), new TEvents::TEvWakeup());
     }
 
-    const TLogPrefix& GetLogPrefix() const {
-        static const TLogPrefix LogPrefix = YDB_LOG_CREATE_MESSAGE(
+    const TStructuredLogPrefix& GetLogPrefix() const {
+        static const TStructuredLogPrefix LogPrefix = YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "MonitoringProxy"});
         return LogPrefix;
     }
@@ -370,8 +370,7 @@ bool TPersQueue::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TAc
         return OnRenderAppHtmlPageTx(ev, ctx);
     }
 
-    YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Handle",
-        {LogPrefix()},
+    LOG_I("Handle", 
         {"TEvRemoteHttpInfo", ev->Get()->Query});
 
     TMap<ui32, TActorId> res;

--- a/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
@@ -52,7 +52,7 @@ namespace {
         for (const auto& [name, _] : cgi) {
             if (!IsKnownPublicPersQueueDevUiParam(name)) {
                 YDB_LOG_WARN_COMP(NKikimrServices::PERSQUEUE, "PersQueue DevUI request is admin only",
-                    {"logPrefix", LogPrefix()},
+                    {LogPrefix()},
                     {"param", name},
                     {"cgi", cgi.Print()});
                 return false;
@@ -371,7 +371,7 @@ bool TPersQueue::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TAc
     }
 
     YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Handle",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"TEvRemoteHttpInfo", ev->Get()->Query});
 
     TMap<ui32, TActorId> res;

--- a/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
@@ -102,8 +102,7 @@ public:
     }
 
     const TStructuredLogPrefix& GetLogPrefix() const {
-        static const TStructuredLogPrefix LogPrefix = YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "MonitoringProxy"});
+        static const TStructuredLogPrefix LogPrefix;
         return LogPrefix;
     }
 

--- a/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
@@ -101,8 +101,8 @@ public:
         ctx.Schedule(TDuration::Seconds(10), new TEvents::TEvWakeup());
     }
 
-    const TStructuredLogPrefix& GetLogPrefix() const {
-        static const TStructuredLogPrefix LogPrefix;
+    const TStructuredMessage& GetLogPrefix() const {
+        static const TStructuredMessage LogPrefix;
         return LogPrefix;
     }
 

--- a/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
@@ -368,7 +368,7 @@ bool TPersQueue::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TAc
         return OnRenderAppHtmlPageTx(ev, ctx);
     }
 
-    LOG_I("Handle", 
+    LOG_I("Handle",
         {"TEvRemoteHttpInfo", ev->Get()->Query});
 
     TMap<ui32, TActorId> res;

--- a/ydb/core/persqueue/pqtablet/quota/account_read_quoter.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/account_read_quoter.cpp
@@ -226,7 +226,7 @@ THolder<NAccountQuoterEvents::TEvCounters> TAccountReadQuoter::MakeCountersUpdat
     return MakeHolder<NAccountQuoterEvents::TEvCounters>(Counters, true, User);
 }
 
-TStructuredLogPrefix TAccountReadQuoter::BuildLogPrefix() const {
+TStructuredMessage TAccountReadQuoter::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"topic", TopicConverter->GetClientsideName()},
         {"partition", Partition.ToString()},
@@ -286,7 +286,7 @@ THolder<NAccountQuoterEvents::TEvCounters> TAccountWriteQuoter::MakeCountersUpda
     return MakeHolder<NAccountQuoterEvents::TEvCounters>(Counters, false, TString{});
 }
 
-TStructuredLogPrefix TAccountWriteQuoter::BuildLogPrefix() const {
+TStructuredMessage TAccountWriteQuoter::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"topic", TopicConverter->GetClientsideName()},
         {"partition", Partition.ToString()});

--- a/ydb/core/persqueue/pqtablet/quota/account_read_quoter.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/account_read_quoter.cpp
@@ -228,7 +228,6 @@ THolder<NAccountQuoterEvents::TEvCounters> TAccountReadQuoter::MakeCountersUpdat
 
 TStructuredLogPrefix TAccountReadQuoter::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "AccountReadQuoter"},
         {"topic", TopicConverter->GetClientsideName()},
         {"partition", Partition.ToString()},
         {"consumer", User});
@@ -289,7 +288,6 @@ THolder<NAccountQuoterEvents::TEvCounters> TAccountWriteQuoter::MakeCountersUpda
 
 TStructuredLogPrefix TAccountWriteQuoter::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "AccountWriteQuoter"},
         {"topic", TopicConverter->GetClientsideName()},
         {"partition", Partition.ToString()});
 }

--- a/ydb/core/persqueue/pqtablet/quota/account_read_quoter.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/account_read_quoter.cpp
@@ -226,7 +226,7 @@ THolder<NAccountQuoterEvents::TEvCounters> TAccountReadQuoter::MakeCountersUpdat
     return MakeHolder<NAccountQuoterEvents::TEvCounters>(Counters, true, User);
 }
 
-TLogPrefix TAccountReadQuoter::BuildLogPrefix() const {
+TStructuredLogPrefix TAccountReadQuoter::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "AccountReadQuoter"},
         {"topic", TopicConverter->GetClientsideName()},
@@ -287,7 +287,7 @@ THolder<NAccountQuoterEvents::TEvCounters> TAccountWriteQuoter::MakeCountersUpda
     return MakeHolder<NAccountQuoterEvents::TEvCounters>(Counters, false, TString{});
 }
 
-TLogPrefix TAccountWriteQuoter::BuildLogPrefix() const {
+TStructuredLogPrefix TAccountWriteQuoter::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "AccountWriteQuoter"},
         {"topic", TopicConverter->GetClientsideName()},

--- a/ydb/core/persqueue/pqtablet/quota/account_read_quoter.h
+++ b/ydb/core/persqueue/pqtablet/quota/account_read_quoter.h
@@ -160,7 +160,7 @@ public:
 
 protected:
     void InitCountersImpl(const TActorContext& ctx) override;
-    TLogPrefix BuildLogPrefix() const override;
+    TStructuredLogPrefix BuildLogPrefix() const override;
     THolder<NAccountQuoterEvents::TEvCounters> MakeCountersUpdateEvent() override;
 
 private:
@@ -187,7 +187,7 @@ public:
 
 protected:
     void InitCountersImpl(const TActorContext& ctx) override;
-    TLogPrefix BuildLogPrefix() const override;
+    TStructuredLogPrefix BuildLogPrefix() const override;
     THolder<NAccountQuoterEvents::TEvCounters> MakeCountersUpdateEvent() override;
 };
 

--- a/ydb/core/persqueue/pqtablet/quota/account_read_quoter.h
+++ b/ydb/core/persqueue/pqtablet/quota/account_read_quoter.h
@@ -160,7 +160,7 @@ public:
 
 protected:
     void InitCountersImpl(const TActorContext& ctx) override;
-    TStructuredLogPrefix BuildLogPrefix() const override;
+    TStructuredMessage BuildLogPrefix() const override;
     THolder<NAccountQuoterEvents::TEvCounters> MakeCountersUpdateEvent() override;
 
 private:
@@ -187,7 +187,7 @@ public:
 
 protected:
     void InitCountersImpl(const TActorContext& ctx) override;
-    TStructuredLogPrefix BuildLogPrefix() const override;
+    TStructuredMessage BuildLogPrefix() const override;
     THolder<NAccountQuoterEvents::TEvCounters> MakeCountersUpdateEvent() override;
 };
 

--- a/ydb/core/persqueue/pqtablet/quota/read_quoter.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/read_quoter.cpp
@@ -35,7 +35,7 @@ IEventBase* TReadQuoter::MakeQuotaApprovedEvent(TRequestContext& context) {
     return new TEvPQ::TEvApproveReadQuota(IEventHandle::Downcast<TEvPQ::TEvRead>(std::move(context.Request->Request)), context.TotalQuotaWaitTime);
 };
 
-TLogPrefix TReadQuoter::BuildLogPrefix() const {
+TStructuredLogPrefix TReadQuoter::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "ReadQuoter"},
         {"partition", Partition.ToString()});

--- a/ydb/core/persqueue/pqtablet/quota/read_quoter.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/read_quoter.cpp
@@ -35,7 +35,7 @@ IEventBase* TReadQuoter::MakeQuotaApprovedEvent(TRequestContext& context) {
     return new TEvPQ::TEvApproveReadQuota(IEventHandle::Downcast<TEvPQ::TEvRead>(std::move(context.Request->Request)), context.TotalQuotaWaitTime);
 };
 
-TStructuredLogPrefix TReadQuoter::BuildLogPrefix() const {
+TStructuredMessage TReadQuoter::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"partition", Partition.ToString()});
 }

--- a/ydb/core/persqueue/pqtablet/quota/read_quoter.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/read_quoter.cpp
@@ -37,7 +37,6 @@ IEventBase* TReadQuoter::MakeQuotaApprovedEvent(TRequestContext& context) {
 
 TStructuredLogPrefix TReadQuoter::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "ReadQuoter"},
         {"partition", Partition.ToString()});
 }
 

--- a/ydb/core/persqueue/pqtablet/quota/read_quoter.h
+++ b/ydb/core/persqueue/pqtablet/quota/read_quoter.h
@@ -47,7 +47,7 @@ public:
     void UpdateQuotaConfigImpl(bool totalQuotaUpdated, const TActorContext& ctx) override;
     IEventBase* MakeQuotaApprovedEvent(TRequestContext& context) override;
     void Bootstrap(const TActorContext& ctx) override;
-    TLogPrefix BuildLogPrefix() const override;
+    TStructuredLogPrefix BuildLogPrefix() const override;
 
 protected:
     void HandleQuotaRequestImpl(TRequestContext& context) override;

--- a/ydb/core/persqueue/pqtablet/quota/read_quoter.h
+++ b/ydb/core/persqueue/pqtablet/quota/read_quoter.h
@@ -47,7 +47,7 @@ public:
     void UpdateQuotaConfigImpl(bool totalQuotaUpdated, const TActorContext& ctx) override;
     IEventBase* MakeQuotaApprovedEvent(TRequestContext& context) override;
     void Bootstrap(const TActorContext& ctx) override;
-    TStructuredLogPrefix BuildLogPrefix() const override;
+    TStructuredMessage BuildLogPrefix() const override;
 
 protected:
     void HandleQuotaRequestImpl(TRequestContext& context) override;

--- a/ydb/core/persqueue/pqtablet/quota/write_quoter.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/write_quoter.cpp
@@ -24,7 +24,7 @@ TWriteQuoter::TWriteQuoter(
 {
 }
 
-TLogPrefix TWriteQuoter::BuildLogPrefix() const {
+TStructuredLogPrefix TWriteQuoter::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "WriteQuoter"},
         {"partition", Partition.ToString()});

--- a/ydb/core/persqueue/pqtablet/quota/write_quoter.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/write_quoter.cpp
@@ -26,7 +26,6 @@ TWriteQuoter::TWriteQuoter(
 
 TStructuredLogPrefix TWriteQuoter::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "WriteQuoter"},
         {"partition", Partition.ToString()});
 }
 

--- a/ydb/core/persqueue/pqtablet/quota/write_quoter.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/write_quoter.cpp
@@ -24,7 +24,7 @@ TWriteQuoter::TWriteQuoter(
 {
 }
 
-TStructuredLogPrefix TWriteQuoter::BuildLogPrefix() const {
+TStructuredMessage TWriteQuoter::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"partition", Partition.ToString()});
 }

--- a/ydb/core/persqueue/pqtablet/quota/write_quoter.h
+++ b/ydb/core/persqueue/pqtablet/quota/write_quoter.h
@@ -31,7 +31,7 @@ public:
     void Bootstrap(const TActorContext &ctx) override;
     THolder<TAccountQuoterHolder> CreateAccountQuotaTracker() const;
 
-    TStructuredLogPrefix BuildLogPrefix() const override;
+    TStructuredMessage BuildLogPrefix() const override;
 
 protected:
     void HandleQuotaRequestImpl(TRequestContext& context) override;

--- a/ydb/core/persqueue/pqtablet/quota/write_quoter.h
+++ b/ydb/core/persqueue/pqtablet/quota/write_quoter.h
@@ -31,7 +31,7 @@ public:
     void Bootstrap(const TActorContext &ctx) override;
     THolder<TAccountQuoterHolder> CreateAccountQuotaTracker() const;
 
-    TLogPrefix BuildLogPrefix() const override;
+    TStructuredLogPrefix BuildLogPrefix() const override;
 
 protected:
     void HandleQuotaRequestImpl(TRequestContext& context) override;

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -61,7 +61,7 @@ public:
         Become(&TThis::StateFunc);
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "ReadProxy"},
             {"selfId", SelfId()});

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -63,8 +63,7 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "ReadProxy"},
-            {"selfId", SelfId()});
+            {"actorClassName", "ReadProxy"});
     }
 
 private:

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -61,7 +61,7 @@ public:
         Become(&TThis::StateFunc);
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return {};
     }
 

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -62,8 +62,7 @@ public:
     }
 
     TStructuredLogPrefix BuildLogPrefix() const override {
-        return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "ReadProxy"});
+        return {};
     }
 
 private:

--- a/ydb/core/persqueue/pqtablet/transaction.cpp
+++ b/ydb/core/persqueue/pqtablet/transaction.cpp
@@ -92,7 +92,7 @@ TDistributedTransaction::TDistributedTransaction(const NKikimrPQ::TTransaction& 
     }
 }
 
-NActors::NStructuredLog::TStructuredMessage TDistributedTransaction::LogPrefix() const
+TStructuredLogPrefix TDistributedTransaction::LogPrefix() const
 {
     return YDB_LOG_CREATE_MESSAGE(
         {"txId", TxId});
@@ -252,8 +252,7 @@ void TDistributedTransaction::OnPlanStep(ui64 step)
 
 void TDistributedTransaction::OnTxCalcPredicateResult(const TEvPQ::TEvTxCalcPredicateResult& event)
 {
-    YDB_LOG_DEBUG("Handle TEvTxCalcPredicateResult",
-        {LogPrefix()});
+    LOG_D("Handle TEvTxCalcPredicateResult");
 
     TMaybe<EDecision> decision;
 
@@ -288,8 +287,7 @@ void UpdatePartitionsData(NKikimrPQ::TPartitions& partitionsData, NKikimrPQ::TPa
 
 void TDistributedTransaction::OnProposePartitionConfigResult(TEvPQ::TEvProposePartitionConfigResult& event)
 {
-    YDB_LOG_DEBUG("Handle TEvProposePartitionConfigResult",
-        {LogPrefix()});
+    LOG_D("Handle TEvProposePartitionConfigResult");
 
     UpdatePartitionsData(PartitionsData, event.Data);
 
@@ -311,9 +309,7 @@ void TDistributedTransaction::OnPartitionResult(const E& event, TMaybe<EDecision
 
     ++PartitionRepliesCount;
 
-    YDB_LOG_DEBUG("Partition responses ",
-        {LogPrefix()},
-        {"partitionRepliesCount", PartitionRepliesCount},
+    LOG_D("Partition responses ", {"partitionRepliesCount", PartitionRepliesCount},
         {"partitionRepliesExpected", PartitionRepliesExpected});
 }
 
@@ -321,9 +317,7 @@ void TDistributedTransaction::OnReadSet(const NKikimrTx::TEvReadSet& event,
                                         const TActorId& sender,
                                         std::unique_ptr<TEvTxProcessing::TEvReadSetAck> ack)
 {
-    YDB_LOG_DEBUG("Handle TEvReadSet",
-        {LogPrefix()},
-        {"txId", TxId});
+    LOG_D("Handle TEvReadSet");
 
     TX_ENSURE((Step == Max<ui64>()) || (event.HasStep() && (Step == event.GetStep())));
     TX_ENSURE(event.HasTxId() && (TxId == event.GetTxId()));
@@ -340,9 +334,7 @@ void TDistributedTransaction::OnReadSet(const NKikimrTx::TEvReadSet& event,
             p.SetPredicate(data.GetDecision() == NKikimrTx::TReadSetData::DECISION_COMMIT);
             ++ReadSetCount;
 
-            YDB_LOG_DEBUG("Predicates ",
-                {LogPrefix()},
-                {"readSetCount", ReadSetCount},
+            LOG_D("Predicates ", {"readSetCount", ReadSetCount},
                 {"predicatesReceivedSize", PredicatesReceived.size()});
         }
 
@@ -362,9 +354,7 @@ void TDistributedTransaction::OnReadSet(const NKikimrTx::TEvReadSet& event,
 
 void TDistributedTransaction::OnReadSetAck(const NKikimrTx::TEvReadSetAck& event)
 {
-    YDB_LOG_DEBUG("Handle TEvReadSetAck",
-        {LogPrefix()},
-        {"txId", TxId});
+    LOG_D("Handle TEvReadSetAck");
 
     TX_ENSURE(event.HasStep() && (Step == event.GetStep()));
     TX_ENSURE(event.HasTxId() && (TxId == event.GetTxId()));
@@ -378,9 +368,7 @@ void TDistributedTransaction::OnReadSetAck(ui64 tabletId)
         PredicateRecipients[tabletId] = true;
         ++PredicateAcksCount;
 
-        YDB_LOG_DEBUG("Predicate acks",
-            {LogPrefix()},
-            {"predicateAcksCount", PredicateAcksCount},
+        LOG_D("Predicate acks", {"predicateAcksCount", PredicateAcksCount},
             {"predicateRecipientsSize", PredicateRecipients.size()});
     }
 }
@@ -428,9 +416,7 @@ bool TDistributedTransaction::HaveParticipantsDecision() const
 
 bool TDistributedTransaction::HaveAllRecipientsReceive() const
 {
-    YDB_LOG_DEBUG("HaveAllRecipientsReceive",
-        {LogPrefix()},
-        {"predicateAcks", PredicateAcksCount},
+    LOG_D("HaveAllRecipientsReceive", {"predicateAcks", PredicateAcksCount},
         {"predicateRecipientsSize", PredicateRecipients.size()});
     return PredicateRecipients.size() == PredicateAcksCount;
 }
@@ -439,9 +425,7 @@ void TDistributedTransaction::AddCmdWrite(NKikimrClient::TKeyValueRequest& reque
                                           EState state)
 {
     auto tx = Serialize(state);
-    YDB_LOG_DEBUG("Save tx",
-        {LogPrefix()},
-        {"tx", tx.ShortDebugString()});
+    LOG_D("Save tx", {"tx", tx.ShortDebugString()});
 
     TString value;
     TX_ENSURE(tx.SerializeToString(&value));

--- a/ydb/core/persqueue/pqtablet/transaction.cpp
+++ b/ydb/core/persqueue/pqtablet/transaction.cpp
@@ -92,7 +92,7 @@ TDistributedTransaction::TDistributedTransaction(const NKikimrPQ::TTransaction& 
     }
 }
 
-TStructuredLogPrefix TDistributedTransaction::LogPrefix() const
+TStructuredMessage TDistributedTransaction::LogPrefix() const
 {
     return YDB_LOG_CREATE_MESSAGE(
         {"txId", TxId});

--- a/ydb/core/persqueue/pqtablet/transaction.cpp
+++ b/ydb/core/persqueue/pqtablet/transaction.cpp
@@ -92,9 +92,10 @@ TDistributedTransaction::TDistributedTransaction(const NKikimrPQ::TTransaction& 
     }
 }
 
-TString TDistributedTransaction::LogPrefix() const
+NActors::NStructuredLog::TStructuredMessage TDistributedTransaction::LogPrefix() const
 {
-    return TStringBuilder() << "[TxId: " << TxId << "] ";
+    return YDB_LOG_CREATE_MESSAGE(
+        {"txId", TxId});
 }
 
 void TDistributedTransaction::InitDataTransaction(const NKikimrPQ::TTransaction& tx)
@@ -252,7 +253,7 @@ void TDistributedTransaction::OnPlanStep(ui64 step)
 void TDistributedTransaction::OnTxCalcPredicateResult(const TEvPQ::TEvTxCalcPredicateResult& event)
 {
     YDB_LOG_DEBUG("Handle TEvTxCalcPredicateResult",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     TMaybe<EDecision> decision;
 
@@ -288,7 +289,7 @@ void UpdatePartitionsData(NKikimrPQ::TPartitions& partitionsData, NKikimrPQ::TPa
 void TDistributedTransaction::OnProposePartitionConfigResult(TEvPQ::TEvProposePartitionConfigResult& event)
 {
     YDB_LOG_DEBUG("Handle TEvProposePartitionConfigResult",
-        {"logPrefix", LogPrefix()});
+        {LogPrefix()});
 
     UpdatePartitionsData(PartitionsData, event.Data);
 
@@ -311,7 +312,7 @@ void TDistributedTransaction::OnPartitionResult(const E& event, TMaybe<EDecision
     ++PartitionRepliesCount;
 
     YDB_LOG_DEBUG("Partition responses ",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"partitionRepliesCount", PartitionRepliesCount},
         {"partitionRepliesExpected", PartitionRepliesExpected});
 }
@@ -321,7 +322,7 @@ void TDistributedTransaction::OnReadSet(const NKikimrTx::TEvReadSet& event,
                                         std::unique_ptr<TEvTxProcessing::TEvReadSetAck> ack)
 {
     YDB_LOG_DEBUG("Handle TEvReadSet",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txId", TxId});
 
     TX_ENSURE((Step == Max<ui64>()) || (event.HasStep() && (Step == event.GetStep())));
@@ -340,7 +341,7 @@ void TDistributedTransaction::OnReadSet(const NKikimrTx::TEvReadSet& event,
             ++ReadSetCount;
 
             YDB_LOG_DEBUG("Predicates ",
-                {"logPrefix", LogPrefix()},
+                {LogPrefix()},
                 {"readSetCount", ReadSetCount},
                 {"predicatesReceivedSize", PredicatesReceived.size()});
         }
@@ -362,7 +363,7 @@ void TDistributedTransaction::OnReadSet(const NKikimrTx::TEvReadSet& event,
 void TDistributedTransaction::OnReadSetAck(const NKikimrTx::TEvReadSetAck& event)
 {
     YDB_LOG_DEBUG("Handle TEvReadSetAck",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"txId", TxId});
 
     TX_ENSURE(event.HasStep() && (Step == event.GetStep()));
@@ -378,7 +379,7 @@ void TDistributedTransaction::OnReadSetAck(ui64 tabletId)
         ++PredicateAcksCount;
 
         YDB_LOG_DEBUG("Predicate acks",
-            {"logPrefix", LogPrefix()},
+            {LogPrefix()},
             {"predicateAcksCount", PredicateAcksCount},
             {"predicateRecipientsSize", PredicateRecipients.size()});
     }
@@ -428,7 +429,7 @@ bool TDistributedTransaction::HaveParticipantsDecision() const
 bool TDistributedTransaction::HaveAllRecipientsReceive() const
 {
     YDB_LOG_DEBUG("HaveAllRecipientsReceive",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"predicateAcks", PredicateAcksCount},
         {"predicateRecipientsSize", PredicateRecipients.size()});
     return PredicateRecipients.size() == PredicateAcksCount;
@@ -439,7 +440,7 @@ void TDistributedTransaction::AddCmdWrite(NKikimrClient::TKeyValueRequest& reque
 {
     auto tx = Serialize(state);
     YDB_LOG_DEBUG("Save tx",
-        {"logPrefix", LogPrefix()},
+        {LogPrefix()},
         {"tx", tx.ShortDebugString()});
 
     TString value;

--- a/ydb/core/persqueue/pqtablet/transaction.h
+++ b/ydb/core/persqueue/pqtablet/transaction.h
@@ -106,7 +106,7 @@ struct TDistributedTransaction : TLogPrefix {
     template<class E>
     void OnPartitionResult(const E& event, TMaybe<EDecision> decision);
 
-    TStructuredLogPrefix LogPrefix() const override;
+    TStructuredMessage LogPrefix() const override;
 
     THashMap<ui64, TVector<NKikimrTx::TEvReadSet>> OutputMsgs;
 

--- a/ydb/core/persqueue/pqtablet/transaction.h
+++ b/ydb/core/persqueue/pqtablet/transaction.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/protos/pqconfig.pb.h>
@@ -9,8 +10,6 @@
 #include <ydb/core/tx/tx_processing.h>
 
 #include <ydb/library/actors/core/actorid.h>
-#include <ydb/core/persqueue/common/logging.h>
-#include <ydb/library/actors/core/log.h>
 
 #include <util/generic/hash.h>
 #include <util/generic/hash_set.h>

--- a/ydb/core/persqueue/pqtablet/transaction.h
+++ b/ydb/core/persqueue/pqtablet/transaction.h
@@ -9,6 +9,7 @@
 #include <ydb/core/tx/tx_processing.h>
 
 #include <ydb/library/actors/core/actorid.h>
+#include <ydb/library/actors/core/log.h>
 
 #include <util/generic/hash.h>
 #include <util/generic/hash_set.h>
@@ -102,7 +103,7 @@ struct TDistributedTransaction {
     template<class E>
     void OnPartitionResult(const E& event, TMaybe<EDecision> decision);
 
-    TString LogPrefix() const;
+    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
 
     THashMap<ui64, TVector<NKikimrTx::TEvReadSet>> OutputMsgs;
 

--- a/ydb/core/persqueue/pqtablet/transaction.h
+++ b/ydb/core/persqueue/pqtablet/transaction.h
@@ -9,6 +9,7 @@
 #include <ydb/core/tx/tx_processing.h>
 
 #include <ydb/library/actors/core/actorid.h>
+#include <ydb/core/persqueue/common/logging.h>
 #include <ydb/library/actors/core/log.h>
 
 #include <util/generic/hash.h>
@@ -19,8 +20,11 @@
 
 namespace NKikimr::NPQ {
 
-struct TDistributedTransaction {
-    TDistributedTransaction() = default;
+struct TDistributedTransaction : TLogPrefix {
+    TDistributedTransaction()
+        : TLogPrefix(NKikimrServices::PQ_TX)
+    {
+    }
     explicit TDistributedTransaction(const NKikimrPQ::TTransaction& tx);
 
     void OnProposeTransaction(const NKikimrPQ::TEvProposeTransaction& event,
@@ -103,7 +107,7 @@ struct TDistributedTransaction {
     template<class E>
     void OnPartitionResult(const E& event, TMaybe<EDecision> decision);
 
-    NActors::NStructuredLog::TStructuredMessage LogPrefix() const;
+    TStructuredLogPrefix LogPrefix() const override;
 
     THashMap<ui64, TVector<NKikimrTx::TEvReadSet>> OutputMsgs;
 

--- a/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.cpp
+++ b/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.cpp
@@ -27,7 +27,7 @@ void TPartitionWriterCacheActor::Bootstrap(const TActorContext& ctx)
     this->Become(&TPartitionWriterCacheActor::StateWork);
 }
 
-TLogPrefix TPartitionWriterCacheActor::BuildLogPrefix() const {
+TStructuredLogPrefix TPartitionWriterCacheActor::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "PartitionWriterCache"},
         {"tabletId", TabletId},

--- a/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.cpp
+++ b/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.cpp
@@ -29,7 +29,6 @@ void TPartitionWriterCacheActor::Bootstrap(const TActorContext& ctx)
 
 TStructuredLogPrefix TPartitionWriterCacheActor::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
-        {"actorClassName", "PartitionWriterCache"},
         {"partition", Partition});
 }
 

--- a/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.cpp
+++ b/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.cpp
@@ -27,7 +27,7 @@ void TPartitionWriterCacheActor::Bootstrap(const TActorContext& ctx)
     this->Become(&TPartitionWriterCacheActor::StateWork);
 }
 
-TStructuredLogPrefix TPartitionWriterCacheActor::BuildLogPrefix() const {
+TStructuredMessage TPartitionWriterCacheActor::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"partition", Partition});
 }

--- a/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.cpp
+++ b/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.cpp
@@ -13,9 +13,9 @@ TPartitionWriterCacheActor::TPartitionWriterCacheActor(const TActorId& owner,
                                                        ui64 tabletId,
                                                        const TPartitionWriterOpts& opts)
     : TBase(NKikimrServices::PQ_WRITE_PROXY)
+    , TabletId(tabletId)
     , Owner(owner)
     , Partition(partition)
-    , TabletId(tabletId)
     , Opts(opts)
 {
 }
@@ -30,7 +30,6 @@ void TPartitionWriterCacheActor::Bootstrap(const TActorContext& ctx)
 TStructuredLogPrefix TPartitionWriterCacheActor::BuildLogPrefix() const {
     return YDB_LOG_CREATE_MESSAGE(
         {"actorClassName", "PartitionWriterCache"},
-        {"tabletId", TabletId},
         {"partition", Partition});
 }
 

--- a/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.h
+++ b/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.h
@@ -22,6 +22,8 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override;
 
+    ui64 TabletId;
+
 private:
     using TPartitionWriterPtr = std::unique_ptr<TCachedPartitionWriter>;
     using EErrorCode = TEvPartitionWriter::TEvWriteResponse::EErrorCode;
@@ -78,7 +80,6 @@ private:
 
     TActorId Owner;
     ui32 Partition;
-    ui64 TabletId;
     TPartitionWriterOpts Opts;
 
     THashMap<std::pair<TString, TString>, TPartitionWriterPtr> Writers;

--- a/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.h
+++ b/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.h
@@ -20,7 +20,7 @@ public:
     void PassAway() override;
     void OnException(const std::exception& exc) override;
 
-    TStructuredLogPrefix BuildLogPrefix() const override;
+    TStructuredMessage BuildLogPrefix() const override;
 
     ui64 TabletId;
 

--- a/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.h
+++ b/ydb/core/persqueue/public/dataplane/write/partition_writer_cache_actor.h
@@ -20,7 +20,7 @@ public:
     void PassAway() override;
     void OnException(const std::exception& exc) override;
 
-    TLogPrefix BuildLogPrefix() const override;
+    TStructuredLogPrefix BuildLogPrefix() const override;
 
 private:
     using TPartitionWriterPtr = std::unique_ptr<TCachedPartitionWriter>;

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -44,8 +44,7 @@ public:
     }
 
     TStructuredLogPrefix BuildLogPrefix() const override {
-        return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "Describer"});
+        return {};
     }
 
     void Bootstrap() {

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -2,8 +2,8 @@
 
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/path.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/persqueue/public/nameresolver/nameresolver.h>
-#include <ydb/library/actors/core/log.h>
 
 #include <library/cpp/containers/absl/flat_hash_map.h>
 #include <library/cpp/containers/absl/flat_hash_set.h>
@@ -11,11 +11,6 @@
 #include <util/string/join.h>
 
 #include <optional>
-
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_DESCRIBER
-
-#define LOG_PREFIX YDB_LOG_CREATE_MESSAGE( \
-    {"selfId", NActors::TlsActivationContext->AsActorContext().SelfID})
 
 namespace NKikimr::NPQ::NDescriber {
 
@@ -36,14 +31,21 @@ bool HasAccess(const TDescribeSettings& settings, TIntrusivePtr<TSecurityObject>
     return false;
 }
 
-class TDescribeActor : public TActorBootstrapped<TDescribeActor> {
+class TDescribeActor : public TBaseActor<TDescribeActor>
+                      , public TConstantLogPrefix {
 public:
     TDescribeActor(const NActors::TActorId& parent, const TString& databasePath, absl::flat_hash_set<TString>&& topicPaths, const TDescribeSettings& settings)
-        : Parent(parent)
+        : TBaseActor(NKikimrServices::PQ_DESCRIBER)
+        , Parent(parent)
         , DatabasePath(databasePath)
         , TopicPaths(std::move(topicPaths))
         , Settings(settings)
     {
+    }
+
+    TStructuredLogPrefix BuildLogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"actorClassName", "Describer"});
     }
 
     void Bootstrap() {
@@ -54,15 +56,13 @@ public:
         for (const auto& topic : TopicPaths) {
             auto resolved = NNameResolver::ResolveName(DatabasePath, topic);
             if (!resolved) {
-                YDB_LOG_DEBUG("Name resolve failed",
-                    {LOG_PREFIX},
+                LOG_D("Name resolve failed",
                     {"topic", topic},
                     {"reason", resolved.error()});
                 SetErrorResult(topic, EStatus::BadRequest);
                 continue;
             }
-            YDB_LOG_DEBUG("Name resolved",
-                {LOG_PREFIX},
+            LOG_D("Name resolved",
                 {"topic", topic},
                 {"resolvedPath", resolved->Path},
                 {"navigateDatabase", resolved->NavigateDatabase});
@@ -79,8 +79,7 @@ public:
     }
 
     void DoRequest(const absl::flat_hash_set<TString>& topicPath) {
-        YDB_LOG_DEBUG("Create request with",
-            {LOG_PREFIX},
+        LOG_D("Create request with",
             {"topicPaths", JoinRange(", ", topicPath.begin(), topicPath.end())},
             {"syncVersion", RetryWithSyncVersion},
             {"databaseName", RequestDatabaseName});
@@ -102,8 +101,7 @@ public:
     }
 
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
-        YDB_LOG_DEBUG("Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult",
-            {LOG_PREFIX});
+        LOG_D("Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult");
         auto& result = ev->Get()->Request;
 
         absl::flat_hash_set<TString> unknownPaths;
@@ -128,14 +126,12 @@ public:
                 case TSchemeCacheNavigate::EStatus::RootUnknown: {
                     if (RetryWithSyncVersion) {
                         if (entry.SecurityObject && !HasAccess(Settings, entry.SecurityObject)) {
-                            YDB_LOG_DEBUG("Path UNAUTHORIZED",
-                                {LOG_PREFIX},
+                            LOG_D("Path UNAUTHORIZED",
                                 {"realPath", realPath});
 
                             SetErrorResults(originals, EStatus::Unauthorized);
                         } else {
-                            YDB_LOG_DEBUG("Path not found",
-                                {LOG_PREFIX},
+                            LOG_D("Path not found",
                                 {"realPath", realPath});
 
                             SetErrorResults(originals, EStatus::NotFound);
@@ -146,16 +142,14 @@ public:
                     break;
                 }
                 case TSchemeCacheNavigate::EStatus::AccessDenied: {
-                    YDB_LOG_DEBUG("Path ACCESS DENIED",
-                        {LOG_PREFIX},
+                    LOG_D("Path ACCESS DENIED",
                         {"realPath", realPath});
                     SetErrorResults(originals, EStatus::Unauthorized);
                     break;
                 }
                 case TSchemeCacheNavigate::EStatus::Ok: {
                     if (entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
-                        YDB_LOG_DEBUG("Path is CDC",
-                            {LOG_PREFIX},
+                        LOG_D("Path is CDC",
                             {"realPath", realPath});
 
                         // Copy before mutating PathToOriginalPaths (rehash must not invalidate originals).
@@ -170,8 +164,7 @@ public:
                     } else if (entry.Kind == TSchemeCacheNavigate::EKind::KindTopic) {
                         if (!entry.PQGroupInfo || entry.PQGroupInfo->Description.GetBalancerTabletID() == 0) {
                             if (RetryWithSyncVersion) {
-                                YDB_LOG_DEBUG("Path not found",
-                                    {LOG_PREFIX},
+                                LOG_D("Path not found",
                                     {"realPath", realPath});
                                 SetErrorResults(originals, EStatus::NotFound);
                             } else {
@@ -179,8 +172,7 @@ public:
                             }
                         } else {
                             if (!HasAccess(Settings, entry.SecurityObject)) {
-                                YDB_LOG_DEBUG("Path UNAUTHORIZED",
-                                    {LOG_PREFIX},
+                                LOG_D("Path UNAUTHORIZED",
                                     {"realPath", realPath});
 
                                 SetTopicResults(originals, TTopicInfo{
@@ -188,8 +180,7 @@ public:
                                             ? EStatus::UnauthorizedWithDescribeAccess : EStatus::Unauthorized
                                 });
                             } else {
-                                YDB_LOG_DEBUG("Path SUCCESS",
-                                    {LOG_PREFIX},
+                                LOG_D("Path SUCCESS",
                                     {"realPath", realPath});
                                 SetTopicResults(originals, TTopicInfo{
                                     .Status = EStatus::Success,
@@ -204,13 +195,11 @@ public:
                             }
                         }
                     } else {
-                        YDB_LOG_DEBUG("Path is not a",
-                            {LOG_PREFIX},
+                        LOG_D("Path is not a",
                             {"realPath", realPath},
                             {"topic", entry.Kind});
                         if (Settings.UserToken && !entry.SecurityObject->CheckAccess(NACLib::EAccessRights::DescribeSchema, *Settings.UserToken)) {
-                            YDB_LOG_DEBUG("Path UNAUTHORIZED",
-                                {LOG_PREFIX},
+                            LOG_D("Path UNAUTHORIZED",
                                 {"realPath", realPath});
                             SetTopicResults(originals, TTopicInfo{
                                 .Status = EStatus::Unauthorized
@@ -225,8 +214,7 @@ public:
                     break;
                 }
                 default: {
-                    YDB_LOG_DEBUG("Path unknown error",
-                        {LOG_PREFIX},
+                    LOG_D("Path unknown error",
                         {"realPath", realPath});
                     SetTopicResults(originals, TTopicInfo{
                         .Status = EStatus::UnknownError,

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -43,7 +43,7 @@ public:
     {
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return {};
     }
 

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/path.h>
 #include <ydb/core/persqueue/public/nameresolver/nameresolver.h>
+#include <ydb/library/actors/core/log.h>
 
 #include <library/cpp/containers/absl/flat_hash_map.h>
 #include <library/cpp/containers/absl/flat_hash_set.h>
@@ -13,7 +14,8 @@
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_DESCRIBER
 
-#define LOG_PREFIX NActors::TlsActivationContext->AsActorContext().SelfID
+#define LOG_PREFIX YDB_LOG_CREATE_MESSAGE( \
+    {"selfId", NActors::TlsActivationContext->AsActorContext().SelfID})
 
 namespace NKikimr::NPQ::NDescriber {
 
@@ -53,14 +55,14 @@ public:
             auto resolved = NNameResolver::ResolveName(DatabasePath, topic);
             if (!resolved) {
                 YDB_LOG_DEBUG("Name resolve failed",
-                    {"logPrefix", LOG_PREFIX},
+                    {LOG_PREFIX},
                     {"topic", topic},
                     {"reason", resolved.error()});
                 SetErrorResult(topic, EStatus::BadRequest);
                 continue;
             }
             YDB_LOG_DEBUG("Name resolved",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"topic", topic},
                 {"resolvedPath", resolved->Path},
                 {"navigateDatabase", resolved->NavigateDatabase});
@@ -78,7 +80,7 @@ public:
 
     void DoRequest(const absl::flat_hash_set<TString>& topicPath) {
         YDB_LOG_DEBUG("Create request with",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"topicPaths", JoinRange(", ", topicPath.begin(), topicPath.end())},
             {"syncVersion", RetryWithSyncVersion},
             {"databaseName", RequestDatabaseName});
@@ -101,7 +103,7 @@ public:
 
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
         YDB_LOG_DEBUG("Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult",
-            {"logPrefix", LOG_PREFIX});
+            {LOG_PREFIX});
         auto& result = ev->Get()->Request;
 
         absl::flat_hash_set<TString> unknownPaths;
@@ -127,13 +129,13 @@ public:
                     if (RetryWithSyncVersion) {
                         if (entry.SecurityObject && !HasAccess(Settings, entry.SecurityObject)) {
                             YDB_LOG_DEBUG("Path UNAUTHORIZED",
-                                {"logPrefix", LOG_PREFIX},
+                                {LOG_PREFIX},
                                 {"realPath", realPath});
 
                             SetErrorResults(originals, EStatus::Unauthorized);
                         } else {
                             YDB_LOG_DEBUG("Path not found",
-                                {"logPrefix", LOG_PREFIX},
+                                {LOG_PREFIX},
                                 {"realPath", realPath});
 
                             SetErrorResults(originals, EStatus::NotFound);
@@ -145,7 +147,7 @@ public:
                 }
                 case TSchemeCacheNavigate::EStatus::AccessDenied: {
                     YDB_LOG_DEBUG("Path ACCESS DENIED",
-                        {"logPrefix", LOG_PREFIX},
+                        {LOG_PREFIX},
                         {"realPath", realPath});
                     SetErrorResults(originals, EStatus::Unauthorized);
                     break;
@@ -153,7 +155,7 @@ public:
                 case TSchemeCacheNavigate::EStatus::Ok: {
                     if (entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
                         YDB_LOG_DEBUG("Path is CDC",
-                            {"logPrefix", LOG_PREFIX},
+                            {LOG_PREFIX},
                             {"realPath", realPath});
 
                         // Copy before mutating PathToOriginalPaths (rehash must not invalidate originals).
@@ -169,7 +171,7 @@ public:
                         if (!entry.PQGroupInfo || entry.PQGroupInfo->Description.GetBalancerTabletID() == 0) {
                             if (RetryWithSyncVersion) {
                                 YDB_LOG_DEBUG("Path not found",
-                                    {"logPrefix", LOG_PREFIX},
+                                    {LOG_PREFIX},
                                     {"realPath", realPath});
                                 SetErrorResults(originals, EStatus::NotFound);
                             } else {
@@ -178,7 +180,7 @@ public:
                         } else {
                             if (!HasAccess(Settings, entry.SecurityObject)) {
                                 YDB_LOG_DEBUG("Path UNAUTHORIZED",
-                                    {"logPrefix", LOG_PREFIX},
+                                    {LOG_PREFIX},
                                     {"realPath", realPath});
 
                                 SetTopicResults(originals, TTopicInfo{
@@ -187,7 +189,7 @@ public:
                                 });
                             } else {
                                 YDB_LOG_DEBUG("Path SUCCESS",
-                                    {"logPrefix", LOG_PREFIX},
+                                    {LOG_PREFIX},
                                     {"realPath", realPath});
                                 SetTopicResults(originals, TTopicInfo{
                                     .Status = EStatus::Success,
@@ -203,12 +205,12 @@ public:
                         }
                     } else {
                         YDB_LOG_DEBUG("Path is not a",
-                            {"logPrefix", LOG_PREFIX},
+                            {LOG_PREFIX},
                             {"realPath", realPath},
                             {"topic", entry.Kind});
                         if (Settings.UserToken && !entry.SecurityObject->CheckAccess(NACLib::EAccessRights::DescribeSchema, *Settings.UserToken)) {
                             YDB_LOG_DEBUG("Path UNAUTHORIZED",
-                                {"logPrefix", LOG_PREFIX},
+                                {LOG_PREFIX},
                                 {"realPath", realPath});
                             SetTopicResults(originals, TTopicInfo{
                                 .Status = EStatus::Unauthorized
@@ -224,7 +226,7 @@ public:
                 }
                 default: {
                     YDB_LOG_DEBUG("Path unknown error",
-                        {"logPrefix", LOG_PREFIX},
+                        {LOG_PREFIX},
                         {"realPath", realPath});
                     SetTopicResults(originals, TTopicInfo{
                         .Status = EStatus::UnknownError,

--- a/ydb/core/persqueue/public/describer/ya.make
+++ b/ydb/core/persqueue/public/describer/ya.make
@@ -6,6 +6,7 @@ SRCS(
 
 PEERDIR(
     library/cpp/containers/absl
+    ydb/core/persqueue/common
     ydb/core/persqueue/events
     ydb/core/persqueue/public/nameresolver
 #    ydb/core/persqueue/public

--- a/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
@@ -3,22 +3,19 @@
 #include <ydb/core/actorlib_impl/long_timer.h>
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/client/server/msgbus_server_pq_metacache.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/persqueue/public/describer/describer.h>
 #include <ydb/core/persqueue/public/write_meta/write_meta.h>
 #include <ydb/core/tx/replication/ydb_proxy/ydb_proxy.h>
-#include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/log.h>
 
 #include <library/cpp/containers/absl/flat_hash_set.h>
 
 #include <optional>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_FETCH_REQUEST
-
-#define LOG_PREFIX YDB_LOG_CREATE_MESSAGE( \
-    {"selfId", NActors::TlsActivationContext->AsActorContext().SelfID})
+#define YDB_LOG_THIS_FILE_COMPONENT Service
 
 namespace NKikimr::NPQ {
 
@@ -51,7 +48,8 @@ struct TTopicInfo {
 
 using namespace NActors;
 
-class TPQFetchRequestActor : public TActorBootstrapped<TPQFetchRequestActor>
+class TPQFetchRequestActor : public TBaseActor<TPQFetchRequestActor>
+                           , public TConstantLogPrefix
                            , private TRlHelpers {
 private:
     TFetchRequestSettings Settings;
@@ -91,7 +89,8 @@ public:
     }
 
     TPQFetchRequestActor(const TFetchRequestSettings& settings, const TActorId& schemeCacheId, const TActorId& requesterId)
-        : TRlHelpers({}, settings.RlCtx, 8_KB, false, TDuration::Seconds(1))
+        : TBaseActor(NKikimrServices::PQ_FETCH_REQUEST)
+        , TRlHelpers({}, settings.RlCtx, 8_KB, false, TDuration::Seconds(1))
         , Settings(settings)
         , FetchRequestCurrentPartitionIndex(0)
         , FetchRequestCurrentReadTablet(0)
@@ -156,9 +155,14 @@ public:
         }
     }
 
+    TStructuredLogPrefix BuildLogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"database", Settings.Database},
+            {"consumer", Settings.Consumer});
+    }
+
     void Bootstrap(const TActorContext& ctx) {
-        YDB_LOG_INFO("Fetch request actor boostrapped. Request is",
-            {LOG_PREFIX},
+        LOG_I("Fetch request actor boostrapped. Request is",
             {"valid", (!Response)});
 
         // handle error from constructor
@@ -174,8 +178,7 @@ public:
     }
 
     void DescribeTopics(const TActorContext&) {
-        YDB_LOG_DEBUG("DescribeTopics",
-            {LOG_PREFIX});
+        LOG_D("DescribeTopics");
 
         absl::flat_hash_set<TString> topics;
         for (const auto& part : Settings.Partitions) {
@@ -190,8 +193,7 @@ public:
     }
 
     void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev, const TActorContext& ctx) {
-        YDB_LOG_DEBUG("Handle NDescriber::TEvDescribeTopicsResponse",
-            {LOG_PREFIX});
+        LOG_D("Handle NDescriber::TEvDescribeTopicsResponse");
 
         for (auto& [topicPath, info] : ev->Get()->Topics) {
             switch (info.Status) {
@@ -259,8 +261,7 @@ public:
             auto& fetchInfo = topicInfo.HasDataRequests[partitionId];
             const auto partitionIndex = fetchInfo->Record.GetCookie();
             tabletInfo.PartitionIndexes.push_back(partitionIndex);
-            YDB_LOG_DEBUG("Sending TEvPersQueue::TEvHasDataInfo",
-                {LOG_PREFIX},
+            LOG_D("Sending TEvPersQueue::TEvHasDataInfo",
                 {"fetchInfoRecord", fetchInfo->Record.ShortDebugString()});
             NTabletPipe::SendData(ctx, tabletInfo.PipeClient, fetchInfo.Release());
             PartitionStatus[partitionIndex] = EPartitionStatus::HasDataRequested;
@@ -276,8 +277,7 @@ public:
 
     void ProceedFetchRequest(const TActorContext& ctx) {
         if (FetchRequestCurrentReadTablet) { //already got active read request
-            YDB_LOG_DEBUG("Fetch request is pending. /",
-                {LOG_PREFIX},
+            LOG_D("Fetch request is pending. /",
                 {"tabletId", FetchRequestCurrentReadTablet},
                 {"partitionIndex", FetchRequestCurrentPartitionIndex},
                 {"settingsPartitionsSize", Settings.Partitions.size()});
@@ -289,8 +289,7 @@ public:
             ("r", Settings.Partitions.size());
 
         while (true) {
-            YDB_LOG_DEBUG("Processing /",
-                {LOG_PREFIX},
+            LOG_D("Processing /",
                 {"fetchRequestCurrentPartitionIndex", FetchRequestCurrentPartitionIndex},
                 {"settingsPartitionsSize", Settings.Partitions.size()});
             if (FetchRequestCurrentPartitionIndex == Settings.Partitions.size()) {
@@ -300,16 +299,14 @@ public:
 
             auto& status = PartitionStatus[FetchRequestCurrentPartitionIndex];
             if (status == EPartitionStatus::DataReceived) {
-                YDB_LOG_DEBUG("Skip partition because status is DataReceived",
-                    {LOG_PREFIX},
+                LOG_D("Skip partition because status is DataReceived",
                     {"fetchRequestCurrentPartitionIndex", FetchRequestCurrentPartitionIndex});
                 ++FetchRequestCurrentPartitionIndex;
                 continue;
             }
 
             if (FetchRequestBytesLeft == 0) {
-                YDB_LOG_DEBUG("Partition status is",
-                    {LOG_PREFIX},
+                LOG_D("Partition status is",
                     {"fetchRequestCurrentPartitionIndex", FetchRequestCurrentPartitionIndex},
                     {"status", (int)status},
                     {"bytesLeft", FetchRequestBytesLeft});
@@ -344,8 +341,7 @@ public:
 
             //Form read request
             auto request = CreateReadRequest(topic, req);
-            YDB_LOG_DEBUG("Sending",
-                {LOG_PREFIX},
+            LOG_D("Sending",
                 {"request", request->Record.ShortDebugString()});
             NTabletPipe::SendData(ctx, tabletInfo.PipeClient, request.release());
 
@@ -356,16 +352,14 @@ public:
     void Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, const TActorContext& ctx) {
         auto& record = ev->Get()->Record;
         auto partitionIndex = record.GetCookie();
-        YDB_LOG_DEBUG("Handle TEvPersQueue::TEvHasDataInfoResponse",
-            {LOG_PREFIX},
+        LOG_D("Handle TEvPersQueue::TEvHasDataInfoResponse",
             {"ev", record.ShortDebugString()});
         if (partitionIndex >= PartitionStatus.size()) {
             Y_VERIFY_DEBUG(partitionIndex < PartitionStatus.size());
             return;
         }
         auto& status = PartitionStatus[partitionIndex];
-        YDB_LOG_DEBUG("Partition status is",
-            {LOG_PREFIX},
+        LOG_D("Partition status is",
             {"partitionIndex", partitionIndex},
             {"status", (int)status});
         if (status != EPartitionStatus::HasDataRequested) {
@@ -395,14 +389,12 @@ public:
 
     void Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorContext& ctx) {
         auto& record = ev->Get()->Record;
-        YDB_LOG_DEBUG("Handle TEvPersQueue::TEvResponse",
-            {LOG_PREFIX},
+        LOG_D("Handle TEvPersQueue::TEvResponse",
             {"ev", record.ShortDebugString()});
         AFL_ENSURE(record.HasPartitionResponse());
 
         if (record.GetPartitionResponse().GetCookie() != FetchRequestCurrentPartitionIndex || FetchRequestCurrentReadTablet == 0) {
-            YDB_LOG_WARN("Proxy fetch error: got response from tablet while waiting from and requested tablet is",
-                {LOG_PREFIX},
+            LOG_W("Proxy fetch error: got response from tablet while waiting from and requested tablet is",
                 {"partitionResponseCookie", record.GetPartitionResponse().GetCookie()},
                 {"fetchRequestCurrentPartitionIndex", FetchRequestCurrentPartitionIndex},
                 {"fetchRequestCurrentReadTablet", FetchRequestCurrentReadTablet});
@@ -447,8 +439,7 @@ public:
             Response->Response.SetTimestampType(timestampType);
         }
 
-        YDB_LOG_DEBUG("After processing result",
-            {LOG_PREFIX},
+        LOG_D("After processing result",
             {"fetchRequestBytesLeft", FetchRequestBytesLeft});
         if (FetchRequestBytesLeft == 0) {
             FinishProcessing(ctx);
@@ -537,8 +528,7 @@ public:
                 fetchInfo->Record.SetDeadline(0);
 
                 auto tabletId = topicInfo.PartitionToTablet[p.Partition];
-                YDB_LOG_DEBUG("Sending TEvPersQueue::TEvHasDataInfo",
-                    {LOG_PREFIX},
+                LOG_D("Sending TEvPersQueue::TEvHasDataInfo",
                     {"fetchInfoRecord", fetchInfo->Record.ShortDebugString()});
                 NTabletPipe::SendData(ctx, TabletInfo[tabletId].PipeClient, fetchInfo.release());
             }
@@ -591,8 +581,7 @@ public:
     }
 
     void SendReplyAndDie(THolder<TEvPQ::TEvFetchResponse> event, const TActorContext& ctx) {
-        YDB_LOG_DEBUG("Reply",
-            {LOG_PREFIX},
+        LOG_D("Reply",
             {"requesterId", RequesterId},
             {"response", event->Response.ShortDebugString()});
         ctx.Send(RequesterId, event.Release());

--- a/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
@@ -17,7 +17,8 @@
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_FETCH_REQUEST
 
-#define LOG_PREFIX TStringBuilder() << "[" << NActors::TlsActivationContext->AsActorContext().SelfID << "] "
+#define LOG_PREFIX YDB_LOG_CREATE_MESSAGE( \
+    {"selfId", NActors::TlsActivationContext->AsActorContext().SelfID})
 
 namespace NKikimr::NPQ {
 
@@ -157,7 +158,7 @@ public:
 
     void Bootstrap(const TActorContext& ctx) {
         YDB_LOG_INFO("Fetch request actor boostrapped. Request is",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"valid", (!Response)});
 
         // handle error from constructor
@@ -174,7 +175,7 @@ public:
 
     void DescribeTopics(const TActorContext&) {
         YDB_LOG_DEBUG("DescribeTopics",
-            {"logPrefix", LOG_PREFIX});
+            {LOG_PREFIX});
 
         absl::flat_hash_set<TString> topics;
         for (const auto& part : Settings.Partitions) {
@@ -190,7 +191,7 @@ public:
 
     void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev, const TActorContext& ctx) {
         YDB_LOG_DEBUG("Handle NDescriber::TEvDescribeTopicsResponse",
-            {"logPrefix", LOG_PREFIX});
+            {LOG_PREFIX});
 
         for (auto& [topicPath, info] : ev->Get()->Topics) {
             switch (info.Status) {
@@ -259,7 +260,7 @@ public:
             const auto partitionIndex = fetchInfo->Record.GetCookie();
             tabletInfo.PartitionIndexes.push_back(partitionIndex);
             YDB_LOG_DEBUG("Sending TEvPersQueue::TEvHasDataInfo",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"fetchInfoRecord", fetchInfo->Record.ShortDebugString()});
             NTabletPipe::SendData(ctx, tabletInfo.PipeClient, fetchInfo.Release());
             PartitionStatus[partitionIndex] = EPartitionStatus::HasDataRequested;
@@ -276,7 +277,7 @@ public:
     void ProceedFetchRequest(const TActorContext& ctx) {
         if (FetchRequestCurrentReadTablet) { //already got active read request
             YDB_LOG_DEBUG("Fetch request is pending. /",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"tabletId", FetchRequestCurrentReadTablet},
                 {"partitionIndex", FetchRequestCurrentPartitionIndex},
                 {"settingsPartitionsSize", Settings.Partitions.size()});
@@ -289,7 +290,7 @@ public:
 
         while (true) {
             YDB_LOG_DEBUG("Processing /",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"fetchRequestCurrentPartitionIndex", FetchRequestCurrentPartitionIndex},
                 {"settingsPartitionsSize", Settings.Partitions.size()});
             if (FetchRequestCurrentPartitionIndex == Settings.Partitions.size()) {
@@ -300,7 +301,7 @@ public:
             auto& status = PartitionStatus[FetchRequestCurrentPartitionIndex];
             if (status == EPartitionStatus::DataReceived) {
                 YDB_LOG_DEBUG("Skip partition because status is DataReceived",
-                    {"logPrefix", LOG_PREFIX},
+                    {LOG_PREFIX},
                     {"fetchRequestCurrentPartitionIndex", FetchRequestCurrentPartitionIndex});
                 ++FetchRequestCurrentPartitionIndex;
                 continue;
@@ -308,7 +309,7 @@ public:
 
             if (FetchRequestBytesLeft == 0) {
                 YDB_LOG_DEBUG("Partition status is",
-                    {"logPrefix", LOG_PREFIX},
+                    {LOG_PREFIX},
                     {"fetchRequestCurrentPartitionIndex", FetchRequestCurrentPartitionIndex},
                     {"status", (int)status},
                     {"bytesLeft", FetchRequestBytesLeft});
@@ -344,7 +345,7 @@ public:
             //Form read request
             auto request = CreateReadRequest(topic, req);
             YDB_LOG_DEBUG("Sending",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"request", request->Record.ShortDebugString()});
             NTabletPipe::SendData(ctx, tabletInfo.PipeClient, request.release());
 
@@ -356,7 +357,7 @@ public:
         auto& record = ev->Get()->Record;
         auto partitionIndex = record.GetCookie();
         YDB_LOG_DEBUG("Handle TEvPersQueue::TEvHasDataInfoResponse",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"ev", record.ShortDebugString()});
         if (partitionIndex >= PartitionStatus.size()) {
             Y_VERIFY_DEBUG(partitionIndex < PartitionStatus.size());
@@ -364,7 +365,7 @@ public:
         }
         auto& status = PartitionStatus[partitionIndex];
         YDB_LOG_DEBUG("Partition status is",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"partitionIndex", partitionIndex},
             {"status", (int)status});
         if (status != EPartitionStatus::HasDataRequested) {
@@ -395,13 +396,13 @@ public:
     void Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorContext& ctx) {
         auto& record = ev->Get()->Record;
         YDB_LOG_DEBUG("Handle TEvPersQueue::TEvResponse",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"ev", record.ShortDebugString()});
         AFL_ENSURE(record.HasPartitionResponse());
 
         if (record.GetPartitionResponse().GetCookie() != FetchRequestCurrentPartitionIndex || FetchRequestCurrentReadTablet == 0) {
             YDB_LOG_WARN("Proxy fetch error: got response from tablet while waiting from and requested tablet is",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"partitionResponseCookie", record.GetPartitionResponse().GetCookie()},
                 {"fetchRequestCurrentPartitionIndex", FetchRequestCurrentPartitionIndex},
                 {"fetchRequestCurrentReadTablet", FetchRequestCurrentReadTablet});
@@ -447,7 +448,7 @@ public:
         }
 
         YDB_LOG_DEBUG("After processing result",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"fetchRequestBytesLeft", FetchRequestBytesLeft});
         if (FetchRequestBytesLeft == 0) {
             FinishProcessing(ctx);
@@ -537,7 +538,7 @@ public:
 
                 auto tabletId = topicInfo.PartitionToTablet[p.Partition];
                 YDB_LOG_DEBUG("Sending TEvPersQueue::TEvHasDataInfo",
-                    {"logPrefix", LOG_PREFIX},
+                    {LOG_PREFIX},
                     {"fetchInfoRecord", fetchInfo->Record.ShortDebugString()});
                 NTabletPipe::SendData(ctx, TabletInfo[tabletId].PipeClient, fetchInfo.release());
             }
@@ -591,7 +592,7 @@ public:
 
     void SendReplyAndDie(THolder<TEvPQ::TEvFetchResponse> event, const TActorContext& ctx) {
         YDB_LOG_DEBUG("Reply",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"requesterId", RequesterId},
             {"response", event->Response.ShortDebugString()});
         ctx.Send(RequesterId, event.Release());

--- a/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
@@ -155,7 +155,7 @@ public:
         }
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"database", Settings.Database},
             {"consumer", Settings.Consumer});

--- a/ydb/core/persqueue/public/fetcher/ya.make
+++ b/ydb/core/persqueue/public/fetcher/ya.make
@@ -5,6 +5,7 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/core/persqueue/common
     ydb/core/persqueue/events
     ydb/core/persqueue/public
 )

--- a/ydb/core/persqueue/public/mlp/mlp_changer.h
+++ b/ydb/core/persqueue/public/mlp/mlp_changer.h
@@ -52,7 +52,6 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "MLPChanger"},
             {"topic", Settings.TopicName},
             {"consumer", Settings.Consumer});
     }

--- a/ydb/core/persqueue/public/mlp/mlp_changer.h
+++ b/ydb/core/persqueue/public/mlp/mlp_changer.h
@@ -50,7 +50,7 @@ public:
         TBase::PassAway();
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "MLPChanger"},
             {"topic", Settings.TopicName},

--- a/ydb/core/persqueue/public/mlp/mlp_changer.h
+++ b/ydb/core/persqueue/public/mlp/mlp_changer.h
@@ -50,7 +50,7 @@ public:
         TBase::PassAway();
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"topic", Settings.TopicName},
             {"consumer", Settings.Consumer});

--- a/ydb/core/persqueue/public/mlp/mlp_describer.h
+++ b/ydb/core/persqueue/public/mlp/mlp_describer.h
@@ -20,7 +20,7 @@ public:
     void PassAway() override;
 
 protected:
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"topic", Settings.TopicName},
             {"consumer", Settings.Consumer});

--- a/ydb/core/persqueue/public/mlp/mlp_describer.h
+++ b/ydb/core/persqueue/public/mlp/mlp_describer.h
@@ -22,7 +22,6 @@ public:
 protected:
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "MLPDescriber"},
             {"topic", Settings.TopicName},
             {"consumer", Settings.Consumer});
     }

--- a/ydb/core/persqueue/public/mlp/mlp_describer.h
+++ b/ydb/core/persqueue/public/mlp/mlp_describer.h
@@ -20,7 +20,7 @@ public:
     void PassAway() override;
 
 protected:
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "MLPDescriber"},
             {"topic", Settings.TopicName},

--- a/ydb/core/persqueue/public/mlp/mlp_purger.h
+++ b/ydb/core/persqueue/public/mlp/mlp_purger.h
@@ -21,7 +21,7 @@ public:
     void PassAway() override;
 
 protected:
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "MLPPurger"},
             {"topic", Settings.TopicName},

--- a/ydb/core/persqueue/public/mlp/mlp_purger.h
+++ b/ydb/core/persqueue/public/mlp/mlp_purger.h
@@ -23,7 +23,6 @@ public:
 protected:
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "MLPPurger"},
             {"topic", Settings.TopicName},
             {"consumer", Settings.Consumer});
     }

--- a/ydb/core/persqueue/public/mlp/mlp_purger.h
+++ b/ydb/core/persqueue/public/mlp/mlp_purger.h
@@ -21,7 +21,7 @@ public:
     void PassAway() override;
 
 protected:
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"topic", Settings.TopicName},
             {"consumer", Settings.Consumer});

--- a/ydb/core/persqueue/public/mlp/mlp_reader.h
+++ b/ydb/core/persqueue/public/mlp/mlp_reader.h
@@ -20,7 +20,7 @@ public:
     void PassAway() override;
 
 protected:
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"topic", Settings.TopicName},
             {"consumer", Settings.Consumer});

--- a/ydb/core/persqueue/public/mlp/mlp_reader.h
+++ b/ydb/core/persqueue/public/mlp/mlp_reader.h
@@ -22,7 +22,6 @@ public:
 protected:
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "MLPReader"},
             {"topic", Settings.TopicName},
             {"consumer", Settings.Consumer});
     }

--- a/ydb/core/persqueue/public/mlp/mlp_reader.h
+++ b/ydb/core/persqueue/public/mlp/mlp_reader.h
@@ -20,7 +20,7 @@ public:
     void PassAway() override;
 
 protected:
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "MLPReader"},
             {"topic", Settings.TopicName},

--- a/ydb/core/persqueue/public/mlp/mlp_writer.h
+++ b/ydb/core/persqueue/public/mlp/mlp_writer.h
@@ -21,7 +21,7 @@ public:
     void PassAway() override;
 
 protected:
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"topic", Settings.TopicName});
     }

--- a/ydb/core/persqueue/public/mlp/mlp_writer.h
+++ b/ydb/core/persqueue/public/mlp/mlp_writer.h
@@ -23,7 +23,6 @@ public:
 protected:
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "MLPWriter"},
             {"topic", Settings.TopicName});
     }
 

--- a/ydb/core/persqueue/public/mlp/mlp_writer.h
+++ b/ydb/core/persqueue/public/mlp/mlp_writer.h
@@ -21,7 +21,7 @@ public:
     void PassAway() override;
 
 protected:
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "MLPWriter"},
             {"topic", Settings.TopicName});

--- a/ydb/core/persqueue/public/ru_quoter/ru_quoter.cpp
+++ b/ydb/core/persqueue/public/ru_quoter/ru_quoter.cpp
@@ -78,7 +78,7 @@ public:
         SendDatabaseNavigate();
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"database", Settings_.Database});
     }

--- a/ydb/core/persqueue/public/ru_quoter/ru_quoter.cpp
+++ b/ydb/core/persqueue/public/ru_quoter/ru_quoter.cpp
@@ -80,7 +80,6 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "RequestUnitsQuoter"},
             {"database", Settings_.Database});
     }
 

--- a/ydb/core/persqueue/public/ru_quoter/ru_quoter.cpp
+++ b/ydb/core/persqueue/public/ru_quoter/ru_quoter.cpp
@@ -78,7 +78,7 @@ public:
         SendDatabaseNavigate();
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "RequestUnitsQuoter"},
             {"database", Settings_.Database});

--- a/ydb/core/persqueue/public/schema/alter_topic_internal.cpp
+++ b/ydb/core/persqueue/public/schema/alter_topic_internal.cpp
@@ -44,7 +44,6 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "AlterTopicInternal"},
             {"path", Path});
     }
 

--- a/ydb/core/persqueue/public/schema/alter_topic_internal.cpp
+++ b/ydb/core/persqueue/public/schema/alter_topic_internal.cpp
@@ -42,7 +42,7 @@ public:
         Promise.SetValue(std::move(response));
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"path", Path});
     }

--- a/ydb/core/persqueue/public/schema/alter_topic_internal.cpp
+++ b/ydb/core/persqueue/public/schema/alter_topic_internal.cpp
@@ -42,7 +42,7 @@ public:
         Promise.SetValue(std::move(response));
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "AlterTopicInternal"},
             {"path", Path});

--- a/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
@@ -31,7 +31,7 @@ public:
         DoDescribe();
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "AlterTopic"},
             {"topic", Settings.Strategy->GetTopicName()});

--- a/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
@@ -33,7 +33,6 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "AlterTopic"},
             {"topic", Settings.Strategy->GetTopicName()});
     }
 

--- a/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
@@ -31,7 +31,7 @@ public:
         DoDescribe();
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"topic", Settings.Strategy->GetTopicName()});
     }

--- a/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
+++ b/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/protos/pqconfig.pb.h>
 #include <ydb/library/aclib/aclib.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/log.h>
 
 #include <library/cpp/containers/absl/flat_hash_set.h>
 
@@ -19,7 +20,8 @@
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_SCHEMA
 
-#define LOG_PREFIX NActors::TlsActivationContext->AsActorContext().SelfID
+#define LOG_PREFIX YDB_LOG_CREATE_MESSAGE( \
+    {"selfId", NActors::TlsActivationContext->AsActorContext().SelfID})
 
 namespace NKikimr::NPQ::NSchema {
 
@@ -86,7 +88,7 @@ public:
         }
 
         YDB_LOG_DEBUG("Check DLQ topics",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"database", DatabasePath},
             {"paths", JoinRange(", ", DlqPaths.begin(), DlqPaths.end())});
 
@@ -117,7 +119,7 @@ public:
             const auto& info = ev->Get()->Topics.at(path);
             if (auto error = MapStatus(path, info); error) {
                 YDB_LOG_DEBUG("DLQ check failed",
-                    {"logPrefix", LOG_PREFIX},
+                    {LOG_PREFIX},
                     {"path", path},
                     {"status", error->first},
                     {"errorMessage", error->second});

--- a/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
+++ b/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
@@ -79,7 +79,7 @@ public:
     {
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"database", DatabasePath});
     }

--- a/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
+++ b/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
@@ -2,11 +2,11 @@
 
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/path.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/persqueue/public/describer/describer.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/pqconfig.pb.h>
 #include <ydb/library/aclib/aclib.h>
-#include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/log.h>
 
 #include <library/cpp/containers/absl/flat_hash_set.h>
@@ -18,10 +18,7 @@
 #include <algorithm>
 #include <optional>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_SCHEMA
-
-#define LOG_PREFIX YDB_LOG_CREATE_MESSAGE( \
-    {"selfId", NActors::TlsActivationContext->AsActorContext().SelfID})
+#define YDB_LOG_THIS_FILE_COMPONENT Service
 
 namespace NKikimr::NPQ::NSchema {
 
@@ -65,7 +62,8 @@ TString AccessDeniedMessage(const TIntrusiveConstPtr<NACLib::TUserToken>& userTo
         << " with any of access rights AlterSchema or UpdateRow";
 }
 
-class TCheckDlqTopicsActor : public TActorBootstrapped<TCheckDlqTopicsActor> {
+class TCheckDlqTopicsActor : public TBaseActor<TCheckDlqTopicsActor>
+                             , public TConstantLogPrefix {
 public:
     TCheckDlqTopicsActor(
         const TActorId& parent,
@@ -73,11 +71,17 @@ public:
         absl::flat_hash_set<TString>&& dlqPaths,
         const TCheckDlqTopicsSettings& settings
     )
-        : Parent(parent)
+        : TBaseActor(NKikimrServices::PQ_SCHEMA)
+        , Parent(parent)
         , DatabasePath(databasePath)
         , DlqPaths(std::move(dlqPaths))
         , Settings(settings)
     {
+    }
+
+    TStructuredLogPrefix BuildLogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"database", DatabasePath});
     }
 
     void Bootstrap() {
@@ -87,9 +91,7 @@ public:
             return ReplyAndDie(Ydb::StatusIds::SUCCESS, {});
         }
 
-        YDB_LOG_DEBUG("Check DLQ topics",
-            {LOG_PREFIX},
-            {"database", DatabasePath},
+        LOG_D("Check DLQ topics",
             {"paths", JoinRange(", ", DlqPaths.begin(), DlqPaths.end())});
 
         Register(NDescriber::CreateDescriberActor(
@@ -118,8 +120,7 @@ public:
         for (const auto& path : paths) {
             const auto& info = ev->Get()->Topics.at(path);
             if (auto error = MapStatus(path, info); error) {
-                YDB_LOG_DEBUG("DLQ check failed",
-                    {LOG_PREFIX},
+                LOG_D("DLQ check failed",
                     {"path", path},
                     {"status", error->first},
                     {"errorMessage", error->second});

--- a/ydb/core/persqueue/public/schema/create_topic_internal.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_internal.cpp
@@ -42,7 +42,7 @@ public:
         Promise.SetValue(std::move(response));
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"path", Path});
     }

--- a/ydb/core/persqueue/public/schema/create_topic_internal.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_internal.cpp
@@ -42,7 +42,7 @@ public:
         Promise.SetValue(std::move(response));
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "CreateTopicInternal"},
             {"path", Path});

--- a/ydb/core/persqueue/public/schema/create_topic_internal.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_internal.cpp
@@ -44,7 +44,6 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "CreateTopicInternal"},
             {"path", Path});
     }
 

--- a/ydb/core/persqueue/public/schema/create_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_operation.cpp
@@ -40,7 +40,6 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "CreateTopic"},
             {"topic", Settings.Strategy->GetTopicName()});
     }
 

--- a/ydb/core/persqueue/public/schema/create_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_operation.cpp
@@ -38,7 +38,7 @@ public:
         }
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"topic", Settings.Strategy->GetTopicName()});
     }

--- a/ydb/core/persqueue/public/schema/create_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_operation.cpp
@@ -38,7 +38,7 @@ public:
         }
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "CreateTopic"},
             {"topic", Settings.Strategy->GetTopicName()});

--- a/ydb/core/persqueue/public/schema/describe_operation.cpp
+++ b/ydb/core/persqueue/public/schema/describe_operation.cpp
@@ -78,7 +78,7 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", Strategy->GetName()});
+            {"strategy", Strategy->GetName()});
     }
 
     bool OnUnhandledException(const std::exception& exc) override {

--- a/ydb/core/persqueue/public/schema/describe_operation.cpp
+++ b/ydb/core/persqueue/public/schema/describe_operation.cpp
@@ -76,7 +76,7 @@ public:
             }));
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", Strategy->GetName()});
     }

--- a/ydb/core/persqueue/public/schema/describe_operation.cpp
+++ b/ydb/core/persqueue/public/schema/describe_operation.cpp
@@ -76,7 +76,7 @@ public:
             }));
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"strategy", Strategy->GetName()});
     }

--- a/ydb/core/persqueue/public/schema/describe_operation.cpp
+++ b/ydb/core/persqueue/public/schema/describe_operation.cpp
@@ -82,7 +82,7 @@ public:
     }
 
     bool OnUnhandledException(const std::exception& exc) override {
-        DoLogUnhandledException(Service, NPQ_LOG_PREFIX, exc);
+        DoLogUnhandledException(Service, *this, exc);
         ReplyWithError(
             Ydb::StatusIds::INTERNAL_ERROR,
             TStringBuilder() << "Unhandled exception: " << exc.what(),

--- a/ydb/core/persqueue/public/schema/drop_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/drop_topic_operation.cpp
@@ -31,7 +31,7 @@ public:
         DoDescribe();
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "DropTopic"},
             {"path", Settings.Path});

--- a/ydb/core/persqueue/public/schema/drop_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/drop_topic_operation.cpp
@@ -31,7 +31,7 @@ public:
         DoDescribe();
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"path", Settings.Path});
     }

--- a/ydb/core/persqueue/public/schema/drop_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/drop_topic_operation.cpp
@@ -33,7 +33,6 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "DropTopic"},
             {"path", Settings.Path});
     }
 

--- a/ydb/core/persqueue/public/schema/schema_operation.cpp
+++ b/ydb/core/persqueue/public/schema/schema_operation.cpp
@@ -49,7 +49,6 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "SchemaOperation"},
             {"path", Path});
     }
 

--- a/ydb/core/persqueue/public/schema/schema_operation.cpp
+++ b/ydb/core/persqueue/public/schema/schema_operation.cpp
@@ -47,7 +47,7 @@ public:
         TBaseActor<TSchemaOperationActor>::PassAway();
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"path", Path});
     }

--- a/ydb/core/persqueue/public/schema/schema_operation.cpp
+++ b/ydb/core/persqueue/public/schema/schema_operation.cpp
@@ -47,7 +47,7 @@ public:
         TBaseActor<TSchemaOperationActor>::PassAway();
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "SchemaOperation"},
             {"path", Path});

--- a/ydb/core/persqueue/writer/partition_chooser_impl__abstract_chooser_actor.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__abstract_chooser_actor.h
@@ -48,7 +48,7 @@ public:
         return TActor<TDerived>::SelfId();
     }
 
-    TLogPrefix BuildLogPrefix() const override {
+    TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"actorClassName", "PartitionChooser"},
             {"sourceId", SourceId},

--- a/ydb/core/persqueue/writer/partition_chooser_impl__abstract_chooser_actor.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__abstract_chooser_actor.h
@@ -50,7 +50,6 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "PartitionChooser"},
             {"sourceId", SourceId},
             {"preferredPartition", PreferedPartition});
     }

--- a/ydb/core/persqueue/writer/partition_chooser_impl__abstract_chooser_actor.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__abstract_chooser_actor.h
@@ -48,7 +48,7 @@ public:
         return TActor<TDerived>::SelfId();
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"sourceId", SourceId},
             {"preferredPartition", PreferedPartition});

--- a/ydb/core/persqueue/writer/writer.cpp
+++ b/ydb/core/persqueue/writer/writer.cpp
@@ -11,6 +11,7 @@
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/kqp/common/events/events.h>
 #include <ydb/core/kqp/common/simple/services.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/public/pq_rl_helpers.h>
 #include <ydb/library/wilson_ids/wilson.h>
@@ -23,19 +24,7 @@
 
 #include <library/cpp/retry/retry_policy.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_WRITE_PROXY
-
 namespace NKikimr::NPQ {
-
-#if defined(LOG_PREFIX)
-#error "Already defined LOG_PREFIX"
-#endif
-
-
-#define LOG_PREFIX YDB_LOG_CREATE_MESSAGE( \
-    {"actorClassName", "TPartitionWriter"}, \
-    {"tabletId", TabletId}, \
-    {"partition", PartitionId})
 
 static const ui64 WRITE_BLOCK_SIZE = 4_KB;
 static const ui32 INVALID_PARTITION_ID = Max<ui32>();
@@ -107,7 +96,10 @@ TString TEvPartitionWriter::TEvWriteResponse::ToString() const {
     return out;
 }
 
-class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPartitionWriterOpts::IGetter, private TRlHelpers {
+class TPartitionWriter : public TBaseActor<TPartitionWriter>
+                        , public TPartitionWriterOpts::IGetter
+                        , private TRlHelpers
+                        , public TConstantLogPrefix {
     using EErrorCode = TEvPartitionWriter::TEvWriteResponse::EErrorCode;
 
     struct TUserWriteRequest {
@@ -249,8 +241,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         }
 
         if (auto delay = RetryState->GetNextRetryDelay(code); delay.Defined()) {
-            YDB_LOG_DEBUG("Repeat the request to KQP",
-                {LOG_PREFIX},
+            LOG_D("Repeat the request to KQP",
                 {"delay", *delay});
             Schedule(*delay, new TEvents::TEvWakeup());
         }
@@ -283,8 +274,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     /// GetWriteId
 
     void GetWriteId(const TActorContext& ctx) {
-        YDB_LOG_DEBUG("Start of a request to KQP for a WriteId",
-            {LOG_PREFIX},
+        LOG_D("Start of a request to KQP for a WriteId",
             {"sessionId", Opts.SessionId},
             {"txId", Opts.TxId});
 
@@ -304,8 +294,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     }
 
     void HandleWriteId(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev, const TActorContext& /*ctx*/) {
-        YDB_LOG_DEBUG("End of the request to KQP for the WriteId",
-            {LOG_PREFIX},
+        LOG_D("End of the request to KQP for the WriteId",
             {"sessionId", Opts.SessionId},
             {"txId", Opts.TxId},
             {"status", ev->Get()->Record.GetYdbStatus()});
@@ -323,8 +312,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
         WriteId = NPQ::GetWriteId(record.GetResponse().GetTopicOperations());
 
-        YDB_LOG_DEBUG("",
-            {LOG_PREFIX},
+        LOG_D("",
             {"sessionId", Opts.SessionId},
             {"txId", Opts.TxId},
             {"writeId", WriteId});
@@ -431,12 +419,10 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
         TString error;
         if (!BasicCheck(record, error)) {
-            YDB_LOG_ERROR("CmdAbortDeferredStaging failed",
-                {LOG_PREFIX},
+            LOG_E("CmdAbortDeferredStaging failed",
                 {"error", error});
         } else if (!record.GetPartitionResponse().HasCmdAbortDeferredStagingResult()) {
-            YDB_LOG_ERROR("CmdAbortDeferredStaging: absent result",
-                {LOG_PREFIX});
+            LOG_E("CmdAbortDeferredStaging: absent result");
         }
 
         if (UpsertRollbackPending) {
@@ -518,8 +504,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
     void HandleUpsertPermanentFailure(const TString& reason) {
         UpsertRollbackPending = true;
-        YDB_LOG_ERROR("Upsert destination failed",
-            {LOG_PREFIX},
+        LOG_E("Upsert destination failed",
             {"error", reason});
         AbortDeferredStaging();
     }
@@ -547,8 +532,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         AFL_ENSURE(HasWriteId())("topic", Opts.TopicPath)("tablet_id", TabletId);
         AFL_ENSURE(HasSupportivePartitionId())("topic", Opts.TopicPath)("tablet_id", TabletId);
 
-        YDB_LOG_DEBUG("Start of a request to KQP to save PartitionId",
-            {LOG_PREFIX},
+        LOG_D("Start of a request to KQP to save PartitionId",
             {"sessionId", Opts.SessionId},
             {"txId", Opts.TxId});
 
@@ -557,8 +541,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     }
 
     void HandlePartitionIdSaved(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev, const TActorContext&) {
-        YDB_LOG_DEBUG("End of a request to KQP to save PartitionId",
-            {LOG_PREFIX},
+        LOG_D("End of a request to KQP to save PartitionId",
             {"sessionId", Opts.SessionId},
             {"txId", Opts.TxId},
             {"status", ev->Get()->Record.GetYdbStatus()});
@@ -692,8 +675,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     /// Work
 
     STATEFN(StateWork) {
-        YDB_LOG_DEBUG("Received",
-            {LOG_PREFIX},
+        LOG_D("Received",
             {"event", (*ev.Get()).GetTypeName()});
         switch (ev->GetTypeRewrite()) {
             HFunc(TEvPartitionWriter::TEvWriteRequest, Handle);
@@ -719,8 +701,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         auto writeValid = (PendingWrite.empty() || PendingWrite.back().Cookie < cookie);
 
         if (!(pendingValid && reserveValid && writeValid)) {
-            YDB_LOG_ERROR("The cookie of WriteRequest is invalid",
-                {LOG_PREFIX},
+            LOG_E("The cookie of WriteRequest is invalid",
                 {"cookie", cookie});
             Disconnected(EErrorCode::InternalError);
             return false;
@@ -816,16 +797,14 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
     void EnqueueReservedAndProcess(ui64 cookie) {
         if (PendingReserve.empty()) {
-            YDB_LOG_ERROR("The state of the PartitionWriter is invalid. PendingReserve is empty. Marker #01",
-                {LOG_PREFIX});
+            LOG_E("The state of the PartitionWriter is invalid. PendingReserve is empty. Marker #01");
             Disconnected(EErrorCode::InternalError);
             return;
         }
         auto it = PendingReserve.begin();
 
         if(it->first != cookie) {
-            YDB_LOG_ERROR("The order of reservation is invalid",
-                {LOG_PREFIX},
+            LOG_E("The order of reservation is invalid",
                 {"cookie", cookie},
                 {"reserveCookie", it->first});
             Disconnected(EErrorCode::InternalError);
@@ -844,8 +823,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         while (rit != ReceivedReserve.end() && qit != ReceivedQuota.end()) {
             auto& request = rit->second;
             const auto cookie = rit->first;
-            YDB_LOG_TRACE("Processing quota for request",
-                {LOG_PREFIX},
+            LOG_T("Processing quota for request",
                 {"cookie", cookie},
                 {"quotaCheckEnabled", request.QuotaCheckEnabled},
                 {"quotaAccepted", request.QuotaAccepted});
@@ -857,8 +835,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
             }
 
             if (cookie != *qit) {
-                YDB_LOG_ERROR("The order of reservation and quota requests should be the same",
-                    {LOG_PREFIX},
+                LOG_E("The order of reservation and quota requests should be the same",
                     {"reserveCookie", cookie},
                     {"quotaCookie", *qit});
                 Disconnected(EErrorCode::InternalError);
@@ -873,8 +850,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         while (rit != ReceivedReserve.end()) {
             auto& request = rit->second;
             const auto cookie = rit->first;
-            YDB_LOG_TRACE("Processing quota for request",
-                {LOG_PREFIX},
+            LOG_T("Processing quota for request",
                 {"cookie", cookie},
                 {"quotaCheckEnabled", request.QuotaCheckEnabled},
                 {"quotaAccepted", request.QuotaAccepted});
@@ -889,14 +865,12 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
         while (qit != ReceivedQuota.end()) {
             auto cookie = *qit;
-            YDB_LOG_TRACE("Processing quota for request",
-                {LOG_PREFIX},
+            LOG_T("Processing quota for request",
                 {"cookie", cookie});
             auto pit = PendingReserve.find(cookie);
 
             if (pit == PendingReserve.end()) {
-                YDB_LOG_ERROR("The received quota does not apply to any request",
-                    {LOG_PREFIX},
+                LOG_E("The received quota does not apply to any request",
                     {"cookie", *qit});
                 Disconnected(EErrorCode::InternalError);
                 return;
@@ -958,8 +932,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
             auto cookieWriteValid = (PendingWrite.empty() || PendingWrite.back().Cookie < cookie);
             if (!cookieWriteValid) {
-                YDB_LOG_ERROR("The cookie of Write is invalid",
-                    {LOG_PREFIX},
+                LOG_E("The cookie of Write is invalid",
                     {"cookie", cookie});
                 Disconnected(EErrorCode::InternalError);
                 return;
@@ -998,17 +971,14 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
     void Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev) {
         auto msg = ev->Get();
-        YDB_LOG_DEBUG("TEvClientConnected Status NodeId",
-            {LOG_PREFIX},
+        LOG_D("TEvClientConnected Status NodeId",
             {"status", msg->Status},
-            {"tabletId", msg->TabletId},
             {"serverIdNodeId", msg->ServerId.NodeId()},
             {"generation", msg->Generation});
         Y_DEBUG_ABORT_UNLESS(msg->TabletId == TabletId);
 
         if (msg->Status != NKikimrProto::OK) {
-            YDB_LOG_ERROR("Received TEvClientConnected with status",
-                {LOG_PREFIX},
+            LOG_E("Received TEvClientConnected with status",
                 {"Status", ev->Get()->Status});
             Disconnected(EErrorCode::InternalError);
             return;
@@ -1020,8 +990,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         {
             if(*ExpectedGeneration != msg->Generation)
             {
-                YDB_LOG_INFO("Received TEvClientConnected with wrong generation. received",
-                    {LOG_PREFIX},
+                LOG_I("Received TEvClientConnected with wrong generation. received",
                     {"expected", *ExpectedGeneration},
                     {"generation", msg->Generation});
                 Disconnected(EErrorCode::PartitionNotLocal);
@@ -1029,8 +998,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
             }
             if (NActors::TActivationContext::ActorSystem()->NodeId != msg->ServerId.NodeId())
             {
-                YDB_LOG_INFO("Received TEvClientConnected with wrong NodeId. received",
-                    {LOG_PREFIX},
+                LOG_I("Received TEvClientConnected with wrong NodeId. received",
                     {"expected", NActors::TActivationContext::ActorSystem()->NodeId},
                     {"serverIdNodeId", msg->ServerId.NodeId()});
                 Disconnected(EErrorCode::PartitionNotLocal);
@@ -1041,8 +1009,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
     void Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev) {
         if (ev->Get()->TabletId == TabletId) {
-            YDB_LOG_DEBUG("Received TEvClientDestroyed",
-                {LOG_PREFIX});
+            LOG_D("Received TEvClientDestroyed");
             Disconnected(EErrorCode::PartitionDisconnected);
         }
     }
@@ -1053,7 +1020,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         }
         SendError("Unexpected termination");
         TRlHelpers::PassAway(SelfId());
-        TActorBootstrapped::PassAway();
+        TBaseActor::PassAway();
     }
 
     void Handle(TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx) {
@@ -1098,7 +1065,8 @@ public:
             ui64 tabletId,
             ui32 partitionId,
             const TPartitionWriterOpts& opts)
-        : TRlHelpers(opts.TopicPath, opts.RlCtx, WRITE_BLOCK_SIZE, !!opts.RlCtx)
+        : TBaseActor(NKikimrServices::PQ_WRITE_PROXY)
+        , TRlHelpers(opts.TopicPath, opts.RlCtx, WRITE_BLOCK_SIZE, !!opts.RlCtx)
         , Client(client)
         , TabletId(tabletId)
         , PartitionId(partitionId)
@@ -1109,6 +1077,12 @@ public:
         if (Opts.MeteringMode) {
             SetMeteringMode(*Opts.MeteringMode);
         }
+    }
+
+    TStructuredLogPrefix BuildLogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"actorClassName", "TPartitionWriter"},
+            {"partition", PartitionId});
     }
 
     void Bootstrap(const TActorContext& ctx) {
@@ -1157,6 +1131,9 @@ public:
         return Opts;
     }
 
+    const TActorId Client;
+    const ui64 TabletId;
+
 private:
     bool HasWriteId() const {
         return WriteId.Defined();
@@ -1166,8 +1143,6 @@ private:
         return SupportivePartitionId != INVALID_PARTITION_ID;
     }
 
-    const TActorId Client;
-    const ui64 TabletId;
     const ui32 PartitionId;
     const std::optional<ui32> ExpectedGeneration;
     const TString SourceId;
@@ -1225,7 +1200,5 @@ IActor* CreatePartitionWriter(const TActorId& client,
                               const TPartitionWriterOpts& opts) {
     return new TPartitionWriter(client, tabletId, partitionId, opts);
 }
-
-#undef LOG_PREFIX
 
 }

--- a/ydb/core/persqueue/writer/writer.cpp
+++ b/ydb/core/persqueue/writer/writer.cpp
@@ -1081,7 +1081,6 @@ public:
 
     TStructuredLogPrefix BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
-            {"actorClassName", "TPartitionWriter"},
             {"partition", PartitionId});
     }
 

--- a/ydb/core/persqueue/writer/writer.cpp
+++ b/ydb/core/persqueue/writer/writer.cpp
@@ -1079,7 +1079,7 @@ public:
         }
     }
 
-    TStructuredLogPrefix BuildLogPrefix() const override {
+    TStructuredMessage BuildLogPrefix() const override {
         return YDB_LOG_CREATE_MESSAGE(
             {"partition", PartitionId});
     }

--- a/ydb/core/persqueue/writer/writer.cpp
+++ b/ydb/core/persqueue/writer/writer.cpp
@@ -32,7 +32,10 @@ namespace NKikimr::NPQ {
 #endif
 
 
-#define LOG_PREFIX TStringBuilder() << "TPartitionWriter " << TabletId << " (partition=" << PartitionId << ") "
+#define LOG_PREFIX YDB_LOG_CREATE_MESSAGE( \
+    {"actorClassName", "TPartitionWriter"}, \
+    {"tabletId", TabletId}, \
+    {"partition", PartitionId})
 
 static const ui64 WRITE_BLOCK_SIZE = 4_KB;
 static const ui32 INVALID_PARTITION_ID = Max<ui32>();
@@ -247,7 +250,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
         if (auto delay = RetryState->GetNextRetryDelay(code); delay.Defined()) {
             YDB_LOG_DEBUG("Repeat the request to KQP",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"delay", *delay});
             Schedule(*delay, new TEvents::TEvWakeup());
         }
@@ -281,7 +284,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
     void GetWriteId(const TActorContext& ctx) {
         YDB_LOG_DEBUG("Start of a request to KQP for a WriteId",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"sessionId", Opts.SessionId},
             {"txId", Opts.TxId});
 
@@ -302,7 +305,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
     void HandleWriteId(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev, const TActorContext& /*ctx*/) {
         YDB_LOG_DEBUG("End of the request to KQP for the WriteId",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"sessionId", Opts.SessionId},
             {"txId", Opts.TxId},
             {"status", ev->Get()->Record.GetYdbStatus()});
@@ -321,7 +324,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         WriteId = NPQ::GetWriteId(record.GetResponse().GetTopicOperations());
 
         YDB_LOG_DEBUG("",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"sessionId", Opts.SessionId},
             {"txId", Opts.TxId},
             {"writeId", WriteId});
@@ -429,11 +432,11 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         TString error;
         if (!BasicCheck(record, error)) {
             YDB_LOG_ERROR("CmdAbortDeferredStaging failed",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"error", error});
         } else if (!record.GetPartitionResponse().HasCmdAbortDeferredStagingResult()) {
             YDB_LOG_ERROR("CmdAbortDeferredStaging: absent result",
-                {"logPrefix", LOG_PREFIX});
+                {LOG_PREFIX});
         }
 
         if (UpsertRollbackPending) {
@@ -516,7 +519,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     void HandleUpsertPermanentFailure(const TString& reason) {
         UpsertRollbackPending = true;
         YDB_LOG_ERROR("Upsert destination failed",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"error", reason});
         AbortDeferredStaging();
     }
@@ -545,7 +548,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         AFL_ENSURE(HasSupportivePartitionId())("topic", Opts.TopicPath)("tablet_id", TabletId);
 
         YDB_LOG_DEBUG("Start of a request to KQP to save PartitionId",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"sessionId", Opts.SessionId},
             {"txId", Opts.TxId});
 
@@ -555,7 +558,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
     void HandlePartitionIdSaved(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev, const TActorContext&) {
         YDB_LOG_DEBUG("End of a request to KQP to save PartitionId",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"sessionId", Opts.SessionId},
             {"txId", Opts.TxId},
             {"status", ev->Get()->Record.GetYdbStatus()});
@@ -690,7 +693,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
     STATEFN(StateWork) {
         YDB_LOG_DEBUG("Received",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"event", (*ev.Get()).GetTypeName()});
         switch (ev->GetTypeRewrite()) {
             HFunc(TEvPartitionWriter::TEvWriteRequest, Handle);
@@ -717,7 +720,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
         if (!(pendingValid && reserveValid && writeValid)) {
             YDB_LOG_ERROR("The cookie of WriteRequest is invalid",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"cookie", cookie});
             Disconnected(EErrorCode::InternalError);
             return false;
@@ -814,7 +817,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     void EnqueueReservedAndProcess(ui64 cookie) {
         if (PendingReserve.empty()) {
             YDB_LOG_ERROR("The state of the PartitionWriter is invalid. PendingReserve is empty. Marker #01",
-                {"logPrefix", LOG_PREFIX});
+                {LOG_PREFIX});
             Disconnected(EErrorCode::InternalError);
             return;
         }
@@ -822,7 +825,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
         if(it->first != cookie) {
             YDB_LOG_ERROR("The order of reservation is invalid",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"cookie", cookie},
                 {"reserveCookie", it->first});
             Disconnected(EErrorCode::InternalError);
@@ -842,7 +845,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
             auto& request = rit->second;
             const auto cookie = rit->first;
             YDB_LOG_TRACE("Processing quota for request",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"cookie", cookie},
                 {"quotaCheckEnabled", request.QuotaCheckEnabled},
                 {"quotaAccepted", request.QuotaAccepted});
@@ -855,7 +858,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
             if (cookie != *qit) {
                 YDB_LOG_ERROR("The order of reservation and quota requests should be the same",
-                    {"logPrefix", LOG_PREFIX},
+                    {LOG_PREFIX},
                     {"reserveCookie", cookie},
                     {"quotaCookie", *qit});
                 Disconnected(EErrorCode::InternalError);
@@ -871,7 +874,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
             auto& request = rit->second;
             const auto cookie = rit->first;
             YDB_LOG_TRACE("Processing quota for request",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"cookie", cookie},
                 {"quotaCheckEnabled", request.QuotaCheckEnabled},
                 {"quotaAccepted", request.QuotaAccepted});
@@ -887,13 +890,13 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         while (qit != ReceivedQuota.end()) {
             auto cookie = *qit;
             YDB_LOG_TRACE("Processing quota for request",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"cookie", cookie});
             auto pit = PendingReserve.find(cookie);
 
             if (pit == PendingReserve.end()) {
                 YDB_LOG_ERROR("The received quota does not apply to any request",
-                    {"logPrefix", LOG_PREFIX},
+                    {LOG_PREFIX},
                     {"cookie", *qit});
                 Disconnected(EErrorCode::InternalError);
                 return;
@@ -956,7 +959,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
             auto cookieWriteValid = (PendingWrite.empty() || PendingWrite.back().Cookie < cookie);
             if (!cookieWriteValid) {
                 YDB_LOG_ERROR("The cookie of Write is invalid",
-                    {"logPrefix", LOG_PREFIX},
+                    {LOG_PREFIX},
                     {"cookie", cookie});
                 Disconnected(EErrorCode::InternalError);
                 return;
@@ -996,7 +999,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     void Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev) {
         auto msg = ev->Get();
         YDB_LOG_DEBUG("TEvClientConnected Status NodeId",
-            {"logPrefix", LOG_PREFIX},
+            {LOG_PREFIX},
             {"status", msg->Status},
             {"tabletId", msg->TabletId},
             {"serverIdNodeId", msg->ServerId.NodeId()},
@@ -1005,7 +1008,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
         if (msg->Status != NKikimrProto::OK) {
             YDB_LOG_ERROR("Received TEvClientConnected with status",
-                {"logPrefix", LOG_PREFIX},
+                {LOG_PREFIX},
                 {"Status", ev->Get()->Status});
             Disconnected(EErrorCode::InternalError);
             return;
@@ -1018,7 +1021,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
             if(*ExpectedGeneration != msg->Generation)
             {
                 YDB_LOG_INFO("Received TEvClientConnected with wrong generation. received",
-                    {"logPrefix", LOG_PREFIX},
+                    {LOG_PREFIX},
                     {"expected", *ExpectedGeneration},
                     {"generation", msg->Generation});
                 Disconnected(EErrorCode::PartitionNotLocal);
@@ -1027,7 +1030,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
             if (NActors::TActivationContext::ActorSystem()->NodeId != msg->ServerId.NodeId())
             {
                 YDB_LOG_INFO("Received TEvClientConnected with wrong NodeId. received",
-                    {"logPrefix", LOG_PREFIX},
+                    {LOG_PREFIX},
                     {"expected", NActors::TActivationContext::ActorSystem()->NodeId},
                     {"serverIdNodeId", msg->ServerId.NodeId()});
                 Disconnected(EErrorCode::PartitionNotLocal);
@@ -1039,7 +1042,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     void Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev) {
         if (ev->Get()->TabletId == TabletId) {
             YDB_LOG_DEBUG("Received TEvClientDestroyed",
-                {"logPrefix", LOG_PREFIX});
+                {LOG_PREFIX});
             Disconnected(EErrorCode::PartitionDisconnected);
         }
     }

--- a/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
+++ b/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
@@ -49,7 +49,10 @@ bool IsKafkaBatchDataChunk(const NKikimrPQClient::TDataChunk& proto) {
 #undef PQ_LOG_PREFIX
 #endif
 
-#define PQ_LOG_PREFIX (TStringBuilder() << "session cookie " << Cookie << " client " << InternalClientId << " session " << Session)
+#define PQ_LOG_PREFIX YDB_LOG_CREATE_MESSAGE( \
+    {"sessionCookie", Cookie}, \
+    {"client", InternalClientId}, \
+    {"session", Session})
 
 //11 tries = 10,23 seconds, then each try for 5 seconds , so 21 retries will take near 1 min
 static const NTabletPipe::TClientRetryPolicy RetryPolicyForPipes = {
@@ -362,7 +365,7 @@ void TReadSessionActor::Die(const TActorContext& ctx) {
             NTabletPipe::CloseClient(ctx, t.second->PipeClient);
     }
     YDB_LOG_INFO_CTX(ctx, "Is DEAD",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX});
+        {PQ_LOG_PREFIX});
 
     if (SessionsActive) {
         --(*SessionsActive);
@@ -419,7 +422,7 @@ void TReadSessionActor::Handle(TEvPQProxy::TEvCommit::TPtr& ev, const TActorCont
         return;
     }
     YDB_LOG_DEBUG_CTX(ctx, "Commit request from client",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"readId", readId});
     MakeCommit(ctx);
 }
@@ -440,7 +443,7 @@ void TReadSessionActor::MakeCommit(const TActorContext& ctx) {
         return;
     NextCommits.erase(NextCommits.begin(), it);
     YDB_LOG_DEBUG_CTX(ctx, "Commit request",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"readIdCommittedPlus1", ReadIdCommitted + 1},
         {"readId", readId});
 
@@ -502,7 +505,7 @@ void TReadSessionActor::Handle(TEvPQProxy::TEvGetStatus::TPtr& ev, const TActorC
     if (it == Partitions.end() || it->second.Releasing || it->second.LockGeneration != ev->Get()->Generation) {
         //do nothing - already released partition
         YDB_LOG_WARN_CTX(ctx, "Got NOTACTUAL get status request from client for generation",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", ev->Get()->Topic},
             {"partition", ev->Get()->Partition},
             {"generation", ev->Get()->Generation});
@@ -533,7 +536,7 @@ void TReadSessionActor::Handle(TEvPQProxy::TEvLocked::TPtr& ev, const TActorCont
     if (it == Partitions.end() || it->second.Releasing || it->second.LockGeneration != ev->Get()->Generation) {
         //do nothing - already released partition
         YDB_LOG_WARN_CTX(ctx, "Got NOTACTUAL lock from client for at offset generation",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", topic},
             {"partition", ev->Get()->Partition},
             {"readOffset", ev->Get()->ReadOffset},
@@ -542,7 +545,7 @@ void TReadSessionActor::Handle(TEvPQProxy::TEvLocked::TPtr& ev, const TActorCont
         return;
     }
     YDB_LOG_INFO_CTX(ctx, "Got lock from client for at readOffset commitOffset generation",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", ev->Get()->Topic},
         {"partition", ev->Get()->Partition},
         {"readOffset", ev->Get()->ReadOffset},
@@ -610,7 +613,7 @@ void TReadSessionActor::AnswerForCommitsIfCan(const TActorContext& ctx) {
             result.MutableCommit()->AddCookie(i);
         }
         YDB_LOG_DEBUG_CTX(ctx, "Replying for commits",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"startReadId", it->second.StartReadId},
             {"readId", readId});
         ui64 diff = result.ByteSize();
@@ -737,7 +740,7 @@ void TReadSessionActor::Handle(TEvPQProxy::TEvReadInit::TPtr& ev, const TActorCo
         topicsToResolve.insert(t);
     }
     YDB_LOG_INFO_CTX(ctx, "From",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"init", event->Request},
         {"peerName", PeerName});
 
@@ -865,7 +868,7 @@ void TReadSessionActor::Handle(TEvTicketParser::TEvAuthorizeTicketResult::TPtr& 
 void TReadSessionActor::RegisterSession(const TActorId& pipe, const TString& topic, const TActorContext& ctx) {
 
     YDB_LOG_INFO_CTX(ctx, "Register session",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", topic});
     THolder<TEvPersQueue::TEvRegisterReadSession> request;
     request.Reset(new TEvPersQueue::TEvRegisterReadSession);
@@ -980,7 +983,7 @@ void TReadSessionActor::Handle(V1::TEvPQProxy::TEvAuthResultOk::TPtr& ev, const 
     LastACLCheckTimestamp = ctx.Now();
 
     YDB_LOG_DEBUG_CTX(ctx, "Auth ok, got topics, init done",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topicAndTablets", ev->Get()->TopicAndTablets.size()},
         {"initDone", InitDone});
 
@@ -1089,7 +1092,7 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvLockPartition::TPtr& ev, const T
     auto converterIter = FullPathToConverter.find(NPersQueue::NormalizeFullPath(path));
     if (converterIter.IsEnd()) {
         YDB_LOG_ALERT_CTX(ctx, "Ignored ev lock for event path not recognized",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"record", record.ShortDebugString()});
         CloseSession(
                 TStringBuilder() << "Internal server error, cannot parse lock event: " << record.ShortDebugString() << ", reason: topic not found",
@@ -1104,7 +1107,7 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvLockPartition::TPtr& ev, const T
 
     if (jt == Topics.end() || pipe != jt->second->PipeClient) { //this is message from old version of pipe
         YDB_LOG_DEBUG_CTX(ctx, "Ignored ev lock for topic path recognized, but topic is unknown, this is unexpected",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", converterIter->second->GetPrintableString()});
         return;
     }
@@ -1113,7 +1116,7 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvLockPartition::TPtr& ev, const T
     auto* partitionNode = partitionGraph->GetPartition(record.GetPartition());
     if (!partitionNode) {
         YDB_LOG_DEBUG_CTX(ctx, "Lock for unknown partition",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", record.GetPartition()});
         Locks.push_back(ev->Release());
         if (!AuthInflight) {
@@ -1163,7 +1166,7 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvLockPartition::TPtr& ev, const T
     it->second.PartitionsInfly.Inc();
 
     YDB_LOG_INFO_CTX(ctx, "Lock partition",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"ev", record});
 
     ctx.Send(actorId, new TEvPQProxy::TEvLockPartition(0, 0, false, !ClientsideLocksAllowed));
@@ -1178,7 +1181,7 @@ void TReadSessionActor::Handle(TEvPQProxy::TEvPartitionStatus::TPtr& ev, const T
     Y_ABORT_UNLESS(it != Partitions.end());
     if (!it->second.LockGeneration) {
         YDB_LOG_ALERT_CTX(ctx, "The unlocked partition status has been requested",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", ev->Get()->Partition});
         CloseSession(
                 TStringBuilder() << "Internal server error, the unlocked partition " << ev->Get()->Partition << " status has been requested",
@@ -1254,7 +1257,7 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvReleasePartition::TPtr& ev, cons
     auto converterIter = FullPathToConverter.find(NPersQueue::NormalizeFullPath(topic));
     if (converterIter.IsEnd()) {
         YDB_LOG_ALERT_CTX(ctx, "Failed to parse balancer",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"response", record.ShortDebugString()});
         CloseSession(
                 TStringBuilder() << "Internal server error, cannot parse release event: " << record.ShortDebugString() << ", path not recognized",
@@ -1276,7 +1279,7 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvReleasePartition::TPtr& ev, cons
 
     auto onUnknownPartition = [&](auto& marker) {
         YDB_LOG_ALERT_CTX(ctx, "Releasing unknown",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", record.ShortDebugString()},
             {"marker", marker});
         CloseSession(
@@ -1312,7 +1315,7 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvReleasePartition::TPtr& ev, cons
     }
 
     YDB_LOG_INFO_CTX(ctx, "Releasing",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"key", jt->first.first},
         {"partition", jt->first.second});
     jt->second.Releasing = true;
@@ -1369,7 +1372,7 @@ void TReadSessionActor::InformBalancerAboutRelease(const THashMap<std::pair<TStr
     req.SetPartition(it->first.second);
 
     YDB_LOG_INFO_CTX(ctx, "Released",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"key", it->first.first},
         {"partition", it->first.second});
 
@@ -1400,7 +1403,7 @@ void TReadSessionActor::CloseSession(const TString& errorReason, const NPersQueu
         error->SetCode(errorCode);
 
         YDB_LOG_INFO_CTX(ctx, "Closed with error",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"reason", errorReason});
         if (!Handler->IsShuttingDown()) {
             ui64 diff = result.ByteSize();
@@ -1409,11 +1412,11 @@ void TReadSessionActor::CloseSession(const TString& errorReason, const NPersQueu
             Handler->Reply(std::move(result));
         } else {
             YDB_LOG_WARN_CTX(ctx, "GRps is shutting down, skip reply",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX});
+                {PQ_LOG_PREFIX});
         }
     } else {
         YDB_LOG_INFO_CTX(ctx, "Closed",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX});
+            {PQ_LOG_PREFIX});
     }
 
     Die(ctx);
@@ -1514,7 +1517,7 @@ bool TReadSessionActor::ProcessBalancerDead(const ui64 tablet, const TActorConte
     for (auto& t : Topics) {
         if (t.second->TabletID == tablet) {
             YDB_LOG_INFO_CTX(ctx, "Balancer for topic is dead, restarting all from this topic",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                {PQ_LOG_PREFIX},
                 {"topic", t.first});
 
             //Drop all partitions from this topic
@@ -1579,7 +1582,7 @@ void TReadSessionActor::Handle(TEvPQProxy::TEvRead::TPtr& ev, const TActorContex
     event->Request.ClearCredentials();
 
     YDB_LOG_DEBUG_CTX(ctx, "Got read with",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"request", event->Request.GetRead()},
         {"guid", event->Guid});
 
@@ -1624,7 +1627,7 @@ void TReadSessionActor::Handle(TEvPQProxy::TEvReadResponse::TPtr& ev, const TAct
     TFormedReadResponse::TPtr formedResponse = it->second;
 
     YDB_LOG_DEBUG_CTX(ctx, "Read done guid size",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"guid", formedResponse->Guid},
         {"keyFirst", key.first},
         {"keySecond", key.second},
@@ -1674,7 +1677,7 @@ bool TReadSessionActor::ProcessAnswer(const TActorContext& ctx, TFormedReadRespo
     const bool hasMessages = HasMessages(formedResponse->Response.GetBatchedData());
     if (hasMessages) {
         YDB_LOG_DEBUG_CTX(ctx, "Assign read id to read request",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"readIdToResponse", ReadIdToResponse},
             {"guid", formedResponse->Guid});
         formedResponse->Response.MutableBatchedData()->SetCookie(ReadIdToResponse);
@@ -1686,7 +1689,7 @@ bool TReadSessionActor::ProcessAnswer(const TActorContext& ctx, TFormedReadRespo
         Handler->Reply(std::move(formedResponse->Response));
     } else {
         YDB_LOG_DEBUG_CTX(ctx, "Empty read result start new reading",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"guid", formedResponse->Guid});
     }
 
@@ -1834,7 +1837,7 @@ bool TReadSessionActor::ProcessReads(const TActorContext& ctx) {
             readR->SetReadTimestampMs(ReadTimestampMs);
 
             YDB_LOG_DEBUG_CTX(ctx, "Performing read with guid from count size partitionsAsked maxTimeLag ms",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                {PQ_LOG_PREFIX},
                 {"request", (*readR)},
                 {"guid", read->Guid},
                 {"topic", part.Topic->GetPrintableString()},
@@ -1882,7 +1885,7 @@ void TReadSessionActor::Handle(TEvPQProxy::TEvPartitionReady::TPtr& ev, const TA
         return;
 
     YDB_LOG_DEBUG_CTX(ctx, "Ready for read with readOffset endOffset WTime sizeLag",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", ev->Get()->Topic->GetPrintableString()},
         {"partition", ev->Get()->Partition},
         {"readOffset", ev->Get()->ReadOffset},
@@ -1913,7 +1916,7 @@ void TReadSessionActor::HandleWakeup(const TActorContext& ctx) {
         RequestNotChecked = false;
         Y_ABORT_UNLESS(!AuthInitActor);
         YDB_LOG_DEBUG_CTX(ctx, "Checking auth because of timeout",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX});
+            {PQ_LOG_PREFIX});
 
         SendAuthRequest(ctx);
     }
@@ -2015,7 +2018,7 @@ void TPartitionActor::CheckRelease(const TActorContext& ctx) {
     const bool hasUncommittedData = ReadOffset > ClientCommitOffset && ReadOffset > ClientReadOffset;
     if (NeedRelease) {
         YDB_LOG_DEBUG_CTX(ctx, "Checking release readOffset committedOffset ReadGuid CommitsInfly.size Released",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", Topic->GetPrintableString()},
             {"partition", Partition},
             {"readOffset", ReadOffset},
@@ -2029,7 +2032,7 @@ void TPartitionActor::CheckRelease(const TActorContext& ctx) {
         Released = true;
         ctx.Send(ParentId, new TEvPQProxy::TEvPartitionReleased(Topic, Partition));
         YDB_LOG_INFO_CTX(ctx, "Check release done - releasing; readOffset committedOffset ReadGuid CommitsInfly.size Released",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", Topic->GetPrintableString()},
             {"partition", Partition},
             {"readOffset", ReadOffset},
@@ -2083,7 +2086,7 @@ void TPartitionActor::SendCommit(const ui64 readId, const ui64 offset, const TAc
         commit->SetSessionId(Session);
 
         YDB_LOG_DEBUG_CTX(ctx, "Committing to position prev end by cookie",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", Topic->GetPrintableString()},
             {"partition", Partition},
             {"offset", offset},
@@ -2101,7 +2104,7 @@ void TPartitionActor::SendCommit(const ui64 readId, const ui64 offset, const TAc
 void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
     if (CommitsInfly.empty()) {
         YDB_LOG_DEBUG_CTX(ctx, "Unwaited commit-response with cookie waiting for nothing",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", Topic->GetPrintableString()},
             {"partition", Partition},
             {"cookie", cookie});
@@ -2111,7 +2114,7 @@ void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
 
     if (cookie != readId) {
         YDB_LOG_DEBUG_CTX(ctx, "Unwaited commit-response with cookie waiting",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", Topic->GetPrintableString()},
             {"partition", Partition},
             {"cookie", cookie},
@@ -2127,7 +2130,7 @@ void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
     if (readId != Max<ui64>()) //this readId is reserved for upcommits on client skipping with ClientCommitOffset
         ctx.Send(ParentId, new TEvPQProxy::TEvCommitDone(readId, Topic, Partition));
     YDB_LOG_DEBUG_CTX(ctx, "Commit done to position endOffset with cookie",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", Topic->GetPrintableString()},
         {"partition", Partition},
         {"committedOffset", CommittedOffset},
@@ -2139,7 +2142,7 @@ void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
         CommitsInfly.pop_front();
         ctx.Send(ParentId, new TEvPQProxy::TEvCommitDone(readId, Topic, Partition));
         YDB_LOG_DEBUG_CTX(ctx, "Partition commit done with no effect with cookie",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", Topic->GetPrintableString()},
             {"partition", Partition},
             {"readId", readId});
@@ -2151,7 +2154,7 @@ void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
 
 void TPartitionActor::SendPartitionReady(const TActorContext& ctx) {
     YDB_LOG_DEBUG_CTX(ctx, "Ready for read with readOffset endOffset",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", Topic->GetPrintableString()},
         {"partition", Partition},
         {"readOffset", ReadOffset},
@@ -2184,7 +2187,7 @@ void TPartitionActor::RestartPipe(const TActorContext& ctx, const TString& reaso
     ctx.Schedule(TDuration::MilliSeconds(RESTART_PIPE_DELAY_MS), new TEvPQProxy::TEvRestartPipe());
 
     YDB_LOG_INFO_CTX(ctx, "Schedule pipe restart attempt",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", Topic->GetPrintableString()},
         {"partition", Partition},
         {"pipeGeneration", PipeGeneration},
@@ -2208,7 +2211,7 @@ void TPartitionActor::Handle(const TEvPQProxy::TEvRestartPipe::TPtr&, const TAct
     Y_ABORT_UNLESS(TabletID);
 
     YDB_LOG_INFO_CTX(ctx, "Pipe restart attempt RequestInfly ReadOffset EndOffset InitDone WaitForData",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", Topic->GetPrintableString()},
         {"partition", Partition},
         {"pipeGeneration", PipeGeneration},
@@ -2220,7 +2223,7 @@ void TPartitionActor::Handle(const TEvPQProxy::TEvRestartPipe::TPtr&, const TAct
 
     if (RequestInfly) { //got read infly
         YDB_LOG_INFO_CTX(ctx, "Resend",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", Topic->GetPrintableString()},
             {"partition", Partition},
             {"currentRequest", CurrentRequest});
@@ -2278,7 +2281,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
     }
 
     YDB_LOG_DEBUG_CTX(ctx, "InitDone event",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", Topic->GetPrintableString()},
         {"partition", Partition},
         {"initDone", InitDone},
@@ -2288,7 +2291,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
     if (!InitDone) {
         if (result.GetCookie() != INIT_COOKIE) {
             YDB_LOG_DEBUG_CTX(ctx, "Unwaited response in init with cookie",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                {PQ_LOG_PREFIX},
                 {"topic", Topic->GetPrintableString()},
                 {"partition", Partition},
                 {"cookie", result.GetCookie()});
@@ -2314,7 +2317,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
         InitDone = true;
         PipeGeneration = 0; //reset tries counter - all ok
         YDB_LOG_INFO_CTX(ctx, "INIT DONE EndOffset readOffset committedOffset",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", Topic->GetPrintableString()},
             {"partition", Partition},
             {"endOffset", EndOffset},
@@ -2342,7 +2345,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
 
     if (result.GetCookie() != (ui64)ReadOffset) {
         YDB_LOG_DEBUG_CTX(ctx, "Partition unwaited read-response with cookie waiting for current read guid is",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", Topic->GetPrintableString()},
             {"partition", Partition},
             {"cookie", result.GetCookie()},
@@ -2392,7 +2395,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
         if (!r.GetSourceId().empty()) {
             if (!NPQ::NSourceIdEncoding::IsValidEncoded(r.GetSourceId())) {
                 YDB_LOG_ERROR_CTX(ctx, "Read bad sourceId from topic offset seqNo sourceId ReadGuid",
-                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {PQ_LOG_PREFIX},
                     {"topic", Topic->GetPrintableString()},
                     {"partition", Partition},
                     {"offset", r.GetOffset()},
@@ -2456,7 +2459,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
             const auto codec = proto.GetCodec();
             if (codec < Min<int>() || codec > Max<int>() || !NPersQueueCommon::ECodec_IsValid(codec)) {
                 YDB_LOG_ERROR_CTX(ctx, "Data chunk codec is not a valid NPersQueueCommon::ECodec; compression codec info may be lost",
-                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {PQ_LOG_PREFIX},
                     {"topic", Topic->GetInternalName()},
                     {"partition", Partition},
                     {"offset", r.GetOffset()},
@@ -2487,7 +2490,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
     }
 
     YDB_LOG_DEBUG_CTX(ctx, "After read state EndOffset ReadOffset ReadGuid",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", Topic->GetPrintableString()},
         {"partition", Partition},
         {"endOffset", EndOffset},
@@ -2512,7 +2515,7 @@ void TPartitionActor::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const 
     TEvTabletPipe::TEvClientConnected *msg = ev->Get();
 
     YDB_LOG_INFO_CTX(ctx, "Pipe restart attempt pipe creation",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", Topic->GetPrintableString()},
         {"partition", Partition},
         {"pipeGeneration", PipeGeneration},
@@ -2531,7 +2534,7 @@ void TPartitionActor::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev, const 
 
 void TPartitionActor::Handle(TEvPQProxy::TEvReleasePartition::TPtr&, const TActorContext& ctx) {
     YDB_LOG_INFO_CTX(ctx, "(partition)releasing",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", Topic->GetPrintableString()},
         {"partition", Partition},
         {"readOffset", ReadOffset},
@@ -2607,7 +2610,7 @@ void TPartitionActor::InitStartReading(const TActorContext& ctx) {
     Y_ABORT_UNLESS(AllPrepareInited);
     Y_ABORT_UNLESS(!WaitForData);
     YDB_LOG_INFO_CTX(ctx, "Start reading EndOffset readOffset committedOffset clientCommittedOffset clientReadOffset",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", Topic->GetPrintableString()},
         {"partition", Partition},
         {"endOffset", EndOffset},
@@ -2700,7 +2703,7 @@ void TPartitionActor::InitLockPartition(const TActorContext& ctx) {
         cmd->SetStep(Step);
 
         YDB_LOG_INFO_CTX(ctx, "INITING",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", Topic->GetPrintableString()},
             {"partition", Partition});
 
@@ -2742,7 +2745,7 @@ void TPartitionActor::WaitDataInPartition(const TActorContext& ctx) {
     event->Record.SetClientId(InternalClientId);
 
     YDB_LOG_DEBUG_CTX(ctx, "Wait data in partition inited",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", Topic->GetPrintableString()},
         {"partition", Partition},
         {"waitDataCookie", WaitDataCookie});
@@ -2763,7 +2766,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, con
     auto it = WaitDataInfly.find(ev->Get()->Record.GetCookie());
     if (it == WaitDataInfly.end()) {
         YDB_LOG_DEBUG_CTX(ctx, "Unwaited response for WaitData",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", Topic->GetPrintableString()},
             {"partition", Partition},
             {"record", ev->Get()->Record});
@@ -2781,7 +2784,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, con
     Y_ABORT_UNLESS(ReadOffset >= EndOffset); //otherwise no WaitData were needed
 
     YDB_LOG_DEBUG_CTX(ctx, "Wait for data done: readOffset EndOffset newEndOffset commitOffset clientCommitOffset cookie",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", Topic->GetPrintableString()},
         {"partition", Partition},
         {"readOffset", ReadOffset},
@@ -2822,7 +2825,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, con
 
 void TPartitionActor::Handle(TEvPQProxy::TEvRead::TPtr& ev, const TActorContext& ctx) {
     YDB_LOG_DEBUG_CTX(ctx, "READ FROM event readOffset EndOffset ClientCommitOffset committedOffset Guid",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", Topic->GetPrintableString()},
         {"partition", Partition},
         {"request", ev->Get()->Request},
@@ -2888,7 +2891,7 @@ void TPartitionActor::Handle(TEvPQProxy::TEvCommit::TPtr& ev, const TActorContex
     Y_ABORT_UNLESS(offset != Max<ui64>()); // has concreete offset
     if (offset < ClientCommitOffset) {
         YDB_LOG_ERROR_CTX(ctx, "Commit done to too small position committedOffset cookie",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"topic", Topic->GetPrintableString()},
             {"partition", Partition},
             {"offset", offset},
@@ -2902,7 +2905,7 @@ void TPartitionActor::Handle(TEvPQProxy::TEvCommit::TPtr& ev, const TActorContex
     if (!hasProgress) {//nothing to commit for this partition
         if (CommitsInfly.empty()) {
             YDB_LOG_DEBUG_CTX(ctx, "Commit done with no effect with cookie",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                {PQ_LOG_PREFIX},
                 {"topic", Topic->GetPrintableString()},
                 {"partition", Partition},
                 {"readId", readId});

--- a/ydb/services/persqueue_v1/actors/commit_offset_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/commit_offset_actor.cpp
@@ -94,7 +94,7 @@ void TCommitOffsetActor::Bootstrap(const TActorContext& ctx) {
 }
 
 bool TCommitOffsetActor::OnUnhandledException(const std::exception& exc) {
-    NPQ::DoLogUnhandledException(Service, NPQ_LOG_PREFIX, exc);
+    NPQ::DoLogUnhandledException(Service, *this, exc);
 
     Ydb::Topic::CommitOffsetResult result;
     Request().SendResult(result, Ydb::StatusIds::INTERNAL_ERROR);

--- a/ydb/services/persqueue_v1/actors/commit_offset_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/commit_offset_actor.cpp
@@ -4,12 +4,8 @@
 #include "read_init_auth_actor.h"
 
 #include <ydb/core/client/server/msgbus_server_persqueue.h>
-
-#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/public/api/protos/ydb_persqueue_v1.pb.h>
 #include <ydb/public/lib/base/msgbus_status.h>
-
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_READ_PROXY
 
 namespace NKikimr::NGRpcProxy::V1 {
 
@@ -22,6 +18,7 @@ TCommitOffsetActor::TCommitOffsetActor(
         TIntrusivePtr<::NMonitoring::TDynamicCounters> counters
 )
     : TBase(request)
+    , TLogPrefix(NKikimrServices::PQ_READ_PROXY)
     , SchemeCache(schemeCache)
     , NewSchemeCache(newSchemeCache)
     , AuthInitActor()
@@ -33,6 +30,7 @@ TCommitOffsetActor::TCommitOffsetActor(
 
 TCommitOffsetActor::TCommitOffsetActor(NKikimr::NGRpcService::IRequestOpCtx * ctx)
     : TBase(ctx)
+    , TLogPrefix(NKikimrServices::PQ_READ_PROXY)
     , SchemeCache(NMsgBusProxy::CreatePersQueueMetaCacheV2Id())
     , NewSchemeCache(MakeSchemeCacheID())
     , AuthInitActor()
@@ -96,7 +94,7 @@ void TCommitOffsetActor::Bootstrap(const TActorContext& ctx) {
 }
 
 bool TCommitOffsetActor::OnUnhandledException(const std::exception& exc) {
-    NPQ::DoLogUnhandledException(NKikimrServices::PQ_READ_PROXY, "[CommitOffsetActor]", exc);
+    NPQ::DoLogUnhandledException(Service, NPQ_LOG_PREFIX, exc);
 
     Ydb::Topic::CommitOffsetResult result;
     Request().SendResult(result, Ydb::StatusIds::INTERNAL_ERROR);
@@ -116,7 +114,7 @@ void TCommitOffsetActor::Die(const TActorContext& ctx) {
 }
 
 void TCommitOffsetActor::Handle(TEvPQProxy::TEvAuthResultOk::TPtr& ev, const TActorContext& ctx) {
-    YDB_LOG_DEBUG_CTX(ctx, "CommitOffset auth ok, got topics",
+    LOG_D("CommitOffset auth ok, got topics",
         {"topicAndTabletsSize", ev->Get()->TopicAndTablets.size()});
     TopicAndTablets = std::move(ev->Get()->TopicAndTablets);
     if (TopicAndTablets.empty()) {
@@ -191,7 +189,7 @@ void TCommitOffsetActor::Handle(NKqp::TEvKqp::TEvCreateSessionResponse::TPtr& ev
 void TCommitOffsetActor::Handle(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev, const TActorContext& ctx) {
     auto& record = ev->Get()->Record;
     if (record.GetYdbStatus() != Ydb::StatusIds::SUCCESS) {
-        YDB_LOG_DEBUG_CTX(ctx, "Strict CommitOffset failed. Kqp",
+        LOG_D("Strict CommitOffset failed. Kqp",
             {"error", ev->Get()->Record});
 
         Ydb::Topic::CommitOffsetResult result;
@@ -221,7 +219,7 @@ void TCommitOffsetActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActo
     const auto& partitionResult = ev->Get()->Record.GetPartitionResponse();
     AFL_ENSURE(!partitionResult.HasCmdReadResult());
 
-    YDB_LOG_DEBUG_CTX(ctx, "CommitOffset, commit done");
+    LOG_D("CommitOffset, commit done");
 
     Ydb::Topic::CommitOffsetResult result;
     Request().SendResult(result, Ydb::StatusIds::SUCCESS);
@@ -256,7 +254,7 @@ void TCommitOffsetActor::SendCommit(const TTopicInitInfo& topic, const Ydb::Topi
         commit->SetSessionId(commitRequest->read_session_id());
     }
 
-    YDB_LOG_DEBUG_CTX(ctx, "Strict CommitOffset, partition committing to position prev end by cookie",
+    LOG_D("Strict CommitOffset, partition committing to position prev end by cookie",
         {"partitionId", commitRequest->partition_id()},
         {"offset", commitRequest->offset()});
 

--- a/ydb/services/persqueue_v1/actors/commit_offset_actor.h
+++ b/ydb/services/persqueue_v1/actors/commit_offset_actor.h
@@ -4,10 +4,10 @@
 #include "distributed_commit_helper.h"
 
 
-#include <ydb/core/kqp/common/events/events.h>
-#include <ydb/core/grpc_services/rpc_deferrable.h>
 #include <ydb/core/client/server/msgbus_server_pq_metacache.h>
-
+#include <ydb/core/grpc_services/rpc_deferrable.h>
+#include <ydb/core/kqp/common/events/events.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
 
@@ -17,8 +17,8 @@ namespace NKikimr::NGRpcProxy::V1 {
 using namespace NKikimr::NGRpcService;
 
 class TCommitOffsetActor : public TRpcOperationRequestActor<TCommitOffsetActor, TEvCommitOffsetRequest>
-                         , public NActors::IActorExceptionHandler {
-
+                         , public NActors::IActorExceptionHandler
+                         , public NPQ::TLogPrefix {
     using TBase = TRpcOperationRequestActor<TCommitOffsetActor, TEvCommitOffsetRequest>;
 
     using TEvDescribeTopicsResponse = NMsgBusProxy::NPqMetaCacheV2::TEvPqNewMetaCache::TEvDescribeTopicsResponse;
@@ -42,6 +42,10 @@ public:
     bool OnUnhandledException(const std::exception& exc) override;
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() { return NKikimrServices::TActivity::FRONT_PQ_COMMIT; }
+
+    NPQ::TStructuredMessage LogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE({"consumer", ClientId});
+    }
 
     bool HasCancelOperation() {
         return false;

--- a/ydb/services/persqueue_v1/actors/direct_read_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/direct_read_actor.cpp
@@ -20,7 +20,10 @@
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_READ_PROXY
 
-#define LOG_PREFIX (TStringBuilder() << "Direct read proxy " << ctx.SelfID.ToString() << ": " << PQ_LOG_PREFIX)
+#define LOG_PREFIX YDB_LOG_CREATE_MESSAGE( \
+    {"actorClassName", "DirectReadProxy"}, \
+    {"selfId", ctx.SelfID}, \
+    PQ_LOG_PREFIX)
 
 namespace NKikimr::NGRpcProxy::V1 {
 
@@ -67,14 +70,14 @@ void TDirectReadSessionActor::Bootstrap(const TActorContext& ctx) {
 
 void TDirectReadSessionActor::Handle(typename IContext::TEvNotifiedWhenDone::TPtr&, const TActorContext& ctx) {
     YDB_LOG_INFO_CTX(ctx, "Grpc closed",
-        {"LOGPREFIX", LOG_PREFIX});
+        {LOG_PREFIX});
     Die(ctx);
 }
 
 bool TDirectReadSessionActor::ReadFromStreamOrDie(const TActorContext& ctx) {
     if (!Request->Read()) {
         YDB_LOG_INFO_CTX(ctx, "Grpc read failed at start",
-            {"LOGPREFIX", LOG_PREFIX});
+            {LOG_PREFIX});
         Die(ctx);
         return false;
     }
@@ -85,13 +88,13 @@ void TDirectReadSessionActor::Handle(typename IContext::TEvReadFinished::TPtr& e
     auto& request = ev->Get()->Record;
 
     YDB_LOG_DEBUG_CTX(ctx, "Grpc read done",
-        {"LOGPREFIX", LOG_PREFIX},
+        {LOG_PREFIX},
         {"success", ev->Get()->Success},
         {"data", request});
 
     if (!ev->Get()->Success) {
         YDB_LOG_INFO_CTX(ctx, "Grpc read failed",
-            {"LOGPREFIX", LOG_PREFIX});
+            {LOG_PREFIX});
         ctx.Send(ctx.SelfID, new TEvPQProxy::TEvDone());
         return;
     }
@@ -135,7 +138,7 @@ bool TDirectReadSessionActor::WriteToStreamOrDie(const TActorContext& ctx, TServ
 
     if (!res) {
         YDB_LOG_INFO_CTX(ctx, "Grpc write failed at start",
-            {"LOGPREFIX", LOG_PREFIX});
+            {LOG_PREFIX});
         Die(ctx);
     }
 
@@ -146,7 +149,7 @@ bool TDirectReadSessionActor::WriteToStreamOrDie(const TActorContext& ctx, TServ
 void TDirectReadSessionActor::Handle(typename IContext::TEvWriteFinished::TPtr& ev, const TActorContext& ctx) {
     if (!ev->Get()->Success) {
         YDB_LOG_INFO_CTX(ctx, "Grpc write failed",
-            {"LOGPREFIX", LOG_PREFIX});
+            {LOG_PREFIX});
         return Die(ctx);
     }
 }
@@ -174,7 +177,7 @@ void TDirectReadSessionActor::Die(const TActorContext& ctx) {
     }
 
     YDB_LOG_INFO_CTX(ctx, "Proxy is DEAD",
-        {"LOGPREFIX", LOG_PREFIX});
+        {LOG_PREFIX});
     ctx.Send(GetPQReadServiceActorID(), new TEvPQProxy::TEvSessionDead(Cookie));
     ctx.Send(NPQ::MakePQDReadCacheServiceActorId(), new TEvPQProxy::TEvDirectReadDataSessionDead(Session));
     TRlHelpers::PassAway(SelfId());
@@ -202,7 +205,7 @@ void TDirectReadSessionActor::Handle(TEvPQProxy::TEvAuth::TPtr& ev, const TActor
 
 void TDirectReadSessionActor::Handle(TEvPQProxy::TEvStartDirectRead::TPtr& ev, const TActorContext& ctx) {
     YDB_LOG_INFO_CTX(ctx, "Got StartDirectRead from client",
-        {"LOGPREFIX", LOG_PREFIX},
+        {LOG_PREFIX},
         {"sessionId", Session},
         {"assignId", ev->Get()->AssignId},
         {"lastDirectReadId", ev->Get()->LastDirectReadId},
@@ -230,7 +233,7 @@ void TDirectReadSessionActor::Handle(TEvPQProxy::TEvDirectReadDataSessionConnect
 
 void TDirectReadSessionActor::Handle(TEvPQProxy::TEvInitDirectRead::TPtr& ev, const TActorContext& ctx) {
     YDB_LOG_DEBUG_CTX(ctx, "Got init",
-        {"LOGPREFIX", LOG_PREFIX},
+        {LOG_PREFIX},
         {"request", ev->Get()->Request.DebugString()});
 
     if (Initing) {
@@ -293,7 +296,7 @@ void TDirectReadSessionActor::Handle(TEvPQProxy::TEvInitDirectRead::TPtr& ev, co
     }
 
     YDB_LOG_INFO_CTX(ctx, "Read init",
-        {"LOGPREFIX", LOG_PREFIX},
+        {LOG_PREFIX},
         {"from", PeerName},
         {"request", ev->Get()->Request});
 
@@ -326,7 +329,7 @@ void TDirectReadSessionActor::SetupCounters() {
 
 void TDirectReadSessionActor::Handle(TEvPQProxy::TEvAuthResultOk::TPtr& ev, const TActorContext& ctx) {
     YDB_LOG_INFO_CTX(ctx, "Auth ok",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topics", ev->Get()->TopicAndTablets.size()},
         {"initDone", InitDone});
 
@@ -379,7 +382,7 @@ void TDirectReadSessionActor::InitSession(const TActorContext& ctx) {
 void TDirectReadSessionActor::CloseSession(PersQueue::ErrorCode::ErrorCode code, const TString& reason) {
     auto ctx = ActorContext();
     YDB_LOG_DEBUG_CTX(ctx, "Close session with",
-        {"LOGPREFIX", LOG_PREFIX},
+        {LOG_PREFIX},
         {"reason", reason});
     if (code != PersQueue::ErrorCode::OK) {
         if (Errors) {
@@ -393,18 +396,18 @@ void TDirectReadSessionActor::CloseSession(PersQueue::ErrorCode::ErrorCode code,
         FillIssue(result.add_issues(), code, reason);
 
         YDB_LOG_INFO_CTX(ctx, "Closed with error",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"reason", reason});
         if (!WriteToStreamOrDie(ctx, std::move(result), true)) {
             return;
         }
     } else {
         YDB_LOG_INFO_CTX(ctx, "Closed",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX});
+            {PQ_LOG_PREFIX});
         const Ydb::StatusIds::StatusCode statusCode = ConvertPersQueueInternalCodeToStatus(code);
         if (!Request->Finish(statusCode)) {
             YDB_LOG_INFO_CTX(ctx, "Grpc double finish failed",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX});
+                {PQ_LOG_PREFIX});
         }
     }
     Die(ctx);
@@ -495,7 +498,7 @@ void TDirectReadSessionActor::RecheckACL(const TActorContext& ctx) {
         ForceACLCheck = false;
 
         YDB_LOG_DEBUG_CTX(ctx, "Checking auth because of timeout",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX});
+            {PQ_LOG_PREFIX});
         RunAuthActor(ctx);
     }
 }
@@ -511,7 +514,7 @@ void TDirectReadSessionActor::RunAuthActor(const TActorContext& ctx) {
 void TDirectReadSessionActor::HandleDestroyPartitionSession(TEvPQProxy::TEvDirectReadDestroyPartitionSession::TPtr& ev) {
     const auto& ctx = ActorContext();
     YDB_LOG_DEBUG_CTX(ctx, "Got EvDirectReadDestroyPartitionSession",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"assignId", ev->Get()->ReadKey.PartitionSessionId});
 
     TServerMessage result;
@@ -531,7 +534,7 @@ void TDirectReadSessionActor::HandleSessionKilled(TEvPQProxy::TEvDirectReadClose
 void TDirectReadSessionActor::HandleGotData(TEvPQProxy::TEvDirectReadSendClientData::TPtr& ev) {
     const auto& ctx = ActorContext();
     YDB_LOG_DEBUG_CTX(ctx, "Got direct read data, message",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"size", ev->Get()->Message->ByteSizeLong()});
     auto formedResponse = MakeIntrusive<TFormedDirectReadResponse>();
     formedResponse->Response = std::move(ev->Get()->Message);

--- a/ydb/services/persqueue_v1/actors/direct_read_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/direct_read_actor.cpp
@@ -142,7 +142,7 @@ void TDirectReadSessionActor::Handle(typename IContext::TEvWriteFinished::TPtr& 
 }
 
 bool TDirectReadSessionActor::OnUnhandledException(const std::exception& exc) {
-    NPQ::DoLogUnhandledException(Service, NPQ_LOG_PREFIX, exc);
+    NPQ::DoLogUnhandledException(Service, *this, exc);
 
     this->Die(ActorContext());
 

--- a/ydb/services/persqueue_v1/actors/direct_read_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/direct_read_actor.cpp
@@ -4,10 +4,9 @@
 #include "read_init_auth_actor.h"
 #include "read_session_actor.h"
 
-#include <ydb/core/persqueue/common/actor.h>
+#include <ydb/core/persqueue/dread_cache_service/caching_service.h>
 #include <ydb/core/persqueue/public/constants.h>
 #include <ydb/library/persqueue/topic_parser/counters.h>
-#include <ydb/core/persqueue/dread_cache_service/caching_service.h>
 
 #include <library/cpp/protobuf/util/repeated_field_utils.h>
 
@@ -17,13 +16,6 @@
 #include <util/string/strip.h>
 
 #include <utility>
-
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_READ_PROXY
-
-#define LOG_PREFIX YDB_LOG_CREATE_MESSAGE( \
-    {"actorClassName", "DirectReadProxy"}, \
-    {"selfId", ctx.SelfID}, \
-    PQ_LOG_PREFIX)
 
 namespace NKikimr::NGRpcProxy::V1 {
 
@@ -37,7 +29,8 @@ TDirectReadSessionActor::TDirectReadSessionActor(
         TIntrusivePtr<NMonitoring::TDynamicCounters> counters,
         const TMaybe<TString> clientDC,
         const NPersQueue::TTopicsListController& topicsHandler)
-    : TRlHelpers({}, request, READ_BLOCK_SIZE, false, TDuration::Minutes(1))
+    : TBase(NKikimrServices::PQ_READ_PROXY)
+    , TRlHelpers({}, request, READ_BLOCK_SIZE, false, TDuration::Minutes(1))
     , Request(request)
     , Cookie(cookie)
     , ClientDC(clientDC.GetOrElse("other"))
@@ -69,15 +62,13 @@ void TDirectReadSessionActor::Bootstrap(const TActorContext& ctx) {
 }
 
 void TDirectReadSessionActor::Handle(typename IContext::TEvNotifiedWhenDone::TPtr&, const TActorContext& ctx) {
-    YDB_LOG_INFO_CTX(ctx, "Grpc closed",
-        {LOG_PREFIX});
+    LOG_I("Grpc closed");
     Die(ctx);
 }
 
 bool TDirectReadSessionActor::ReadFromStreamOrDie(const TActorContext& ctx) {
     if (!Request->Read()) {
-        YDB_LOG_INFO_CTX(ctx, "Grpc read failed at start",
-            {LOG_PREFIX});
+        LOG_I("Grpc read failed at start");
         Die(ctx);
         return false;
     }
@@ -87,14 +78,12 @@ bool TDirectReadSessionActor::ReadFromStreamOrDie(const TActorContext& ctx) {
 void TDirectReadSessionActor::Handle(typename IContext::TEvReadFinished::TPtr& ev, const TActorContext& ctx) {
     auto& request = ev->Get()->Record;
 
-    YDB_LOG_DEBUG_CTX(ctx, "Grpc read done",
-        {LOG_PREFIX},
+    LOG_D("Grpc read done",
         {"success", ev->Get()->Success},
         {"data", request});
 
     if (!ev->Get()->Success) {
-        YDB_LOG_INFO_CTX(ctx, "Grpc read failed",
-            {LOG_PREFIX});
+        LOG_I("Grpc read failed");
         ctx.Send(ctx.SelfID, new TEvPQProxy::TEvDone());
         return;
     }
@@ -137,8 +126,7 @@ bool TDirectReadSessionActor::WriteToStreamOrDie(const TActorContext& ctx, TServ
     }
 
     if (!res) {
-        YDB_LOG_INFO_CTX(ctx, "Grpc write failed at start",
-            {LOG_PREFIX});
+        LOG_I("Grpc write failed at start");
         Die(ctx);
     }
 
@@ -148,14 +136,13 @@ bool TDirectReadSessionActor::WriteToStreamOrDie(const TActorContext& ctx, TServ
 
 void TDirectReadSessionActor::Handle(typename IContext::TEvWriteFinished::TPtr& ev, const TActorContext& ctx) {
     if (!ev->Get()->Success) {
-        YDB_LOG_INFO_CTX(ctx, "Grpc write failed",
-            {LOG_PREFIX});
+        LOG_I("Grpc write failed");
         return Die(ctx);
     }
 }
 
 bool TDirectReadSessionActor::OnUnhandledException(const std::exception& exc) {
-    NPQ::DoLogUnhandledException(NKikimrServices::PQ_READ_PROXY, "", exc);
+    NPQ::DoLogUnhandledException(Service, NPQ_LOG_PREFIX, exc);
 
     this->Die(ActorContext());
 
@@ -176,12 +163,11 @@ void TDirectReadSessionActor::Die(const TActorContext& ctx) {
         Request->AuditLogRequestEnd(Ydb::StatusIds::SUCCESS);
     }
 
-    YDB_LOG_INFO_CTX(ctx, "Proxy is DEAD",
-        {LOG_PREFIX});
+    LOG_I("Proxy is DEAD");
     ctx.Send(GetPQReadServiceActorID(), new TEvPQProxy::TEvSessionDead(Cookie));
     ctx.Send(NPQ::MakePQDReadCacheServiceActorId(), new TEvPQProxy::TEvDirectReadDataSessionDead(Session));
     TRlHelpers::PassAway(SelfId());
-    TActorBootstrapped<TDirectReadSessionActor>::Die(ctx);
+    TBase::Die(ctx);
 }
 
 
@@ -204,8 +190,7 @@ void TDirectReadSessionActor::Handle(TEvPQProxy::TEvAuth::TPtr& ev, const TActor
 
 
 void TDirectReadSessionActor::Handle(TEvPQProxy::TEvStartDirectRead::TPtr& ev, const TActorContext& ctx) {
-    YDB_LOG_INFO_CTX(ctx, "Got StartDirectRead from client",
-        {LOG_PREFIX},
+    LOG_I("Got StartDirectRead from client",
         {"sessionId", Session},
         {"assignId", ev->Get()->AssignId},
         {"lastDirectReadId", ev->Get()->LastDirectReadId},
@@ -232,8 +217,7 @@ void TDirectReadSessionActor::Handle(TEvPQProxy::TEvDirectReadDataSessionConnect
 }
 
 void TDirectReadSessionActor::Handle(TEvPQProxy::TEvInitDirectRead::TPtr& ev, const TActorContext& ctx) {
-    YDB_LOG_DEBUG_CTX(ctx, "Got init",
-        {LOG_PREFIX},
+    LOG_D("Got init",
         {"request", ev->Get()->Request.DebugString()});
 
     if (Initing) {
@@ -295,8 +279,7 @@ void TDirectReadSessionActor::Handle(TEvPQProxy::TEvInitDirectRead::TPtr& ev, co
         return CloseSession(PersQueue::ErrorCode::BAD_REQUEST, TopicsList.Reason);
     }
 
-    YDB_LOG_INFO_CTX(ctx, "Read init",
-        {LOG_PREFIX},
+    LOG_I("Read init",
         {"from", PeerName},
         {"request", ev->Get()->Request});
 
@@ -328,8 +311,7 @@ void TDirectReadSessionActor::SetupCounters() {
 
 
 void TDirectReadSessionActor::Handle(TEvPQProxy::TEvAuthResultOk::TPtr& ev, const TActorContext& ctx) {
-    YDB_LOG_INFO_CTX(ctx, "Auth ok",
-        {PQ_LOG_PREFIX},
+    LOG_I("Auth ok",
         {"topics", ev->Get()->TopicAndTablets.size()},
         {"initDone", InitDone});
 
@@ -381,8 +363,7 @@ void TDirectReadSessionActor::InitSession(const TActorContext& ctx) {
 
 void TDirectReadSessionActor::CloseSession(PersQueue::ErrorCode::ErrorCode code, const TString& reason) {
     auto ctx = ActorContext();
-    YDB_LOG_DEBUG_CTX(ctx, "Close session with",
-        {LOG_PREFIX},
+    LOG_D("Close session with",
         {"reason", reason});
     if (code != PersQueue::ErrorCode::OK) {
         if (Errors) {
@@ -395,19 +376,16 @@ void TDirectReadSessionActor::CloseSession(PersQueue::ErrorCode::ErrorCode code,
         result.set_status(ConvertPersQueueInternalCodeToStatus(code));
         FillIssue(result.add_issues(), code, reason);
 
-        YDB_LOG_INFO_CTX(ctx, "Closed with error",
-            {PQ_LOG_PREFIX},
+        LOG_I("Closed with error",
             {"reason", reason});
         if (!WriteToStreamOrDie(ctx, std::move(result), true)) {
             return;
         }
     } else {
-        YDB_LOG_INFO_CTX(ctx, "Closed",
-            {PQ_LOG_PREFIX});
+        LOG_I("Closed");
         const Ydb::StatusIds::StatusCode statusCode = ConvertPersQueueInternalCodeToStatus(code);
         if (!Request->Finish(statusCode)) {
-            YDB_LOG_INFO_CTX(ctx, "Grpc double finish failed",
-                {PQ_LOG_PREFIX});
+            LOG_I("Grpc double finish failed");
         }
     }
     Die(ctx);
@@ -497,8 +475,7 @@ void TDirectReadSessionActor::RecheckACL(const TActorContext& ctx) {
     if (Token && !AuthInitActor && (ForceACLCheck || authTimedOut)) {
         ForceACLCheck = false;
 
-        YDB_LOG_DEBUG_CTX(ctx, "Checking auth because of timeout",
-            {PQ_LOG_PREFIX});
+        LOG_D("Checking auth because of timeout");
         RunAuthActor(ctx);
     }
 }
@@ -512,9 +489,7 @@ void TDirectReadSessionActor::RunAuthActor(const TActorContext& ctx) {
 }
 
 void TDirectReadSessionActor::HandleDestroyPartitionSession(TEvPQProxy::TEvDirectReadDestroyPartitionSession::TPtr& ev) {
-    const auto& ctx = ActorContext();
-    YDB_LOG_DEBUG_CTX(ctx, "Got EvDirectReadDestroyPartitionSession",
-        {PQ_LOG_PREFIX},
+    LOG_D("Got EvDirectReadDestroyPartitionSession",
         {"assignId", ev->Get()->ReadKey.PartitionSessionId});
 
     TServerMessage result;
@@ -532,9 +507,7 @@ void TDirectReadSessionActor::HandleSessionKilled(TEvPQProxy::TEvDirectReadClose
 }
 
 void TDirectReadSessionActor::HandleGotData(TEvPQProxy::TEvDirectReadSendClientData::TPtr& ev) {
-    const auto& ctx = ActorContext();
-    YDB_LOG_DEBUG_CTX(ctx, "Got direct read data, message",
-        {PQ_LOG_PREFIX},
+    LOG_D("Got direct read data, message",
         {"size", ev->Get()->Message->ByteSizeLong()});
     auto formedResponse = MakeIntrusive<TFormedDirectReadResponse>();
     formedResponse->Response = std::move(ev->Get()->Message);

--- a/ydb/services/persqueue_v1/actors/direct_read_actor.h
+++ b/ydb/services/persqueue_v1/actors/direct_read_actor.h
@@ -5,11 +5,9 @@
 
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/grpc_services/grpc_request_proxy.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/persqueue/events/global.h>
-
 #include <ydb/core/persqueue/public/pq_rl_helpers.h>
-
-#include <ydb/library/actors/core/actor_bootstrapped.h>
 
 namespace NKikimr::NGRpcProxy::V1 {
 
@@ -34,10 +32,10 @@ struct TFormedDirectReadResponse: public TSimpleRefCount<TFormedDirectReadRespon
 
 
 class TDirectReadSessionActor
-    : public TActorBootstrapped<TDirectReadSessionActor>
+    : public NPQ::TBaseActor<TDirectReadSessionActor>
     , private NPQ::TRlHelpers
-    , public NActors::IActorExceptionHandler
 {
+    using TBase = NPQ::TBaseActor<TDirectReadSessionActor>;
     using TClientMessage = Topic::StreamDirectReadMessage::FromClient;
 
     using TServerMessage = Topic::StreamDirectReadMessage::FromServer;
@@ -60,6 +58,13 @@ public:
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
         return NKikimrServices::TActivity::FRONT_PQ_READ;
+    }
+
+    NPQ::TStructuredMessage LogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"sessionCookie", Cookie},
+            {"consumer", ClientPath},
+            {"session", Session});
     }
 
 private:

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -4,7 +4,7 @@
 #include "fill_batched_data.h"
 
 #include <limits>
-#include <ydb/core/persqueue/common/actor.h>
+
 #include <ydb/core/persqueue/public/codecs/pqv1.h>
 #include <ydb/core/persqueue/public/write_meta/write_meta.h>
 #include <ydb/core/persqueue/writer/source_id_encoding.h>
@@ -18,8 +18,6 @@
 
 #include <library/cpp/string_utils/base64/base64.h>
 #include <util/charset/utf8.h>
-
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_READ_PROXY
 
 #define PARTITION_ENSURE(condition) \
     AFL_ENSURE(condition)("session", Session)("partition", Partition)("tablet_id", TabletID)
@@ -38,7 +36,8 @@ TPartitionActor::TPartitionActor(
         bool directRead, EProtocol protocol, ui32 maxTimeLagMs, ui64 readTimestampMs, const TTopicHolder::TPtr& topicHolder,
         const std::unordered_set<ui64>& notCommitedToFinishParents, ui64 partitionMaxInFlightBytes, bool canReadBatches
 )
-    : ParentId(parentId)
+    : TBase(NKikimrServices::PQ_READ_PROXY)
+    , ParentId(parentId)
     , ClientId(clientId)
     , ClientPath(clientPath)
     , Cookie(cookie)
@@ -143,8 +142,7 @@ void TPartitionActor::MakeCommit(const TActorContext& ctx) {
         return;
     }
     NextCommits.erase(NextCommits.begin(), it);
-    YDB_LOG_DEBUG_CTX(ctx, "Commit request",
-        {PQ_LOG_PREFIX},
+    LOG_D("Commit request",
         {"readIdCommittedPlus1", ReadIdCommitted + 1},
         {"readId", readId},
         {"partition", Partition});
@@ -227,8 +225,7 @@ void TPartitionActor::SendCommit(const ui64 readId, const ui64 offset, const TAc
             ("read_id", readId);
         commit->SetSessionId(Session);
 
-        YDB_LOG_DEBUG_CTX(ctx, "Committing to position prev end by cookie",
-            {PQ_LOG_PREFIX},
+        LOG_D("Committing to position prev end by cookie",
             {"partition", Partition},
             {"offset", offset},
             {"committedOffset", CommittedOffset},
@@ -299,8 +296,7 @@ void TPartitionActor::SendPublishDirectRead(const ui64 directReadId, const TActo
     publish->MutableSessionKey()->SetSessionId(Session);
     publish->MutableSessionKey()->SetPartitionSessionId(Partition.AssignId);
 
-    YDB_LOG_DEBUG_CTX(ctx, "Publishing direct read with id",
-        {PQ_LOG_PREFIX},
+    LOG_D("Publishing direct read with id",
         {"partition", Partition},
         {"directReadId", directReadId});
 
@@ -328,8 +324,7 @@ void TPartitionActor::SendForgetDirectRead(const ui64 directReadId, const TActor
     publish->MutableSessionKey()->SetSessionId(Session);
     publish->MutableSessionKey()->SetPartitionSessionId(Partition.AssignId);
 
-    YDB_LOG_DEBUG_CTX(ctx, "Forgetting",
-        {PQ_LOG_PREFIX},
+    LOG_D("Forgetting",
         {"partition", Partition},
         {"directReadId", directReadId});
 
@@ -347,8 +342,7 @@ void TPartitionActor::RestartPipe(const TActorContext& ctx, const TString& reaso
 
     NTabletPipe::CloseClient(ctx, PipeClient);
 
-    YDB_LOG_INFO_CTX(ctx, "Schedule pipe restart attempt current",
-        {PQ_LOG_PREFIX},
+    LOG_I("Schedule pipe restart attempt current",
         {"partition", Partition},
         {"pipeGeneration", PipeGeneration},
         {"reason", reason},
@@ -380,15 +374,13 @@ void TPartitionActor::Handle(TEvPQProxy::TEvDirectReadAck::TPtr& ev, const TActo
     if (DirectReadRestoreStage != EDirectReadRestoreStage::None) {
         if (RestoredDirectReadId == ev->Get()->DirectReadId) {
             // This direct read is already being restored. Have to forget it later.
-            YDB_LOG_DEBUG_CTX(ctx, "Got ack for direct read while restoring, store it to forget further",
-                {PQ_LOG_PREFIX},
+            LOG_D("Got ack for direct read while restoring, store it to forget further",
                 {"directReadId", ev->Get()->DirectReadId});
             DirectReadsToForget.insert(ev->Get()->DirectReadId);
             return;
         }
         if (DirectReadsToRestore.contains(ev->Get()->DirectReadId)) {
-            YDB_LOG_DEBUG_CTX(ctx, "Got ack for direct read while restoring, remove it from restore list",
-                {PQ_LOG_PREFIX},
+            LOG_D("Got ack for direct read while restoring, remove it from restore list",
                 {"directReadId", ev->Get()->DirectReadId});
             // This direct read is pending for restore. No need to foreget - not yet prepared, just erase it;
             DirectReadsToRestore.erase(ev->Get()->DirectReadId);
@@ -421,8 +413,7 @@ void TPartitionActor::Handle(const TEvPQProxy::TEvRestartPipe::TPtr&, const TAct
     PipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, TabletID, clientConfig));
     PARTITION_ENSURE(TabletID);
 
-    YDB_LOG_INFO_CTX(ctx, "Pipe restart attempt RequestInfly ReadOffset EndOffset InitDone WaitForData",
-        {PQ_LOG_PREFIX},
+    LOG_I("Pipe restart attempt RequestInfly ReadOffset EndOffset InitDone WaitForData",
         {"partition", Partition},
         {"pipeGeneration", PipeGeneration},
         {"requestInfly", RequestInfly},
@@ -455,8 +446,7 @@ void TPartitionActor::ResendRecentRequests() {
 
     const auto& ctx = ActorContext();
     if (RequestInfly) { //got read infly
-        YDB_LOG_INFO_CTX(ctx, "Resend",
-            {PQ_LOG_PREFIX},
+        LOG_I("Resend",
             {"partition", Partition},
             {"currentRequest", CurrentRequest});
 
@@ -597,7 +587,7 @@ bool FillBatchedData(
         TString sourceId;
         if (!r.GetSourceId().empty()) {
             if (!NPQ::NSourceIdEncoding::IsValidEncoded(r.GetSourceId())) {
-                YDB_LOG_ERROR("Read bad sourceId from offset seqNo sourceId",
+                YDB_LOG_ERROR_COMP(NKikimrServices::PQ_READ_PROXY, "Read bad sourceId from offset seqNo sourceId",
                     {"partition", Partition},
                     {"offset", r.GetOffset()},
                     {"seqNo", r.GetSeqNo()},
@@ -709,8 +699,7 @@ void TPartitionActor::HandleInit(const NKikimrClient::TPersQueuePartitionRespons
     PARTITION_ENSURE(DirectReadRestoreStage == EDirectReadRestoreStage::None)
         ("direct_read_restore_stage", static_cast<int>(DirectReadRestoreStage));
     if (result.GetCookie() != InitCookie) {
-        YDB_LOG_DEBUG_CTX(ctx, "Unwaited response in init with cookie",
-            {PQ_LOG_PREFIX},
+        LOG_D("Unwaited response in init with cookie",
             {"partition", Partition},
             {"cookie", result.GetCookie()});
         return;
@@ -740,8 +729,7 @@ void TPartitionActor::HandleInit(const NKikimrClient::TPersQueuePartitionRespons
 
     InitDone = true;
     PipeGeneration = 0; //reset tries counter - all ok
-    YDB_LOG_INFO_CTX(ctx, "INIT DONE EndOffset readOffset committedOffset",
-        {PQ_LOG_PREFIX},
+    LOG_I("INIT DONE EndOffset readOffset committedOffset",
         {"partition", Partition},
         {"endOffset", EndOffset},
         {"readOffset", ReadOffset},
@@ -764,14 +752,12 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             return;
         case EDirectReadRestoreStage::Session:
             if (result.GetCookie() != InitCookie || !result.HasCmdRestoreDirectReadResult()) {
-                YDB_LOG_DEBUG_CTX(ctx, "Direct read - session restarted for partition with unwaited cookie",
-                    {PQ_LOG_PREFIX},
+                LOG_D("Direct read - session restarted for partition with unwaited cookie",
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
             }
-            YDB_LOG_DEBUG_CTX(ctx, "Direct read - session restarted for partition",
-                {PQ_LOG_PREFIX},
+            LOG_D("Direct read - session restarted for partition",
                 {"partition", Partition});
             if (!SendNextRestorePrepareOrForget()) {
                 OnDirectReadsRestored();
@@ -782,8 +768,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
                 ("restored_direct_read_id", RestoredDirectReadId);
             // Late/duplicate non-Prepare is possible after nested pipe restart — soft-ignore.
             if (!result.HasCmdPrepareReadResult()) {
-                YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PrepareReadResult, got",
-                    {PQ_LOG_PREFIX},
+                LOG_D("Invalid response on direct read restore for expect PrepareReadResult, got",
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
@@ -791,8 +776,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // Empty queue while expecting Prepare is a bookkeeping anomaly (not a stale reply).
             // Soft-ignore would hang restore forever; close the session so the client recovers.
             if (DirectReadsToRestore.empty()) {
-                YDB_LOG_WARN_CTX(ctx, "Direct read restore Prepare with empty DirectReadsToRestore",
-                    {PQ_LOG_PREFIX},
+                LOG_W("Direct read restore Prepare with empty DirectReadsToRestore",
                     {"partition", Partition},
                     {"response_cookie", result.GetCookie()},
                     {"result", result.ShortDebugString()});
@@ -804,8 +788,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
                 return;
             }
             if (DirectReadsToRestore.begin()->first != result.GetCmdPrepareReadResult().GetDirectReadId()) {
-                YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PrepareReadResult, got",
-                    {PQ_LOG_PREFIX},
+                LOG_D("Invalid response on direct read restore for expect PrepareReadResult, got",
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
@@ -831,8 +814,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // restore may re-send Prepare for the same id while a previous Prepare is still delivered
             // after we have already moved to Publish. Soft-ignore like Prepare stage.
             if (!result.HasCmdPublishReadResult()) {
-                YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PublishReadResult, got",
-                    {PQ_LOG_PREFIX},
+                LOG_D("Invalid response on direct read restore for expect PublishReadResult, got",
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
@@ -840,8 +822,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // Empty queue while expecting Publish is a bookkeeping anomaly (not a stale reply).
             // Soft-ignore would hang restore forever; close the session so the client recovers.
             if (DirectReadsToPublish.empty()) {
-                YDB_LOG_WARN_CTX(ctx, "Direct read restore Publish with empty DirectReadsToPublish",
-                    {PQ_LOG_PREFIX},
+                LOG_W("Direct read restore Publish with empty DirectReadsToPublish",
                     {"partition", Partition},
                     {"response_cookie", result.GetCookie()},
                     {"result", result.ShortDebugString()});
@@ -853,8 +834,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
                 return;
             }
             if (*DirectReadsToPublish.begin() != result.GetCmdPublishReadResult().GetDirectReadId()) {
-                YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PublishReadResult, got",
-                    {PQ_LOG_PREFIX},
+                LOG_D("Invalid response on direct read restore for expect PublishReadResult, got",
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
@@ -870,8 +850,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // Late Prepare/Publish (or other non-Forget / wrong id) is possible after nested pipe
             // restart — soft-ignore like Prepare/Publish stages.
             if (!result.HasCmdForgetReadResult()) {
-                YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect ForgetReadResult, got",
-                    {PQ_LOG_PREFIX},
+                LOG_D("Invalid response on direct read restore for expect ForgetReadResult, got",
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
@@ -879,8 +858,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // Empty queue while expecting Forget is a bookkeeping anomaly (not a stale reply).
             // Soft-ignore would hang restore forever; close the session so the client recovers.
             if (DirectReadsToForget.empty()) {
-                YDB_LOG_WARN_CTX(ctx, "Direct read restore Forget with empty DirectReadsToForget",
-                    {PQ_LOG_PREFIX},
+                LOG_W("Direct read restore Forget with empty DirectReadsToForget",
                     {"partition", Partition},
                     {"response_cookie", result.GetCookie()},
                     {"result", result.ShortDebugString()});
@@ -892,8 +870,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
                 return;
             }
             if (*DirectReadsToForget.begin() != result.GetCmdForgetReadResult().GetDirectReadId()) {
-                YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect ForgetReadResult, got",
-                    {PQ_LOG_PREFIX},
+                LOG_D("Invalid response on direct read restore for expect ForgetReadResult, got",
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
@@ -921,8 +898,7 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
     // id is normally dropped earlier by cookie!=ReadOffset, but if it still reaches here
     // we must soft-ignore instead of PARTITION_ENSURE(DirectReadId).
     if (!RequestInfly) {
-        YDB_LOG_DEBUG_CTX(ctx, "Unwaited prepare-response for direct read id",
-            {PQ_LOG_PREFIX},
+        LOG_D("Unwaited prepare-response for direct read id",
             {"partition", Partition},
             {"directReadId", res.GetDirectReadId()},
             {"readOffset", ReadOffset},
@@ -943,8 +919,7 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
 
     DirectReadResults[DirectReadId] = res;
 
-    YDB_LOG_DEBUG_CTX(ctx, "After direct read state EndOffset ReadOffset ReadGuid with direct read id",
-        {PQ_LOG_PREFIX},
+    LOG_D("After direct read state EndOffset ReadOffset ReadGuid with direct read id",
         {"partition", Partition},
         {"endOffset", EndOffset},
         {"readOffset", ReadOffset},
@@ -990,8 +965,7 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
     bool isInFlightMemoryOk = PartitionInFlightMemoryController.Add(dr.GetReadOffset(), dr.GetBytesSizeEstimate());
     ReadOffset = dr.GetLastOffset() + 1;
 
-    YDB_LOG_DEBUG_CTX(ctx, "After publish direct read EndOffset ReadOffset ReadGuid with direct read id isInFlightMemoryOk",
-        {PQ_LOG_PREFIX},
+    LOG_D("After publish direct read EndOffset ReadOffset ReadGuid with direct read id isInFlightMemoryOk",
         {"partition", Partition},
         {"endOffset", EndOffset},
         {"readOffset", ReadOffset},
@@ -1055,8 +1029,7 @@ void TPartitionActor::Handle(const NKikimrClient::TCmdReadResult& res, const TAc
     }
 
     auto isMemoryLimitReached = PartitionInFlightMemoryController.IsMemoryLimitReached();
-    YDB_LOG_DEBUG_CTX(ctx, "IsMemoryLimitReached EndOffset ReadOffset MaxOffset read result size",
-        {PQ_LOG_PREFIX},
+    LOG_D("IsMemoryLimitReached EndOffset ReadOffset MaxOffset read result size",
         {"partition", Partition},
         {"isMemoryLimitReached", isMemoryLimitReached},
         {"endOffset", EndOffset},
@@ -1075,8 +1048,7 @@ void TPartitionActor::Handle(const NKikimrClient::TCmdReadResult& res, const TAc
         ++ReadIdToResponse;
     }
 
-    YDB_LOG_DEBUG_CTX(ctx, "After read state EndOffset ReadOffset ReadGuid has messages",
-        {PQ_LOG_PREFIX},
+    LOG_D("After read state EndOffset ReadOffset ReadGuid has messages",
         {"partition", Partition},
         {"endOffset", EndOffset},
         {"readOffset", ReadOffset},
@@ -1158,8 +1130,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
             return resp;
         };
 
-    YDB_LOG_DEBUG_CTX(ctx, "InitDone event",
-        {PQ_LOG_PREFIX},
+    LOG_D("InitDone event",
         {"partition", Partition},
         {"initDone", InitDone},
         {"result", MaskResult(result)});
@@ -1194,8 +1165,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
     }
 
     if (result.GetCookie() != (ui64)ReadOffset) {
-        YDB_LOG_DEBUG_CTX(ctx, "Unwaited read-response with cookie waiting for current read guid is",
-            {PQ_LOG_PREFIX},
+        LOG_D("Unwaited read-response with cookie waiting for current read guid is",
             {"partition", Partition},
             {"cookie", result.GetCookie()},
             {"readOffset", ReadOffset},
@@ -1222,8 +1192,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
 
 void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
     if (CommitsInfly.empty()) {
-        YDB_LOG_DEBUG_CTX(ctx, "Unwaited commit-response with cookie waiting for nothing",
-            {PQ_LOG_PREFIX},
+        LOG_D("Unwaited commit-response with cookie waiting for nothing",
             {"partition", Partition},
             {"cookie", cookie});
         return;
@@ -1231,8 +1200,7 @@ void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
     ui64 readId = CommitsInfly.front().first;
 
     if (cookie != readId) {
-        YDB_LOG_DEBUG_CTX(ctx, "Unwaited commit-response with cookie waiting",
-            {PQ_LOG_PREFIX},
+        LOG_D("Unwaited commit-response with cookie waiting",
             {"partition", Partition},
             {"cookie", cookie},
             {"readId", readId});
@@ -1256,8 +1224,7 @@ void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
     bool wasMemoryLimitReached = PartitionInFlightMemoryController.IsMemoryLimitReached();
     bool isMemoryOkNow = PartitionInFlightMemoryController.Remove(CommittedOffset);
     if (wasMemoryLimitReached && isMemoryOkNow && IsPartitionDataReady()) {
-        YDB_LOG_DEBUG_CTX(ctx, "Ready for read after commit with readOffset endOffset",
-            {PQ_LOG_PREFIX},
+        LOG_D("Ready for read after commit with readOffset endOffset",
             {"partition", Partition},
             {"readOffset", ReadOffset},
             {"endOffset", EndOffset});
@@ -1270,8 +1237,7 @@ void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
     Kqps.erase(CommitsInfly.front().first);
     CommitsInfly.pop_front();
 
-    YDB_LOG_DEBUG_CTX(ctx, "Commit done to position endOffset with cookie",
-        {PQ_LOG_PREFIX},
+    LOG_D("Commit done to position endOffset with cookie",
         {"partition", Partition},
         {"committedOffset", CommittedOffset},
         {"endOffset", EndOffset},
@@ -1282,8 +1248,7 @@ void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
 }
 
 void TPartitionActor::SendPartitionReady(const TActorContext& ctx) {
-    YDB_LOG_DEBUG_CTX(ctx, "Ready for read with readOffset endOffset",
-        {PQ_LOG_PREFIX},
+    LOG_D("Ready for read with readOffset endOffset",
         {"partition", Partition},
         {"readOffset", ReadOffset},
         {"endOffset", EndOffset});
@@ -1298,8 +1263,7 @@ void TPartitionActor::SendPartitionReady(const TActorContext& ctx) {
 void TPartitionActor::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const TActorContext& ctx) {
     TEvTabletPipe::TEvClientConnected *msg = ev->Get();
 
-    YDB_LOG_INFO_CTX(ctx, "Pipe restart attempt pipe creation",
-        {PQ_LOG_PREFIX},
+    LOG_I("Pipe restart attempt pipe creation",
         {"partition", Partition},
         {"pipeGeneration", PipeGeneration},
         {"result", msg->Status},
@@ -1327,8 +1291,7 @@ void TPartitionActor::Handle(TEvPQProxy::TEvGetStatus::TPtr&, const TActorContex
 void TPartitionActor::Handle(TEvPQProxy::TEvUpdateReadMetrics::TPtr&, const TActorContext& ctx) {
     auto inFlightLimitReachedDuration = PartitionInFlightMemoryController.GetLimitReachedDuration();
 
-    YDB_LOG_DEBUG_CTX(ctx, "Update read metrics inFlightLimitReachedDuration",
-        {PQ_LOG_PREFIX},
+    LOG_D("Update read metrics inFlightLimitReachedDuration",
         {"partition", Partition},
         {"inFlightLimitReachedDurationMilliSeconds", inFlightLimitReachedDuration.MilliSeconds()});
 
@@ -1366,8 +1329,7 @@ void TPartitionActor::InitStartReading(const TActorContext& ctx) {
     PARTITION_ENSURE(AllPrepareInited)
         ("start_reading", StartReading);
     PARTITION_ENSURE(!WaitForData);
-    YDB_LOG_INFO_CTX(ctx, "Start reading EndOffset readOffset committedOffset clientCommitOffset clientReadOffset clientMaxOffset",
-        {PQ_LOG_PREFIX},
+    LOG_I("Start reading EndOffset readOffset committedOffset clientCommitOffset clientReadOffset clientMaxOffset",
         {"partition", Partition},
         {"endOffset", EndOffset},
         {"readOffset", ReadOffset},
@@ -1515,8 +1477,7 @@ void TPartitionActor::InitLockPartition(const TActorContext& ctx) {
         PipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, TabletID, clientConfig));
         auto request = MakeCreateSessionRequest(true, ++InitCookie);
 
-        YDB_LOG_INFO_CTX(ctx, "INITING",
-            {PQ_LOG_PREFIX},
+        LOG_I("INITING",
             {"partition", Partition});
 
         TAutoPtr<TEvPersQueue::TEvRequest> req(new TEvPersQueue::TEvRequest);
@@ -1539,8 +1500,7 @@ void TPartitionActor::RestartDirectReadSession() {
     const auto& ctx = ActorContext();
     DirectReadRestoreStage = EDirectReadRestoreStage::Session;
     auto request = MakeCreateSessionRequest(false, ++InitCookie);
-    YDB_LOG_DEBUG_CTX(ctx, "Re-init direct read session",
-        {PQ_LOG_PREFIX},
+    LOG_D("Re-init direct read session",
         {"partition", Partition});
     TAutoPtr<TEvPersQueue::TEvRequest> req(new TEvPersQueue::TEvRequest);
     req->Record.Swap(&request);
@@ -1558,16 +1518,14 @@ bool TPartitionActor::SendNextRestorePrepareOrForget() {
     if (shouldForget) {
         // We have something to forget from what was already restored; Do NOT change RestoredDirectReadId
         DirectReadRestoreStage = EDirectReadRestoreStage::Forget;
-        YDB_LOG_DEBUG_CTX(ctx, "Restore direct read, forget id for partition",
-            {PQ_LOG_PREFIX},
+        LOG_D("Restore direct read, forget id for partition",
             {"forgetId", *DirectReadsToForget.begin()},
             {"partition", Partition});
         SendForgetDirectRead(*DirectReadsToForget.begin(), ctx);
         return true;
     } else {
         auto& dr = DirectReadsToRestore.begin()->second;
-        YDB_LOG_DEBUG_CTX(ctx, "Resend prepare direct read id (internal for partition",
-            {PQ_LOG_PREFIX},
+        LOG_D("Resend prepare direct read id (internal for partition",
             {"prepareId", prepareId},
             {"id", dr.GetDirectReadId()},
             {"partition", Partition});
@@ -1611,8 +1569,7 @@ bool TPartitionActor::SendNextRestorePublishRequest() {
         return false;
     }
     auto id = *DirectReadsToPublish.begin();
-    YDB_LOG_DEBUG_CTX(ctx, "Resend publish direct read on restore, for partition",
-        {PQ_LOG_PREFIX},
+    LOG_D("Resend publish direct read on restore, for partition",
         {"id", id},
         {"partition", Partition});
 
@@ -1636,8 +1593,7 @@ void TPartitionActor::OnDirectReadsRestored() {
     DirectReadRestoreStage = EDirectReadRestoreStage::None;
 
     const auto& ctx = ActorContext();
-    YDB_LOG_DEBUG_CTX(ctx, "Restore direct reads done, continue working",
-        {PQ_LOG_PREFIX},
+    LOG_D("Restore direct reads done, continue working",
         {"partition", Partition});
 
     if (InitDone) {
@@ -1684,8 +1640,7 @@ void TPartitionActor::WaitDataInPartition(const TActorContext& ctx) {
     }
 
 
-    YDB_LOG_DEBUG_CTX(ctx, "Wait data in partition inited, cookie from offset",
-        {PQ_LOG_PREFIX},
+    LOG_D("Wait data in partition inited, cookie from offset",
         {"partition", Partition},
         {"waitDataCookie", WaitDataCookie},
         {"readOffset", ReadOffset});
@@ -1704,8 +1659,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, con
 
     auto it = WaitDataInfly.find(ev->Get()->Record.GetCookie());
     if (it == WaitDataInfly.end()) {
-        YDB_LOG_DEBUG_CTX(ctx, "Unwaited response for WaitData",
-            {PQ_LOG_PREFIX},
+        LOG_D("Unwaited response for WaitData",
             {"partition", Partition},
             {"record", ev->Get()->Record});
         return;
@@ -1715,8 +1669,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, con
         return;
 
     if (record.GetSessionInvalidated()) {
-        YDB_LOG_DEBUG_CTX(ctx, "Session invalidated while waiting for data, close read session",
-            {PQ_LOG_PREFIX},
+        LOG_D("Session invalidated while waiting for data, close read session",
             {"partition", Partition},
             {"session", Session});
         WaitForData = false;
@@ -1744,8 +1697,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, con
         ("read_offset", ReadOffset)
         ("end_offset", EndOffset);
 
-    YDB_LOG_DEBUG_CTX(ctx, "Wait for data done: readOffset EndOffset newEndOffset commitOffset clientCommitOffset clientMaxOffset cookie readingFinished firstRead",
-        {PQ_LOG_PREFIX},
+    LOG_D("Wait for data done: readOffset EndOffset newEndOffset commitOffset clientCommitOffset clientMaxOffset cookie readingFinished firstRead",
         {"partition", Partition},
         {"readOffset", ReadOffset},
         {"endOffset", EndOffset},
@@ -1838,8 +1790,7 @@ NKikimrClient::TPersQueueRequest TPartitionActor::MakeReadRequest(
 }
 
 void TPartitionActor::Handle(TEvPQProxy::TEvRead::TPtr& ev, const TActorContext& ctx) {
-    YDB_LOG_DEBUG_CTX(ctx, "READ FROM maxCount maxSize maxTimeLagMs readTimestampMs readOffset EndOffset ClientCommitOffset committedOffset ClientMaxOffset Guid",
-        {PQ_LOG_PREFIX},
+    LOG_D("READ FROM maxCount maxSize maxTimeLagMs readTimestampMs readOffset EndOffset ClientCommitOffset committedOffset ClientMaxOffset Guid",
         {"partition", Partition},
         {"maxCount", ev->Get()->MaxCount},
         {"maxSize", ev->Get()->MaxSize},
@@ -1869,8 +1820,7 @@ void TPartitionActor::Handle(TEvPQProxy::TEvRead::TPtr& ev, const TActorContext&
         return;
 
     if (DirectReadRestoreStage != EDirectReadRestoreStage::None) {
-        YDB_LOG_DEBUG_CTX(ctx, "READ FROM store this request utill direct read is restored",
-            {PQ_LOG_PREFIX},
+        LOG_D("READ FROM store this request utill direct read is restored",
             {"partition", Partition});
         return;
     }
@@ -1909,8 +1859,7 @@ void TPartitionActor::Handle(TEvPQProxy::TEvCommitCookie::TPtr& ev, const TActor
             ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession(TStringBuilder() << "double commit of cookie " << readId << " in " << Partition, PersQueue::ErrorCode::BAD_REQUEST));
             return;
         }
-        YDB_LOG_DEBUG_CTX(ctx, "Commit request from client",
-            {PQ_LOG_PREFIX},
+        LOG_D("Commit request from client",
             {"readId", readId},
             {"partition", Partition});
     }
@@ -1951,7 +1900,7 @@ void TPartitionActor::Handle(TEvPQProxy::TEvCommitRange::TPtr& ev, const TActorC
 void TPartitionActor::Die(const TActorContext& ctx) {
     if (PipeClient)
         NTabletPipe::CloseClient(ctx, PipeClient);
-    TActorBootstrapped<TPartitionActor>::Die(ctx);
+    TBase::Die(ctx);
 }
 
 void TPartitionActor::CloseSessionAndDie(const TString& reason, PersQueue::ErrorCode::ErrorCode code,
@@ -1961,7 +1910,7 @@ void TPartitionActor::CloseSessionAndDie(const TString& reason, PersQueue::Error
 }
 
 bool TPartitionActor::OnUnhandledException(const std::exception& exc) {
-    NPQ::DoLogUnhandledException(NKikimrServices::PQ_READ_PROXY, TStringBuilder() << "[" << Session <<"][" << Partition << "] ", exc);
+    NPQ::DoLogUnhandledException(Service, NPQ_LOG_PREFIX, exc);
 
     CloseSessionAndDie(
         TStringBuilder() << "unexpected error: " << exc.what(),

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -144,7 +144,7 @@ void TPartitionActor::MakeCommit(const TActorContext& ctx) {
     }
     NextCommits.erase(NextCommits.begin(), it);
     YDB_LOG_DEBUG_CTX(ctx, "Commit request",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"readIdCommittedPlus1", ReadIdCommitted + 1},
         {"readId", readId},
         {"partition", Partition});
@@ -228,7 +228,7 @@ void TPartitionActor::SendCommit(const ui64 readId, const ui64 offset, const TAc
         commit->SetSessionId(Session);
 
         YDB_LOG_DEBUG_CTX(ctx, "Committing to position prev end by cookie",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", Partition},
             {"offset", offset},
             {"committedOffset", CommittedOffset},
@@ -300,7 +300,7 @@ void TPartitionActor::SendPublishDirectRead(const ui64 directReadId, const TActo
     publish->MutableSessionKey()->SetPartitionSessionId(Partition.AssignId);
 
     YDB_LOG_DEBUG_CTX(ctx, "Publishing direct read with id",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"directReadId", directReadId});
 
@@ -329,7 +329,7 @@ void TPartitionActor::SendForgetDirectRead(const ui64 directReadId, const TActor
     publish->MutableSessionKey()->SetPartitionSessionId(Partition.AssignId);
 
     YDB_LOG_DEBUG_CTX(ctx, "Forgetting",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"directReadId", directReadId});
 
@@ -348,7 +348,7 @@ void TPartitionActor::RestartPipe(const TActorContext& ctx, const TString& reaso
     NTabletPipe::CloseClient(ctx, PipeClient);
 
     YDB_LOG_INFO_CTX(ctx, "Schedule pipe restart attempt current",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"pipeGeneration", PipeGeneration},
         {"reason", reason},
@@ -381,14 +381,14 @@ void TPartitionActor::Handle(TEvPQProxy::TEvDirectReadAck::TPtr& ev, const TActo
         if (RestoredDirectReadId == ev->Get()->DirectReadId) {
             // This direct read is already being restored. Have to forget it later.
             YDB_LOG_DEBUG_CTX(ctx, "Got ack for direct read while restoring, store it to forget further",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                {PQ_LOG_PREFIX},
                 {"directReadId", ev->Get()->DirectReadId});
             DirectReadsToForget.insert(ev->Get()->DirectReadId);
             return;
         }
         if (DirectReadsToRestore.contains(ev->Get()->DirectReadId)) {
             YDB_LOG_DEBUG_CTX(ctx, "Got ack for direct read while restoring, remove it from restore list",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                {PQ_LOG_PREFIX},
                 {"directReadId", ev->Get()->DirectReadId});
             // This direct read is pending for restore. No need to foreget - not yet prepared, just erase it;
             DirectReadsToRestore.erase(ev->Get()->DirectReadId);
@@ -422,7 +422,7 @@ void TPartitionActor::Handle(const TEvPQProxy::TEvRestartPipe::TPtr&, const TAct
     PARTITION_ENSURE(TabletID);
 
     YDB_LOG_INFO_CTX(ctx, "Pipe restart attempt RequestInfly ReadOffset EndOffset InitDone WaitForData",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"pipeGeneration", PipeGeneration},
         {"requestInfly", RequestInfly},
@@ -456,7 +456,7 @@ void TPartitionActor::ResendRecentRequests() {
     const auto& ctx = ActorContext();
     if (RequestInfly) { //got read infly
         YDB_LOG_INFO_CTX(ctx, "Resend",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", Partition},
             {"currentRequest", CurrentRequest});
 
@@ -710,7 +710,7 @@ void TPartitionActor::HandleInit(const NKikimrClient::TPersQueuePartitionRespons
         ("direct_read_restore_stage", static_cast<int>(DirectReadRestoreStage));
     if (result.GetCookie() != InitCookie) {
         YDB_LOG_DEBUG_CTX(ctx, "Unwaited response in init with cookie",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", Partition},
             {"cookie", result.GetCookie()});
         return;
@@ -741,7 +741,7 @@ void TPartitionActor::HandleInit(const NKikimrClient::TPersQueuePartitionRespons
     InitDone = true;
     PipeGeneration = 0; //reset tries counter - all ok
     YDB_LOG_INFO_CTX(ctx, "INIT DONE EndOffset readOffset committedOffset",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"endOffset", EndOffset},
         {"readOffset", ReadOffset},
@@ -765,13 +765,13 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
         case EDirectReadRestoreStage::Session:
             if (result.GetCookie() != InitCookie || !result.HasCmdRestoreDirectReadResult()) {
                 YDB_LOG_DEBUG_CTX(ctx, "Direct read - session restarted for partition with unwaited cookie",
-                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {PQ_LOG_PREFIX},
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
             }
             YDB_LOG_DEBUG_CTX(ctx, "Direct read - session restarted for partition",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                {PQ_LOG_PREFIX},
                 {"partition", Partition});
             if (!SendNextRestorePrepareOrForget()) {
                 OnDirectReadsRestored();
@@ -783,7 +783,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // Late/duplicate non-Prepare is possible after nested pipe restart — soft-ignore.
             if (!result.HasCmdPrepareReadResult()) {
                 YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PrepareReadResult, got",
-                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {PQ_LOG_PREFIX},
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
@@ -792,7 +792,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // Soft-ignore would hang restore forever; close the session so the client recovers.
             if (DirectReadsToRestore.empty()) {
                 YDB_LOG_WARN_CTX(ctx, "Direct read restore Prepare with empty DirectReadsToRestore",
-                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {PQ_LOG_PREFIX},
                     {"partition", Partition},
                     {"response_cookie", result.GetCookie()},
                     {"result", result.ShortDebugString()});
@@ -805,7 +805,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             }
             if (DirectReadsToRestore.begin()->first != result.GetCmdPrepareReadResult().GetDirectReadId()) {
                 YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PrepareReadResult, got",
-                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {PQ_LOG_PREFIX},
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
@@ -832,7 +832,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // after we have already moved to Publish. Soft-ignore like Prepare stage.
             if (!result.HasCmdPublishReadResult()) {
                 YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PublishReadResult, got",
-                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {PQ_LOG_PREFIX},
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
@@ -841,7 +841,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // Soft-ignore would hang restore forever; close the session so the client recovers.
             if (DirectReadsToPublish.empty()) {
                 YDB_LOG_WARN_CTX(ctx, "Direct read restore Publish with empty DirectReadsToPublish",
-                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {PQ_LOG_PREFIX},
                     {"partition", Partition},
                     {"response_cookie", result.GetCookie()},
                     {"result", result.ShortDebugString()});
@@ -854,7 +854,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             }
             if (*DirectReadsToPublish.begin() != result.GetCmdPublishReadResult().GetDirectReadId()) {
                 YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PublishReadResult, got",
-                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {PQ_LOG_PREFIX},
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
@@ -871,7 +871,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // restart — soft-ignore like Prepare/Publish stages.
             if (!result.HasCmdForgetReadResult()) {
                 YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect ForgetReadResult, got",
-                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {PQ_LOG_PREFIX},
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
@@ -880,7 +880,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // Soft-ignore would hang restore forever; close the session so the client recovers.
             if (DirectReadsToForget.empty()) {
                 YDB_LOG_WARN_CTX(ctx, "Direct read restore Forget with empty DirectReadsToForget",
-                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {PQ_LOG_PREFIX},
                     {"partition", Partition},
                     {"response_cookie", result.GetCookie()},
                     {"result", result.ShortDebugString()});
@@ -893,7 +893,7 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             }
             if (*DirectReadsToForget.begin() != result.GetCmdForgetReadResult().GetDirectReadId()) {
                 YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect ForgetReadResult, got",
-                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {PQ_LOG_PREFIX},
                     {"partition", Partition},
                     {"cookie", result.GetCookie()});
                 return;
@@ -922,7 +922,7 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
     // we must soft-ignore instead of PARTITION_ENSURE(DirectReadId).
     if (!RequestInfly) {
         YDB_LOG_DEBUG_CTX(ctx, "Unwaited prepare-response for direct read id",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", Partition},
             {"directReadId", res.GetDirectReadId()},
             {"readOffset", ReadOffset},
@@ -944,7 +944,7 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
     DirectReadResults[DirectReadId] = res;
 
     YDB_LOG_DEBUG_CTX(ctx, "After direct read state EndOffset ReadOffset ReadGuid with direct read id",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"endOffset", EndOffset},
         {"readOffset", ReadOffset},
@@ -991,7 +991,7 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
     ReadOffset = dr.GetLastOffset() + 1;
 
     YDB_LOG_DEBUG_CTX(ctx, "After publish direct read EndOffset ReadOffset ReadGuid with direct read id isInFlightMemoryOk",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"endOffset", EndOffset},
         {"readOffset", ReadOffset},
@@ -1056,7 +1056,7 @@ void TPartitionActor::Handle(const NKikimrClient::TCmdReadResult& res, const TAc
 
     auto isMemoryLimitReached = PartitionInFlightMemoryController.IsMemoryLimitReached();
     YDB_LOG_DEBUG_CTX(ctx, "IsMemoryLimitReached EndOffset ReadOffset MaxOffset read result size",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"isMemoryLimitReached", isMemoryLimitReached},
         {"endOffset", EndOffset},
@@ -1076,7 +1076,7 @@ void TPartitionActor::Handle(const NKikimrClient::TCmdReadResult& res, const TAc
     }
 
     YDB_LOG_DEBUG_CTX(ctx, "After read state EndOffset ReadOffset ReadGuid has messages",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"endOffset", EndOffset},
         {"readOffset", ReadOffset},
@@ -1159,7 +1159,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
         };
 
     YDB_LOG_DEBUG_CTX(ctx, "InitDone event",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"initDone", InitDone},
         {"result", MaskResult(result)});
@@ -1195,7 +1195,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
 
     if (result.GetCookie() != (ui64)ReadOffset) {
         YDB_LOG_DEBUG_CTX(ctx, "Unwaited read-response with cookie waiting for current read guid is",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", Partition},
             {"cookie", result.GetCookie()},
             {"readOffset", ReadOffset},
@@ -1223,7 +1223,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
 void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
     if (CommitsInfly.empty()) {
         YDB_LOG_DEBUG_CTX(ctx, "Unwaited commit-response with cookie waiting for nothing",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", Partition},
             {"cookie", cookie});
         return;
@@ -1232,7 +1232,7 @@ void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
 
     if (cookie != readId) {
         YDB_LOG_DEBUG_CTX(ctx, "Unwaited commit-response with cookie waiting",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", Partition},
             {"cookie", cookie},
             {"readId", readId});
@@ -1257,7 +1257,7 @@ void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
     bool isMemoryOkNow = PartitionInFlightMemoryController.Remove(CommittedOffset);
     if (wasMemoryLimitReached && isMemoryOkNow && IsPartitionDataReady()) {
         YDB_LOG_DEBUG_CTX(ctx, "Ready for read after commit with readOffset endOffset",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", Partition},
             {"readOffset", ReadOffset},
             {"endOffset", EndOffset});
@@ -1271,7 +1271,7 @@ void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
     CommitsInfly.pop_front();
 
     YDB_LOG_DEBUG_CTX(ctx, "Commit done to position endOffset with cookie",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"committedOffset", CommittedOffset},
         {"endOffset", EndOffset},
@@ -1283,7 +1283,7 @@ void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
 
 void TPartitionActor::SendPartitionReady(const TActorContext& ctx) {
     YDB_LOG_DEBUG_CTX(ctx, "Ready for read with readOffset endOffset",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"readOffset", ReadOffset},
         {"endOffset", EndOffset});
@@ -1299,7 +1299,7 @@ void TPartitionActor::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const 
     TEvTabletPipe::TEvClientConnected *msg = ev->Get();
 
     YDB_LOG_INFO_CTX(ctx, "Pipe restart attempt pipe creation",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"pipeGeneration", PipeGeneration},
         {"result", msg->Status},
@@ -1328,7 +1328,7 @@ void TPartitionActor::Handle(TEvPQProxy::TEvUpdateReadMetrics::TPtr&, const TAct
     auto inFlightLimitReachedDuration = PartitionInFlightMemoryController.GetLimitReachedDuration();
 
     YDB_LOG_DEBUG_CTX(ctx, "Update read metrics inFlightLimitReachedDuration",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"inFlightLimitReachedDurationMilliSeconds", inFlightLimitReachedDuration.MilliSeconds()});
 
@@ -1367,7 +1367,7 @@ void TPartitionActor::InitStartReading(const TActorContext& ctx) {
         ("start_reading", StartReading);
     PARTITION_ENSURE(!WaitForData);
     YDB_LOG_INFO_CTX(ctx, "Start reading EndOffset readOffset committedOffset clientCommitOffset clientReadOffset clientMaxOffset",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"endOffset", EndOffset},
         {"readOffset", ReadOffset},
@@ -1516,7 +1516,7 @@ void TPartitionActor::InitLockPartition(const TActorContext& ctx) {
         auto request = MakeCreateSessionRequest(true, ++InitCookie);
 
         YDB_LOG_INFO_CTX(ctx, "INITING",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", Partition});
 
         TAutoPtr<TEvPersQueue::TEvRequest> req(new TEvPersQueue::TEvRequest);
@@ -1540,7 +1540,7 @@ void TPartitionActor::RestartDirectReadSession() {
     DirectReadRestoreStage = EDirectReadRestoreStage::Session;
     auto request = MakeCreateSessionRequest(false, ++InitCookie);
     YDB_LOG_DEBUG_CTX(ctx, "Re-init direct read session",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition});
     TAutoPtr<TEvPersQueue::TEvRequest> req(new TEvPersQueue::TEvRequest);
     req->Record.Swap(&request);
@@ -1559,7 +1559,7 @@ bool TPartitionActor::SendNextRestorePrepareOrForget() {
         // We have something to forget from what was already restored; Do NOT change RestoredDirectReadId
         DirectReadRestoreStage = EDirectReadRestoreStage::Forget;
         YDB_LOG_DEBUG_CTX(ctx, "Restore direct read, forget id for partition",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"forgetId", *DirectReadsToForget.begin()},
             {"partition", Partition});
         SendForgetDirectRead(*DirectReadsToForget.begin(), ctx);
@@ -1567,7 +1567,7 @@ bool TPartitionActor::SendNextRestorePrepareOrForget() {
     } else {
         auto& dr = DirectReadsToRestore.begin()->second;
         YDB_LOG_DEBUG_CTX(ctx, "Resend prepare direct read id (internal for partition",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"prepareId", prepareId},
             {"id", dr.GetDirectReadId()},
             {"partition", Partition});
@@ -1612,7 +1612,7 @@ bool TPartitionActor::SendNextRestorePublishRequest() {
     }
     auto id = *DirectReadsToPublish.begin();
     YDB_LOG_DEBUG_CTX(ctx, "Resend publish direct read on restore, for partition",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"id", id},
         {"partition", Partition});
 
@@ -1637,7 +1637,7 @@ void TPartitionActor::OnDirectReadsRestored() {
 
     const auto& ctx = ActorContext();
     YDB_LOG_DEBUG_CTX(ctx, "Restore direct reads done, continue working",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition});
 
     if (InitDone) {
@@ -1685,7 +1685,7 @@ void TPartitionActor::WaitDataInPartition(const TActorContext& ctx) {
 
 
     YDB_LOG_DEBUG_CTX(ctx, "Wait data in partition inited, cookie from offset",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"waitDataCookie", WaitDataCookie},
         {"readOffset", ReadOffset});
@@ -1705,7 +1705,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, con
     auto it = WaitDataInfly.find(ev->Get()->Record.GetCookie());
     if (it == WaitDataInfly.end()) {
         YDB_LOG_DEBUG_CTX(ctx, "Unwaited response for WaitData",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", Partition},
             {"record", ev->Get()->Record});
         return;
@@ -1716,7 +1716,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, con
 
     if (record.GetSessionInvalidated()) {
         YDB_LOG_DEBUG_CTX(ctx, "Session invalidated while waiting for data, close read session",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", Partition},
             {"session", Session});
         WaitForData = false;
@@ -1745,7 +1745,7 @@ void TPartitionActor::Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, con
         ("end_offset", EndOffset);
 
     YDB_LOG_DEBUG_CTX(ctx, "Wait for data done: readOffset EndOffset newEndOffset commitOffset clientCommitOffset clientMaxOffset cookie readingFinished firstRead",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"readOffset", ReadOffset},
         {"endOffset", EndOffset},
@@ -1839,7 +1839,7 @@ NKikimrClient::TPersQueueRequest TPartitionActor::MakeReadRequest(
 
 void TPartitionActor::Handle(TEvPQProxy::TEvRead::TPtr& ev, const TActorContext& ctx) {
     YDB_LOG_DEBUG_CTX(ctx, "READ FROM maxCount maxSize maxTimeLagMs readTimestampMs readOffset EndOffset ClientCommitOffset committedOffset ClientMaxOffset Guid",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", Partition},
         {"maxCount", ev->Get()->MaxCount},
         {"maxSize", ev->Get()->MaxSize},
@@ -1870,7 +1870,7 @@ void TPartitionActor::Handle(TEvPQProxy::TEvRead::TPtr& ev, const TActorContext&
 
     if (DirectReadRestoreStage != EDirectReadRestoreStage::None) {
         YDB_LOG_DEBUG_CTX(ctx, "READ FROM store this request utill direct read is restored",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", Partition});
         return;
     }
@@ -1910,7 +1910,7 @@ void TPartitionActor::Handle(TEvPQProxy::TEvCommitCookie::TPtr& ev, const TActor
             return;
         }
         YDB_LOG_DEBUG_CTX(ctx, "Commit request from client",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"readId", readId},
             {"partition", Partition});
     }

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -1910,7 +1910,7 @@ void TPartitionActor::CloseSessionAndDie(const TString& reason, PersQueue::Error
 }
 
 bool TPartitionActor::OnUnhandledException(const std::exception& exc) {
-    NPQ::DoLogUnhandledException(Service, NPQ_LOG_PREFIX, exc);
+    NPQ::DoLogUnhandledException(Service, *this, exc);
 
     CloseSessionAndDie(
         TStringBuilder() << "unexpected error: " << exc.what(),

--- a/ydb/services/persqueue_v1/actors/partition_actor.h
+++ b/ydb/services/persqueue_v1/actors/partition_actor.h
@@ -5,20 +5,18 @@
 #include "helpers.h"
 #include "partition_id.h"
 
-#include <ydb/library/actors/core/actorid.h>
-#include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/services/persqueue_v1/actors/distributed_commit_helper.h>
-#include <library/cpp/containers/disjoint_interval_tree/disjoint_interval_tree.h>
-
 #include <ydb/core/base/tablet_pipe.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/persqueue/events/global.h>
-#include <ydb/core/persqueue/public/utils.h>
 #include <ydb/core/persqueue/public/inflight_limiter.h>
+#include <ydb/core/persqueue/public/utils.h>
 #include <ydb/core/util/ulid.h>
 
-#include <ydb/library/services/services.pb.h>
-
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
+#include <ydb/library/services/services.pb.h>
+#include <ydb/services/persqueue_v1/actors/distributed_commit_helper.h>
+
+#include <library/cpp/containers/disjoint_interval_tree/disjoint_interval_tree.h>
 
 
 namespace NKikimr::NGRpcProxy::V1 {
@@ -57,8 +55,9 @@ struct TTopicCounters {
 };
 
 
-class TPartitionActor : public NActors::TActorBootstrapped<TPartitionActor>
-                      , public NActors::IActorExceptionHandler {
+class TPartitionActor : public NPQ::TBaseActor<TPartitionActor>
+                      , public NPQ::TConstantLogPrefix {
+    using TBase = NPQ::TBaseActor<TPartitionActor>;
 private:
     static constexpr TDuration READ_TIMEOUT_DURATION = TDuration::Seconds(1);
 
@@ -89,6 +88,15 @@ public:
                             const NActors::TActorContext& ctx);
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() { return NKikimrServices::TActivity::FRONT_PQ_PARTITION; }
+
+    NPQ::TStructuredMessage BuildLogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"sessionCookie", Cookie},
+            {"consumer", ClientPath},
+            {"session", Session},
+            {"tabletId", TabletID});
+    }
+
 private:
     STFUNC(StateFunc) {
         switch (ev->GetTypeRewrite()) {

--- a/ydb/services/persqueue_v1/actors/persqueue_utils.h
+++ b/ydb/services/persqueue_v1/actors/persqueue_utils.h
@@ -3,6 +3,7 @@
 #include <ydb/public/api/protos/persqueue_error_codes_v1.pb.h>
 
 #include <ydb/library/aclib/aclib.h>
+#include <ydb/library/actors/core/log.h>
 #include <ydb/library/cloud_permissions/cloud_permissions.h>
 #include <ydb/core/scheme/scheme_tabledefs.h>
 #include <ydb/core/base/counters.h>
@@ -24,7 +25,10 @@ namespace NKikimr::NGRpcProxy::V1 {
 #ifdef PQ_LOG_PREFIX
 #undef PQ_LOG_PREFIX
 #endif
-#define PQ_LOG_PREFIX (TStringBuilder() << "session cookie " << Cookie << " consumer " << ClientPath << " session " << Session)
+#define PQ_LOG_PREFIX YDB_LOG_CREATE_MESSAGE( \
+    {"sessionCookie", Cookie}, \
+    {"consumer", ClientPath}, \
+    {"session", Session})
 
 // moved to ydb/core/client/server/msgbus_server_persqueue.h?
 // const TString& TopicPrefix(const TActorContext& ctx);

--- a/ydb/services/persqueue_v1/actors/persqueue_utils.h
+++ b/ydb/services/persqueue_v1/actors/persqueue_utils.h
@@ -3,7 +3,6 @@
 #include <ydb/public/api/protos/persqueue_error_codes_v1.pb.h>
 
 #include <ydb/library/aclib/aclib.h>
-#include <ydb/library/actors/core/log.h>
 #include <ydb/library/cloud_permissions/cloud_permissions.h>
 #include <ydb/core/scheme/scheme_tabledefs.h>
 #include <ydb/core/base/counters.h>
@@ -21,14 +20,6 @@ namespace Ydb::Topic {
 }
 
 namespace NKikimr::NGRpcProxy::V1 {
-
-#ifdef PQ_LOG_PREFIX
-#undef PQ_LOG_PREFIX
-#endif
-#define PQ_LOG_PREFIX YDB_LOG_CREATE_MESSAGE( \
-    {"sessionCookie", Cookie}, \
-    {"consumer", ClientPath}, \
-    {"session", Session})
 
 // moved to ydb/core/client/server/msgbus_server_persqueue.h?
 // const TString& TopicPrefix(const TActorContext& ctx);

--- a/ydb/services/persqueue_v1/actors/read_info_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/read_info_actor.cpp
@@ -8,8 +8,6 @@
 #include <ydb/public/api/protos/ydb_persqueue_v1.pb.h>
 #include <ydb/public/lib/base/msgbus_status.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_READ_PROXY
-
 namespace NKikimr::NGRpcProxy::V1 {
 
 using namespace PersQueue::V1;
@@ -21,6 +19,7 @@ TReadInfoActor::TReadInfoActor(
         TIntrusivePtr<::NMonitoring::TDynamicCounters> counters
 )
     : TBase(request)
+    , TLogPrefix(NKikimrServices::PQ_READ_PROXY)
     , SchemeCache(schemeCache)
     , NewSchemeCache(newSchemeCache)
     , AuthInitActor()
@@ -83,7 +82,7 @@ void TReadInfoActor::Bootstrap(const TActorContext& ctx) {
 
 bool TReadInfoActor::OnUnhandledException(const std::exception& exc) {
     auto ctx = *NActors::TlsActivationContext;
-    YDB_LOG_CRIT_CTX(ctx, "Unhandled exception",
+    LOG_C("Unhandled exception",
         {"typeName", TypeName(exc)},
         {"exception", exc.what()},
         {"backTrace", TBackTrace::FromCurrentException().PrintToString()});
@@ -103,7 +102,7 @@ void TReadInfoActor::Die(const TActorContext& ctx) {
 
 void TReadInfoActor::Handle(TEvPQProxy::TEvAuthResultOk::TPtr& ev, const TActorContext& ctx) {
 
-    YDB_LOG_DEBUG_CTX(ctx, "GetReadInfo auth ok fo read info, got topics",
+    LOG_D("GetReadInfo auth ok fo read info, got topics",
         {"topicAndTabletsSize", ev->Get()->TopicAndTablets.size()});
     TopicAndTablets = std::move(ev->Get()->TopicAndTablets);
     if (TopicAndTablets.empty()) {

--- a/ydb/services/persqueue_v1/actors/read_info_actor.h
+++ b/ydb/services/persqueue_v1/actors/read_info_actor.h
@@ -3,7 +3,7 @@
 #include "events.h"
 
 #include <ydb/core/grpc_services/rpc_deferrable.h>
-
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/persqueue/events/global.h>
 
 
@@ -12,7 +12,8 @@ namespace NKikimr::NGRpcProxy::V1 {
 using namespace NKikimr::NGRpcService;
 
 class TReadInfoActor : public TRpcOperationRequestActor<TReadInfoActor, TEvPQReadInfoRequest>
-                     , public NActors::IActorExceptionHandler {
+                     , public NActors::IActorExceptionHandler
+                     , public NPQ::TLogPrefix {
 using TBase = TRpcOperationRequestActor<TReadInfoActor, TEvPQReadInfoRequest>;
 public:
      TReadInfoActor(
@@ -26,6 +27,10 @@ public:
     bool OnUnhandledException(const std::exception& exc) override;
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() { return NKikimrServices::TActivity::PQ_META_REQUEST_PROCESSOR; }
+
+    NPQ::TStructuredMessage LogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE({"consumer", ClientId});
+    }
 
     bool HasCancelOperation() {
         return false;

--- a/ydb/services/persqueue_v1/actors/read_init_auth_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/read_init_auth_actor.cpp
@@ -41,7 +41,7 @@ TReadInitAndAuthActor::~TReadInitAndAuthActor() = default;
 
 void TReadInitAndAuthActor::Bootstrap(const TActorContext &ctx) {
     YDB_LOG_DEBUG_CTX(ctx, "Auth",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"clientId", ClientId});
     Become(&TThis::StateFunc);
     DoCheckACL = AppData(ctx)->PQConfig.GetCheckACL() && Token;
@@ -70,7 +70,7 @@ void TReadInitAndAuthActor::Die(const TActorContext& ctx) {
     }
 
     YDB_LOG_DEBUG_CTX(ctx, "Auth is DEAD",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX});
+        {PQ_LOG_PREFIX});
 
     TActorBootstrapped<TReadInitAndAuthActor>::Die(ctx);
 }
@@ -78,7 +78,7 @@ void TReadInitAndAuthActor::Die(const TActorContext& ctx) {
 bool TReadInitAndAuthActor::OnUnhandledException(const std::exception& exc) {
     auto ctx = *NActors::TlsActivationContext;
     YDB_LOG_CRIT_CTX(ctx, "Unhandled exception",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"typeName", TypeName(exc)},
         {"exception", exc.what()},
         {"backTrace", TBackTrace::FromCurrentException().PrintToString()});
@@ -104,7 +104,7 @@ void TReadInitAndAuthActor::SendCacheNavigateRequest(const TActorContext& ctx, c
     schemeCacheRequest->ResultSet.emplace_back(entry);
     schemeCacheRequest->DatabaseName = AppData(ctx)->PQConfig.GetDatabase();
     YDB_LOG_DEBUG_CTX(ctx, "Send client acl request",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX});
+        {PQ_LOG_PREFIX});
     ctx.Send(NewSchemeCache, new TEvTxProxySchemeCache::TEvNavigateKeySet(schemeCacheRequest.Release()));
 }
 
@@ -148,7 +148,7 @@ bool TReadInitAndAuthActor::ProcessTopicSchemeCacheResponse(
 
 void TReadInitAndAuthActor::HandleTopicsDescribeResponse(TEvDescribeTopicsResponse::TPtr& ev, const TActorContext& ctx) {
     YDB_LOG_DEBUG_CTX(ctx, "Handle describe topics response",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX});
+        {PQ_LOG_PREFIX});
 
     bool reDescribe = false;
     auto i = 0u;

--- a/ydb/services/persqueue_v1/actors/read_init_auth_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/read_init_auth_actor.cpp
@@ -6,8 +6,6 @@
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/persqueue/public/utils.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_READ_PROXY
-
 
 namespace NKikimr::NGRpcProxy::V1 {
 
@@ -18,7 +16,8 @@ TReadInitAndAuthActor::TReadInitAndAuthActor(
         TIntrusivePtr<::NMonitoring::TDynamicCounters> counters, TIntrusiveConstPtr<NACLib::TUserToken> token,
         const NPersQueue::TTopicsToConverter& topics, const TString& localCluster, bool skipReadRuleCheck
 )
-    : ParentId(parentId)
+    : TBase(NKikimrServices::PQ_READ_PROXY)
+    , ParentId(parentId)
     , Cookie(cookie)
     , Session(session)
     , MetaCacheId(metaCache)
@@ -40,8 +39,7 @@ TReadInitAndAuthActor::~TReadInitAndAuthActor() = default;
 
 
 void TReadInitAndAuthActor::Bootstrap(const TActorContext &ctx) {
-    YDB_LOG_DEBUG_CTX(ctx, "Auth",
-        {PQ_LOG_PREFIX},
+    LOG_D("Auth",
         {"clientId", ClientId});
     Become(&TThis::StateFunc);
     DoCheckACL = AppData(ctx)->PQConfig.GetCheckACL() && Token;
@@ -55,7 +53,6 @@ void TReadInitAndAuthActor::DescribeTopics(const NActors::TActorContext& ctx, bo
         AFL_ENSURE(topic.second.DiscoveryConverter->IsValid());
     }
 
-    //LOG_DEBUG_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " describe topics: " << JoinSeq(", ", topicNames));
     ctx.Send(MetaCacheId, new TEvDescribeTopicsRequest(topics, true, showPrivate));
 }
 
@@ -69,16 +66,14 @@ void TReadInitAndAuthActor::Die(const TActorContext& ctx) {
             holder.DiscoveryConverter->RestorePrimaryPath();
     }
 
-    YDB_LOG_DEBUG_CTX(ctx, "Auth is DEAD",
-        {PQ_LOG_PREFIX});
+    LOG_D("Auth is DEAD");
 
-    TActorBootstrapped<TReadInitAndAuthActor>::Die(ctx);
+    TBase::Die(ctx);
 }
 
 bool TReadInitAndAuthActor::OnUnhandledException(const std::exception& exc) {
     auto ctx = *NActors::TlsActivationContext;
-    YDB_LOG_CRIT_CTX(ctx, "Unhandled exception",
-        {PQ_LOG_PREFIX},
+    LOG_C("Unhandled exception",
         {"typeName", TypeName(exc)},
         {"exception", exc.what()},
         {"backTrace", TBackTrace::FromCurrentException().PrintToString()});
@@ -103,8 +98,7 @@ void TReadInitAndAuthActor::SendCacheNavigateRequest(const TActorContext& ctx, c
     entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
     schemeCacheRequest->ResultSet.emplace_back(entry);
     schemeCacheRequest->DatabaseName = AppData(ctx)->PQConfig.GetDatabase();
-    YDB_LOG_DEBUG_CTX(ctx, "Send client acl request",
-        {PQ_LOG_PREFIX});
+    LOG_D("Send client acl request");
     ctx.Send(NewSchemeCache, new TEvTxProxySchemeCache::TEvNavigateKeySet(schemeCacheRequest.Release()));
 }
 
@@ -147,8 +141,7 @@ bool TReadInitAndAuthActor::ProcessTopicSchemeCacheResponse(
 
 
 void TReadInitAndAuthActor::HandleTopicsDescribeResponse(TEvDescribeTopicsResponse::TPtr& ev, const TActorContext& ctx) {
-    YDB_LOG_DEBUG_CTX(ctx, "Handle describe topics response",
-        {PQ_LOG_PREFIX});
+    LOG_D("Handle describe topics response");
 
     bool reDescribe = false;
     auto i = 0u;

--- a/ydb/services/persqueue_v1/actors/read_init_auth_actor.h
+++ b/ydb/services/persqueue_v1/actors/read_init_auth_actor.h
@@ -1,21 +1,18 @@
 #pragma once
 
-#include <ydb/library/actors/core/actor_bootstrapped.h>
-
 #include <ydb/core/client/server/msgbus_server_pq_metacache.h>
-
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/library/aclib/aclib.h>
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
-
 #include <ydb/public/api/protos/persqueue_error_codes_v1.pb.h>
-
 #include <ydb/services/lib/actors/type_definitions.h>
 
 
 namespace NKikimr::NGRpcProxy::V1 {
 
-class TReadInitAndAuthActor : public NActors::TActorBootstrapped<TReadInitAndAuthActor>
-                            , public NActors::IActorExceptionHandler {
+class TReadInitAndAuthActor : public NPQ::TBaseActor<TReadInitAndAuthActor>
+                            , public NPQ::TConstantLogPrefix {
+    using TBase = NPQ::TBaseActor<TReadInitAndAuthActor>;
     using TEvDescribeTopicsResponse = NMsgBusProxy::NPqMetaCacheV2::TEvPqNewMetaCache::TEvDescribeTopicsResponse;
     using TEvDescribeTopicsRequest = NMsgBusProxy::NPqMetaCacheV2::TEvPqNewMetaCache::TEvDescribeTopicsRequest;
 
@@ -32,6 +29,13 @@ public:
     bool OnUnhandledException(const std::exception& exc) override;
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() { return NKikimrServices::TActivity::FRONT_PQ_READ; }
+
+    NPQ::TStructuredMessage BuildLogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"sessionCookie", Cookie},
+            {"consumer", ClientPath},
+            {"session", Session});
+    }
 
 private:
 

--- a/ydb/services/persqueue_v1/actors/read_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.cpp
@@ -1,6 +1,5 @@
 #include "read_session_actor.h"
 
-
 #include "helpers.h"
 #include "read_init_auth_actor.h"
 
@@ -14,8 +13,6 @@
 #include <util/string/strip.h>
 
 #include <utility>
-
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_READ_PROXY
 
 namespace NKikimr::NGRpcProxy::V1 {
 
@@ -32,7 +29,8 @@ TReadSessionActor<Protocol>::TReadSessionActor(
         TIntrusivePtr<NMonitoring::TDynamicCounters> counters,
         const TMaybe<TString> clientDC,
         const NPersQueue::TTopicsListController& topicsHandler)
-    : TRlHelpers({}, request, READ_BLOCK_SIZE, false)
+    : TBase(NKikimrServices::PQ_READ_PROXY)
+    , TRlHelpers({}, request, READ_BLOCK_SIZE, false)
     , Request(request)
     , ClientDC(clientDC.GetOrElse("other"))
     , StartTimestamp(TInstant::Now())
@@ -88,16 +86,14 @@ void TReadSessionActor<Protocol>::Bootstrap(const TActorContext& ctx) {
 
 template <EProtocol Protocol>
 void TReadSessionActor<Protocol>::Handle(typename IContext::TEvNotifiedWhenDone::TPtr&, const TActorContext& ctx) {
-    YDB_LOG_INFO_CTX(ctx, "Grpc closed",
-        {PQ_LOG_PREFIX});
+    LOG_I("Grpc closed");
     Die(ctx);
 }
 
 template <EProtocol Protocol>
 bool TReadSessionActor<Protocol>::ReadFromStreamOrDie(const TActorContext& ctx) {
     if (!Request->Read()) {
-        YDB_LOG_INFO_CTX(ctx, "Grpc read failed at start",
-            {PQ_LOG_PREFIX});
+        LOG_I("Grpc read failed at start");
         Die(ctx);
         return false;
     }
@@ -118,14 +114,12 @@ void TReadSessionActor<Protocol>::Handle(typename IContext::TEvReadFinished::TPt
         }
     }
 
-    YDB_LOG_DEBUG_CTX(ctx, "Grpc read done",
-        {PQ_LOG_PREFIX},
+    LOG_D("Grpc read done",
         {"success", ev->Get()->Success},
         {"data", request});
 
     if (!ev->Get()->Success) {
-        YDB_LOG_INFO_CTX(ctx, "Grpc read failed",
-            {PQ_LOG_PREFIX});
+        LOG_I("Grpc read failed");
         ctx.Send(ctx.SelfID, new TEvPQProxy::TEvDone());
         return;
     }
@@ -313,8 +307,7 @@ bool TReadSessionActor<Protocol>::WriteToStreamOrDie(const TActorContext& ctx, T
     }
 
     if (!res) {
-        YDB_LOG_INFO_CTX(ctx, "Grpc write failed at start",
-            {PQ_LOG_PREFIX});
+        LOG_I("Grpc write failed at start");
         Die(ctx);
     }
 
@@ -324,8 +317,7 @@ bool TReadSessionActor<Protocol>::WriteToStreamOrDie(const TActorContext& ctx, T
 template <EProtocol Protocol>
 void TReadSessionActor<Protocol>::Handle(typename IContext::TEvWriteFinished::TPtr& ev, const TActorContext& ctx) {
     if (!ev->Get()->Success) {
-        YDB_LOG_INFO_CTX(ctx, "Grpc write failed",
-            {PQ_LOG_PREFIX});
+        LOG_I("Grpc write failed");
         return Die(ctx);
     }
 
@@ -386,18 +378,16 @@ void TReadSessionActor<Protocol>::Die(const TActorContext& ctx) {
         Request->AuditLogRequestEnd(Ydb::StatusIds::SUCCESS);
     }
 
-    YDB_LOG_INFO_CTX(ctx, "Is DEAD",
-        {PQ_LOG_PREFIX});
+    LOG_I("Is DEAD");
     ctx.Send(GetPQReadServiceActorID(), new TEvPQProxy::TEvSessionDead(Cookie));
-    TRlHelpers::PassAway(TActorBootstrapped<TReadSessionActor>::SelfId());
-    TActorBootstrapped<TReadSessionActor>::Die(ctx);
+    TRlHelpers::PassAway(TBase::SelfId());
+    TBase::Die(ctx);
 }
 
 template <EProtocol Protocol>
 bool TReadSessionActor<Protocol>::OnUnhandledException(const std::exception& exc) {
     auto ctx = *NActors::TlsActivationContext;
-    YDB_LOG_CRIT_CTX(ctx, "Unhandled exception",
-        {PQ_LOG_PREFIX},
+    LOG_C("Unhandled exception",
         {"typeName", TypeName(exc)},
         {"exception", exc.what()},
         {"backTrace", TBackTrace::FromCurrentException().PrintToString()});
@@ -487,8 +477,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvDirectReadAck::TPtr& ev,
 
     auto directReadId = ev->Get()->DirectReadId;
 
-    YDB_LOG_DEBUG_CTX(ctx, "Got DirectReadAck from client",
-        {PQ_LOG_PREFIX},
+    LOG_D("Got DirectReadAck from client",
         {"partition", it->second.Partition},
         {"directReadId", directReadId},
         {"bytesInflight", BytesInflight_});
@@ -520,8 +509,7 @@ void TReadSessionActor<Protocol>::ProcessDirectReads(TPartitionsMap::iterator it
             return;
         }
 
-        YDB_LOG_DEBUG_CTX(ctx, "Processing direct read ack",
-            {PQ_LOG_PREFIX},
+        LOG_D("Processing direct read ack",
             {"directReadId", directReadId});
         pendingAcks.pop();
         BytesInflight_ -= drIt->second.ByteSize;
@@ -543,15 +531,13 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvStartRead::TPtr& ev, con
     auto it = Partitions.find(ev->Get()->AssignId);
     if (it == Partitions.end() || it->second.Releasing) {
         // do nothing - already released partition
-        YDB_LOG_WARN_CTX(ctx, "Got irrelevant StartRead from client",
-            {PQ_LOG_PREFIX},
+        LOG_W("Got irrelevant StartRead from client",
             {"partition", ev->Get()->AssignId},
             {"offset", ev->Get()->ReadOffset});
         return;
     }
 
-    YDB_LOG_INFO_CTX(ctx, "Got StartRead from client",
-        {PQ_LOG_PREFIX},
+    LOG_I("Got StartRead from client",
         {"partition", it->second.Partition},
         {"readOffset", ev->Get()->ReadOffset},
         {"commitOffset", ev->Get()->CommitOffset},
@@ -575,8 +561,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvReleased::TPtr& ev, cons
 
     auto& partitionInfo = it->second;
 
-    YDB_LOG_INFO_CTX(ctx, "Got Released from client",
-        {PQ_LOG_PREFIX},
+    LOG_I("Got Released from client",
         {"partition", partitionInfo.Partition});
 
     if (!partitionInfo.LockSent) {
@@ -718,8 +703,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvCommitDone::TPtr& ev, co
     partition.EndOffset = msg->EndOffset;
     partition.ReadingFinished = msg->ReadingFinishedSent;
 
-    YDB_LOG_DEBUG_CTX(ctx, "Replying for commits",
-        {PQ_LOG_PREFIX},
+    LOG_D("Replying for commits",
         {"assignId", msg->AssignId},
         {"from", msg->StartCookie},
         {"to", msg->LastCookie},
@@ -946,8 +930,7 @@ void TReadSessionActor<Protocol>::Handle(typename TEvReadInit::TPtr& ev, const T
         }
     }
 
-    YDB_LOG_INFO_CTX(ctx, "Read init",
-        {PQ_LOG_PREFIX},
+    LOG_I("Read init",
         {"from", PeerName},
         {"request", ev->Get()->Request});
 
@@ -1064,8 +1047,7 @@ void TReadSessionActor<Protocol>::SetupTopicCounters(const NPersQueue::TTopicCon
 
 template <EProtocol Protocol>
 void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvAuthResultOk::TPtr& ev, const TActorContext& ctx) {
-    YDB_LOG_INFO_CTX(ctx, "Auth ok",
-        {PQ_LOG_PREFIX},
+    LOG_I("Auth ok",
         {"topics", ev->Get()->TopicAndTablets.size()},
         {"initDone", InitDone});
 
@@ -1245,8 +1227,7 @@ bool TReadSessionActor<Protocol>::SendLockPartitionToSelf(ui32 partitionId, TStr
 
 template <EProtocol Protocol>
 void TReadSessionActor<Protocol>::RegisterSession(const TString& topic, const TActorId& pipe, const TVector<ui32>& groups, const TActorContext& ctx) {
-    YDB_LOG_INFO_CTX(ctx, "Register session",
-        {PQ_LOG_PREFIX},
+    LOG_I("Register session",
         {"topic", topic});
 
     auto request = MakeHolder<TEvPersQueue::TEvRegisterReadSession>();
@@ -1277,8 +1258,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPersQueue::TEvLockPartition::TPtr& e
 
     auto converterIter = FullPathToConverter.find(NPersQueue::NormalizeFullPath(path));
     if (converterIter == FullPathToConverter.end()) {
-        YDB_LOG_DEBUG_CTX(ctx, "Ignored ev lock not recognized",
-            {PQ_LOG_PREFIX},
+        LOG_D("Ignored ev lock not recognized",
             {"path", path},
             {"reason", "path"});
         return;
@@ -1289,8 +1269,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPersQueue::TEvLockPartition::TPtr& e
 
     auto topicIt = Topics.find(name);
     if (topicIt == Topics.end() || (!ReadWithoutConsumer && topicIt->second->PipeClient != ActorIdFromProto(record.GetPipeClient()))) {
-        YDB_LOG_ALERT_CTX(ctx, "Ignored ev lock is unknown",
-            {PQ_LOG_PREFIX},
+        LOG_A("Ignored ev lock is unknown",
             {"path", name},
             {"reason", "topic"});
         return;
@@ -1329,7 +1308,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPersQueue::TEvLockPartition::TPtr& e
 
     BalancerGeneration[assignId] = {record.GetGeneration(), record.GetStep()};
     const TPartitionId partitionId{converterIter->second, record.GetPartition(), assignId};
-    auto [error, maxLag, readTimestampMs] = GetReadFrom(converter, ctx);
+    auto [error, maxLag, readTimestampMs] = GetReadFrom(converter);
     if (error) {
         return CloseSession(PersQueue::ErrorCode::ERROR, error, ctx);
     }
@@ -1367,8 +1346,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPersQueue::TEvLockPartition::TPtr& e
     it->second.PartitionsLocked.Inc();
     it->second.PartitionsInfly.Inc();
 
-    YDB_LOG_INFO_CTX(ctx, "Assign",
-        {PQ_LOG_PREFIX},
+    LOG_I("Assign",
         {"from", PeerName},
         {"user", (Token ? Token->GetUserSID() : "-")},
         {"topic", converter->GetPrintableString()},
@@ -1471,8 +1449,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvPartitionStatus::TPtr& e
         }
     }
 
-    YDB_LOG_DEBUG_CTX(ctx, "Sending to client partition status",
-        {PQ_LOG_PREFIX});
+    LOG_D("Sending to client partition status");
     SendControlMessage(it->second.Partition, std::move(result), ctx, false);
 }
 
@@ -1509,8 +1486,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvUpdateSession::TPtr& ev,
 
     }
 
-    YDB_LOG_INFO_CTX(ctx, "Sending to client update partition stream event",
-        {PQ_LOG_PREFIX});
+    LOG_I("Sending to client update partition stream event");
     SendControlMessage(partitionInfo.Partition, std::move(result), ctx);
 }
 
@@ -1599,8 +1575,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPersQueue::TEvReleasePartition::TPtr
 
         counters.PartitionsToBeReleased.Inc();
 
-        YDB_LOG_INFO_CTX(ctx, "Releasing",
-            {PQ_LOG_PREFIX},
+        LOG_I("Releasing",
             {"partition", it->second.Partition});
         partitionInfo.Releasing = true;
 
@@ -1615,8 +1590,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPersQueue::TEvReleasePartition::TPtr
     bool found = false;
 
     // Release partitions by partition id
-    YDB_LOG_DEBUG_CTX(ctx, "Gone release",
-        {PQ_LOG_PREFIX},
+    LOG_D("Gone release",
         {"partition", partitionId});
 
     for (auto it = Partitions.begin(); it != Partitions.end(); ++it) {
@@ -1679,8 +1653,7 @@ void TReadSessionActor<Protocol>::InformBalancerAboutRelease(typename TPartition
     req.SetTopic(converter->GetPrimaryPath());
     req.SetPartition(partitionInfo.Partition.Partition);
 
-    YDB_LOG_INFO_CTX(ctx, "Released",
-        {PQ_LOG_PREFIX},
+    LOG_I("Released",
         {"partition", partitionInfo.Partition});
     NTabletPipe::SendData(ctx, topicInfo->PipeClient, request.Release());
 }
@@ -1702,19 +1675,16 @@ void TReadSessionActor<Protocol>::CloseSession(PersQueue::ErrorCode::ErrorCode c
         result.set_status(ConvertPersQueueInternalCodeToStatus(code));
         FillIssue(result.add_issues(), code, reason);
 
-        YDB_LOG_INFO_CTX(ctx, "Closed with error",
-            {PQ_LOG_PREFIX},
+        LOG_I("Closed with error",
             {"reason", reason});
         if (!WriteToStreamOrDie(ctx, std::move(result), true)) {
             return;
         }
     } else {
-        YDB_LOG_INFO_CTX(ctx, "Closed",
-            {PQ_LOG_PREFIX});
+        LOG_I("Closed");
         const Ydb::StatusIds::StatusCode statusCode = ConvertPersQueueInternalCodeToStatus(code);
         if (!Request->Finish(statusCode)) {
-            YDB_LOG_INFO_CTX(ctx, "Grpc double finish failed",
-                {PQ_LOG_PREFIX});
+            LOG_I("Grpc double finish failed");
         }
     }
     Die(ctx);
@@ -1759,8 +1729,7 @@ void TReadSessionActor<Protocol>::ReleasePartition(TPartitionsMapIterator& it, b
     AFL_ENSURE(couldBeReads || !partition.Reading);
     typename TFormedReadResponse<TServerMessage>::TPtr response;
 
-    YDB_LOG_INFO_CTX(ctx, "Got all from client, actual releasing",
-        {PQ_LOG_PREFIX},
+    LOG_I("Got all from client, actual releasing",
         {"partition", partition.Partition});
 
 
@@ -1810,8 +1779,7 @@ void TReadSessionActor<Protocol>::ProcessBalancerDead(ui64 tabletId, const TActo
                 break;
             }
 
-            YDB_LOG_INFO_CTX(ctx, "Balancer dead, restarting all from topic",
-                {PQ_LOG_PREFIX},
+            LOG_I("Balancer dead, restarting all from topic",
                 {"topic", topic->FullConverter->GetPrintableString()});
 
             // Drop all partitions from this topic
@@ -1884,8 +1852,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvRead::TPtr& ev, const TA
         return;
     }
 
-    YDB_LOG_DEBUG_CTX(ctx, "Got read request",
-        {PQ_LOG_PREFIX},
+    LOG_D("Got read request",
         {"guid", ev->Get()->Guid});
 
     if constexpr (Protocol == EProtocol::PQv1) {
@@ -1984,8 +1951,7 @@ void TReadSessionActor<Protocol>::Handle(typename TEvReadResponse::TPtr& ev, con
         partitionInfo.ReadIdToResponse = partitionCookie + 1;
     }
 
-    YDB_LOG_DEBUG_CTX(ctx, "Read done",
-        {PQ_LOG_PREFIX},
+    LOG_D("Read done",
         {"guid", formedResponse->Guid},
         {"partition", partitionInfo.Partition},
         {"size", response.ByteSize()});
@@ -2046,8 +2012,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvDirectReadResponse::TPtr
     AFL_ENSURE(it->second.Reading);
     it->second.Reading = false;
 
-    YDB_LOG_DEBUG_CTX(ctx, "Direct read preparation done",
-        {PQ_LOG_PREFIX},
+    LOG_D("Direct read preparation done",
         {"guid", formedResponse->Guid},
         {"partition", it->second.Partition},
         {"size", ev->Get()->ByteSize},
@@ -2150,15 +2115,13 @@ void TReadSessionActor<Protocol>::ProcessAnswer(typename TFormedReadResponse<TSe
 
         ProcessDirectReads(it, ctx);
     } else if (formedResponse->HasMessages) {
-        YDB_LOG_DEBUG_CTX(ctx, "Response to read",
-            {PQ_LOG_PREFIX},
+        LOG_D("Response to read",
             {"guid", formedResponse->Guid});
         if (!WriteToStreamOrDie(ctx, std::move(formedResponse->Response))) {
             return;
         }
     } else {
-        YDB_LOG_DEBUG_CTX(ctx, "Empty read result, start new reading",
-            {PQ_LOG_PREFIX},
+        LOG_D("Empty read result, start new reading",
             {"guid", formedResponse->Guid});
     }
     BytesInflight_ -= diff;
@@ -2196,8 +2159,7 @@ void TReadSessionActor<Protocol>::ProcessAnswer(typename TFormedReadResponse<TSe
     // Bring back available partitions.
     // If some partition was removed from partitions container, it is not bad because it will be checked during read processing.
     AvailablePartitions.insert(formedResponse->PartitionsBecameAvailable.begin(), formedResponse->PartitionsBecameAvailable.end());
-    YDB_LOG_DEBUG_CTX(ctx, "Process answer. Aval",
-        {PQ_LOG_PREFIX},
+    LOG_D("Process answer. Aval",
         {"parts", AvailablePartitions.size()});
 
 
@@ -2236,17 +2198,15 @@ ui32 TReadSessionActor<Protocol>::NormalizeMaxReadSize(ui32 sourceValue) {
 }
 
 template <EProtocol Protocol>
-std::tuple<TString, ui32, ui64> TReadSessionActor<Protocol>::GetReadFrom(const NPersQueue::TTopicConverterPtr& topic, const TActorContext& ctx) const {
+std::tuple<TString, ui32, ui64> TReadSessionActor<Protocol>::GetReadFrom(const NPersQueue::TTopicConverterPtr& topic) const {
     auto jt = ReadFromTimestamp.find(topic->GetInternalName());
     if (jt == ReadFromTimestamp.end()) {
-        YDB_LOG_ALERT_CTX(ctx, "Error searching for topic",
-            {PQ_LOG_PREFIX},
+        LOG_A("Error searching for topic",
             {"internalName", topic->GetInternalName()},
             {"prettyName", topic->GetPrintableString()});
 
         for (const auto& kv : ReadFromTimestamp) {
-            YDB_LOG_ALERT_CTX(ctx, "Have topic",
-                {PQ_LOG_PREFIX},
+            LOG_A("Have topic",
                 {"topic", kv.first});
         }
 
@@ -2308,15 +2268,14 @@ void TReadSessionActor<Protocol>::ProcessReads(const TActorContext& ctx) {
             size -= csize;
             AFL_ENSURE(csize < Max<i32>());
 
-            auto [error, maxLag, readTimestampMs] = GetReadFrom(it->second.Topic, ctx);
+            auto [error, maxLag, readTimestampMs] = GetReadFrom(it->second.Topic);
             if (error) {
                 return CloseSession(PersQueue::ErrorCode::ERROR, error, ctx);
             }
 
             auto ev = MakeHolder<TEvPQProxy::TEvRead>(guid, ccount, csize, maxLag, readTimestampMs);
 
-            YDB_LOG_DEBUG_CTX(ctx, "Performing read request ms",
-                {PQ_LOG_PREFIX},
+            LOG_D("Performing read request ms",
                 {"guid", ev->Guid},
                 {"from", it->second.Partition},
                 {"count", ccount},
@@ -2383,8 +2342,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvPartitionReady::TPtr& ev
         return;
     }
 
-    YDB_LOG_DEBUG_CTX(ctx, "Partition ready for read",
-        {PQ_LOG_PREFIX},
+    LOG_D("Partition ready for read",
         {"partition", ev->Get()->Partition},
         {"readOffset", ev->Get()->ReadOffset},
         {"endOffset", ev->Get()->EndOffset},
@@ -2400,8 +2358,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvPartitionReady::TPtr& ev
         ev->Get()->SizeLag,
         ev->Get()->EndOffset - ev->Get()->ReadOffset).second;
     AFL_ENSURE(res);
-    YDB_LOG_DEBUG_CTX(ctx, "TEvPartitionReady. Aval",
-        {PQ_LOG_PREFIX},
+    LOG_D("TEvPartitionReady. Aval",
         {"parts", AvailablePartitions.size()});
 
     ProcessReads(ctx);
@@ -2460,8 +2417,7 @@ void TReadSessionActor<Protocol>::RecheckACL(const TActorContext& ctx) {
         ForceACLCheck = false;
         RequestNotChecked = false;
 
-        YDB_LOG_DEBUG_CTX(ctx, "Checking auth because of timeout",
-            {PQ_LOG_PREFIX});
+        LOG_D("Checking auth because of timeout");
         RunAuthActor(ctx);
     }
 }
@@ -2536,8 +2492,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvReadingFinished::TPtr& e
                 }
             }
 
-            YDB_LOG_INFO_CTX(ctx, "Sending to client end partition stream event",
-                {PQ_LOG_PREFIX});
+            LOG_I("Sending to client end partition stream event");
             SendControlMessage(partitionInfo->Partition, std::move(result), ctx);
         }
     }

--- a/ydb/services/persqueue_v1/actors/read_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.cpp
@@ -89,7 +89,7 @@ void TReadSessionActor<Protocol>::Bootstrap(const TActorContext& ctx) {
 template <EProtocol Protocol>
 void TReadSessionActor<Protocol>::Handle(typename IContext::TEvNotifiedWhenDone::TPtr&, const TActorContext& ctx) {
     YDB_LOG_INFO_CTX(ctx, "Grpc closed",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX});
+        {PQ_LOG_PREFIX});
     Die(ctx);
 }
 
@@ -97,7 +97,7 @@ template <EProtocol Protocol>
 bool TReadSessionActor<Protocol>::ReadFromStreamOrDie(const TActorContext& ctx) {
     if (!Request->Read()) {
         YDB_LOG_INFO_CTX(ctx, "Grpc read failed at start",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX});
+            {PQ_LOG_PREFIX});
         Die(ctx);
         return false;
     }
@@ -119,13 +119,13 @@ void TReadSessionActor<Protocol>::Handle(typename IContext::TEvReadFinished::TPt
     }
 
     YDB_LOG_DEBUG_CTX(ctx, "Grpc read done",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"success", ev->Get()->Success},
         {"data", request});
 
     if (!ev->Get()->Success) {
         YDB_LOG_INFO_CTX(ctx, "Grpc read failed",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX});
+            {PQ_LOG_PREFIX});
         ctx.Send(ctx.SelfID, new TEvPQProxy::TEvDone());
         return;
     }
@@ -314,7 +314,7 @@ bool TReadSessionActor<Protocol>::WriteToStreamOrDie(const TActorContext& ctx, T
 
     if (!res) {
         YDB_LOG_INFO_CTX(ctx, "Grpc write failed at start",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX});
+            {PQ_LOG_PREFIX});
         Die(ctx);
     }
 
@@ -325,7 +325,7 @@ template <EProtocol Protocol>
 void TReadSessionActor<Protocol>::Handle(typename IContext::TEvWriteFinished::TPtr& ev, const TActorContext& ctx) {
     if (!ev->Get()->Success) {
         YDB_LOG_INFO_CTX(ctx, "Grpc write failed",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX});
+            {PQ_LOG_PREFIX});
         return Die(ctx);
     }
 
@@ -387,7 +387,7 @@ void TReadSessionActor<Protocol>::Die(const TActorContext& ctx) {
     }
 
     YDB_LOG_INFO_CTX(ctx, "Is DEAD",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX});
+        {PQ_LOG_PREFIX});
     ctx.Send(GetPQReadServiceActorID(), new TEvPQProxy::TEvSessionDead(Cookie));
     TRlHelpers::PassAway(TActorBootstrapped<TReadSessionActor>::SelfId());
     TActorBootstrapped<TReadSessionActor>::Die(ctx);
@@ -397,7 +397,7 @@ template <EProtocol Protocol>
 bool TReadSessionActor<Protocol>::OnUnhandledException(const std::exception& exc) {
     auto ctx = *NActors::TlsActivationContext;
     YDB_LOG_CRIT_CTX(ctx, "Unhandled exception",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"typeName", TypeName(exc)},
         {"exception", exc.what()},
         {"backTrace", TBackTrace::FromCurrentException().PrintToString()});
@@ -488,7 +488,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvDirectReadAck::TPtr& ev,
     auto directReadId = ev->Get()->DirectReadId;
 
     YDB_LOG_DEBUG_CTX(ctx, "Got DirectReadAck from client",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", it->second.Partition},
         {"directReadId", directReadId},
         {"bytesInflight", BytesInflight_});
@@ -521,7 +521,7 @@ void TReadSessionActor<Protocol>::ProcessDirectReads(TPartitionsMap::iterator it
         }
 
         YDB_LOG_DEBUG_CTX(ctx, "Processing direct read ack",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"directReadId", directReadId});
         pendingAcks.pop();
         BytesInflight_ -= drIt->second.ByteSize;
@@ -544,14 +544,14 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvStartRead::TPtr& ev, con
     if (it == Partitions.end() || it->second.Releasing) {
         // do nothing - already released partition
         YDB_LOG_WARN_CTX(ctx, "Got irrelevant StartRead from client",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", ev->Get()->AssignId},
             {"offset", ev->Get()->ReadOffset});
         return;
     }
 
     YDB_LOG_INFO_CTX(ctx, "Got StartRead from client",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", it->second.Partition},
         {"readOffset", ev->Get()->ReadOffset},
         {"commitOffset", ev->Get()->CommitOffset},
@@ -576,7 +576,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvReleased::TPtr& ev, cons
     auto& partitionInfo = it->second;
 
     YDB_LOG_INFO_CTX(ctx, "Got Released from client",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", partitionInfo.Partition});
 
     if (!partitionInfo.LockSent) {
@@ -719,7 +719,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvCommitDone::TPtr& ev, co
     partition.ReadingFinished = msg->ReadingFinishedSent;
 
     YDB_LOG_DEBUG_CTX(ctx, "Replying for commits",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"assignId", msg->AssignId},
         {"from", msg->StartCookie},
         {"to", msg->LastCookie},
@@ -947,7 +947,7 @@ void TReadSessionActor<Protocol>::Handle(typename TEvReadInit::TPtr& ev, const T
     }
 
     YDB_LOG_INFO_CTX(ctx, "Read init",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"from", PeerName},
         {"request", ev->Get()->Request});
 
@@ -1065,7 +1065,7 @@ void TReadSessionActor<Protocol>::SetupTopicCounters(const NPersQueue::TTopicCon
 template <EProtocol Protocol>
 void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvAuthResultOk::TPtr& ev, const TActorContext& ctx) {
     YDB_LOG_INFO_CTX(ctx, "Auth ok",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topics", ev->Get()->TopicAndTablets.size()},
         {"initDone", InitDone});
 
@@ -1246,7 +1246,7 @@ bool TReadSessionActor<Protocol>::SendLockPartitionToSelf(ui32 partitionId, TStr
 template <EProtocol Protocol>
 void TReadSessionActor<Protocol>::RegisterSession(const TString& topic, const TActorId& pipe, const TVector<ui32>& groups, const TActorContext& ctx) {
     YDB_LOG_INFO_CTX(ctx, "Register session",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"topic", topic});
 
     auto request = MakeHolder<TEvPersQueue::TEvRegisterReadSession>();
@@ -1278,7 +1278,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPersQueue::TEvLockPartition::TPtr& e
     auto converterIter = FullPathToConverter.find(NPersQueue::NormalizeFullPath(path));
     if (converterIter == FullPathToConverter.end()) {
         YDB_LOG_DEBUG_CTX(ctx, "Ignored ev lock not recognized",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"path", path},
             {"reason", "path"});
         return;
@@ -1290,7 +1290,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPersQueue::TEvLockPartition::TPtr& e
     auto topicIt = Topics.find(name);
     if (topicIt == Topics.end() || (!ReadWithoutConsumer && topicIt->second->PipeClient != ActorIdFromProto(record.GetPipeClient()))) {
         YDB_LOG_ALERT_CTX(ctx, "Ignored ev lock is unknown",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"path", name},
             {"reason", "topic"});
         return;
@@ -1368,7 +1368,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPersQueue::TEvLockPartition::TPtr& e
     it->second.PartitionsInfly.Inc();
 
     YDB_LOG_INFO_CTX(ctx, "Assign",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"from", PeerName},
         {"user", (Token ? Token->GetUserSID() : "-")},
         {"topic", converter->GetPrintableString()},
@@ -1472,7 +1472,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvPartitionStatus::TPtr& e
     }
 
     YDB_LOG_DEBUG_CTX(ctx, "Sending to client partition status",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX});
+        {PQ_LOG_PREFIX});
     SendControlMessage(it->second.Partition, std::move(result), ctx, false);
 }
 
@@ -1510,7 +1510,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvUpdateSession::TPtr& ev,
     }
 
     YDB_LOG_INFO_CTX(ctx, "Sending to client update partition stream event",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX});
+        {PQ_LOG_PREFIX});
     SendControlMessage(partitionInfo.Partition, std::move(result), ctx);
 }
 
@@ -1600,7 +1600,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPersQueue::TEvReleasePartition::TPtr
         counters.PartitionsToBeReleased.Inc();
 
         YDB_LOG_INFO_CTX(ctx, "Releasing",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"partition", it->second.Partition});
         partitionInfo.Releasing = true;
 
@@ -1616,7 +1616,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPersQueue::TEvReleasePartition::TPtr
 
     // Release partitions by partition id
     YDB_LOG_DEBUG_CTX(ctx, "Gone release",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", partitionId});
 
     for (auto it = Partitions.begin(); it != Partitions.end(); ++it) {
@@ -1680,7 +1680,7 @@ void TReadSessionActor<Protocol>::InformBalancerAboutRelease(typename TPartition
     req.SetPartition(partitionInfo.Partition.Partition);
 
     YDB_LOG_INFO_CTX(ctx, "Released",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", partitionInfo.Partition});
     NTabletPipe::SendData(ctx, topicInfo->PipeClient, request.Release());
 }
@@ -1703,18 +1703,18 @@ void TReadSessionActor<Protocol>::CloseSession(PersQueue::ErrorCode::ErrorCode c
         FillIssue(result.add_issues(), code, reason);
 
         YDB_LOG_INFO_CTX(ctx, "Closed with error",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"reason", reason});
         if (!WriteToStreamOrDie(ctx, std::move(result), true)) {
             return;
         }
     } else {
         YDB_LOG_INFO_CTX(ctx, "Closed",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX});
+            {PQ_LOG_PREFIX});
         const Ydb::StatusIds::StatusCode statusCode = ConvertPersQueueInternalCodeToStatus(code);
         if (!Request->Finish(statusCode)) {
             YDB_LOG_INFO_CTX(ctx, "Grpc double finish failed",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX});
+                {PQ_LOG_PREFIX});
         }
     }
     Die(ctx);
@@ -1760,7 +1760,7 @@ void TReadSessionActor<Protocol>::ReleasePartition(TPartitionsMapIterator& it, b
     typename TFormedReadResponse<TServerMessage>::TPtr response;
 
     YDB_LOG_INFO_CTX(ctx, "Got all from client, actual releasing",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", partition.Partition});
 
 
@@ -1811,7 +1811,7 @@ void TReadSessionActor<Protocol>::ProcessBalancerDead(ui64 tabletId, const TActo
             }
 
             YDB_LOG_INFO_CTX(ctx, "Balancer dead, restarting all from topic",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                {PQ_LOG_PREFIX},
                 {"topic", topic->FullConverter->GetPrintableString()});
 
             // Drop all partitions from this topic
@@ -1885,7 +1885,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvRead::TPtr& ev, const TA
     }
 
     YDB_LOG_DEBUG_CTX(ctx, "Got read request",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"guid", ev->Get()->Guid});
 
     if constexpr (Protocol == EProtocol::PQv1) {
@@ -1985,7 +1985,7 @@ void TReadSessionActor<Protocol>::Handle(typename TEvReadResponse::TPtr& ev, con
     }
 
     YDB_LOG_DEBUG_CTX(ctx, "Read done",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"guid", formedResponse->Guid},
         {"partition", partitionInfo.Partition},
         {"size", response.ByteSize()});
@@ -2047,7 +2047,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvDirectReadResponse::TPtr
     it->second.Reading = false;
 
     YDB_LOG_DEBUG_CTX(ctx, "Direct read preparation done",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"guid", formedResponse->Guid},
         {"partition", it->second.Partition},
         {"size", ev->Get()->ByteSize},
@@ -2151,14 +2151,14 @@ void TReadSessionActor<Protocol>::ProcessAnswer(typename TFormedReadResponse<TSe
         ProcessDirectReads(it, ctx);
     } else if (formedResponse->HasMessages) {
         YDB_LOG_DEBUG_CTX(ctx, "Response to read",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"guid", formedResponse->Guid});
         if (!WriteToStreamOrDie(ctx, std::move(formedResponse->Response))) {
             return;
         }
     } else {
         YDB_LOG_DEBUG_CTX(ctx, "Empty read result, start new reading",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"guid", formedResponse->Guid});
     }
     BytesInflight_ -= diff;
@@ -2197,7 +2197,7 @@ void TReadSessionActor<Protocol>::ProcessAnswer(typename TFormedReadResponse<TSe
     // If some partition was removed from partitions container, it is not bad because it will be checked during read processing.
     AvailablePartitions.insert(formedResponse->PartitionsBecameAvailable.begin(), formedResponse->PartitionsBecameAvailable.end());
     YDB_LOG_DEBUG_CTX(ctx, "Process answer. Aval",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"parts", AvailablePartitions.size()});
 
 
@@ -2240,13 +2240,13 @@ std::tuple<TString, ui32, ui64> TReadSessionActor<Protocol>::GetReadFrom(const N
     auto jt = ReadFromTimestamp.find(topic->GetInternalName());
     if (jt == ReadFromTimestamp.end()) {
         YDB_LOG_ALERT_CTX(ctx, "Error searching for topic",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {PQ_LOG_PREFIX},
             {"internalName", topic->GetInternalName()},
             {"prettyName", topic->GetPrintableString()});
 
         for (const auto& kv : ReadFromTimestamp) {
             YDB_LOG_ALERT_CTX(ctx, "Have topic",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                {PQ_LOG_PREFIX},
                 {"topic", kv.first});
         }
 
@@ -2316,7 +2316,7 @@ void TReadSessionActor<Protocol>::ProcessReads(const TActorContext& ctx) {
             auto ev = MakeHolder<TEvPQProxy::TEvRead>(guid, ccount, csize, maxLag, readTimestampMs);
 
             YDB_LOG_DEBUG_CTX(ctx, "Performing read request ms",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                {PQ_LOG_PREFIX},
                 {"guid", ev->Guid},
                 {"from", it->second.Partition},
                 {"count", ccount},
@@ -2384,7 +2384,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvPartitionReady::TPtr& ev
     }
 
     YDB_LOG_DEBUG_CTX(ctx, "Partition ready for read",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"partition", ev->Get()->Partition},
         {"readOffset", ev->Get()->ReadOffset},
         {"endOffset", ev->Get()->EndOffset},
@@ -2401,7 +2401,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvPartitionReady::TPtr& ev
         ev->Get()->EndOffset - ev->Get()->ReadOffset).second;
     AFL_ENSURE(res);
     YDB_LOG_DEBUG_CTX(ctx, "TEvPartitionReady. Aval",
-        {"PQLOGPREFIX", PQ_LOG_PREFIX},
+        {PQ_LOG_PREFIX},
         {"parts", AvailablePartitions.size()});
 
     ProcessReads(ctx);
@@ -2461,7 +2461,7 @@ void TReadSessionActor<Protocol>::RecheckACL(const TActorContext& ctx) {
         RequestNotChecked = false;
 
         YDB_LOG_DEBUG_CTX(ctx, "Checking auth because of timeout",
-            {"PQLOGPREFIX", PQ_LOG_PREFIX});
+            {PQ_LOG_PREFIX});
         RunAuthActor(ctx);
     }
 }
@@ -2537,7 +2537,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvReadingFinished::TPtr& e
             }
 
             YDB_LOG_INFO_CTX(ctx, "Sending to client end partition stream event",
-                {"PQLOGPREFIX", PQ_LOG_PREFIX});
+                {PQ_LOG_PREFIX});
             SendControlMessage(partitionInfo->Partition, std::move(result), ctx);
         }
     }

--- a/ydb/services/persqueue_v1/actors/read_session_actor.h
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.h
@@ -7,12 +7,11 @@
 
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/grpc_services/grpc_request_proxy.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/persqueue/dread_cache_service/caching_service.h>
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/persqueue/public/pq_rl_helpers.h>
-
-#include <ydb/library/actors/core/actor_bootstrapped.h>
 
 #include <library/cpp/containers/disjoint_interval_tree/disjoint_interval_tree.h>
 
@@ -22,7 +21,6 @@
 #include <google/protobuf/util/time_util.h>
 
 #include <type_traits>
-#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NGRpcProxy::V1 {
 
@@ -163,10 +161,10 @@ struct TFormedReadResponse: public TSimpleRefCount<TFormedReadResponse<TServerMe
 
 template <EProtocol Protocol>
 class TReadSessionActor
-    : public TActorBootstrapped<TReadSessionActor<Protocol>>
+    : public NPQ::TBaseActor<TReadSessionActor<Protocol>>
     , private NPQ::TRlHelpers
-    , public NActors::IActorExceptionHandler
 {
+    using TBase = NPQ::TBaseActor<TReadSessionActor<Protocol>>;
     using TClientMessage = typename std::conditional_t<Protocol == EProtocol::PQv1,
         PersQueue::V1::MigrationStreamingReadClientMessage,
         Topic::StreamReadMessage::FromClient>;
@@ -227,6 +225,13 @@ public:
     }
 
     bool OnUnhandledException(const std::exception& exc) override;
+
+    NPQ::TStructuredMessage LogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"sessionCookie", Cookie},
+            {"consumer", ClientPath},
+            {"session", Session});
+    }
 
 private:
     STFUNC(StateFunc) {
@@ -356,7 +361,7 @@ private:
     void SendReleaseSignal(TPartitionActorInfo& partition, bool kill, const TActorContext& ctx);
     void InformBalancerAboutRelease(TPartitionsMapIterator it, const TActorContext& ctx);
 
-    std::tuple<TString, ui32, ui64> GetReadFrom(const NPersQueue::TTopicConverterPtr& topic, const TActorContext& ctx) const;
+    std::tuple<TString, ui32, ui64> GetReadFrom(const NPersQueue::TTopicConverterPtr& topic) const;
 
     static ui32 NormalizeMaxReadMessagesCount(ui32 sourceValue);
     static ui32 NormalizeMaxReadSize(ui32 sourceValue);

--- a/ydb/services/persqueue_v1/actors/schema_actors.cpp
+++ b/ydb/services/persqueue_v1/actors/schema_actors.cpp
@@ -9,9 +9,6 @@
 #include <ydb/public/sdk/cpp/src/library/persqueue/obfuscate/obfuscate.h>
 
 #include <library/cpp/json/json_writer.h>
-#include <ydb/library/actors/core/log.h>
-
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_READ_PROXY
 
 namespace NKikimr::NGRpcProxy::V1 {
 

--- a/ydb/services/persqueue_v1/actors/write_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/write_session_actor.cpp
@@ -23,15 +23,12 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
 #include <ydb/core/persqueue/public/config.h>
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
-#include <ydb/library/actors/core/log.h>
 #include <google/protobuf/util/time_util.h>
 #include <util/string/cast.h>
 #include <util/string/hex.h>
 #include <util/string/vector.h>
 #include <util/string/escape.h>
 #include <util/string/printf.h>
-
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_WRITE_PROXY
 
 using namespace NActors;
 using namespace NKikimrClient;
@@ -210,7 +207,8 @@ TWriteSessionActor<Protocol>::TWriteSessionActor(
         TIntrusivePtr<::NMonitoring::TDynamicCounters> counters, const TMaybe<TString> clientDC,
         const NPersQueue::TTopicsListController& topicsController
 )
-    : TRlHelpers({}, request, WRITE_BLOCK_SIZE, false)
+    : TBase(NKikimrServices::PQ_WRITE_PROXY)
+    , TRlHelpers({}, request, WRITE_BLOCK_SIZE, false)
     , Request(request)
     , State(ES_CREATED)
     , SchemeCache(schemeCache)
@@ -254,7 +252,7 @@ void TWriteSessionActor<Protocol>::Bootstrap(const TActorContext& ctx) {
 
     Request->Attach(ctx.SelfID);
     if (!Request->Read()) {
-        YDB_LOG_INFO_CTX(ctx, "Grpc read failed at start");
+        LOG_I("Grpc read failed at start");
         Die(ctx);
         return;
     }
@@ -265,9 +263,7 @@ void TWriteSessionActor<Protocol>::Bootstrap(const TActorContext& ctx) {
 template <EProtocol Protocol>
 void TWriteSessionActor<Protocol>::Handle(typename IContext::TEvNotifiedWhenDone::TPtr& ev, const TActorContext& ctx) {
     CloseSpans("Done", ev->Get()->Success ? PersQueue::ErrorCode::OK : PersQueue::ErrorCode::BAD_REQUEST);
-    YDB_LOG_INFO_CTX(ctx, "Session v1 grpc closed",
-        {"cookie", Cookie},
-        {"sessionId", OwnerCookie});
+    LOG_I("Session v1 grpc closed");
     Die(ctx);
 }
 
@@ -289,15 +285,11 @@ TString WriteRequestToLog(const TClientMessage& proto) {
 
 template <EProtocol Protocol>
 void TWriteSessionActor<Protocol>::Handle(typename IContext::TEvReadFinished::TPtr& ev, const TActorContext& ctx) {
-    YDB_LOG_DEBUG_CTX(ctx, "Session v1 grpc read done",
-        {"cookie", Cookie},
-        {"sessionId", OwnerCookie},
+    LOG_D("Session v1 grpc read done",
         {"success", ev->Get()->Success},
         {"data", WriteRequestToLog(ev->Get()->Record)});
     if (!ev->Get()->Success) {
-        YDB_LOG_INFO_CTX(ctx, "Session v1 grpc read failed",
-            {"cookie", Cookie},
-            {"sessionId", OwnerCookie});
+        LOG_I("Session v1 grpc read failed");
         ctx.Send(ctx.SelfID, new TEvPQProxy::TEvDone());
         return;
     }
@@ -325,9 +317,7 @@ void TWriteSessionActor<Protocol>::Handle(typename IContext::TEvReadFinished::TP
 template <EProtocol Protocol>
 void TWriteSessionActor<Protocol>::Handle(typename IContext::TEvWriteFinished::TPtr& ev, const TActorContext& ctx) {
     if (!ev->Get()->Success) {
-        YDB_LOG_INFO_CTX(ctx, "Session v1 grpc write failed",
-            {"cookie", Cookie},
-            {"sessionId", OwnerCookie});
+        LOG_I("Session v1 grpc write failed");
         Die(ctx);
     }
 }
@@ -335,9 +325,7 @@ void TWriteSessionActor<Protocol>::Handle(typename IContext::TEvWriteFinished::T
 template <EProtocol Protocol>
 void TWriteSessionActor<Protocol>::Die(const TActorContext& ctx) {
     if (State == ES_DYING) {
-        YDB_LOG_INFO_CTX(ctx, "Session v1 is already DEAD",
-            {"cookie", Cookie},
-            {"sessionId", OwnerCookie});
+        LOG_I("Session v1 is already DEAD");
         return;
     }
 
@@ -349,9 +337,7 @@ void TWriteSessionActor<Protocol>::Die(const TActorContext& ctx) {
         }
     }
 
-    YDB_LOG_INFO_CTX(ctx, "Session v1 is DEAD",
-        {"cookie", Cookie},
-        {"sessionId", OwnerCookie});
+    LOG_I("Session v1 is DEAD");
 
     ctx.Send(GetPQWriteServiceActorID(), new TEvPQProxy::TEvSessionDead(Cookie));
 
@@ -366,15 +352,15 @@ void TWriteSessionActor<Protocol>::Die(const TActorContext& ctx) {
     }
 
     State = ES_DYING;
-    TRlHelpers::PassAway(TActorBootstrapped<TWriteSessionActor>::SelfId());
-    TActorBootstrapped<TWriteSessionActor>::Die(ctx);
+    TRlHelpers::PassAway(TBase::SelfId());
+    TBase::Die(ctx);
 }
 
 
 template <EProtocol Protocol>
 bool TWriteSessionActor<Protocol>::OnUnhandledException(const std::exception& exc) {
     auto ctx = *NActors::TlsActivationContext;
-    YDB_LOG_CRIT_CTX(ctx, "Unhandled exception",
+    LOG_C("Unhandled exception",
         {"typeName", TypeName(exc)},
         {"exception", exc.what()},
         {"backTrace", TBackTrace::FromCurrentException().PrintToString()});
@@ -423,9 +409,7 @@ void TWriteSessionActor<Protocol>::CheckACL(const TActorContext& ctx) {
             serverMessage.set_status(Ydb::StatusIds::SUCCESS);
             serverMessage.mutable_update_token_response();
             if (!Request->Write(std::move(serverMessage))) {
-                YDB_LOG_INFO_CTX(ctx, "Session v1 grpc write failed",
-                    {"cookie", Cookie},
-                    {"sessionId", OwnerCookie});
+                LOG_I("Session v1 grpc write failed");
                 Die(ctx);
             }
         }
@@ -510,13 +494,11 @@ void TWriteSessionActor<Protocol>::Handle(typename TEvWriteInit::TPtr& ev, const
             return !InitRequest.message_group_id().empty() ? InitRequest.message_group_id() : InitRequest.producer_id();
         }
     }();
-    YDB_LOG_INFO_CTX(ctx, "Session request",
-        {"cookie", Cookie},
+    LOG_I("Session request",
         {"initRequest", InitRequest},
         {"peerName", PeerName});
     if (!UseDeduplication) {
-        YDB_LOG_DEBUG_CTX(ctx, "Session request Disable deduplication for empty producer id",
-            {"cookie", Cookie});
+        LOG_D("Session request Disable deduplication for empty producer id");
     }
     LogSession(ctx);
 
@@ -542,13 +524,13 @@ void TWriteSessionActor<Protocol>::Handle(typename TEvWriteInit::TPtr& ev, const
     } else {
         if (InitRequest.has_partition_id()) {
             PreferedPartition = InitRequest.partition_id();
-            YDB_LOG_INFO_CTX(ctx, "Session",
+            LOG_I("Session",
                 {"partition", PreferedPartition});
         }
         else if (InitRequest.has_partition_with_generation()) {
             PreferedPartition = InitRequest.partition_with_generation().partition_id();
             ExpectedGeneration = InitRequest.partition_with_generation().generation();
-            YDB_LOG_INFO_CTX(ctx, "Session",
+            LOG_I("Session",
                 {"partition", PreferedPartition},
                 {"generation", ExpectedGeneration});
         }
@@ -641,7 +623,7 @@ void TWriteSessionActor<Protocol>::SetupCounters(const TString& cloudId, const T
 
 template <EProtocol Protocol>
 void TWriteSessionActor<Protocol>::InitCheckSchema(const TActorContext& ctx, bool needWaitSchema, NWilson::TTraceId traceId) {
-    YDB_LOG_INFO_CTX(ctx, "Init check schema");
+    LOG_I("Init check schema");
 
     if (!needWaitSchema) {
         ACLCheckInProgress = true;
@@ -703,9 +685,7 @@ void TWriteSessionActor<Protocol>::Handle(TEvDescribeTopicsResponse::TPtr& ev, c
 
     AFL_ENSURE(entry.SecurityObject);
     ACL.Reset(new TAclWrapper(entry.SecurityObject));
-    YDB_LOG_INFO_CTX(ctx, "Session v1 describe result for acl check",
-        {"cookie", Cookie},
-        {"sessionId", OwnerCookie});
+    LOG_I("Session v1 describe result for acl check");
 
     const auto meteringMode = config.GetPQTabletConfig().GetMeteringMode();
     if (meteringMode != GetMeteringMode().GetOrElse(meteringMode)) {
@@ -776,9 +756,7 @@ template <EProtocol Protocol>
 void TWriteSessionActor<Protocol>::ProceedPartition(const ui32 partition, const TActorContext& ctx) {
     Partition = partition;
 
-    YDB_LOG_DEBUG_CTX(ctx, "ProceedPartition. session",
-        {"cookie", Cookie},
-        {"sessionId", OwnerCookie},
+    LOG_D("ProceedPartition. session",
         {"partition", Partition},
         {"expectedGeneration", ExpectedGeneration});
 
@@ -924,25 +902,17 @@ void TWriteSessionActor<Protocol>::CloseSession(
         result.set_status(statusCode);
         FillIssue(result.add_issues(), errorCode, errorReason);
 
-        YDB_LOG_INFO_CTX(ctx, "Session v1 error",
-            {"cookie", Cookie},
-            {"reason", errorReason},
-            {"sessionId", OwnerCookie});
+        LOG_I("Session v1 error",
+            {"reason", errorReason});
 
         if (!Request->WriteAndFinish(std::move(result), statusCode)) {
-            YDB_LOG_INFO_CTX(ctx, "Session v1 grpc last write failed",
-                {"cookie", Cookie},
-                {"sessionId", OwnerCookie});
+            LOG_I("Session v1 grpc last write failed");
         }
     } else {
         if (!Request->Finish(statusCode)) {
-            YDB_LOG_INFO_CTX(ctx, "Session v1 double finish call",
-                {"cookie", Cookie},
-                {"sessionId", OwnerCookie});
+            LOG_I("Session v1 double finish call");
         }
-        YDB_LOG_INFO_CTX(ctx, "Session v1 closed",
-            {"cookie", Cookie},
-            {"sessionId", OwnerCookie});
+        LOG_I("Session v1 closed");
     }
     CloseSpans(errorReason, errorCode);
     Die(ctx);
@@ -989,16 +959,12 @@ void TWriteSessionActor<Protocol>::MakeAndSendInitResponse(
     InitSpan.End();
     InitSpan = {};
 
-    YDB_LOG_INFO_CTX(ctx, "Session inited",
-        {"cookie", Cookie},
+    LOG_I("Session inited",
         {"partition", Partition},
-        {"maxSeqNo", maxSeqNo},
-        {"sessionId", OwnerCookie});
+        {"maxSeqNo", maxSeqNo});
 
     if (!Request->Write(std::move(response))) {
-        YDB_LOG_INFO_CTX(ctx, "Session v1 grpc write failed",
-            {"cookie", Cookie},
-            {"sessionId", OwnerCookie});
+        LOG_I("Session v1 grpc write failed");
         Die(ctx);
         return;
     }
@@ -1010,9 +976,7 @@ void TWriteSessionActor<Protocol>::MakeAndSendInitResponse(
     //init completed; wait for first data chunk
     NextRequestInited = true;
     if (!Request->Read()) {
-        YDB_LOG_INFO_CTX(ctx, "Session v1 grpc read failed",
-            {"cookie", Cookie},
-            {"sessionId", OwnerCookie});
+        LOG_I("Session v1 grpc read failed");
         Die(ctx);
         return;
     }
@@ -1079,9 +1043,7 @@ void TWriteSessionActor<Protocol>::Handle(NPQ::TEvPartitionWriter::TEvWriteAccep
     if (!NextRequestInited && BytesInflight_ < AppData(ctx)->PQConfig.GetMaxWriteSessionBytesInflight()) { //allow only one big request to be readed but not sended
         NextRequestInited = true;
         if (!Request->Read()) {
-            YDB_LOG_INFO_CTX(ctx, "Session v1 grpc read failed",
-                {"cookie", Cookie},
-                {"sessionId", OwnerCookie});
+            LOG_I("Session v1 grpc read failed");
             Die(ctx);
             return;
         }
@@ -1221,9 +1183,7 @@ void TWriteSessionActor<Protocol>::ProcessWriteResponse(
 
         if (!Request->Write(std::move(result))) {
             // TODO: Log gRPC write error code
-            YDB_LOG_INFO_CTX(ctx, "Session v1 grpc write failed",
-                {"cookie", Cookie},
-                {"sessionId", OwnerCookie});
+            LOG_I("Session v1 grpc write failed");
             Die(ctx);
             return;
         }
@@ -1474,9 +1434,7 @@ void TWriteSessionActor<Protocol>::Handle(typename TEvUpdateToken::TPtr& ev, con
         serverMessage.set_status(Ydb::StatusIds::SUCCESS);
         serverMessage.mutable_update_token_response();
         if (!Request->Write(std::move(serverMessage))) {
-            YDB_LOG_INFO_CTX(ctx, "Session v1 grpc write failed",
-                {"cookie", Cookie},
-                {"sessionId", OwnerCookie});
+            LOG_I("Session v1 grpc write failed");
             Die(ctx);
             return;
         }
@@ -1495,9 +1453,7 @@ void TWriteSessionActor<Protocol>::Handle(typename TEvUpdateToken::TPtr& ev, con
 
     NextRequestInited = true;
     if (!Request->Read()) {
-        YDB_LOG_INFO_CTX(ctx, "Session v1 grpc read failed",
-            {"cookie", Cookie},
-            {"sessionId", OwnerCookie});
+        LOG_I("Session v1 grpc read failed");
         Die(ctx);
         return;
     }
@@ -1505,7 +1461,7 @@ void TWriteSessionActor<Protocol>::Handle(typename TEvUpdateToken::TPtr& ev, con
 
 template <EProtocol Protocol>
 void TWriteSessionActor<Protocol>::Handle(NGRpcService::TGRpcRequestProxy::TEvRefreshTokenResponse::TPtr &ev , const TActorContext& ctx) {
-    YDB_LOG_INFO_CTX(ctx, "Updating token");
+    LOG_I("Updating token");
 
     if (ev->Get()->Authenticated && ev->Get()->InternalToken && !ev->Get()->InternalToken->GetSerializedToken().empty()) {
         UpdateTokenSpan.EndOk();
@@ -1582,9 +1538,7 @@ void TWriteSessionActor<Protocol>::Handle(typename TEvWrite::TPtr& ev, const TAc
                 const auto& extPublicationId = deferredPublish.ext_publication_id();
                 const auto knownExt = DeferredPublicationExtByInt.FindPtr(intPublicationId);
                 if (knownExt && *knownExt != extPublicationId) {
-                    YDB_LOG_WARN_CTX(ctx, "Deferred publish ext_publication_id mismatch",
-                        {"cookie", Cookie},
-                        {"sessionId", OwnerCookie},
+                    LOG_W("Deferred publish ext_publication_id mismatch",
                         {"intPublicationId", intPublicationId},
                         {"expectedExtPublicationId", *knownExt},
                         {"actualExtPublicationId", extPublicationId});
@@ -1713,9 +1667,7 @@ void TWriteSessionActor<Protocol>::Handle(typename TEvWrite::TPtr& ev, const TAc
     if (BytesInflight_ < AppData(ctx)->PQConfig.GetMaxWriteSessionBytesInflight()) { //allow only one big request to be readed but not sended
         AFL_ENSURE(NextRequestInited);
         if (!Request->Read()) {
-            YDB_LOG_INFO_CTX(ctx, "Session v1 grpc read failed",
-                {"cookie", Cookie},
-                {"sessionId", OwnerCookie});
+            LOG_I("Session v1 grpc read failed");
             Die(ctx);
             return;
 
@@ -1744,9 +1696,7 @@ void TWriteSessionActor<Protocol>::LogSession(const TActorContext& ctx) {
     if (DiscoveryConverter && DiscoveryConverter->IsValid()) {
         topic_path = DiscoveryConverter->GetPrintableString();
     }
-    YDB_LOG_INFO_CTX(ctx, "Write session: userAgent=",
-        {"cookie", Cookie},
-        {"sessionId", OwnerCookie},
+    LOG_I("Write session: userAgent=",
         {"userAgent", UserAgent},
         {"ip", PeerName},
         {"proto", ProtoName},
@@ -1798,7 +1748,7 @@ void TWriteSessionActor<Protocol>::Handle(TEvents::TEvWakeup::TPtr& ev, const TA
 template <EProtocol Protocol>
 void TWriteSessionActor<Protocol>::RecheckACL(const TActorContext& ctx) {
     if (State != ES_INITED) {
-        YDB_LOG_ERROR_CTX(ctx, "WriteSessionActor state is wrong. Actual state",
+        LOG_E("WriteSessionActor state is wrong. Actual state",
             {"state", (int)State});
         return CloseSession("erroneous internal state", PersQueue::ErrorCode::ERROR, ctx);
     }

--- a/ydb/services/persqueue_v1/actors/write_session_actor.h
+++ b/ydb/services/persqueue_v1/actors/write_session_actor.h
@@ -5,13 +5,12 @@
 #include "persqueue_utils.h"
 #include "write_request_info.h"
 
-#include <ydb/library/actors/core/actor_bootstrapped.h>
-
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/client/server/msgbus_server_pq_metacache.h>
 #include <ydb/core/grpc_services/grpc_request_proxy.h>
 #include <ydb/core/jaeger_tracing/request_discriminator.h>
 #include <ydb/core/kqp/common/kqp.h>
+#include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/public/pq_rl_helpers.h>
 #include <ydb/core/persqueue/writer/partition_chooser.h>
@@ -30,10 +29,10 @@ inline TActorId GetPQWriteServiceActorID() {
 
 template <EProtocol Protocol>
 class TWriteSessionActor
-    : public NActors::TActorBootstrapped<TWriteSessionActor<Protocol>>
+    : public NPQ::TBaseActor<TWriteSessionActor<Protocol>>
     , private NPQ::TRlHelpers
-    , public NActors::IActorExceptionHandler
 {
+    using TBase = NPQ::TBaseActor<TWriteSessionActor<Protocol>>;
     using TSelf = TWriteSessionActor<Protocol>;
     using TClientMessage = std::conditional_t<Protocol == EProtocol::PQv1, PersQueue::V1::StreamingWriteClientMessage,
                                               Topic::StreamWriteMessage::FromClient>;
@@ -81,6 +80,12 @@ public:
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
         return NKikimrServices::TActivity::FRONT_PQ_WRITE;
+    }
+
+    NPQ::TStructuredMessage LogPrefix() const override {
+        return YDB_LOG_CREATE_MESSAGE(
+            {"cookie", Cookie},
+            {"sessionId", OwnerCookie});
     }
 
 private:

--- a/ydb/services/persqueue_v1/grpc_pq_read.cpp
+++ b/ydb/services/persqueue_v1/grpc_pq_read.cpp
@@ -53,7 +53,7 @@ TPQReadService::TPQReadService(const TActorId& schemeCache, const TActorId& newS
 void TPQReadService::Bootstrap(const TActorContext& ctx) {
     HaveClusters = !AppData(ctx)->PQConfig.GetTopicsAreFirstClassCitizen(); // ToDo[migration] - proper condition
     if (HaveClusters) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "TPQReadService: send TEvClusterTracker::TEvSubscribe");
+        LOG_D("send TEvClusterTracker::TEvSubscribe");
 
         ctx.Send(NPQ::NClusterTracker::MakeClusterTrackerID(),
                  new NPQ::NClusterTracker::TEvClusterTracker::TEvSubscribe);

--- a/ydb/services/persqueue_v1/grpc_pq_read.cpp
+++ b/ydb/services/persqueue_v1/grpc_pq_read.cpp
@@ -9,7 +9,6 @@
 #include <ydb/core/tx/scheme_board/cache.h>
 
 #include <algorithm>
-#include <ydb/library/actors/core/log.h>
 
 using namespace NActors;
 using namespace NKikimrClient;
@@ -41,7 +40,8 @@ IActor* CreatePQReadService(const TActorId& schemeCache, const TActorId& newSche
 
 TPQReadService::TPQReadService(const TActorId& schemeCache, const TActorId& newSchemeCache,
                              TIntrusivePtr<::NMonitoring::TDynamicCounters> counters, const ui32 maxSessions)
-    : SchemeCache(schemeCache)
+    : TBase(NKikimrServices::PQ_READ_PROXY)
+    , SchemeCache(schemeCache)
     , NewSchemeCache(newSchemeCache)
     , Counters(counters)
     , MaxSessions(maxSessions)
@@ -53,7 +53,7 @@ TPQReadService::TPQReadService(const TActorId& schemeCache, const TActorId& newS
 void TPQReadService::Bootstrap(const TActorContext& ctx) {
     HaveClusters = !AppData(ctx)->PQConfig.GetTopicsAreFirstClassCitizen(); // ToDo[migration] - proper condition
     if (HaveClusters) {
-        YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "TPQReadService: send TEvClusterTracker::TEvSubscribe");
+        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "TPQReadService: send TEvClusterTracker::TEvSubscribe");
 
         ctx.Send(NPQ::NClusterTracker::MakeClusterTrackerID(),
                  new NPQ::NClusterTracker::TEvClusterTracker::TEvSubscribe);
@@ -75,10 +75,10 @@ ui64 TPQReadService::NextCookie() {
 }
 
 void TPQReadService::Handle(NGRpcService::TEvCommitOffsetRequest::TPtr& ev, const TActorContext& ctx) {
-    YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New commit offset request");
+    LOG_D("New commit offset request");
 
     if (HaveClusters && (Clusters.empty() || LocalCluster.empty())) {
-        YDB_LOG_INFO_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New commit offset request failed - cluster is not known yet");
+        LOG_I("New commit offset request failed - cluster is not known yet");
 
         auto e = dynamic_cast<TEvCommitOffsetRequest*>(ev->Get());
         AFL_ENSURE(e)("reason", "unexpected event type for commit offset")("local_cluster", LocalCluster);
@@ -145,17 +145,17 @@ void TPQReadService::Handle(NGRpcService::TEvStreamTopicReadRequest::TPtr& ev, c
 
 void TPQReadService::Handle(NGRpcService::TEvStreamTopicDirectReadRequest::TPtr& ev, const TActorContext& ctx) {
 
-    YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New grpc connection");
+    LOG_D("New grpc connection");
 
     if (TooMuchSessions()) {
-        YDB_LOG_INFO_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New grpc connection failed - too much sessions");
+        LOG_I("New grpc connection failed - too much sessions");
         ev->Get()->Attach(ctx.SelfID);
         ev->Get()->WriteAndFinish(
             FillDirectReadResponse("proxy overloaded", PersQueue::ErrorCode::OVERLOAD), Ydb::StatusIds::OVERLOADED); //CANCELLED
         return;
     }
     if (HaveClusters && (Clusters.empty() || LocalCluster.empty())) {
-        YDB_LOG_INFO_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New grpc connection failed - cluster is not known yet");
+        LOG_I("New grpc connection failed - cluster is not known yet");
 
         ev->Get()->Attach(ctx.SelfID);
         ev->Get()->WriteAndFinish(
@@ -168,7 +168,7 @@ void TPQReadService::Handle(NGRpcService::TEvStreamTopicDirectReadRequest::TPtr&
 
         const ui64 cookie = NextCookie();
 
-        YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New direct session created cookie",
+        LOG_D("New direct session created cookie",
             {"cookie", cookie});
 
         TActorId worker = ctx.Register(new TDirectReadSessionActor(
@@ -190,10 +190,10 @@ void TPQReadService::HandleReadInfo(TAutoPtr<NActors::IEventHandle>& evHandle, c
     evHandle->DropRewrite();
     auto* ev = evHandle->Get<TEvPQReadInfoRequest>();
 
-    YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New read info request");
+    LOG_D("New read info request");
 
     if (HaveClusters && (Clusters.empty() || LocalCluster.empty())) {
-        YDB_LOG_INFO_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New read info request failed - cluster is not known yet");
+        LOG_I("New read info request failed - cluster is not known yet");
 
         ev->RaiseIssue(FillIssue("cluster initializing", PersQueue::ErrorCode::INITIALIZING));
         ev->ReplyWithYdbStatus(ConvertPersQueueInternalCodeToStatus(PersQueue::ErrorCode::INITIALIZING));

--- a/ydb/services/persqueue_v1/grpc_pq_read.h
+++ b/ydb/services/persqueue_v1/grpc_pq_read.h
@@ -4,8 +4,9 @@
 #include "actors/direct_read_actor.h"
 
 #include <ydb/core/client/server/grpc_base.h>
-#include <ydb/core/persqueue/public/cluster_tracker/cluster_tracker.h>
 #include <ydb/core/mind/address_classification/net_classifier.h>
+#include <ydb/core/persqueue/common/actor.h>
+#include <ydb/core/persqueue/public/cluster_tracker/cluster_tracker.h>
 
 #include <ydb/library/actors/core/actorid.h>
 
@@ -13,7 +14,6 @@
 #include <util/system/mutex.h>
 
 #include <type_traits>
-#include <ydb/library/actors/core/log.h>
 
 
 namespace NKikimr {
@@ -25,7 +25,9 @@ namespace V1 {
 IActor* CreatePQReadService(const NActors::TActorId& schemeCache, const NActors::TActorId& newSchemeCache,
                             TIntrusivePtr<::NMonitoring::TDynamicCounters> counters, const ui32 maxSessions);
 
-class TPQReadService : public NActors::TActorBootstrapped<TPQReadService> {
+class TPQReadService : public NPQ::TBaseActor<TPQReadService>
+                     , public NPQ::TConstantLogPrefix {
+    using TBase = NPQ::TBaseActor<TPQReadService>;
 public:
     TPQReadService(const NActors::TActorId& schemeCache, const NActors::TActorId& newSchemeCache,
                    TIntrusivePtr<::NMonitoring::TDynamicCounters> counters, const ui32 maxSessions);
@@ -108,17 +110,17 @@ template <typename ReadRequest>
 void TPQReadService::HandleStreamPQReadRequest(typename ReadRequest::TPtr& ev, const TActorContext& ctx) {
     constexpr EProtocol Protocol = std::is_same_v<ReadRequest, NGRpcService::TEvStreamPQMigrationReadRequest> ? EProtocol::PQv1 : EProtocol::Topic;
 
-    YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New grpc connection");
+    LOG_D("New grpc connection");
 
     if (TooMuchSessions()) {
-        YDB_LOG_INFO_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New grpc connection failed - too much sessions");
+        LOG_I("New grpc connection failed - too much sessions");
         ev->Get()->Attach(ctx.SelfID);
         ev->Get()->WriteAndFinish(
             FillReadResponse<Protocol>("proxy overloaded", PersQueue::ErrorCode::OVERLOAD), Ydb::StatusIds::OVERLOADED); //CANCELLED
         return;
     }
     if (HaveClusters && (Clusters.empty() || LocalCluster.empty())) {
-        YDB_LOG_INFO_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New grpc connection failed - cluster is not known yet");
+        LOG_I("New grpc connection failed - cluster is not known yet");
 
         ev->Get()->Attach(ctx.SelfID);
         ev->Get()->WriteAndFinish(
@@ -130,7 +132,7 @@ void TPQReadService::HandleStreamPQReadRequest(typename ReadRequest::TPtr& ev, c
         AFL_ENSURE(TopicsHandler != nullptr)("local_cluster", LocalCluster)("have_clusters", HaveClusters);
         const ui64 cookie = NextCookie();
 
-        YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New session created cookie",
+        LOG_D("New session created cookie",
             {"cookie", cookie});
 
         auto ip = ev->Get()->GetPeerName();

--- a/ydb/services/persqueue_v1/grpc_pq_write.cpp
+++ b/ydb/services/persqueue_v1/grpc_pq_write.cpp
@@ -39,7 +39,7 @@ TPQWriteService::TPQWriteService(const TActorId& schemeCache,
 void TPQWriteService::Bootstrap(const TActorContext& ctx) {
     HaveClusters = !AppData(ctx)->PQConfig.GetTopicsAreFirstClassCitizen(); // ToDo[migration]: switch to proper option
     if (HaveClusters) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "TPQWriteService: send TEvClusterTracker::TEvSubscribe");
+        LOG_D("send TEvClusterTracker::TEvSubscribe");
 
         ctx.Send(NPQ::NClusterTracker::MakeClusterTrackerID(),
                  new NPQ::NClusterTracker::TEvClusterTracker::TEvSubscribe);

--- a/ydb/services/persqueue_v1/grpc_pq_write.cpp
+++ b/ydb/services/persqueue_v1/grpc_pq_write.cpp
@@ -1,9 +1,9 @@
 #include "grpc_pq_write.h"
 
-#include <ydb/core/tx/scheme_board/cache.h>
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/tx/scheme_board/cache.h>
+
 #include <util/generic/queue.h>
-#include <ydb/library/actors/core/log.h>
 
 using namespace NActors;
 using namespace NKikimrClient;
@@ -27,7 +27,8 @@ IActor* CreatePQWriteService(const TActorId& schemeCache,
 
 TPQWriteService::TPQWriteService(const TActorId& schemeCache,
                              TIntrusivePtr<::NMonitoring::TDynamicCounters> counters, const ui32 maxSessions)
-    : SchemeCache(schemeCache)
+    : TBase(NKikimrServices::PQ_WRITE_PROXY)
+    , SchemeCache(schemeCache)
     , Counters(counters)
     , MaxSessions(maxSessions)
     , Enabled(false)
@@ -38,7 +39,7 @@ TPQWriteService::TPQWriteService(const TActorId& schemeCache,
 void TPQWriteService::Bootstrap(const TActorContext& ctx) {
     HaveClusters = !AppData(ctx)->PQConfig.GetTopicsAreFirstClassCitizen(); // ToDo[migration]: switch to proper option
     if (HaveClusters) {
-        YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "TPQWriteService: send TEvClusterTracker::TEvSubscribe");
+        YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "TPQWriteService: send TEvClusterTracker::TEvSubscribe");
 
         ctx.Send(NPQ::NClusterTracker::MakeClusterTrackerID(),
                  new NPQ::NClusterTracker::TEvClusterTracker::TEvSubscribe);
@@ -132,11 +133,11 @@ void TPQWriteService::Handle(NPQ::NClusterTracker::TEvClusterTracker::TEvCluster
     }
 }
 
-void TPQWriteService::Handle(TEvPQProxy::TEvSessionSetPreferredCluster::TPtr& ev, const TActorContext& ctx) {
+void TPQWriteService::Handle(TEvPQProxy::TEvSessionSetPreferredCluster::TPtr& ev, const TActorContext&) {
     const auto& cookie = ev->Get()->Cookie;
     const auto& preferredCluster = ev->Get()->PreferredCluster;
     if (!Sessions.contains(cookie)) {
-        YDB_LOG_ERROR_CTX_COMP(ctx, NKikimrServices::PQ_WRITE_PROXY, "Got TEvSessionSetPreferredCluster message from session with cookie that is not in session collection",
+        LOG_E("Got TEvSessionSetPreferredCluster message from session with cookie that is not in session collection",
             {"cookie", cookie});
         return;
     }

--- a/ydb/services/persqueue_v1/grpc_pq_write.h
+++ b/ydb/services/persqueue_v1/grpc_pq_write.h
@@ -3,8 +3,9 @@
 #include "actors/write_session_actor.h"
 
 #include <ydb/core/client/server/grpc_base.h>
-#include <ydb/core/persqueue/public/cluster_tracker/cluster_tracker.h>
 #include <ydb/core/mind/address_classification/net_classifier.h>
+#include <ydb/core/persqueue/common/actor.h>
+#include <ydb/core/persqueue/public/cluster_tracker/cluster_tracker.h>
 
 #include <ydb/library/actors/core/actorid.h>
 
@@ -19,7 +20,9 @@ namespace V1 {
 IActor* CreatePQWriteService(const NActors::TActorId& schemeCache,
                              TIntrusivePtr<::NMonitoring::TDynamicCounters> counters, const ui32 maxSessions);
 
-class TPQWriteService : public NActors::TActorBootstrapped<TPQWriteService> {
+class TPQWriteService : public NPQ::TBaseActor<TPQWriteService>
+                      , public NPQ::TConstantLogPrefix {
+    using TBase = NPQ::TBaseActor<TPQWriteService>;
 public:
     TPQWriteService(const NActors::TActorId& schemeCache,
                     TIntrusivePtr<::NMonitoring::TDynamicCounters> counters, const ui32 maxSessions);
@@ -104,10 +107,10 @@ template <typename WriteRequest>
 void TPQWriteService::HandleWriteRequest(typename WriteRequest::TPtr& ev, const TActorContext& ctx) {
     constexpr EProtocol Protocol = std::is_same_v<WriteRequest, NGRpcService::TEvStreamPQWriteRequest> ? EProtocol::PQv1 : EProtocol::Topic;
 
-    YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PQ_WRITE_PROXY, "New grpc connection");
+    LOG_D("New grpc connection");
 
     if (TooMuchSessions()) {
-        YDB_LOG_INFO_CTX_COMP(ctx, NKikimrServices::PQ_WRITE_PROXY, "New grpc connection failed - too much sessions");
+        LOG_I("New grpc connection failed - too much sessions");
         ev->Get()->Attach(ctx.SelfID);
         ev->Get()->WriteAndFinish(
             FillWriteResponse<Protocol>("proxy overloaded", PersQueue::ErrorCode::OVERLOAD),
@@ -120,10 +123,10 @@ void TPQWriteService::HandleWriteRequest(typename WriteRequest::TPtr& ev, const 
     if (HaveClusters && localCluster.empty()) {
         ev->Get()->Attach(ctx.SelfID);
         if (LocalCluster) {
-            YDB_LOG_INFO_CTX_COMP(ctx, NKikimrServices::PQ_WRITE_PROXY, "New grpc connection failed - cluster disabled");
+            LOG_I("New grpc connection failed - cluster disabled");
             ev->Get()->WriteAndFinish(FillWriteResponse<Protocol>("cluster disabled", PersQueue::ErrorCode::CLUSTER_DISABLED), Ydb::StatusIds::UNSUPPORTED); //CANCELLED
         } else {
-            YDB_LOG_INFO_CTX_COMP(ctx, NKikimrServices::PQ_WRITE_PROXY, "New grpc connection failed - initializing");
+            LOG_I("New grpc connection failed - initializing");
             ev->Get()->WriteAndFinish(FillWriteResponse<Protocol>("initializing", PersQueue::ErrorCode::INITIALIZING), Ydb::StatusIds::UNAVAILABLE); //CANCELLED
         }
         return;
@@ -138,7 +141,7 @@ void TPQWriteService::HandleWriteRequest(typename WriteRequest::TPtr& ev, const 
         );
         const ui64 cookie = NextCookie();
 
-        YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PQ_WRITE_PROXY, "New session created cookie",
+        LOG_D("New session created cookie",
             {"cookie", cookie});
 
         auto ip = ev->Get()->GetPeerName();

--- a/ydb/services/persqueue_v1/ya.make
+++ b/ydb/services/persqueue_v1/ya.make
@@ -24,6 +24,7 @@ PEERDIR(
     ydb/core/kqp/common
     ydb/core/kqp/common/events
     ydb/core/kqp/common/simple
+    ydb/core/persqueue/common
     ydb/core/persqueue/events
     ydb/core/persqueue/public/codecs
     ydb/core/persqueue/writer


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Topics: logs now expose tablet, topic, consumer, and session as separate fields instead of one concatenated prefix string.

### Description for reviewers <!-- (optional) description for those who read this PR -->

`YDB_LOG` was still getting prefix as a named string (`logPrefix` / `PQLOGPREFIX`). Named `TStructuredMessage` nests under that key; a `TString` is one unfilterable blob. Unnamed `{LogPrefix()}` flattens fields into the message root, same as kafka_proxy.

**What changed**
- `LogPrefix()` / `PQ_LOG_PREFIX` return `TStructuredMessage` via `YDB_LOG_CREATE_MESSAGE`.
- Call sites pass `{LogPrefix()}` instead of `{"logPrefix", ...}`.
- Typical fields: `tabletId`, `topic`, `partition`, `consumer`, `session`, `selfId`, `actorClassName`.

**Scope**
- persqueue (tablet, PQRB, writer, init, fetcher, describer)
- persqueue_v1 read path
- persqueue_v0 read actor
- http_proxy

`kafka_proxy` already flattened prefixes. `local_proxy` is out of scope (another team).

### Test plan
- [x] `./ya make --build relwithdebinfo ydb/core/persqueue ydb/services/persqueue_v1 ydb/services/deprecated/persqueue_v0 ydb/core/http_proxy`
- [x] `./ya make --build relwithdebinfo -tA ydb/core/persqueue/common/ut`
- [x] `./ya make --build relwithdebinfo -tA ydb/core/http_proxy`
- [ ] Pre-commit CI on this PR