### PR TITLE
NBS-7513: Add oracle's initial health load

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -169,6 +169,7 @@ TDirectBlockGroup::TDirectBlockGroup(
     size_t directBlockGroupIndex,
     const TVector<NBsController::TDDiskId>& ddisksIds,
     const TVector<NBsController::TDDiskId>& pbufferIds,
+    const TVector<EHostHealth>& hostHealths,
     ui32 dbgConnectionsConfigGeneration,
     NTransport::TStorageTransportPtr storageTransport,
     NMonitoring::TDynamicCounterPtr counters)
@@ -192,7 +193,7 @@ TDirectBlockGroup::TDirectBlockGroup(
           TabletGeneration,
           static_cast<ui32>(DirectBlockGroupIndex),
           dbgConnectionsConfigGeneration)
-    , Oracle(StorageConfig, this)
+    , Oracle(StorageConfig, this, hostHealths)
     , Counters(std::move(counters))
 {
     Y_ABORT_UNLESS(IsSupportedBlockSize(BlockSize));

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -198,6 +198,7 @@ TDirectBlockGroup::TDirectBlockGroup(
 {
     Y_ABORT_UNLESS(IsSupportedBlockSize(BlockSize));
     Y_ASSERT(pbufferIds.size() == ddisksIds.size());
+    Y_ASSERT(hostHealths.size() == ddisksIds.size());
     Y_ASSERT(pbufferIds.size() >= DirectBlockGroupHostCount);
 
     for (THostIndex host = 0; host < ddisksIds.size(); ++host) {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
@@ -45,6 +45,7 @@ public:
         size_t directBlockGroupIndex,
         const TVector<NKikimr::NBsController::TDDiskId>& ddisksIds,
         const TVector<NKikimr::NBsController::TDDiskId>& pbufferIds,
+        const TVector<EHostHealth>& hostHealths,
         ui32 dbgConnectionsConfigGeneration,
         NTransport::TStorageTransportPtr storageTransport,
         NMonitoring::TDynamicCounterPtr counters);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
@@ -164,7 +164,7 @@ TDBGFixture::MakeDirectBlockGroup(
         directBlockGroupIndex,
         ddisksIds,
         pbufferIds,
-        TVector{ddisksIds.size(), EHostHealth::Online},
+        TVector(ddisksIds.size(), EHostHealth::Online),
         dbgConnectionsConfigGeneration,
         std::move(transport),
         nullptr);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
@@ -164,6 +164,7 @@ TDBGFixture::MakeDirectBlockGroup(
         directBlockGroupIndex,
         ddisksIds,
         pbufferIds,
+        TVector{ddisksIds.size(), EHostHealth::Online},
         dbgConnectionsConfigGeneration,
         std::move(transport),
         nullptr);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
@@ -67,7 +67,8 @@ EHostHealth ToPersistentHealth(const EHostHealth health)
 
 TOracle::TOracle(
     TStorageConfigPtr storageConfig,
-    IHostStateController* hostStateController)
+    IHostStateController* hostStateController,
+    const TVector<EHostHealth>& hostHealths)
     : StorageConfig(std::move(storageConfig))
     , OracleConfig(std::make_shared<TOracleConfig>(StorageConfig))
     , HostStateController(hostStateController)
@@ -80,10 +81,11 @@ TOracle::TOracle(
     , DefaultFlushRequestTimeout(StorageConfig->GetFlushRequestTimeout())
     , DefaultEraseRequestTimeout(StorageConfig->GetEraseRequestTimeout())
     , DefaultWriteMode(GetWriteModeFromProto(StorageConfig->GetWriteMode()))
-    , HostStatistics(DirectBlockGroupHostCount)
-    , HostStates(DirectBlockGroupHostCount)
+    , HostStatistics(hostHealths.size())
+    , HostStates(hostHealths.size())
+    , HostsHealths(hostHealths)
     , HostsReconnectDelays(
-          DirectBlockGroupHostCount,
+          hostHealths.size(),
           TBackoffDelayProvider(MinReconnectDelay, MaxReconnectDelay))
     , TimePredictors(
           OperationCount,
@@ -92,9 +94,8 @@ TOracle::TOracle(
               OracleConfig->GetTimePredictionNthFromEnd()))
     , HealthPolicy(CreateDefaultHostHealthPolicy(OracleConfig))
 {
-    HostsHealths.resize(HostStates.size());
-    for (auto& healths: HostsHealths) {
-        healths = EHostHealth::Online;
+    for (size_t hostIndex = 0; hostIndex < hostHealths.size(); ++hostIndex) {
+        HostStates[hostIndex].State = HealthToState(hostHealths[hostIndex]);
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.h
@@ -86,7 +86,8 @@ class TOracle: public IOracle
 public:
     TOracle(
         TStorageConfigPtr storageConfig,
-        IHostStateController* hostStateController);
+        IHostStateController* hostStateController,
+        const TVector<EHostHealth>& hostHealths);
     ~TOracle() override;
 
     void Think(TInstant now);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
@@ -74,6 +74,9 @@ TStorageConfigPtr MakeStorageConfig()
     return std::make_shared<TStorageConfig>(rawConfig);
 }
 
+const auto DefaultHostHealths =
+    TVector{DirectBlockGroupHostCount, EHostHealth::Online};
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -87,7 +90,7 @@ Y_UNIT_TEST_SUITE(TOracle)
 
         const auto hosts = THostMask::MakeAll(5);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultHostHealths);
 
         // Host 2 has the lowest inflight count (zero), all others are higher.
         const auto now = TInstant::Now();
@@ -116,7 +119,7 @@ Y_UNIT_TEST_SUITE(TOracle)
 
         const auto hosts = THostMask::MakeOne(3);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultHostHealths);
 
         // Host 2 has the lowest inflight count (zero), all others are higher.
         const auto now = TInstant::Now();
@@ -149,7 +152,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         hosts.Set(0);
         hosts.Set(3);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultHostHealths);
 
         const auto now = TInstant::Now();
         for (THostIndex hostIndex: {0, 0, 3}) {
@@ -184,7 +187,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         hosts.Set(2);
         hosts.Set(4);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultHostHealths);
 
         std::map<THostIndex, size_t> counts;
         const size_t iterations = 3000;
@@ -220,7 +223,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         // picked - only ties at the global minimum are randomized.
         const auto hosts = THostMask::MakeAll(5);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultHostHealths);
 
         // Host 2 has the lowest inflight count (zero), all others are higher.
         const auto now = TInstant::Now();
