### PR TITLE
[DEMO 2/2, не мержить] С фиксом: то же падение доезжает до try_2, чек красный

### DIFF
--- a/.github/scripts/tests/mute/mute_utils.py
+++ b/.github/scripts/tests/mute/mute_utils.py
@@ -152,31 +152,57 @@ def _split(s: str, sep: str) -> tuple[str, str]:
     else:
         return s[:p], s[p + 1 :]
 
-def get_previously_skipped_tests(report_json_path: str) -> set[tuple[str, str]]:
+def load_report_results(report_json_path: str) -> list[dict]:
+    if not report_json_path:
+        return []
+    with open(report_json_path, 'r') as f:
+        return json.load(f).get('results', [])
+
+
+def get_previously_skipped_tests(results: list[dict]) -> set[tuple[str, str]]:
     result: set[tuple[str, str]] = set()
-    if report_json_path:
-        with open(report_json_path, 'r') as f:
-            report = json.load(f)
-        for test in report.get('results', []):
-            if test.get('status', '') not in {'SKIPPED'}:
-                continue
-            path = test.get('path', '')
-            name = test.get('name', '')
-            sub_name = test.get('subtest_name', '')
-            if name and sub_name:
-                result.add((path, f'{name}.{sub_name}'))
-            elif name:
-                result.add((path, name))
-            elif sub_name:
-                result.add((path, sub_name))
+    for test in results:
+        if test.get('status', '') not in {'SKIPPED'}:
+            continue
+        path = test.get('path', '')
+        name = test.get('name', '')
+        sub_name = test.get('subtest_name', '')
+        if name and sub_name:
+            result.add((path, f'{name}.{sub_name}'))
+        elif name:
+            result.add((path, name))
+        elif sub_name:
+            result.add((path, sub_name))
     return result
+
+
+def get_suites_with_unmuted_failures(results: list[dict]) -> set[str]:
+    """Suites whose previous-run failures were not covered by the mute list.
+
+    Muted failures are rewritten to MUTE by transform_build_results.py, so a leftover
+    FAILED/ERROR is exactly what made this rerun happen.
+
+    Blacklisting such a suite loses those failures: `-X` restarts the whole suite
+    without per-test filters, and the blacklist then subtracts the muted test from a
+    test list that is still empty before the suite is listed. ya reads that as an
+    empty suite and drops it (unittest), or narrows it down to a placeholder name that
+    matches nothing (pytest).
+    """
+    return {
+        test['path']
+        for test in results
+        if test.get('status', '') in {'FAILED', 'ERROR'} and test.get('path', '')
+    }
+
 
 def convert_muted_txt_to_yaml(muted_txt_path: str, report_json_path: str) -> None:
     import yaml
 
     with open(muted_txt_path) as file:
         muted_tests = file.readlines()
-    previously_skipped = get_previously_skipped_tests(report_json_path)
+    results = load_report_results(report_json_path)
+    previously_skipped = get_previously_skipped_tests(results)
+    suites_to_rerun_fully = get_suites_with_unmuted_failures(results)
     filter_by_suite: dict[tuple[str, str], list[str]] = {}
     for test_line in [l.strip() for l in muted_tests]:
         if not test_line:
@@ -185,6 +211,8 @@ def convert_muted_txt_to_yaml(muted_txt_path: str, report_json_path: str) -> Non
         if filter.endswith('chunk'):
             continue
         if (path, filter) in previously_skipped:
+            continue
+        if path in suites_to_rerun_fully:
             continue
         suite_type = ''
         filter = filter.replace('.', '::').replace('::py::', '.py::')

