### PR TITLE
Compact ydb_bench navigation and unify list filters

### DIFF
--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -1142,14 +1142,25 @@ function compactRun(run){
     '<a href="'+runHref(run.id,'config')+'">YAML</a><a href="'+runHref(run.id,'manifest')+'">run.json</a>'+
     '<a href="'+runHref(run.id,'archive')+'">Archive</a></div></details></article>'
 }
+function bindAutomaticFilters(fields,reset,apply,connected){
+  let timer;
+  const update=()=>{reset.hidden=!fields.some(field=>field.value.trim())};
+  const run=()=>{clearTimeout(timer);update();if(connected())apply()};
+  for(const field of fields){
+    field.oninput=()=>{clearTimeout(timer);update();timer=setTimeout(run,250)};
+    field.onchange=run;
+  }
+  reset.onclick=()=>{for(const field of fields)field.value='';run()};
+  update();
+}
 async function renderRuns(){
   clearRefresh();
-  app.innerHTML=shell('runs','<div class=runs-heading><h1 class=page-title>Runs</h1>'+
-    '<a class=new-run-link href="#new"><span aria-hidden=true>+</span> New run</a></div>'+runFilters()+
+  app.innerHTML=shell('runs',runFilters()+
     '<div class=runs-toolbar><label>Sort <select id=runs-sort>'+
     '<option value=newest>Newest first</option><option value=oldest>Oldest first</option>'+
     '<option value=longest>Longest first</option></select></label><div class=runs-actions><button id=open-import>Import</button>'+
-    '<button id=apply-filters>Apply filters</button></div></div><div id=runs-table></div>'+
+    '<button id=reset-run-filters hidden>Reset filters</button>'+
+    '<a class=new-run-link href="#new"><span aria-hidden=true>+</span> New run</a></div></div><div id=runs-table></div>'+
     '<dialog id=import-dialog class=import-dialog aria-labelledby=import-title><h2 id=import-title>Import results</h2>'+
     '<label for=import-file>Portable ZIP archive</label><input id=import-file type=file accept=".zip,application/zip">'+
     '<div id=import-error role=alert></div><div id=import-status role=status></div><div class=toolbar>'+
@@ -1173,7 +1184,8 @@ async function renderRuns(){
     catch(error){if(current===request&&target.isConnected)target.innerHTML=displayError(error)}
   }
   sort.onchange=()=>{runsSort=sort.value;draw()};
-  document.querySelector('#apply-filters').onclick=load;
+  bindAutomaticFilters([...app.querySelectorAll('.filters input,.filters select')],
+    app.querySelector('#reset-run-filters'),load,()=>target.isConnected);
   const dialog=document.querySelector('#import-dialog'),fileInput=document.querySelector('#import-file'),
     importButton=document.querySelector('#import-run'),cancelButton=document.querySelector('#cancel-import'),
     importError=document.querySelector('#import-error'),importStatus=document.querySelector('#import-status');
@@ -2843,7 +2855,7 @@ function parseLocalYdbProfileSelection(groups,selected){
     "p.label)+'</div><div class=cpu-core-grid>'+group.cores.map(core=>\n        '<button class=cpu-core data-core=\"'+core.index+'\" aria-pressed=fa"
     "lse aria-label=\"Core '+core.index+'; vCPU '+esc(core.cpus.join(', '))+'\">'+core.cpus.map(cpu=>'<span class=cpu-cell data-cpu=\"'+cpu+'\">'+cpu"
     "+'</span>').join('')+'</button>'\n      ).join('')+'</div></div>').join('')+'</div></section>').join('');\n    app.innerHTML=shell('topology',"
-    "'<div id=cpu-topology><h1 class=page-title>System topology</h1><p class=muted>'+t.physical_cores.length+' physical cores · '+t.allowed_cpus."
+    "'<div id=cpu-topology><p class=muted>'+t.physical_cores.length+' physical cores · '+t.allowed_cpus."
     "length+' allowed vCPUs · '+t.numa_nodes.length+' NUMA nodes</p>'+\n      sectionTabs('topology',[['layout','Topology & CPU usage'],['affinity"
     "','Affinity availability']])+\n      '<section data-section-panel=\"topology:layout\"><div class=cpu-map-toolbar><div class=cpu-help><button id"
     "=cpu-help-button aria-label=\"About the CPU map\" aria-expanded=false aria-controls=cpu-map-help>?</button><div id=cpu-map-help hidden role=no"
@@ -2882,6 +2894,18 @@ function parseLocalYdbProfileSelection(groups,selected){
     "  };\n    refreshTimer=setInterval(refresh,2000);await refresh();\n  }catch(error){if(location.hash==='#topology')app.innerHTML=shell('topolog"
     "y',displayError(error))}\n}\n"
     """
+function filterSavedComparisons(records,filters){
+  const query=(filters.query||'').trim().toLowerCase();
+  return records.filter(record=>{
+    const date=(record.created_at||'').slice(0,10);
+    return (!query||[record.name,...record.profiles.flat()].join(' ').toLowerCase().includes(query))&&
+      (!filters.since||date>=filters.since)&&(!filters.until||date<=filters.until)
+  }).sort((a,b)=>{
+    const dates=(Date.parse(a.created_at)||0)-(Date.parse(b.created_at)||0);
+    const order=filters.sort==='name'?a.name.localeCompare(b.name):filters.sort==='oldest'?dates:-dates;
+    return order||a.id.localeCompare(b.id)
+  })
+}
 function filterComparisonRuns(runs,filters,selected){
   const query=(filters.query||'').trim().toLowerCase();
   return sortRuns(runs.filter(run=>{
@@ -2901,17 +2925,36 @@ async function renderSavedComparisons(){
     const records=await api('/api/saved-comparisons');
     if(!active())return;
     if(!id){
-      app.innerHTML=shell('comparisons','<div class=toolbar><h1 class=page-title>Comparisons</h1>'+
-        '<a href="#comparisons/new">New comparison</a></div>'+(!records.length?'<div class=empty>No saved comparisons.</div>':
-        '<div class=table-scroll><table><thead><tr><th>Comparison</th><th>Created</th><th>Profiles</th></tr></thead><tbody>'+
-        records.map(record=>'<tr data-comparison-id="'+esc(record.id)+'"><td><a href="#comparisons/'+enc(record.id)+'">'+
-          esc(record.name)+'</a><div class=muted>'+record.profiles.map(pair=>esc(pair[1])).join(' · ')+
-          '</div></td><td>'+esc(humanTime(record.created_at))+'</td><td>'+record.profiles.length+'</td></tr>').join('')+
-        '</tbody></table></div>'));
-      for(const row of app.querySelectorAll('[data-comparison-id]'))row.onclick=event=>{
-        if(event.target.closest('a,button,input,select')||event.button!==0||event.ctrlKey||event.metaKey||event.shiftKey||event.altKey)return;
-        setRoute('comparisons/'+row.dataset.comparisonId)
+      app.innerHTML=shell('comparisons',
+        '<div class=filters><label class=field>Comparison, profile or run<input id=saved-comparison-query type=search placeholder="Search comparisons"></label>'+
+        '<label class=field>Created from (UTC)<input id=saved-comparison-since type=date></label>'+
+        '<label class=field>Created to (UTC)<input id=saved-comparison-until type=date></label></div>'+
+        '<div class=runs-toolbar><label>Sort <select id=saved-comparison-sort><option value=newest>Newest first</option>'+
+        '<option value=oldest>Oldest first</option><option value=name>Name A–Z</option></select></label>'+
+        '<span id=saved-comparison-count class=muted aria-live=polite></span><div class=runs-actions>'+
+        '<button id=reset-comparison-filters hidden>Reset filters</button>'+
+        '<a class=new-run-link href="#comparisons/new"><span aria-hidden=true>+</span> New comparison</a></div></div><div id=saved-comparison-list></div>');
+      const query=app.querySelector('#saved-comparison-query'),since=app.querySelector('#saved-comparison-since'),
+        until=app.querySelector('#saved-comparison-until'),sort=app.querySelector('#saved-comparison-sort'),
+        list=app.querySelector('#saved-comparison-list'),count=app.querySelector('#saved-comparison-count');
+      const draw=()=>{
+        const filtered=filterSavedComparisons(records,{query:query.value,since:since.value,until:until.value,sort:sort.value});
+        count.textContent=filtered.length+' / '+records.length+' comparisons';
+        list.innerHTML=!records.length?'<div class=empty>No saved comparisons.</div>':
+          !filtered.length?'<div class=empty>No comparisons match these filters.</div>':
+          '<div class=table-scroll><table><thead><tr><th>Comparison</th><th>Created</th><th>Profiles</th></tr></thead><tbody>'+
+          filtered.map(record=>'<tr data-comparison-id="'+esc(record.id)+'"><td><a href="#comparisons/'+enc(record.id)+'">'+
+            esc(record.name)+'</a><div class=muted>'+record.profiles.map(pair=>esc(pair[1])).join(' · ')+
+            '</div></td><td>'+esc(humanTime(record.created_at))+'</td><td>'+record.profiles.length+'</td></tr>').join('')+
+          '</tbody></table></div>';
+        for(const row of list.querySelectorAll('[data-comparison-id]'))row.onclick=event=>{
+          if(event.target.closest('a,button,input,select')||event.button!==0||event.ctrlKey||event.metaKey||event.shiftKey||event.altKey)return;
+          setRoute('comparisons/'+row.dataset.comparisonId)
+        }
       };
+      bindAutomaticFilters([query,since,until],app.querySelector('#reset-comparison-filters'),draw,()=>list.isConnected);
+      sort.onchange=draw;
+      draw();
       return
     }
     const record=id==='new'?null:records.find(item=>item.id===id);

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -59,12 +59,14 @@ _CSS = (
     'tion:none}a:hover{text-decoration:underline}button,input,select,textarea{font:inherit}button{cursor:pointer;border:1px s'
     'olid #667085;border-radius:5px;background:#fff;color:var(--text);padding:.38rem .65rem}button.primary{background:var(--a'
     'ccent);color:#fff;border-color:var(--accent)}button.danger{color:var(--bad);border-color:var(--bad)}button:disabled{opac'
-    'ity:.5;cursor:not-allowed}.shell{display:grid;grid-template-columns:14rem minmax(0,1fr);min-height:100vh}.sidebar{paddin'
-    'g:1.4rem 1rem;background:#172033;color:#fff}.brand{font-weight:700;font-size:1.05rem;margin:0 0 1.7rem}.sidebar a{displa'
-    'y:block;color:#d6e2f7;padding:.55rem .65rem;border-radius:5px;margin:.15rem 0}.sidebar a.active,.sidebar a:hover{color:#'
-    'fff;background:#315882;text-decoration:none}.content{min-width:0}.topbar{min-height:3.7rem;border-bottom:1px solid #d0d5'
-    'dd;padding:.8rem 1.6rem;display:flex;justify-content:space-between;gap:1rem;align-items:center}.topbar .active-run{font-'
-    'size:.9rem;color:var(--muted)}main{max-width:1160px;padding:1.5rem 1.6rem 3rem}.breadcrumbs{color:var(--muted);font-size'
+    'ity:.5;cursor:not-allowed}.shell{min-height:100vh}.brand{font-weight:700;font-size:1.05rem;white-space:nowrap;'
+    'color:var(--text)}.content{min-width:0}.topbar{min-height:3.7rem;border-bottom:1px solid #d0d5dd;'
+    'padding:0 1.6rem;display:flex;flex-wrap:wrap;gap:0 1.6rem;align-items:center}.primary-nav{display:flex;'
+    'flex-wrap:wrap;gap:0 1.2rem}.primary-nav a{color:var(--muted);padding:1rem 0;border-bottom:2px solid transparent;'
+    'white-space:nowrap}.primary-nav a:hover{color:var(--accent);text-decoration:none}.primary-nav a[aria-current=page]{'
+    'color:var(--text);font-weight:650;border-bottom-color:var(--accent)}.topbar .active-run{font-size:.9rem;'
+    'color:var(--muted);margin-left:auto;min-width:0;max-width:100%;overflow-wrap:anywhere;padding:.6rem 0}'
+    'main{padding:1.5rem 1.6rem 3rem}.breadcrumbs{color:var(--muted);font-size'
     ':.9rem;margin:0 0 .6rem}.page-title{margin:0 0 1rem;font-size:1.5rem}.toolbar{display:flex;gap:.55rem;align-items:center'
     ';flex-wrap:wrap;margin:.8rem 0}.filters,.grid{display:grid;gap:.7rem}.filters{grid-template-columns:repeat(auto-fit,minm'
     'ax(10rem,1fr));background:var(--panel);padding:.8rem;border:1px solid #d0d5dd;border-radius:6px}.field{display:grid;gap:'
@@ -123,8 +125,8 @@ _CSS = (
     'f}.chart-bg-0{background:#1b62b9}.chart-bg-1{background:#c2410c}.chart-bg-2{background:#087443}.chart-bg-3{background:#7'
     'c3aed}.chart-bg-4{background:#be185d}.chart-bg-5{background:#0e7490}.chart-bg-6{background:#854d0e}.chart-bg-7{backgroun'
     'd:#94a3b8}.chart-bg-8{background:#ef4444}.chart-bg-9{background:#818cf8}.chart-bg-10{background:#22c55e}.chart-bg-11{bac'
-    'kground:#d946ef}@media(max-width:760px){.shell{display:block}.sidebar{padding:.7rem;display:flex;gap:.3rem;overflow:auto'
-    '}.brand{display:none}.sidebar a{white-space:nowrap}.topbar,main{padding-left:1rem;padding-right:1rem}.split,.topology-su'
+    'kground:#d946ef}@media(max-width:1000px){.primary-nav{order:3;flex-basis:100%}.primary-nav a{padding:.6rem 0}'
+    '.brand{padding:.6rem 0}}@media(max-width:760px){.topbar,main{padding-left:1rem;padding-right:1rem}.split,.topology-su'
     'mmary{grid-template-columns:1fr}}\n'
     '.grid,.grid>*{min-width:0}.run-tree{overflow:hidden}.run-tree details{min-width:0}.affinity-details>td>details{overflow:'
     'hidden}.affinity-details table{display:block;max-width:100%;overflow-x:auto}.modal-backdrop{position:fixed;inset:0;z-ind'
@@ -229,6 +231,9 @@ width:15rem;max-width:70vw;padding:.6rem;background:#fff;border:1px solid #d0d5d
 padding:.6rem;border:1px solid #d0d5dd;min-width:8rem;flex-direction:column}
 .dense-run summary{cursor:pointer}.runs-toolbar{display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.8rem 0}
 .runs-actions{display:flex;gap:.6rem;flex-wrap:wrap;margin-left:auto}
+.runs-heading{display:flex;align-items:center;justify-content:space-between;gap:1rem;flex-wrap:wrap;margin-bottom:1rem}
+.runs-heading .page-title{margin:0}.new-run-link{padding:.38rem .65rem;border-radius:5px;background:var(--accent);color:#fff;white-space:nowrap}
+.new-run-link:hover{color:#fff;text-decoration:none}
 .import-dialog{width:min(30rem,calc(100vw - 2rem));padding:1.2rem;border:1px solid var(--line);border-radius:8px;background:#fff;color:var(--text)}
 .import-dialog::backdrop{background:rgb(0 0 0 / 35%)}
 .import-dialog h2{margin-top:0}.import-dialog input{max-width:100%;margin:.8rem 0}
@@ -340,13 +345,18 @@ _JS = (
     "tep.duration_seconds)))return secondsLabel(step.duration_seconds);if(step.state==='running'&&step.started_at)return seco"
     "ndsLabel((Date.now()-Date.parse(step.started_at))/1000);return '—'}\n"
     'function status(value){return \'<span class="status \'+esc(value||\'unknown\')+\'">\'+esc(value||\'unknown\')+\'</span>\'}\n'
-    "function shell(current,body,breadcrumb=''){queueMicrotask(refreshActiveBanner);const navigation=[['runs','Runs'],['new','New run'],['topology','System topol"
-    "ogy'],['comparisons','Comparisons']];return '<div class=shell><aside class=sidebar><div class=brand>YDB benchmark</div>'"
-    '+navigation.map(([id,label])=>\'<a class="\'+(current===id?\'active\':\'\')+\'" href="#\'+id+\'">\'+label+\'</a>\').join(\'\')+\'</asid'
-    "e><div class=content><header class=topbar><strong>'+esc(current==='new'?'New run':current==='topology'?'System topology'"
-    ':current===\'comparisons\'?\'Comparisons\':\'Runs\')+\'</strong><span class=active-run>\'+ (activeRun?\'<a href="#run/\'+enc(activ'
-    'eRun)+\'">Active run: \'+esc(activeRun)+\'</a>\':\'No active run\')+\'</span></header><main>\'+breadcrumb+body+\'</main></div></d'
-    "iv>'}\n"
+    """
+function shell(current,body,breadcrumb=''){
+  queueMicrotask(refreshActiveBanner);
+  const navigation=[['runs','Runs'],['topology','System topology'],['comparisons','Comparisons']];
+  const section=current==='new'?'runs':current;
+  return '<div class=shell><div class=content><header class=topbar><a class=brand href="#runs">YDB benchmark</a>'+
+    '<nav class=primary-nav aria-label="Main navigation">'+navigation.map(([id,label])=>
+      '<a href="#'+id+'"'+(section===id?' aria-current="page"':'')+'>'+label+'</a>').join('')+
+    '</nav><span class=active-run>'+(activeRun?'<a href="#run/'+enc(activeRun)+'">Active run: '+esc(activeRun)+'</a>':
+      'No active run')+'</span></header><main>'+breadcrumb+body+'</main></div></div>'
+}
+"""
     "function breadcrumbs(items){return items.length?'<div class=breadcrumbs>'+items.map((item,index)=>index===items.length-1"
     '?esc(item.label):\'<a href="#\'+esc(item.route)+\'">\'+esc(item.label)+\'</a>\').join(\' / \')+\'</div>\':\'\'}\n'
     "function saveDraft(){sessionStorage.setItem('ydb-bench-draft',editor.yaml)}\n"
@@ -1134,7 +1144,8 @@ function compactRun(run){
 }
 async function renderRuns(){
   clearRefresh();
-  app.innerHTML=shell('runs','<h1 class=page-title>Runs</h1>'+runFilters()+
+  app.innerHTML=shell('runs','<div class=runs-heading><h1 class=page-title>Runs</h1>'+
+    '<a class=new-run-link href="#new"><span aria-hidden=true>+</span> New run</a></div>'+runFilters()+
     '<div class=runs-toolbar><label>Sort <select id=runs-sort>'+
     '<option value=newest>Newest first</option><option value=oldest>Oldest first</option>'+
     '<option value=longest>Longest first</option></select></label><div class=runs-actions><button id=open-import>Import</button>'+

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -7875,6 +7875,38 @@ class WebTest(unittest.TestCase):
         self.assertEqual(model["complete"]["status"], "completed")
         self.assertEqual(model["imported"]["source"], "imported")
 
+    @unittest.skipUnless(shutil.which("node"), "node is required for navigation checks")
+    def test_web_top_navigation(self):
+        script = web._JS[web._JS.index("function shell(") : web._JS.index("function breadcrumbs(")]
+        script += """
+        const assert=require('assert'),enc=encodeURIComponent;
+        const esc=value=>String(value).replaceAll('<','&lt;').replaceAll('"','&quot;');
+        let refreshes=0,activeRun=null;
+        const queueMicrotask=callback=>callback(),refreshActiveBanner=()=>{refreshes++};
+        for(const page of ['runs','new','topology','comparisons']){
+          const html=shell(page,'<h1>Content</h1>','<div>Breadcrumb</div>');
+          assert(html.includes('<nav class=primary-nav aria-label="Main navigation">'));
+          assert(html.includes('href="#'+(page==='new'?'runs':page)+'" aria-current="page"'));
+          assert(!html.includes('href="#new"'));
+          assert.equal((html.match(/aria-current="page"/g)||[]).length,1);
+          assert(!html.includes('sidebar')&&!html.includes('<aside'));
+          assert(html.includes('No active run'));
+          assert(html.includes('<main><div>Breadcrumb</div><h1>Content</h1></main>'));
+          for(const destination of ['runs','topology','comparisons'])assert(html.includes('href="#'+destination+'"'));
+        }
+        activeRun='run/<tag>';
+        const html=shell('runs','');
+        assert(html.includes('href="#run/run%2F%3Ctag%3E"'));
+        assert(html.includes('Active run: run/&lt;tag>'));
+        assert.equal(refreshes,5);
+        """
+        subprocess.run([shutil.which("node"), "-e", script], check=True, capture_output=True, timeout=10)
+
+    def test_new_run_link_is_in_runs_heading(self):
+        runs = web._JS.split("async function renderRuns(){", 1)[1].split("async function", 1)[0]
+        self.assertIn('<div class=runs-heading><h1 class=page-title>Runs</h1>', runs)
+        self.assertIn('<a class=new-run-link href="#new"><span aria-hidden=true>+</span> New run</a></div>', runs)
+
     @unittest.skipUnless(shutil.which("node"), "node is required for the compact Runs UI test")
     def test_web_compact_runs_sorting_and_tabs(self):
         helpers = web._JS[web._JS.index("function sectionTabs") : web._JS.index("let activeBannerLoading")]

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -7902,10 +7902,74 @@ class WebTest(unittest.TestCase):
         """
         subprocess.run([shutil.which("node"), "-e", script], check=True, capture_output=True, timeout=10)
 
-    def test_new_run_link_is_in_runs_heading(self):
+    @unittest.skipUnless(shutil.which("node"), "node is required for automatic filters")
+    def test_automatic_filters(self):
+        script = (
+            "function bindAutomaticFilters"
+            + web._JS.split("function bindAutomaticFilters", 1)[1].split("async function renderRuns", 1)[0]
+        )
+        script += """
+        const assert=require('assert');
+        let pending=null,calls=0,connected=true;
+        global.setTimeout=callback=>{pending=callback;return 1};
+        global.clearTimeout=()=>{pending=null};
+        const fields=[{value:''},{value:''}],reset={hidden:false};
+        bindAutomaticFilters(fields,reset,()=>calls++,()=>connected);
+        assert.equal(reset.hidden,true);
+        fields[0].value='   ';fields[0].oninput();
+        assert.equal(reset.hidden,true);
+        fields[0].value='main';fields[0].oninput();
+        assert.equal(reset.hidden,false);assert.equal(calls,0);
+        pending();assert.equal(calls,1);
+        fields[1].value='2026-09-11';fields[1].onchange();
+        assert.equal(calls,2);assert.equal(pending,null);
+        reset.onclick();assert.deepEqual(fields.map(f=>f.value),['','']);
+        assert.equal(reset.hidden,true);assert.equal(calls,3);
+        fields[0].value='x';fields[0].oninput();connected=false;
+        pending();assert.equal(calls,3);
+        """
+        subprocess.run([shutil.which("node"), "-e", script], check=True, capture_output=True, timeout=10)
+
+    def test_new_run_link_is_in_runs_toolbar(self):
         runs = web._JS.split("async function renderRuns(){", 1)[1].split("async function", 1)[0]
-        self.assertIn('<div class=runs-heading><h1 class=page-title>Runs</h1>', runs)
+        self.assertNotIn('<h1 class=page-title>Runs</h1>', runs)
         self.assertIn('<a class=new-run-link href="#new"><span aria-hidden=true>+</span> New run</a></div>', runs)
+
+    @unittest.skipUnless(shutil.which("node"), "node is required for comparison filters")
+    def test_saved_comparison_filters_and_sorting(self):
+        script = (
+            "function filterSavedComparisons"
+            + web._JS.split("function filterSavedComparisons", 1)[1].split("function filterComparisonRuns", 1)[0]
+        )
+        script += """
+        const assert=require('assert');
+        const records=[
+          {id:'a',name:'Zulu',created_at:'2026-09-09T10:00:00Z',profiles:[['old-run','stable']]},
+          {id:'b',name:'Alpha',created_at:'2026-09-11T10:00:00Z',profiles:[['new-run','united']]},
+          {id:'c',name:'Beta',created_at:'2026-09-10T10:00:00Z',profiles:[['middle-run','shared']]}
+        ];
+        const ids=filters=>filterSavedComparisons(records,filters).map(record=>record.id);
+        assert.deepEqual(ids({}),['b','c','a']);
+        assert.deepEqual(ids({sort:'oldest'}),['a','c','b']);
+        assert.deepEqual(ids({sort:'name'}),['b','c','a']);
+        assert.deepEqual(ids({query:' ZULU '}),['a']);
+        assert.deepEqual(ids({query:'UNITED'}),['b']);
+        assert.deepEqual(ids({query:'middle-run'}),['c']);
+        assert.deepEqual(ids({since:'2026-09-10',until:'2026-09-10'}),['c']);
+        assert.deepEqual(ids({since:'2026-09-11',until:'2026-09-09'}),[]);
+        assert.deepEqual(ids({query:'missing'}),[]);
+        assert.deepEqual(filterSavedComparisons([],{}),[]);
+        assert.deepEqual(records.map(record=>record.id),['a','b','c']);
+        """
+        subprocess.run([shutil.which("node"), "-e", script], check=True, capture_output=True, timeout=10)
+
+    def test_new_comparison_link_matches_new_run_style(self):
+        comparisons = web._JS.split("async function renderSavedComparisons(){", 1)[1]
+        self.assertNotIn('<div class=runs-heading><h1 class=page-title>Comparisons</h1>', comparisons)
+        self.assertIn(
+            '<a class=new-run-link href="#comparisons/new"><span aria-hidden=true>+</span> New comparison</a></div>',
+            comparisons,
+        )
 
     @unittest.skipUnless(shutil.which("node"), "node is required for the compact Runs UI test")
     def test_web_compact_runs_sorting_and_tabs(self):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Simplify ydb_bench navigation and unify automatic filtering and sorting on the Runs and Comparisons pages.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Replace the sidebar with wrapping top navigation, remove redundant list-page headings, and place creation actions beside sorting. Runs and Comparisons apply filters automatically and show Reset filters only for nonempty filters; resetting preserves sorting. Saved comparisons support name/profile/run search, creation-date filters, and sorting.