@@ -249,7 +252,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         auto now = TInstant::Now();
 
         oracle.Think(now);
@@ -320,7 +323,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         auto now = TInstant::Now();
 
         oracle.Think(now);
@@ -363,7 +366,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         auto now = TInstant::Now();
 
         oracle.Think(now);
@@ -413,7 +416,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         auto now = TInstant::Now();
 
         oracle.Think(now);
@@ -454,7 +457,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         NProto::TStorageServiceConfig rawConfig;
         auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultHostHealths);
 
         // No read requests recorded -> predictor returns zero -> fallback to
         // default. Default ReadHedgingDelay is 1ms when not set in config.
@@ -472,7 +475,7 @@ Y_UNIT_TEST_SUITE(TOracle)
     {
         auto storageConfig = MakeStorageConfig();
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultHostHealths);
         auto now = TInstant::Now();
 
         // Feed DDisk reads with 100ms, 200ms on host 0.
@@ -525,7 +528,7 @@ Y_UNIT_TEST_SUITE(TOracle)
     {
         auto storageConfig = MakeStorageConfig();
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultHostHealths);
 
         // No write requests recorded -> predictor returns zero -> fallback to
         // default. Default WriteHedgingDelay is 1ms when not set in config.
@@ -543,7 +546,7 @@ Y_UNIT_TEST_SUITE(TOracle)
     {
         auto storageConfig = MakeStorageConfig();
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultHostHealths);
         auto now = TInstant::Now();
 
         // WriteToPBuffer (direct): [100, 200] -> predict 100ms.
@@ -581,7 +584,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         NProto::TStorageServiceConfig rawConfig;
         auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultHostHealths);
 
         // No errors recorded on any host -> no cooldown.
         UNIT_ASSERT_VALUES_EQUAL(
@@ -594,7 +597,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         NProto::TStorageServiceConfig rawConfig;
         auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultHostHealths);
         const auto now = TInstant::Now();
 
         // Each consecutive error adds a 10ms penalty on host 0.
@@ -625,7 +628,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         NProto::TStorageServiceConfig rawConfig;
         auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultHostHealths);
         const auto now = TInstant::Now();
 
         // Host 1: two consecutive errors -> 20ms.
@@ -663,7 +666,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         NProto::TStorageServiceConfig rawConfig;
         auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultHostHealths);
         const auto now = TInstant::Now();
 
         // The cooldown grows by 10ms per consecutive error and is capped at