--- a/.github/scripts/tests/mute/tests/test_rerun_blacklist.py
+++ b/.github/scripts/tests/mute/tests/test_rerun_blacklist.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Tests for the rerun blacklist built by ``mute_utils.convert_muted_txt_to_yaml``.
+
+Run from ``.github/scripts/tests/mute``: ``python3 -m unittest discover -s tests``
+(running from the repo root shadows the installed ``ydb`` package).
+"""
+import contextlib
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+_HERE = Path(__file__).resolve().parent
+_MUTE_DIR = _HERE.parent
+_TESTS_DIR = _MUTE_DIR.parent
+_SCRIPTS_DIR = _TESTS_DIR.parent
+for _p in (str(_TESTS_DIR), str(_SCRIPTS_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from mute.mute_utils import convert_muted_txt_to_yaml  # noqa: E402
+
+DATASTREAMS = 'ydb/core/kqp/ut/federated_query/datastreams'
+OLTP = 'ydb/tests/stress/oltp_workload/tests'
+
+
+def failed(path, name, subtest_name=''):
+    return {'path': path, 'name': name, 'subtest_name': subtest_name, 'status': 'FAILED'}
+
+
+def muted(path, name, subtest_name=''):
+    return {'path': path, 'name': name, 'subtest_name': subtest_name, 'status': 'MUTE', 'muted': True}
+
+
+def skipped(path, name, subtest_name=''):
+    return {'path': path, 'name': name, 'subtest_name': subtest_name, 'status': 'SKIPPED'}
+
+
+def passed(path, name, subtest_name=''):
+    return {'path': path, 'name': name, 'subtest_name': subtest_name, 'status': 'PASSED'}
+
+
+class ConvertMutedTxtToYamlTest(unittest.TestCase):
+    def convert(self, muted_lines, results):
+        with tempfile.TemporaryDirectory() as tmp:
+            muted_txt = Path(tmp) / 'muted_ya.txt'
+            muted_txt.write_text('\n'.join(muted_lines) + '\n')
+            report = Path(tmp) / 'report.json'
+            report.write_text(json.dumps({'results': results}))
+
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                convert_muted_txt_to_yaml(str(muted_txt), str(report))
+        return yaml.safe_load(out.getvalue()) or []
+
+    def filters_by_path(self, muted_lines, results):
+        return {entry['path']: entry.get('test_filter') for entry in self.convert(muted_lines, results)}
+
+    def test_suite_with_only_muted_failures_is_blacklisted(self):
+        # Nothing else to rerun in the suite, so keep it out of the rerun.
+        filters = self.filters_by_path(
+            [f'{DATASTREAMS} KqpStreamingQueriesDdl.CreateAndAlterStreamingQuery'],
+            [
+                muted(DATASTREAMS, 'KqpStreamingQueriesDdl', 'CreateAndAlterStreamingQuery'),
+                passed(DATASTREAMS, 'KqpStreamingQueriesDdl', 'CreateAndDropStreamingQuery'),
+            ],
+        )
+        self.assertEqual(filters, {DATASTREAMS: 'KqpStreamingQueriesDdl::CreateAndAlterStreamingQuery'})
+
+    def test_unittest_suite_with_unmuted_failure_is_not_blacklisted(self):
+        # PR 50378: 4 crashed tests next to a muted one. Blacklisting the path made ya
+        # drop the whole suite, so the crashes never reran and the check went green.
+        filters = self.filters_by_path(
+            [f'{DATASTREAMS} KqpStreamingQueriesDdl.CreateAndAlterStreamingQuery'],
+            [
+                muted(DATASTREAMS, 'KqpStreamingQueriesDdl', 'CreateAndAlterStreamingQuery'),
+                failed(DATASTREAMS, 'KqpStreamingQueriesDdl', 'StreamingQueryWithStreamLookupJoinLocalTable+WithFeatureFlag'),
+            ],
+        )
+        self.assertEqual(filters, {})
+
+    def test_pytest_suite_with_unmuted_failure_is_not_blacklisted(self):
+        # PR 49067: muted TestYdbWorkload.test next to a failing test_tli. The blacklist
+        # narrowed the suite down to a placeholder name that matches no real test.
+        filters = self.filters_by_path(
+            [f'{OLTP} test_workload.py.TestYdbWorkload.test'],
+            [
+                muted(OLTP, 'test_workload.py', 'TestYdbWorkload.test'),
+                failed(OLTP, 'test_workload.py', 'TestYdbWorkload.test_tli'),
+            ],
+        )
+        self.assertEqual(filters, {})
+
+    def test_unmuted_failure_only_affects_its_own_suite(self):
+        filters = self.filters_by_path(
+            [
+                f'{DATASTREAMS} KqpStreamingQueriesDdl.CreateAndAlterStreamingQuery',
+                f'{OLTP} test_workload.py.TestYdbWorkload.test',
+            ],
+            [
+                muted(DATASTREAMS, 'KqpStreamingQueriesDdl', 'CreateAndAlterStreamingQuery'),
+                failed(DATASTREAMS, 'KqpStreamingQueriesDdl', 'StreamingQueryWithStreamLookupJoinLocalTable+WithFeatureFlag'),
+                muted(OLTP, 'test_workload.py', 'TestYdbWorkload.test'),
+            ],
+        )
+        self.assertEqual(filters, {OLTP: 'test_workload.py::TestYdbWorkload::test'})
+
+    def test_error_status_counts_as_unmuted_failure(self):
+        filters = self.filters_by_path(
+            [f'{DATASTREAMS} KqpStreamingQueriesDdl.CreateAndAlterStreamingQuery'],
+            [{'path': DATASTREAMS, 'name': 'KqpStreamingQueriesDdl', 'subtest_name': 'Other', 'status': 'ERROR'}],
+        )
+        self.assertEqual(filters, {})
+
+    def test_chunk_lines_and_previously_skipped_tests_are_still_dropped(self):
+        filters = self.filters_by_path(
+            [
+                f'{DATASTREAMS} unittest.[*/*] chunk',
+                f'{DATASTREAMS} KqpStreamingQueriesDdl.CreateAndAlterStreamingQuery',
+                f'{OLTP} test_workload.py.TestYdbWorkload.test',
+            ],
+            [
+                muted(DATASTREAMS, 'KqpStreamingQueriesDdl', 'CreateAndAlterStreamingQuery'),
+                skipped(OLTP, 'test_workload.py', 'TestYdbWorkload.test'),
+            ],
+        )
+        self.assertEqual(filters, {DATASTREAMS: 'KqpStreamingQueriesDdl::CreateAndAlterStreamingQuery'})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ydb/core/driver_lib/run/ut/rerun_blacklist_demo_ut.cpp
+++ b/ydb/core/driver_lib/run/ut/rerun_blacklist_demo_ut.cpp
@@ -1,12 +1,17 @@
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <cstdlib>
+
 // DEMO ONLY, must not be merged (see ydb-platform/ydb#52773).
 //
-// This suite lives on a path that already has a muted test in muted_ya.txt, so the path
-// lands in the try_2 rerun blacklist. Before the fix that made ya drop the whole suite
-// from the rerun, and the failure below silently disappeared from try_2.
+// The test has to crash, not fail an assertion: a plain failure is recorded per test in the
+// ya last-failed cache and -X reruns it with a per-test filter, which works fine. Only a
+// crashed chunk marks the whole suite, and then -X restarts the suite without per-test
+// filters. This suite lives on a path that also has a muted test, so the path lands in the
+// try_2 blacklist; before the fix ya dropped the whole suite from the rerun at that point
+// and the crash silently disappeared from try_2.
 Y_UNIT_TEST_SUITE(RerunBlacklistDemo) {
-    Y_UNIT_TEST(AlwaysFails) {
-        UNIT_ASSERT_C(false, "intentional failure: must be rerun in try_2, not skipped");
+    Y_UNIT_TEST(Crashes) {
+        abort();
     }
 }

--- a/ydb/core/driver_lib/run/ut/rerun_blacklist_demo_ut.cpp
+++ b/ydb/core/driver_lib/run/ut/rerun_blacklist_demo_ut.cpp
@@ -1,17 +1,34 @@
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/stream/file.h>
+
 #include <cstdlib>
 
 // DEMO ONLY, must not be merged (see ydb-platform/ydb#52773).
 //
-// The test has to crash, not fail an assertion: a plain failure is recorded per test in the
-// ya last-failed cache and -X reruns it with a per-test filter, which works fine. Only a
-// crashed chunk marks the whole suite, and then -X restarts the suite without per-test
-// filters. This suite lives on a path that also has a muted test, so the path lands in the
-// try_2 blacklist; before the fix ya dropped the whole suite from the rerun at that point
-// and the crash silently disappeared from try_2.
+// ya marks a whole suite in its last-failed cache (and -X then restarts it without per-test
+// filters) only when a chunk-event carries a crashed/fail status. A crash inside a test body
+// does not do that: run_ut attributes it to the test and relaunches the rest of the chunk.
+// The chunk itself is marked CRASHED when the binary dies before the first test, so crash on
+// startup, but only in the process that was asked to run this suite, i.e. only in this
+// suite's chunk. The muted test on this path lives in another chunk and is unaffected, so the
+// path stays in the try_2 blacklist and, before the fix, the whole suite disappears from try_2.
+namespace {
+
+struct TCrashChunkOnStartup {
+    TCrashChunkOnStartup() {
+        try {
+            if (TFileInput("/proc/self/cmdline").ReadAll().Contains("+RerunBlacklistDemo::")) {
+                abort();
+            }
+        } catch (...) {
+        }
+    }
+} CrashChunkOnStartup;
+
+} // namespace
+
 Y_UNIT_TEST_SUITE(RerunBlacklistDemo) {
     Y_UNIT_TEST(Crashes) {
-        abort();
     }
 }

--- a/ydb/core/driver_lib/run/ut/rerun_blacklist_demo_ut.cpp
+++ b/ydb/core/driver_lib/run/ut/rerun_blacklist_demo_ut.cpp
@@ -1,0 +1,12 @@
+#include <library/cpp/testing/unittest/registar.h>
+
+// DEMO ONLY, must not be merged (see ydb-platform/ydb#52773).
+//
+// This suite lives on a path that already has a muted test in muted_ya.txt, so the path
+// lands in the try_2 rerun blacklist. Before the fix that made ya drop the whole suite
+// from the rerun, and the failure below silently disappeared from try_2.
+Y_UNIT_TEST_SUITE(RerunBlacklistDemo) {
+    Y_UNIT_TEST(AlwaysFails) {
+        UNIT_ASSERT_C(false, "intentional failure: must be rerun in try_2, not skipped");
+    }
+}

--- a/ydb/core/driver_lib/run/ut/ya.make
+++ b/ydb/core/driver_lib/run/ut/ya.make
@@ -12,6 +12,7 @@ YQL_LAST_ABI_VERSION()
 
 SRCS(
     auto_config_initializer_ut.cpp
+    rerun_blacklist_demo_ut.cpp
     run_ut.cpp
 )
 


### PR DESCRIPTION
Вторая половина демонстрации к #52773. **Мержить не нужно.** Первая половина (без фикса) — #52793.

## Что здесь

Ровно тот же suite `RerunBlacklistDemo`, что в #52793 (бинарь падает на старте только в своём chunk `[8/10]`), плюс один коммит фикса из #52773. Больше ничего.

## Что ожидается (relwithdebinfo)

- `try_1`: `unittest.[8/10] chunk` — `FAILED` (как в #52793)
- `try_2/muted_tests.yaml`: пути `ydb/core/driver_lib/run/ut` **нет** — на нём есть незамьюченное падение, значит mute-лист его не покрыл и suite должен перезапуститься целиком
- `try_2`: suite перезапущен, chunk `[8/10]` снова `FAILED`, `failed_count.txt` = 1
- то же в `try_3` → **чек красный**

## Как сравнивать

| | #52793 (без фикса) | этот PR (с фиксом) |
|---|---|---|
| `try_1` | chunk `[8/10]` FAILED | chunk `[8/10]` FAILED |
| `ydb/core/driver_lib/run/ut` в `try_2/muted_tests.yaml` | есть | нет |
| suite в `try_2` | отсутствует | перезапущен, снова FAILED |
| итог чека | зелёный | красный |

Красный чек здесь — ожидаемый результат: падение больше не теряется. Замьюченный `XdsBootstrapConfigInitializer.CanSetGrpcXdsBootstrapConfigEnvWithSomeNumberOfXdsServers` на этом пути прогонится на ретрае ещё раз — это цена фикса, и только для путей, где есть чужое падение.

В release-asan на этом пути замьючен ещё и `unittest.[*/*] chunk`, там креш чанка сразу `MUTE` и ретрая не будет — смотреть на relwithdebinfo.
