### PR TITLE
Split block-4-2 phantom replication test to avoid timeouts

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -2,7 +2,6 @@ ydb/core/blobstorage/ddisk/ut_large TDDiskActorPDiskLargeTest.BatchWriteThenRead
 ydb/core/blobstorage/ddisk/ut_large unittest.[*/*] chunk
 ydb/core/blobstorage/ut_blobstorage/ut_race GroupReconfigurationRace.Test_block42
 ydb/core/blobstorage/ut_blobstorage/ut_race unittest.[*/*] chunk
-ydb/core/blobstorage/ut_blobstorage/ut_replication Replication.Phantoms_block4_2
 ydb/core/blobstorage/ut_blobstorage/ut_replication unittest.[*/*] chunk
 ydb/core/blobstorage/ut_blobstorage/ut_scrub BlobScrubbing.mirror3of4
 ydb/core/blobstorage/ut_vdisk unittest.[*/*] chunk

--- a/ydb/core/blobstorage/ut_blobstorage/replication.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/replication.cpp
@@ -262,7 +262,7 @@ TString DoTestCase(TBlobStorageGroupType::EErasureSpecies erasure, const std::ve
     return s.Str();
 }
 
-void DoTest(TBlobStorageGroupType::EErasureSpecies erasure) {
+void DoTest(TBlobStorageGroupType::EErasureSpecies erasure, std::optional<ui32> formattedNodeId = {}) {
     TMutex mutex, logMutex;
     std::vector<std::pair<TBlobStorageGroupType::EErasureSpecies, std::vector<EState>>> queue;
     size_t queueIndex = 0;
@@ -307,6 +307,9 @@ void DoTest(TBlobStorageGroupType::EErasureSpecies erasure) {
             Y_ABORT_UNLESS(states.size() == type.BlobSubgroupSize());
             std::sort(states.begin(), states.end());
             do {
+                if (formattedNodeId && states[*formattedNodeId - 1] != EState::FORMAT) {
+                    continue;
+                }
 #if SINGLE_THREAD
                 DoTestCase(erasure, states);
 #else
@@ -344,7 +347,15 @@ void DoTest(TBlobStorageGroupType::EErasureSpecies erasure) {
 
 Y_UNIT_TEST_SUITE(Replication) {
     Y_UNIT_TEST(Phantoms_mirror3dc) { DoTest(TBlobStorageGroupType::ErasureMirror3dc); }
-    Y_UNIT_TEST(Phantoms_block4_2) { DoTest(TBlobStorageGroupType::Erasure4Plus2Block); }
+    // Fork the 168 placements by formatted disk to keep each test below the timeout.
+    Y_UNIT_TEST(Phantoms_block4_2_disk1) { DoTest(TBlobStorageGroupType::Erasure4Plus2Block, 1); }
+    Y_UNIT_TEST(Phantoms_block4_2_disk2) { DoTest(TBlobStorageGroupType::Erasure4Plus2Block, 2); }
+    Y_UNIT_TEST(Phantoms_block4_2_disk3) { DoTest(TBlobStorageGroupType::Erasure4Plus2Block, 3); }
+    Y_UNIT_TEST(Phantoms_block4_2_disk4) { DoTest(TBlobStorageGroupType::Erasure4Plus2Block, 4); }
+    Y_UNIT_TEST(Phantoms_block4_2_disk5) { DoTest(TBlobStorageGroupType::Erasure4Plus2Block, 5); }
+    Y_UNIT_TEST(Phantoms_block4_2_disk6) { DoTest(TBlobStorageGroupType::Erasure4Plus2Block, 6); }
+    Y_UNIT_TEST(Phantoms_block4_2_disk7) { DoTest(TBlobStorageGroupType::Erasure4Plus2Block, 7); }
+    Y_UNIT_TEST(Phantoms_block4_2_disk8) { DoTest(TBlobStorageGroupType::Erasure4Plus2Block, 8); }
     Y_UNIT_TEST(Phantoms_mirror3of4) { DoTest(TBlobStorageGroupType::ErasureMirror3of4); }
 
     using E = EState;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Avoid timeouts in the block-4-2 phantom replication test.

### Description for reviewers <!-- (optional) description for those who read this PR -->

The test runs 168 failure placements sequentially. Successful CI runs take up to 3599 seconds, and recent 3600-second timeouts occur while simulation is still progressing through the final placements. Split the placements into eight forked tests by formatted disk, preserving every scenario, the six-hour simulation interval, and all assertions. Remove the obsolete mute entry for the old test name.

Fixes #51167.