### PR TITLE
[DEMO 1/2, не мержить] Баг живьём: падающий тест теряется на ретрае, чек зелёный

### DIFF
--- a/ydb/core/driver_lib/run/ut/rerun_blacklist_demo_ut.cpp
+++ b/ydb/core/driver_lib/run/ut/rerun_blacklist_demo_ut.cpp
@@ -1,12 +1,17 @@
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <cstdlib>
+
 // DEMO ONLY, must not be merged (see ydb-platform/ydb#52773).
 //
-// This suite lives on a path that already has a muted test in muted_ya.txt, so the path
-// lands in the try_2 rerun blacklist. Before the fix that made ya drop the whole suite
-// from the rerun, and the failure below silently disappeared from try_2.
+// The test has to crash, not fail an assertion: a plain failure is recorded per test in the
+// ya last-failed cache and -X reruns it with a per-test filter, which works fine. Only a
+// crashed chunk marks the whole suite, and then -X restarts the suite without per-test
+// filters. This suite lives on a path that also has a muted test, so the path lands in the
+// try_2 blacklist; before the fix ya dropped the whole suite from the rerun at that point
+// and the crash silently disappeared from try_2.
 Y_UNIT_TEST_SUITE(RerunBlacklistDemo) {
-    Y_UNIT_TEST(AlwaysFails) {
-        UNIT_ASSERT_C(false, "intentional failure: must be rerun in try_2, not skipped");
+    Y_UNIT_TEST(Crashes) {
+        abort();
     }
 }

--- a/ydb/core/driver_lib/run/ut/rerun_blacklist_demo_ut.cpp
+++ b/ydb/core/driver_lib/run/ut/rerun_blacklist_demo_ut.cpp
@@ -1,17 +1,34 @@
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/stream/file.h>
+
 #include <cstdlib>
 
 // DEMO ONLY, must not be merged (see ydb-platform/ydb#52773).
 //
-// The test has to crash, not fail an assertion: a plain failure is recorded per test in the
-// ya last-failed cache and -X reruns it with a per-test filter, which works fine. Only a
-// crashed chunk marks the whole suite, and then -X restarts the suite without per-test
-// filters. This suite lives on a path that also has a muted test, so the path lands in the
-// try_2 blacklist; before the fix ya dropped the whole suite from the rerun at that point
-// and the crash silently disappeared from try_2.
+// ya marks a whole suite in its last-failed cache (and -X then restarts it without per-test
+// filters) only when a chunk-event carries a crashed/fail status. A crash inside a test body
+// does not do that: run_ut attributes it to the test and relaunches the rest of the chunk.
+// The chunk itself is marked CRASHED when the binary dies before the first test, so crash on
+// startup, but only in the process that was asked to run this suite, i.e. only in this
+// suite's chunk. The muted test on this path lives in another chunk and is unaffected, so the
+// path stays in the try_2 blacklist and, before the fix, the whole suite disappears from try_2.
+namespace {
+
+struct TCrashChunkOnStartup {
+    TCrashChunkOnStartup() {
+        try {
+            if (TFileInput("/proc/self/cmdline").ReadAll().Contains("+RerunBlacklistDemo::")) {
+                abort();
+            }
+        } catch (...) {
+        }
+    }
+} CrashChunkOnStartup;
+
+} // namespace
+
 Y_UNIT_TEST_SUITE(RerunBlacklistDemo) {
     Y_UNIT_TEST(Crashes) {
-        abort();
     }
 }

--- a/ydb/core/driver_lib/run/ut/rerun_blacklist_demo_ut.cpp
+++ b/ydb/core/driver_lib/run/ut/rerun_blacklist_demo_ut.cpp
@@ -1,0 +1,12 @@
+#include <library/cpp/testing/unittest/registar.h>
+
+// DEMO ONLY, must not be merged (see ydb-platform/ydb#52773).
+//
+// This suite lives on a path that already has a muted test in muted_ya.txt, so the path
+// lands in the try_2 rerun blacklist. Before the fix that made ya drop the whole suite
+// from the rerun, and the failure below silently disappeared from try_2.
+Y_UNIT_TEST_SUITE(RerunBlacklistDemo) {
+    Y_UNIT_TEST(AlwaysFails) {
+        UNIT_ASSERT_C(false, "intentional failure: must be rerun in try_2, not skipped");
+    }
+}

--- a/ydb/core/driver_lib/run/ut/ya.make
+++ b/ydb/core/driver_lib/run/ut/ya.make
@@ -12,6 +12,7 @@ YQL_LAST_ABI_VERSION()
 
 SRCS(
     auto_config_initializer_ut.cpp
+    rerun_blacklist_demo_ut.cpp
     run_ut.cpp
 )
 


### PR DESCRIPTION
Первая половина демонстрации к #52773. **Мержить не нужно.** Вторая половина (с фиксом) — #52795.

## Что здесь

Suite `RerunBlacklistDemo` в `ydb/core/driver_lib/run/ut`, бинарь которого падает **на старте** — но только в том процессе, которому ya велел запускать этот suite (список тестов приходит в argv как `+RerunBlacklistDemo::Crashes`), то есть только в chunk `[8/10]`. Замьюченный тест этого пути живёт в chunk `[9/10]` и не задет.

Почему именно так, а не `UNIT_ASSERT(false)` или `abort()` в теле теста — показали два предыдущих прогона этого PR, оба красные:

- обычное падение ya пишет в last-failed кеш по имени теста, `-X` перезапускает его с per-test фильтром, blacklist из непустого списка честно вычитает замьюченный — всё работает;
- `abort()` в теле теста `run_ut` атрибутирует тесту, перезапускает остаток чанка, chunk-event чистый — тот же результат.

Suite помечается целиком (`RERUN_FULL_CHUNK_STATUSES = crashed/fail/internal`) только когда chunk-event несёт ошибку, а `run_ut` вешает её на chunk, когда бинарь умер до первого теста: «Test binary failed before test case execution» → chunk `CRASHED`. Ровно так было в #50378 (крешнувшийся chunk `[71/200]`).

На этом пути в обоих mute-листах есть замьюченный тест:

```
ydb/core/driver_lib/run/ut XdsBootstrapConfigInitializer.CanSetGrpcXdsBootstrapConfigEnvWithSomeNumberOfXdsServers
```

Из-за него путь попадает в `try_2/muted_tests.yaml`. Фикса тут нет.

## Что ожидается (relwithdebinfo)

- `try_1`: `unittest.[8/10] chunk` — `FAILED`, тесты чанка `SKIPPED`, замьюченный — `MUTE`, `failed_count.txt` = 1, запускается ретрай
- `try_2`: `-X --test-blacklist-path muted_tests.yaml`, путь `ydb/core/driver_lib/run/ut` в blacklist → ya выкидывает suite целиком, его нет в отчёте
- `failed_count.txt` = 0 → **чек зелёный, хотя chunk крешится**

В release-asan на этом пути замьючен ещё и `unittest.[*/*] chunk`, поэтому там креш чанка сразу `MUTE`, падений нет и ретрая не будет — смотреть на relwithdebinfo.