@@ -697,7 +700,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
 
         // With the default set of DirectBlockGroupHostCount online hosts, the
         // alive count equals the required count, so no new host is requested.
@@ -716,7 +719,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         auto now = TInstant::Now();
 
         // Push host 0 into the TemporaryOffline state.
@@ -745,7 +748,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         auto now = TInstant::Now();
 
         // Generate a single error on host 0.
@@ -781,7 +784,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         auto now = TInstant::Now();
 
         // Drive host 0 to Offline.
@@ -812,7 +815,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         auto now = TInstant::Now();
 
         // Drive host 0 to Offline so a new host is requested.
@@ -838,7 +841,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         const auto now = TInstant::Now();
 
         // Initially there are DirectBlockGroupHostCount hosts.
@@ -864,7 +867,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         const auto now = TInstant::Now();
 
         // An index that already exists must not change the host count.
@@ -885,7 +888,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = MakeStorageConfig();
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         auto now = TInstant::Now();
 
         // A broken device forces the host offline and requests a replacement.
@@ -918,7 +921,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = MakeStorageConfig();
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         auto now = TInstant::Now();
 
         oracle.OnDDiskBroken(0);
@@ -958,7 +961,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         auto now = TInstant::Now();
 
         // Generate a single error on host 0.
@@ -997,7 +1000,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         auto now = TInstant::Now();
 
         // Generate a single error on host 0.
@@ -1046,7 +1049,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultHostHealths);
         auto now = TInstant::Now();
 
         // Generate a single error on host 0.
@@ -1074,6 +1077,45 @@ Y_UNIT_TEST_SUITE(TOracle)
             EHostState::Online,
             hostStateController.States[0]);
         UNIT_ASSERT_VALUES_EQUAL(0, hostStateController.Healths.size());
+    }
+
+    Y_UNIT_TEST(ConstructorSetsInitialHealth)
+    {
+        const TVector initialHealth{
+            EHostHealth::Online,
+            EHostHealth::TemporaryOffline,
+            EHostHealth::Offline,
+            EHostHealth::Online,
+            EHostHealth::Broken,
+        };
+        const TVector expectedStates{
+            EHostState::Online,
+            EHostState::TemporaryOffline,
+            EHostState::Offline,
+            EHostState::Online,
+            EHostState::Offline,
+        };
+
+        auto config = MakeStorageConfig();
+
+        THostStateControllerMock hostStateController;
+        TOracle oracle(config, &hostStateController, initialHealth);
+        auto now = TInstant::Now();
+
+        auto stats = oracle.BuildHostStats(now);
+
+        UNIT_ASSERT_VALUES_EQUAL(initialHealth.size(), stats.size());
+
+        for (size_t i = 0; i < initialHealth.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                expectedStates[i],
+                stats[i].State,
+                "host #" << i);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                initialHealth[i],
+                stats[i].Health,
+                "host #" << i);
+        }
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct_tablet/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct_tablet/partition_direct_actor.cpp
@@ -337,6 +337,8 @@ TFastPathServicePtr TPartitionActor::CreateFastPathService(
             persistentBufferDDiskIds.push_back(NBsController::TDDiskId(
                 connection.GetPersistentBufferDDiskId()));
         }
+        // Temporarily preserving original behavior
+        TVector<EHostHealth> hostHealths{ddiskIds.size(), EHostHealth::Online};
 
         const bool enableChecksums =
             nbsService->StorageConfig->GetEnableChecksums();
@@ -363,6 +365,7 @@ TFastPathServicePtr TPartitionActor::CreateFastPathService(
             dbgIndex,
             std::move(ddiskIds),
             std::move(persistentBufferDDiskIds),
+            std::move(hostHealths),
             conn.GetDBGConnectionsConfigGeneration(),
             std::move(transport),
             dbgCountersRoot);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct_tablet/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct_tablet/partition_direct_actor.cpp
@@ -338,7 +338,7 @@ TFastPathServicePtr TPartitionActor::CreateFastPathService(
                 connection.GetPersistentBufferDDiskId()));
         }
         // Temporarily preserving original behavior
-        TVector<EHostHealth> hostHealths{ddiskIds.size(), EHostHealth::Online};
+        TVector<EHostHealth> hostHealths(ddiskIds.size(), EHostHealth::Online);
 
         const bool enableChecksums =
             nbsService->StorageConfig->GetEnableChecksums();


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Implemented initial health load in TOracle

Currently loads with all-online, which preserves existing behavior until further integration with Partition db

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
