### PR TITLE
[Backport nbs-26-3-1] PBuffer integrity, cleanup and barrier recovery

### DIFF
--- a/ydb/apps/dstool/lib/dstool_cmd_nbs_partition_create.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_nbs_partition_create.py
@@ -38,9 +38,12 @@ def do(args):
     output = {
         'status': StatusIds.StatusCode.Name(response.operation.status),
     }
-    if common.get_status(response):
+    if response.operation.ready and response.operation.status in (
+        StatusIds.SUCCESS,
+        StatusIds.ALREADY_EXISTS,
+    ):
         result = nbs.CreatePartitionResult()
         response.operation.result.Unpack(result)
-        output['tabletId'] = result.TabletId or ''
+        output['tabletId'] = result.TabletId
 
     print(json.dumps(output))

--- a/ydb/apps/dstool/lib/dstool_cmd_nbs_partition_create.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_nbs_partition_create.py
@@ -1,5 +1,7 @@
+import json
 import ydb.apps.dstool.lib.common as common
 import ydb.public.api.protos.draft.ydb_nbs_pb2 as nbs
+from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
 
 
 description = 'Create NBS 2.0 partition'
@@ -33,6 +35,12 @@ def do(args):
 
     common.print_nbs_request_result(args, request, response)
 
-    result = nbs.CreatePartitionResult()
-    response.operation.result.Unpack(result)
-    print(result)
+    output = {
+        'status': StatusIds.StatusCode.Name(response.operation.status),
+    }
+    if common.get_status(response):
+        result = nbs.CreatePartitionResult()
+        response.operation.result.Unpack(result)
+        output['tabletId'] = result.TabletId or ''
+
+    print(json.dumps(output))

--- a/ydb/apps/dstool/lib/dstool_cmd_nbs_partition_delete.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_nbs_partition_delete.py
@@ -27,6 +27,6 @@ def do(args):
     if common.get_status(response):
         result = nbs.DeletePartitionResult()
         response.operation.result.Unpack(result)
-        output['diskId'] = result.DiskId or ''
+        output['diskId'] = result.DiskId
 
     print(json.dumps(output))

--- a/ydb/core/blobstorage/ddisk/ddisk.h
+++ b/ydb/core/blobstorage/ddisk/ddisk.h
@@ -341,9 +341,18 @@ namespace NKikimr::NDDisk {
         std::optional<ui32> MismatchedBlockIdx; // set only when Status == CORRUPTED
     };
 
+    // True when the request is 4 KiB-aligned and carries exactly one checksum per block.
+    inline bool HasRequiredBlockChecksums(ui32 checksumCount, ui32 offsetInBytes, ui32 size) {
+        return offsetInBytes % IntegrityUnitSize == 0
+            && size > 0
+            && size % IntegrityUnitSize == 0
+            && checksumCount > 0
+            && static_cast<ui64>(checksumCount) * IntegrityUnitSize == size;
+    }
+
     // Validates a sender-supplied per-block payload checksum list against the payload actually received.
-    // For now, checksum validation is opt-in: returns std::nullopt when the sender attached no checksums at all
-    // or when every checksum matches. Otherwise returns the status/reason to send back to the sender:
+    // Callers must reject writes without HasRequiredBlockChecksums first. This function then returns
+    // std::nullopt when every checksum matches, otherwise:
     // * INCORRECT_REQUEST if the checksum count does not match the payload size
     // * CORRUPTED at the first mismatching MinSectorSize block.
     template<typename TRecord>
@@ -611,13 +620,16 @@ struct TPersistentBufferFormat {
 
         TEvReadResult(NKikimrBlobStorage::NDDisk::TReplyStatus::E status,
                 const std::optional<TString>& errorReason = std::nullopt,
-                TRope data = {}) {
+                TRope data = {}, const std::vector<ui64>& checksums = {}) {
             Record.SetStatus(status);
             if (errorReason) {
                 Record.SetErrorReason(*errorReason);
             }
             if (data) {
                 TReadResult(AddPayload(std::move(data))).Serialize(Record.MutableReadResult());
+            }
+            for (const ui64 checksum : checksums) {
+                Record.AddChecksums(checksum);
             }
         }
     };
@@ -789,9 +801,9 @@ struct TPersistentBufferFormat {
                 Record.SetOffsetInBytes(offsetInBytes);
                 Record.SetSizeInBytes(sizeInBytes);
                 TReadResult(AddPayload(std::move(data))).Serialize(Record.MutableReadResult());
-                // Opt-in, mirrors TEvWritePersistentBuffer.Checksums: only attached when the persisted
-                // record actually carries sender-supplied payload checksums (see
-                // TPersistentBuffer::TRecord::PayloadChecksums).
+                // Raw XXH3_64(data) per MinSectorSize block, copied from the persisted record.
+                // Successful writes always store checksums, so a successful read of a live record
+                // returns exactly one value per aligned block.
                 for (ui64 checksum : checksums) {
                     Record.AddChecksums(checksum);
                 }

--- a/ydb/core/blobstorage/ddisk/ddisk.h
+++ b/ydb/core/blobstorage/ddisk/ddisk.h
@@ -862,6 +862,10 @@ struct TPersistentBufferFormat {
             ui32 LsnsCount;
             ui64 Size;
             ui32 FastErasesCount;
+            // Direct block group number this info entry belongs to. See TPersistentBufferId for
+            // rationale; defaults to 0 to preserve the pre-existing single-namespace-per-tablet
+            // behavior.
+            ui8 DirectBlockGroupIndex = 0;
         };
 
         struct TOpStats {
@@ -886,7 +890,8 @@ struct TPersistentBufferFormat {
         ui32 PendingEvents;
         ui64 PerTabletStorageLimit;
         std::vector<TTabletInfo> TabletInfos;
-        std::unordered_map<ui64, ui64> EraseBarriers;
+        // Keyed by (TabletId, DirectBlockGroupIndex), matching TPersistentBufferBarriersManager::GetBarriers().
+        std::map<std::pair<ui64, ui8>, ui64> EraseBarriers;
         std::vector<std::vector<std::tuple<ui32, ui32>>> FreeSpace;
         std::vector<TOpStats> OpStats;
     };

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
@@ -47,6 +47,26 @@ namespace NKikimr::NDDisk {
         }
 
         creds.SerializeResolvedForRequest(record.MutableCredentials());
+        if constexpr (requires { record.ChecksumsSize(); record.GetSelector(); }) {
+            const auto& selector = record.GetSelector();
+            if (!HasRequiredBlockChecksums(record.ChecksumsSize(),
+                    selector.GetOffsetInBytes(), selector.GetSize())) {
+                if (record.ChecksumsSize() == 0) {
+                    Counters.Checksums.WritesWithoutChecksums->Inc();
+                }
+                auto result = std::make_unique<TEvWritePersistentBuffersResult>();
+                for (const auto& id : record.GetPersistentBufferIds()) {
+                    auto* item = result->Record.AddResult();
+                    item->MutablePersistentBufferId()->CopyFrom(id);
+                    item->MutableResult()->SetStatus(
+                        NKikimrBlobStorage::NDDisk::TReplyStatus::INCORRECT_REQUEST);
+                    item->MutableResult()->SetErrorReason(
+                        "one checksum per aligned 4 KiB block is required");
+                }
+                SendReply(*ev, std::move(result));
+                return;
+            }
+        }
         Y_ABORT_UNLESS(WritePersistentBuffersActor);
         TActivationContext::Send(ev->Forward(WritePersistentBuffersActor));
     }
@@ -241,6 +261,10 @@ namespace {
             .Checksums = {
                 COUNTER(Checksums, WritesWithoutChecksums, true)
                 COUNTER(Checksums, ChecksumMismatch, true)
+                COUNTER(Checksums, IntegrityPairReads, true)
+                COUNTER(Checksums, IntegrityPairWrites, true)
+                COUNTER(Checksums, IntegrityCorruption, true)
+                COUNTER(Checksums, IntegrityLostWriteDetected, true)
             },
         };
 
@@ -253,6 +277,7 @@ namespace {
         DdiskIoOpPool.Resize(IoOpPoolCapacity);
         PersistentBufferPartIoOpPool.Resize(IoOpPoolCapacity);
         InternalSyncWriteOpPool.Resize(IoOpPoolCapacity);
+        IntegrityIoOpPool.Resize(IoOpPoolCapacity);
     }
 
     TDDiskActor::~TDDiskActor() {
@@ -263,6 +288,7 @@ namespace {
         FillPool(DdiskIoOpPool);
         FillPool(PersistentBufferPartIoOpPool);
         FillPool(InternalSyncWriteOpPool);
+        FillPool(IntegrityIoOpPool);
 
         YDB_LOG_DEBUG("TDDiskActor::Bootstrap",
             {"marker", "BSDD09"},
@@ -382,6 +408,12 @@ namespace {
                     chunkRef.PendingEventsForChunk.pop();
                     FailPendingDDiskQuery(std::unique_ptr<IEventHandle>(pending.Release()));
                 }
+                while (!chunkRef.PendingSerializedWrites.empty()) {
+                    auto pending = chunkRef.PendingSerializedWrites.front().Release();
+                    chunkRef.PendingSerializedWrites.pop();
+                    FailPendingDDiskQuery(std::unique_ptr<IEventHandle>(pending.Release()));
+                }
+                chunkRef.SerializedWriteResumeScheduled = false;
             }
         }
 
@@ -432,8 +464,30 @@ namespace {
 
         DataChunkAllocationsInFlight.clear();
         ChunkMapIncrementsInFlight.clear();
+
+        std::vector<ui64> pendingWriteIds;
+        pendingWriteIds.reserve(PendingClientWrites.size());
+        for (auto& [operationId, pending] : PendingClientWrites) {
+            pending.IntegrityCompleted = true;
+            pending.IntegrityError = GetBrokenReason();
+            pendingWriteIds.push_back(operationId);
+        }
+        for (const ui64 operationId : pendingWriteIds) {
+            MaybeFinishClientWrite(operationId);
+        }
+
+        for (auto& [operationId, pending] : PendingChecksumReads) {
+            Y_UNUSED(operationId);
+            Counters.Interface.Read.Reply(false);
+            SendReply(*pending.Event, std::make_unique<TEvReadResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR, GetBrokenReason()));
+        }
+        PendingChecksumReads.clear();
+        PendingSyncSegments.clear();
+
         if (IntegrityManager) {
             Y_UNUSED(IntegrityManager->TakeActions());
+            Y_UNUSED(IntegrityManager->TakeCompletedOperations());
         }
 
         // DDisk and PersistentBuffer are separate actor instances sharing
@@ -527,6 +581,7 @@ namespace {
             hFunc(NPDisk::TEvChunkReserveResult, Handle)
             hFunc(NPDisk::TEvLogResult, Handle)
             hFunc(TEvPrivate::TEvHandleEventForChunk, Handle)
+            hFunc(TEvPrivate::TEvHandleSerializedWriteForChunk, Handle)
             hFunc(TEvPrivate::TEvDDiskIoResult, Handle)
             hFunc(TEvPrivate::TEvIntegrityIoResult, Handle)
             hFunc(NPDisk::TEvCutLog, Handle)

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
@@ -117,6 +117,9 @@ namespace {
         , CountersParent(std::move(counters))
         , CountersBase(GetServiceCounters(CountersParent, "ddisks"))
         , IsPersistentBufferActor(isPersistentBufferActor)
+        , MinChunksReserved(isPersistentBufferActor
+            ? MinChunksReservedPersistentBuffer
+            : MinChunksReservedDDisk)
         , SegmentManager(DDiskInstanceGuid)
         , PersistentBufferFormat(std::move(pbFormat))
     {
@@ -277,6 +280,182 @@ namespace {
         }
     }
 
+    bool TDDiskActor::IsBroken() const {
+        return Broken;
+    }
+
+    TString TDDiskActor::GetBrokenReason() const {
+        return BrokenReason ? BrokenReason : TString("DDisk is broken");
+    }
+
+    void TDDiskActor::FailPendingDDiskQuery(std::unique_ptr<IEventHandle> ev) {
+        const TString reason = GetBrokenReason();
+        switch (ev->GetTypeRewrite()) {
+            case TEv::EvWrite:
+                Counters.Interface.Write.Request(0);
+                Counters.Interface.Write.Reply(false);
+                SendReply(*ev, std::make_unique<TEvWriteResult>(
+                    NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR, reason));
+                break;
+            case TEv::EvRead:
+                Counters.Interface.Read.Request(0);
+                Counters.Interface.Read.Reply(false);
+                SendReply(*ev, std::make_unique<TEvReadResult>(
+                    NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR, reason));
+                break;
+            case TEv::EvSync:
+                Counters.Interface.Sync.Request(0);
+                Counters.Interface.Sync.Reply(false);
+                SendReply(*ev, std::make_unique<TEvSyncResult>(
+                    NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR, reason));
+                break;
+            case TEv::EvDeleteTabletChunks:
+                SendReply(*ev, std::make_unique<TEvDeleteTabletChunksResult>(
+                    NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR, reason));
+                break;
+            default:
+                // Internal source-read results are covered by the SyncsInFlight drain below.
+                break;
+        }
+    }
+
+    void TDDiskActor::FailDirectIoOp(std::unique_ptr<TDirectIoOpBase> op, bool wasRunning) {
+        if (wasRunning) {
+            Counters.DirectIO.RunningCount->Dec();
+        } else {
+            Counters.DirectIO.QueueSize->Dec();
+        }
+        switch (op->GetOperationType()) {
+            case NPDisk::TUringOperationBase::EREAD:
+                Counters.DirectIO.Read.Done(op->GetTotalSize());
+                break;
+            case NPDisk::TUringOperationBase::EWRITE:
+                Counters.DirectIO.Write.Done(op->GetTotalSize());
+                break;
+            default:
+                Y_ABORT("Unknown OperationType");
+        }
+        op->Reply(TActivationContext::ActorSystem(),
+            NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR, GetBrokenReason());
+    }
+
+    void TDDiskActor::EnterBroken(TString reason) {
+        if (Broken) {
+            return;
+        }
+        Broken = true;
+        BrokenReason = reason
+            ? std::move(reason)
+            : TString("DDisk is broken");
+
+        YDB_LOG_ERROR("TDDiskActor entered Broken state",
+            {"marker", "BSDD54"},
+            {"DDiskId", DDiskId},
+            {"errorReason", GetBrokenReason()});
+
+        // Complete actor-owned queued/fallback operations immediately. Submitted io_uring
+        // operations post their result events later; the actor normalizes those to ERROR because
+        // Broken is already set.
+        while (!DirectIoQueue.empty()) {
+            auto op = std::move(DirectIoQueue.front());
+            DirectIoQueue.pop();
+            FailDirectIoOp(std::move(op), false);
+        }
+        while (!WriteCallbacks.empty()) {
+            auto it = WriteCallbacks.begin();
+            auto op = std::move(it->second.Op);
+            WriteCallbacks.erase(it);
+            FailDirectIoOp(std::move(op), true);
+        }
+        while (!ReadCallbacks.empty()) {
+            auto it = ReadCallbacks.begin();
+            auto op = std::move(it->second.Op);
+            ReadCallbacks.erase(it);
+            FailDirectIoOp(std::move(op), true);
+        }
+
+        for (auto& [tabletId, chunks] : ChunkRefs) {
+            for (auto& [vChunkIndex, chunkRef] : chunks) {
+                Y_UNUSED(tabletId, vChunkIndex);
+                while (!chunkRef.PendingEventsForChunk.empty()) {
+                    auto pending = chunkRef.PendingEventsForChunk.front().Release();
+                    chunkRef.PendingEventsForChunk.pop();
+                    FailPendingDDiskQuery(std::unique_ptr<IEventHandle>(pending.Release()));
+                }
+            }
+        }
+
+        // Fail every sync exactly once, remove any segment-manager state, and leave late source
+        // reads/internal writes harmless (their handlers already tolerate an absent sync).
+        std::vector<TSegmentManager::TSegment> removedSegments;
+        while (!SyncsInFlight.empty()) {
+            auto it = SyncsInFlight.begin();
+            auto& sync = it->second;
+            if (sync.FirstRequestId != Max<ui64>()) {
+                for (ui64 i = 0; i < sync.Requests.size(); ++i) {
+                    const ui64 requestId = sync.FirstRequestId + i;
+                    SegmentManager.PopRequest(requestId, &removedSegments);
+                    SyncReadCookiesInFlight.erase(requestId);
+                    auto& request = sync.Requests[i];
+                    if (request.Status == NKikimrBlobStorage::NDDisk::TReplyStatus::UNKNOWN) {
+                        request.Status = NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR;
+                        request.ErrorReason << GetBrokenReason();
+                    }
+                }
+            }
+            sync.ErrorReason << GetBrokenReason();
+            ReplySync(it);
+        }
+        SyncReadCookiesInFlight.clear();
+
+        for (const auto& [tabletId, reply] : TabletChunkDeletionReplies) {
+            Y_UNUSED(tabletId);
+            auto h = std::make_unique<IEventHandle>(reply.ReplyTo, SelfId(),
+                new TEvDeleteTabletChunksResult(
+                    NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR, GetBrokenReason()),
+                0, reply.Cookie);
+            if (reply.InterconnectSession) {
+                h->Rewrite(TEvInterconnect::EvForward, reply.InterconnectSession);
+            }
+            TActivationContext::Send(h.release());
+        }
+        TabletChunkDeletionReplies.clear();
+
+        for (auto& [key, allocation] : DataChunkAllocationsInFlight) {
+            Y_UNUSED(key);
+            for (auto& parked : allocation.ParkedWriteResults) {
+                parked.Status = NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR;
+                parked.ErrorMessage = GetBrokenReason();
+            }
+            FlushParkedAllocationReplies(allocation);
+        }
+
+        DataChunkAllocationsInFlight.clear();
+        ChunkMapIncrementsInFlight.clear();
+        if (IntegrityManager) {
+            Y_UNUSED(IntegrityManager->TakeActions());
+        }
+
+        // DDisk and PersistentBuffer are separate actor instances sharing
+        // this class. Only DDisk talks to PDisk, so PB chunk requests still
+        // arrive here as TChunkForPersistentBuffer. Drop data/integrity work
+        // and keep serving those PB allocations if DDisk is the one that
+        // broke. The PersistentBuffer instance never uses this queue.
+        if (!IsPersistentBufferActor) {
+            decltype(ChunkAllocateQueue) persistentBufferAllocations;
+            while (!ChunkAllocateQueue.empty()) {
+                auto allocation = std::move(ChunkAllocateQueue.front());
+                ChunkAllocateQueue.pop();
+                if (std::holds_alternative<TChunkForPersistentBuffer>(
+                        allocation)) {
+                    persistentBufferAllocations.push(std::move(allocation));
+                }
+            }
+            ChunkAllocateQueue.swap(persistentBufferAllocations);
+            HandleChunkReserved();
+        }
+    }
+
     void TDDiskActor::Handle(TEvents::TEvUndelivered::TPtr ev) {
         auto sourceType = ev->Get()->SourceType;
         if (sourceType == TEv::EvRead || sourceType == TEv::EvReadPersistentBuffer) {
@@ -304,13 +483,17 @@ namespace {
             }
             auto& request = sync.Requests[ev->Cookie - sync.FirstRequestId];
 
+            if (request.Status != NKikimrBlobStorage::NDDisk::TReplyStatus::UNKNOWN) {
+                return;
+            }
+
             request.Status = NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR;
             request.ErrorReason << "[" << request.Selector.OffsetInBytes << ';'
                 << request.Selector.OffsetInBytes + request.Selector.Size
                 << "] failed to read; reason: read event undelivered";
             sync.ErrorReason << "[request_idx=" << ev->Cookie - sync.FirstRequestId << "] failed to read; ";
             if (--sync.RequestsInFlight == 0) {
-                ReplySync(it);
+                MaybeReplySync(it);
             }
             return;
         }
@@ -344,6 +527,8 @@ namespace {
             hFunc(NPDisk::TEvChunkReserveResult, Handle)
             hFunc(NPDisk::TEvLogResult, Handle)
             hFunc(TEvPrivate::TEvHandleEventForChunk, Handle)
+            hFunc(TEvPrivate::TEvDDiskIoResult, Handle)
+            hFunc(TEvPrivate::TEvIntegrityIoResult, Handle)
             hFunc(NPDisk::TEvCutLog, Handle)
             hFunc(TEvReadPersistentBufferResult, Handle)
             hFunc(NPDisk::TEvChunkWriteRawResult, Handle)

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.h
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.h
@@ -554,6 +554,7 @@ namespace NKikimr::NDDisk {
 
         struct TChunkRef {
             TChunkIdx ChunkIdx = 0;
+            ui32 InFlightDataIo = 0;
             std::queue<TPendingEvent> PendingEventsForChunk;
         };
 

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.h
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.h
@@ -121,6 +121,7 @@ namespace NKikimr::NDDisk {
         TSpscCircularQueue<std::unique_ptr<TDDiskIoOp>> DdiskIoOpPool;
         TSpscCircularQueue<std::unique_ptr<TPersistentBufferPartIoOp>> PersistentBufferPartIoOpPool;
         TSpscCircularQueue<std::unique_ptr<TInternalSyncWriteOp>> InternalSyncWriteOpPool;
+        TSpscCircularQueue<std::unique_ptr<TIntegrityIoOp>> IntegrityIoOpPool;
 
         template <typename T>
         std::unique_ptr<T> AllocateOp(const IEventHandle* ev = nullptr);
@@ -128,6 +129,7 @@ namespace NKikimr::NDDisk {
         void ReturnOp(TDDiskIoOp* op);
         void ReturnOp(TPersistentBufferPartIoOp* op);
         void ReturnOp(TInternalSyncWriteOp* op);
+        void ReturnOp(TIntegrityIoOp* op);
 
         template <typename T>
         void FillPool(TSpscCircularQueue<std::unique_ptr<T>>& pool);
@@ -227,14 +229,17 @@ namespace NKikimr::NDDisk {
             } PersistentBuffer;
 
             struct {
-                // External (non-internal) TEvWritePersistentBuffer requests received with no Checksums
-                // attached at all. Checksum validation is opt-in, so this tracks how far we are from being
-                // able to make it mandatory.
+                // Writes rejected because no checksum list was attached.
                 NMonitoring::TDynamicCounters::TCounterPtr WritesWithoutChecksums;
                 // Sender-supplied checksum mismatches detected on TEvWrite / TEvWritePersistentBuffer(s),
                 // i.e. rejections with TReplyStatus::CORRUPTED. Covers both the DDisk data path and the
                 // PersistentBuffer path, so it lives in its own subsystem rather than under PersistentBuffer.
                 NMonitoring::TDynamicCounters::TCounterPtr ChecksumMismatch;
+                NMonitoring::TDynamicCounters::TCounterPtr IntegrityPairReads;
+                // Pair-slot writes only; chunk-header and extent-format writes are excluded.
+                NMonitoring::TDynamicCounters::TCounterPtr IntegrityPairWrites;
+                NMonitoring::TDynamicCounters::TCounterPtr IntegrityCorruption;
+                NMonitoring::TDynamicCounters::TCounterPtr IntegrityLostWriteDetected;
             } Checksums;
         };
 
@@ -302,6 +307,7 @@ namespace NKikimr::NDDisk {
                 EvRetryListPersistentBuffer,
                 EvDDiskIoResult,
                 EvIntegrityIoResult,
+                EvHandleSerializedWriteForChunk,
             };
 
            struct TEvRetryListPersistentBuffer : TEventLocal<TEvRetryListPersistentBuffer, EvRetryListPersistentBuffer> {
@@ -338,6 +344,18 @@ namespace NKikimr::NDDisk {
                 ui64 VChunkIndex;
 
                 TEvHandleEventForChunk(ui64 tabletId, ui64 vChunkIndex)
+                    : TabletId(tabletId)
+                    , VChunkIndex(vChunkIndex)
+                {}
+            };
+
+            struct TEvHandleSerializedWriteForChunk
+                : TEventLocal<TEvHandleSerializedWriteForChunk, EvHandleSerializedWriteForChunk>
+            {
+                ui64 TabletId;
+                ui64 VChunkIndex;
+
+                TEvHandleSerializedWriteForChunk(ui64 tabletId, ui64 vChunkIndex)
                     : TabletId(tabletId)
                     , VChunkIndex(vChunkIndex)
                 {}
@@ -411,12 +429,15 @@ namespace NKikimr::NDDisk {
                 ui64 TabletId = 0;
                 ui64 VChunkIndex = 0;
                 bool HasChunkKey = false;
+                ui64 IntegrityOperationId = 0;
+                std::vector<ui64> Checksums;
 
                 TEvDDiskIoResult(NPDisk::TUringOperationBase::EOperationType operationType,
                         NKikimrBlobStorage::NDDisk::TReplyStatus::E status, TString errorMessage,
                         TRope data, TActorId originalRequester, TActorId interconnectSession,
                         ui64 cookie, NWilson::TSpan span, ui64 totalSize, double requestTimeMs,
-                        ui64 tabletId = 0, ui64 vChunkIndex = 0, bool hasChunkKey = false)
+                        ui64 tabletId = 0, ui64 vChunkIndex = 0, bool hasChunkKey = false,
+                        ui64 integrityOperationId = 0, std::vector<ui64> checksums = {})
                     : OperationType(operationType)
                     , Status(status)
                     , ErrorMessage(std::move(errorMessage))
@@ -430,6 +451,8 @@ namespace NKikimr::NDDisk {
                     , TabletId(tabletId)
                     , VChunkIndex(vChunkIndex)
                     , HasChunkKey(hasChunkKey)
+                    , IntegrityOperationId(integrityOperationId)
+                    , Checksums(std::move(checksums))
                 {}
             };
 
@@ -438,12 +461,16 @@ namespace NKikimr::NDDisk {
                 ui64 IoId = 0;
                 NKikimrBlobStorage::NDDisk::TReplyStatus::E Status = NKikimrBlobStorage::NDDisk::TReplyStatus::UNKNOWN;
                 TString ErrorMessage;
+                TRope Data;
+                bool IsRead = false;
 
                 TEvIntegrityIoResult(ui64 ioId, NKikimrBlobStorage::NDDisk::TReplyStatus::E status,
-                        TString errorMessage = {})
+                        TString errorMessage = {}, TRope data = {}, bool isRead = false)
                     : IoId(ioId)
                     , Status(status)
                     , ErrorMessage(std::move(errorMessage))
+                    , Data(std::move(data))
+                    , IsRead(isRead)
                 {}
             };
 
@@ -452,15 +479,18 @@ namespace NKikimr::NDDisk {
                 ui64 RequestId = 0;
                 ui64 SegmentBegin = 0;
                 ui64 SegmentEnd = 0;
+                ui64 IntegrityOperationId = 0;
                 NKikimrBlobStorage::NDDisk::TReplyStatus::E Status = NKikimrBlobStorage::NDDisk::TReplyStatus::UNKNOWN;
                 TString ErrorMessage;
 
                 TEvInternalSyncWriteResult(ui64 syncId, ui64 requestId, ui64 segmentBegin, ui64 segmentEnd,
-                    NKikimrBlobStorage::NDDisk::TReplyStatus::E status, TString errorMessage = {})
+                    ui64 integrityOperationId, NKikimrBlobStorage::NDDisk::TReplyStatus::E status,
+                    TString errorMessage = {})
                     : SyncId(syncId)
                     , RequestId(requestId)
                     , SegmentBegin(segmentBegin)
                     , SegmentEnd(segmentEnd)
+                    , IntegrityOperationId(integrityOperationId)
                     , Status(status)
                     , ErrorMessage(std::move(errorMessage))
                 {}
@@ -556,6 +586,9 @@ namespace NKikimr::NDDisk {
             TChunkIdx ChunkIdx = 0;
             ui32 InFlightDataIo = 0;
             std::queue<TPendingEvent> PendingEventsForChunk;
+            bool IntegrityExtentWriteInFlight = false;
+            bool SerializedWriteResumeScheduled = false;
+            std::queue<TPendingEvent> PendingSerializedWrites;
         };
 
         THashMap<ui64, THashMap<ui64, TChunkRef>> ChunkRefs; // TabletId -> (VChunkIndex -> ChunkIdx)
@@ -702,7 +735,24 @@ namespace NKikimr::NDDisk {
             NWilson::TSpan Span;
             ui64 TotalSize = 0;
             double RequestTimeMs = 0;
+            ui64 TabletId = 0;
+            ui64 VChunkIndex = 0;
         };
+
+        struct TPendingClientWrite {
+            std::optional<TParkedWriteReply> DataResult;
+            bool IntegrityCompleted = false;
+            TIntegrityManager::EOperationStatus IntegrityStatus = TIntegrityManager::EOperationStatus::Ok;
+            TString IntegrityError;
+        };
+
+        absl::flat_hash_map<ui64, TPendingClientWrite> PendingClientWrites; // integrity operation id
+
+        struct TPendingChecksumRead {
+            std::unique_ptr<IEventHandle> Event;
+        };
+
+        absl::flat_hash_map<ui64, TPendingChecksumRead> PendingChecksumReads; // integrity operation id
 
         struct TDataChunkAllocationInFlight {
             TChunkIdx ChunkIdx = 0;
@@ -715,12 +765,19 @@ namespace NKikimr::NDDisk {
         absl::flat_hash_map<std::pair<ui64, ui64>, TDataChunkAllocationInFlight>
             DataChunkAllocationsInFlight; // (tabletId, vChunkIndex)
 
-        // Drains IntegrityManager->TakeActions(): submits TWriteIo-s via TIntegrityIoOp and queues
-        // TChunkForIntegrity entries. Returns true when a chunk allocation was queued; callers not
-        // already inside HandleChunkReserved() must then call it.
+        // Drains IntegrityManager->TakeActions(): submits integrity reads/writes via TIntegrityIoOp
+        // and queues TChunkForIntegrity entries. Returns true when a chunk allocation was queued;
+        // callers not already inside HandleChunkReserved() must then call it.
         bool ProcessIntegrityActions();
+        void ProcessIntegrityCompletions();
+        void MaybeFinishClientWrite(ui64 operationId);
+        void FinishClientWrite(TParkedWriteReply result);
+        void StartDDiskDataRead(std::unique_ptr<IEventHandle> ev, std::vector<ui64> checksums);
         void OpenDataChunkWritePath(std::vector<TIntegrityManager::TDataChunkKey> placedKeys);
         void DrainIntegrityManager(bool kickReserve = true);
+        void ReleaseIntegrityExtentWrite(ui64 tabletId, ui64 vChunkIndex);
+        void ScheduleSerializedWrite(ui64 tabletId, ui64 vChunkIndex);
+        void Handle(TEvPrivate::TEvHandleSerializedWriteForChunk::TPtr ev);
         // Assigns newly free slots to pending extents, submits the resulting actions, and
         // releases integrity chunks that remain completely unused. Never-logged chunks return to
         // the reserve; committed ones are dropped via a snapshot. completion runs after the
@@ -951,6 +1008,21 @@ namespace NKikimr::NDDisk {
         THashSet<ui64> SyncReadCookiesInFlight;
         TSegmentManager SegmentManager;
 
+        struct TPendingSyncSegment {
+            ui64 SyncId = 0;
+            ui64 RequestId = 0;
+            ui64 Begin = 0;
+            ui64 End = 0;
+            bool DataCompleted = false;
+            bool IntegrityCompleted = false;
+            NKikimrBlobStorage::NDDisk::TReplyStatus::E DataStatus =
+                NKikimrBlobStorage::NDDisk::TReplyStatus::UNKNOWN;
+            TString DataError;
+            TIntegrityManager::EOperationStatus IntegrityStatus = TIntegrityManager::EOperationStatus::Ok;
+            TString IntegrityError;
+        };
+        absl::flat_hash_map<ui64, TPendingSyncSegment> PendingSyncSegments; // integrity operation id
+
         void Handle(TEvSync::TPtr ev);
         void Handle(TEvReadResult::TPtr ev);
         void Handle(TEvReadPersistentBufferResult::TPtr ev);
@@ -963,6 +1035,7 @@ namespace NKikimr::NDDisk {
 
         void ReplySync(TSyncIt it);
         void MaybeReplySync(TSyncIt it);
+        void MaybeFinishSyncSegment(ui64 integrityOperationId);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Persistent buffer services

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.h
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.h
@@ -977,7 +977,7 @@ namespace NKikimr::NDDisk {
         TString PersistentBufferToString();
 
         void SanitizePersistentBufferInMemoryCache();
-        void SanitizePersistentBufferInMemoryCache(ui64 tabletId, ui32 generation, ui64 lsn, TPersistentBuffer::TRecord& record);
+        void SanitizePersistentBufferInMemoryCache(ui64 tabletId, ui32 generation, ui64 lsn, TPersistentBuffer::TRecord& record, ui8 directBlockGroupIndex = 0);
 
 
         ui32 SectorSize;
@@ -1014,6 +1014,11 @@ namespace NKikimr::NDDisk {
                 // Sender-supplied per-MinSectorSize-block payload checksums for this record, in order.
                 // Empty when the write carried no checksums. See TPersistentBuffer::TRecord::PayloadChecksums.
                 std::vector<ui64> PayloadChecksums;
+                // Direct block group number this record belongs to. See TPersistentBufferId for
+                // rationale; defaults to 0 to preserve the pre-existing single-namespace-per-tablet
+                // behavior. Declared last so it never conflicts with designated-initializer ordering
+                // at existing call sites that only name fields up to PayloadChecksums.
+                ui8 DirectBlockGroupIndex = 0;
 
                 TRope JoinData(ui32 sectorSize);
             };
@@ -1074,7 +1079,7 @@ namespace NKikimr::NDDisk {
         void IssuePersistentBufferChunkAllocation();
         void ProcessDeallocatePersistentBufferChunk(bool forceToNextChunk = false);
         void ProcessPersistentBufferQueue();
-        std::vector<std::tuple<ui32, ui32, TRope>> SlicePersistentBuffer(ui64 tabletId, ui32 generation, ui64 vchunkIndex, ui64 lsn, ui32 offsetInBytes, ui32 size, TRcBuf&& payloadWithHeader, std::vector<TPersistentBufferSectorInfo>& sectors, const std::vector<ui64>& payloadChecksums);
+        std::vector<std::tuple<ui32, ui32, TRope>> SlicePersistentBuffer(ui64 tabletId, ui32 generation, ui64 vchunkIndex, ui64 lsn, ui32 offsetInBytes, ui32 size, TRcBuf&& payloadWithHeader, std::vector<TPersistentBufferSectorInfo>& sectors, const std::vector<ui64>& payloadChecksums, ui8 directBlockGroupIndex = 0);
         std::vector<std::tuple<ui32, ui32, TRope>> SlicePersistentBufferData(TRope& data, std::vector<TPersistentBufferSectorInfo>& sectors);
         void StartRestorePersistentBuffer();
         void RestorePersistentBufferChunk(TEvPrivate::TEvReadPersistentBufferPart::TPtr ev);

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.h
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.h
@@ -3,6 +3,7 @@
 #include "defs.h"
 
 #include "ddisk.h"
+#include "integrity_manager.h"
 #include "persistent_buffer.h"
 #include "persistent_buffer_header.h"
 #include "persistent_buffer_barriers_manager.h"
@@ -30,6 +31,7 @@
 
 #include <array>
 #include <atomic>
+#include <optional>
 #include <queue>
 
 #include <util/generic/hash_set.h>
@@ -97,6 +99,7 @@ namespace NKikimr::NDDisk {
         class TDDiskIoOp;
         class TPersistentBufferPartIoOp;
         class TInternalSyncWriteOp;
+        class TIntegrityIoOp;
 
         std::queue<std::unique_ptr<TDirectIoOpBase>> DirectIoQueue;
 
@@ -297,6 +300,8 @@ namespace NKikimr::NDDisk {
                 EvDeallocatePersistentBufferChunk,
                 EvDeallocatePersistentBufferChunkResult,
                 EvRetryListPersistentBuffer,
+                EvDDiskIoResult,
+                EvIntegrityIoResult,
             };
 
            struct TEvRetryListPersistentBuffer : TEventLocal<TEvRetryListPersistentBuffer, EvRetryListPersistentBuffer> {
@@ -389,6 +394,59 @@ namespace NKikimr::NDDisk {
                 ~TEvShortIO();
             };
 
+            // Completion-thread callback for a client DDisk read/write. The completion thread
+            // only packages status/data and routing metadata; the actor serializes it with
+            // integrity failures, decides the final reply status, and sends the client response.
+            struct TEvDDiskIoResult : TEventLocal<TEvDDiskIoResult, EvDDiskIoResult> {
+                NPDisk::TUringOperationBase::EOperationType OperationType;
+                NKikimrBlobStorage::NDDisk::TReplyStatus::E Status;
+                TString ErrorMessage;
+                TRope Data;
+                TActorId OriginalRequester;
+                TActorId InterconnectSession;
+                ui64 Cookie = 0;
+                NWilson::TSpan Span;
+                ui64 TotalSize = 0;
+                double RequestTimeMs = 0;
+                ui64 TabletId = 0;
+                ui64 VChunkIndex = 0;
+                bool HasChunkKey = false;
+
+                TEvDDiskIoResult(NPDisk::TUringOperationBase::EOperationType operationType,
+                        NKikimrBlobStorage::NDDisk::TReplyStatus::E status, TString errorMessage,
+                        TRope data, TActorId originalRequester, TActorId interconnectSession,
+                        ui64 cookie, NWilson::TSpan span, ui64 totalSize, double requestTimeMs,
+                        ui64 tabletId = 0, ui64 vChunkIndex = 0, bool hasChunkKey = false)
+                    : OperationType(operationType)
+                    , Status(status)
+                    , ErrorMessage(std::move(errorMessage))
+                    , Data(std::move(data))
+                    , OriginalRequester(originalRequester)
+                    , InterconnectSession(interconnectSession)
+                    , Cookie(cookie)
+                    , Span(std::move(span))
+                    , TotalSize(totalSize)
+                    , RequestTimeMs(requestTimeMs)
+                    , TabletId(tabletId)
+                    , VChunkIndex(vChunkIndex)
+                    , HasChunkKey(hasChunkKey)
+                {}
+            };
+
+            // Completion of a TIntegrityManager-emitted TWriteIo executed via TIntegrityIoOp.
+            struct TEvIntegrityIoResult : TEventLocal<TEvIntegrityIoResult, EvIntegrityIoResult> {
+                ui64 IoId = 0;
+                NKikimrBlobStorage::NDDisk::TReplyStatus::E Status = NKikimrBlobStorage::NDDisk::TReplyStatus::UNKNOWN;
+                TString ErrorMessage;
+
+                TEvIntegrityIoResult(ui64 ioId, NKikimrBlobStorage::NDDisk::TReplyStatus::E status,
+                        TString errorMessage = {})
+                    : IoId(ioId)
+                    , Status(status)
+                    , ErrorMessage(std::move(errorMessage))
+                {}
+            };
+
             struct TEvInternalSyncWriteResult : TEventLocal<TEvInternalSyncWriteResult, EvInternalSyncWriteResult> {
                 ui64 SyncId = 0;
                 ui64 RequestId = 0;
@@ -434,6 +492,17 @@ namespace NKikimr::NDDisk {
         void CollectPbStatsSnapshot();
 
         const bool IsPersistentBufferActor = false;
+
+        // Actor-thread-only health state. Completion threads communicate status/data exclusively
+        // through TEvPrivate callbacks, so Broken ordering is defined by the actor mailbox.
+        bool Broken = false;
+        TString BrokenReason;
+
+        bool IsBroken() const;
+        TString GetBrokenReason() const;
+        void EnterBroken(TString reason);
+        void FailPendingDDiskQuery(std::unique_ptr<IEventHandle> ev);
+        void FailDirectIoOp(std::unique_ptr<TDirectIoOpBase> op, bool wasRunning);
 
     public:
         TDDiskActor(TVDiskConfig::TBaseInfo&& baseInfo, TIntrusivePtr<TBlobStorageGroupInfo> info,
@@ -495,6 +564,8 @@ namespace NKikimr::NDDisk {
         ui64 ChunkMapSnapshotLsn = Max<ui64>();
         std::queue<TPendingEvent> PendingQueries;
         bool HandlingQueries = false;
+        bool LogReplayComplete = false;
+        std::optional<ui64> DeferredCutLogFreeUpToLsn;
         ui64 NextLsn = 1;
         std::set<std::tuple<ui64, ui64, ui32>> ChunkMapIncrementsInFlight;
 
@@ -515,7 +586,11 @@ namespace NKikimr::NDDisk {
 
         // Chunk management code
 
-        static constexpr ui32 MinChunksReserved = 2;
+        // DDisk may pull an integrity chunk from the same reserve as a data
+        // chunk, so it keeps a larger reserve than PersistentBuffer.
+        static constexpr ui32 MinChunksReservedDDisk = 4;
+        static constexpr ui32 MinChunksReservedPersistentBuffer = 2;
+        const ui32 MinChunksReserved;
         std::queue<TChunkIdx> ChunkReserve;
         bool ReserveInFlight = false;
 
@@ -526,8 +601,15 @@ namespace NKikimr::NDDisk {
 
         struct TChunkForPersistentBuffer {};
 
-        std::queue<std::variant<TChunkForData, TChunkForPersistentBuffer>> ChunkAllocateQueue;
-        THashMap<ui64, std::function<void()>> LogCallbacks;
+        struct TChunkForIntegrity {};
+
+        std::queue<std::variant<TChunkForData, TChunkForPersistentBuffer,
+            TChunkForIntegrity>> ChunkAllocateQueue;
+        struct TLogCallback {
+            std::function<void()> Callback;
+            bool IsDDisk = false;
+        };
+        absl::flat_hash_map<ui64, TLogCallback> LogCallbacks;
         ui64 NextCookie = 1;
 
         struct TPendingIoOp {
@@ -556,7 +638,18 @@ namespace NKikimr::NDDisk {
         void Handle(TEvPrivate::TEvHandlePersistentBufferEventForChunk::TPtr ev);
 
         void Handle(NPDisk::TEvCutLog::TPtr ev);
+        void ProcessCutLog(ui64 freeUpToLsn);
         void Handle(TEvDeleteTabletChunks::TPtr ev);
+        // Tablets whose removal snapshot is not committed yet. Their integrity extents are
+        // quarantined in TIntegrityManager and data operations must not start a new incarnation
+        // with the same (TabletId, VChunkIndex) keys until the deletion becomes durable.
+        absl::flat_hash_set<ui64> TabletChunkDeletionsInFlight;
+        struct TTabletChunkDeletionReply {
+            TActorId ReplyTo;
+            ui64 Cookie = 0;
+            TActorId InterconnectSession;
+        };
+        THashMap<ui64, TTabletChunkDeletionReply> TabletChunkDeletionReplies;
 
         void Handle(NPDisk::TEvChunkWriteRawResult::TPtr ev);
         void Handle(NPDisk::TEvChunkReadRawResult::TPtr ev);
@@ -566,11 +659,77 @@ namespace NKikimr::NDDisk {
         void IssuePDiskLogRecord(TLogSignature signature, TChunkIdx chunkIdxToCommit, const NProtoBuf::Message& data,
             ui64 *startingPointLsnPtr, std::function<void()> callback,
             TVector<TChunkIdx> chunksToDelete = {});
+        void IssuePDiskLogRecord(TLogSignature signature, TVector<TChunkIdx> chunksToCommit,
+            const NProtoBuf::Message& data, ui64 *startingPointLsnPtr, std::function<void()> callback,
+            TVector<TChunkIdx> chunksToDelete = {});
 
         NKikimrBlobStorage::NDDisk::NInternal::TPersistentBufferChunkMapLogRecord CreatePersistentBufferChunkMapSnapshot();
         NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord CreateChunkMapSnapshot();
         NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord CreateChunkMapIncrement(ui64 tabletId, ui64 vChunkIndex,
-            TChunkIdx chunkIdx);
+            TChunkIdx chunkIdx, const TIntegrityManager::TExtentRef& extentRef,
+            const TIntegrityManager::TMappingSnapshot::TIntegrityChunkEntry* integrityChunk = nullptr);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Integrity management (DDisk mode only)
+        //
+        // TIntegrityManager is the pure-logic owner of integrity chunks / extents; the actor executes
+        // its queued actions (chunk allocations, formatting writes) asynchronously. A reserved
+        // chunk is formatted immediately. Data writes start once the extent is placed (IntegrityChunk
+        // found). The combined chunk-map increment is logged only after the extent is Ready, and
+        // the originating write/sync is not answered until that record is durable.
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        // Constructed in Handle(TEvYardInitResult) once DiskFormat (chunk size) is known.
+        std::optional<TIntegrityManager> IntegrityManager;
+
+        // Integrity chunks that have appeared in a durable (or in-flight) log record, with the
+        // generation stamped into that record. Appended when the increment is issued, so a
+        // concurrently written snapshot already includes the chunk - by the time that snapshot is
+        // read back the commit has landed.
+        std::vector<TIntegrityManager::TMappingSnapshot::TIntegrityChunkEntry> CommittedIntegrityChunks;
+
+        // DataChunk -> IntegrityExtent mapping accumulated from the chunk-map snapshot and log
+        // increments during boot; fed to IntegrityManager->ApplyMappingSnapshot at end-of-log.
+        TIntegrityManager::TMappingSnapshot RestoredIntegrityMapping;
+
+        struct TParkedWriteReply {
+            NKikimrBlobStorage::NDDisk::TReplyStatus::E Status = NKikimrBlobStorage::NDDisk::TReplyStatus::UNKNOWN;
+            TString ErrorMessage;
+            TActorId OriginalRequester;
+            TActorId InterconnectSession;
+            ui64 Cookie = 0;
+            NWilson::TSpan Span;
+            ui64 TotalSize = 0;
+            double RequestTimeMs = 0;
+        };
+
+        struct TDataChunkAllocationInFlight {
+            TChunkIdx ChunkIdx = 0;
+            bool LogIssued = false;
+            ui32 NewlyCommittedChunks = 0;
+            std::vector<TParkedWriteReply> ParkedWriteResults;
+            std::vector<ui64> ParkedSyncIds;
+        };
+
+        absl::flat_hash_map<std::pair<ui64, ui64>, TDataChunkAllocationInFlight>
+            DataChunkAllocationsInFlight; // (tabletId, vChunkIndex)
+
+        // Drains IntegrityManager->TakeActions(): submits TWriteIo-s via TIntegrityIoOp and queues
+        // TChunkForIntegrity entries. Returns true when a chunk allocation was queued; callers not
+        // already inside HandleChunkReserved() must then call it.
+        bool ProcessIntegrityActions();
+        void OpenDataChunkWritePath(std::vector<TIntegrityManager::TDataChunkKey> placedKeys);
+        void DrainIntegrityManager(bool kickReserve = true);
+        // Assigns newly free slots to pending extents, submits the resulting actions, and
+        // releases integrity chunks that remain completely unused. Never-logged chunks return to
+        // the reserve; committed ones are dropped via a snapshot. completion runs after the
+        // optional release snapshot commits.
+        void ReclaimUnusedIntegrityChunks(std::function<void()> completion = {});
+        void IssueDataChunkIncrement(ui64 tabletId, ui64 vChunkIndex);
+        void CompleteDataChunkAllocation(ui64 tabletId, ui64 vChunkIndex);
+        void FlushParkedAllocationReplies(TDataChunkAllocationInFlight& allocation);
+        bool IsIntegrityChunkCommitted(TChunkIdx chunkIdx) const;
+        void Handle(TEvPrivate::TEvIntegrityIoResult::TPtr ev);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Connection management
@@ -644,6 +803,13 @@ namespace NKikimr::NDDisk {
                     counters->Reply(false);
                 }
             };
+
+            if (IsBroken()) {
+                SendReply(ev, std::make_unique<typename TEvent::TResult>(
+                    NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR, GetBrokenReason()));
+                registerError();
+                return false;
+            }
 
             auto logError = [&](TStringBuf reason) {
                 YDB_LOG_DEBUG_CTX_COMP(*TActivationContext::ActorSystem(), NKikimrServices::BS_DDISK, "TDDiskActor::CheckQuery validation failed",
@@ -742,6 +908,7 @@ namespace NKikimr::NDDisk {
 
         void Handle(TEvWrite::TPtr ev);
         void Handle(TEvRead::TPtr ev);
+        void Handle(TEvPrivate::TEvDDiskIoResult::TPtr ev);
 
         // Regular direct I/O.
         // Note: releases the op on success (returns true).
@@ -794,6 +961,7 @@ namespace NKikimr::NDDisk {
         std::unique_ptr<IEventHandle> MakeSyncResult(const TSyncInFlight& sync);
 
         void ReplySync(TSyncIt it);
+        void MaybeReplySync(TSyncIt it);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Persistent buffer services

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_boot.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_boot.cpp
@@ -33,8 +33,15 @@ namespace NKikimr::NDDisk {
         DiskFormat = std::move(msg.DiskFormat);
         OwnedChunksOnBoot = std::move(msg.OwnedChunks);
         DiskFd = std::move(msg.DiskFd);
+
+        // The integrity manager needs the chunk size, so it is created here rather than in the ctor.
+        // VDiskSlotId + PDiskGuid identify this DDisk in TIntegrityChunkHeader.
+        IntegrityManager.emplace(DiskFormat->ChunkSize, BaseInfo.VDiskSlotId, BaseInfo.PDiskGuid,
+            Config.IntegrityChecksumCacheBytes);
         if (!DiskFd.IsOpen()) {
-            YDB_LOG_INFO("TDDiskActor::Handle(TEvYardInitResult) DiskFd is invalid, all further I/O will be routed through PDisk",
+            YDB_LOG_INFO("TDDiskActor::Handle(TEvYardInitResult) "
+                "DiskFd is invalid, all further I/O will be routed "
+                "through PDisk",
                 {"marker", "BSDD17"},
                 {"DDiskId", DDiskId},
                 {"PDiskActorId", BaseInfo.PDiskActorID});
@@ -53,8 +60,22 @@ namespace NKikimr::NDDisk {
                 for (const auto& chunkRef : tabletRecord.GetChunkRefs()) {
                     tabletChunkMap[chunkRef.GetVChunkIndex()].ChunkIdx = chunkRef.GetChunkIdx();
                     ++*Counters.Chunks.ChunksOwned;
+                    const auto& ref = chunkRef.GetExtentRef();
+                    RestoredIntegrityMapping.Extents.push_back({
+                        .Key = {tabletRecord.GetTabletId(), chunkRef.GetVChunkIndex()},
+                        .DataChunkIdx = chunkRef.GetChunkIdx(),
+                        .Ref = {ref.GetIntegrityChunkIdx(), ref.GetExtentSlot(), ref.GetVChunkGeneration()},
+                    });
                 }
             }
+            for (const auto& chunk : snapshot.GetIntegrityChunks()) {
+                RestoredIntegrityMapping.IntegrityChunks.push_back(
+                    {chunk.GetChunkIdx(), chunk.GetGeneration()});
+                CommittedIntegrityChunks.push_back(
+                    {chunk.GetChunkIdx(), chunk.GetGeneration()});
+                ++*Counters.Chunks.ChunksOwned;
+            }
+            RestoredIntegrityMapping.GenerationCounter = snapshot.GetGenerationCounter();
         }
         if (const auto it = msg.StartingPoints.find(TLogSignature::SignaturePersistentBufferChunkMap); it != msg.StartingPoints.end()) {
             NPDisk::TLogRecord& record = it->second;
@@ -91,10 +112,33 @@ namespace NKikimr::NDDisk {
                         NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord chunkMap;
                         const bool success = chunkMap.ParseFromArray(record.Data.data(), record.Data.size());
                         Y_ABORT_UNLESS(success);
-                        Y_ABORT_UNLESS(chunkMap.HasIncrement());
-                        const auto& increment = chunkMap.GetIncrement();
-                        ChunkRefs[increment.GetTabletId()][increment.GetVChunkIndex()].ChunkIdx = increment.GetChunkIdx();
-                        ++*Counters.Chunks.ChunksOwned;
+                        using TChunkMapLogRecord = NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord;
+                        switch (chunkMap.GetRecordCase()) {
+                            case TChunkMapLogRecord::kIncrement: {
+                                const auto& increment = chunkMap.GetIncrement();
+                                if (increment.HasIntegrityChunk()) {
+                                    const auto& chunk = increment.GetIntegrityChunk();
+                                    RestoredIntegrityMapping.IntegrityChunks.push_back(
+                                        {chunk.GetChunkIdx(), chunk.GetGeneration()});
+                                    CommittedIntegrityChunks.push_back(
+                                        {chunk.GetChunkIdx(), chunk.GetGeneration()});
+                                    ++*Counters.Chunks.ChunksOwned;
+                                }
+                                const auto& data = increment.GetDataChunk();
+                                ChunkRefs[data.GetTabletId()][data.GetVChunkIndex()].ChunkIdx =
+                                    data.GetChunkIdx();
+                                ++*Counters.Chunks.ChunksOwned;
+                                const auto& ref = data.GetExtentRef();
+                                RestoredIntegrityMapping.Extents.push_back({
+                                    .Key = {data.GetTabletId(), data.GetVChunkIndex()},
+                                    .DataChunkIdx = data.GetChunkIdx(),
+                                    .Ref = {ref.GetIntegrityChunkIdx(), ref.GetExtentSlot(), ref.GetVChunkGeneration()},
+                                });
+                                break;
+                            }
+                            default:
+                                Y_ABORT("unexpected chunk map record case");
+                        }
                         ++*Counters.RecoveryLog.LogRecordsApplied;
                     }
                     break;
@@ -111,8 +155,24 @@ namespace NKikimr::NDDisk {
         }
 
         if (msg.IsEndOfLog) {
-            StartHandlingQueries();
+            // Restore the DataChunk -> IntegrityExtent mapping accumulated from the snapshot and
+            // the replayed increments. Used-block bitmaps are not persisted, so the restored
+            // extents come up BitmapUnknown: reads of them pass through unchanged and new writes
+            // are tracked again (bitmap restore from the extents on disk is a later phase).
+            IntegrityManager->ApplyMappingSnapshot(RestoredIntegrityMapping);
+            RestoredIntegrityMapping = {};
+            // A durable increment is only logged after formatting, so restored chunks are Ready.
+            // Empty integrity chunks (no restored extents) are released here.
+            ReclaimUnusedIntegrityChunks();
             CreatePersistentBuffer();
+
+            LogReplayComplete = true;
+            if (DeferredCutLogFreeUpToLsn) {
+                const ui64 freeUpToLsn = *DeferredCutLogFreeUpToLsn;
+                DeferredCutLogFreeUpToLsn.reset();
+                ProcessCutLog(freeUpToLsn);
+            }
+            StartHandlingQueries();
         } else {
             Send(BaseInfo.PDiskActorID, new NPDisk::TEvReadLog(PDiskParams->Owner, PDiskParams->OwnerRound,
                 msg.NextPosition));
@@ -262,6 +322,17 @@ namespace NKikimr::NDDisk {
     void TDDiskActor::IssuePDiskLogRecord(TLogSignature signature, TChunkIdx chunkIdxToCommit,
             const NProtoBuf::Message& data, ui64 *startingPointLsn, std::function<void()> callback,
             TVector<TChunkIdx> chunksToDelete) {
+        TVector<TChunkIdx> chunksToCommit;
+        if (chunkIdxToCommit) {
+            chunksToCommit.push_back(chunkIdxToCommit);
+        }
+        IssuePDiskLogRecord(signature, std::move(chunksToCommit), data, startingPointLsn,
+            std::move(callback), std::move(chunksToDelete));
+    }
+
+    void TDDiskActor::IssuePDiskLogRecord(TLogSignature signature, TVector<TChunkIdx> chunksToCommit,
+            const NProtoBuf::Message& data, ui64 *startingPointLsn, std::function<void()> callback,
+            TVector<TChunkIdx> chunksToDelete) {
         TString buffer;
         const bool success = data.SerializeToString(&buffer);
         Y_ABORT_UNLESS(success);
@@ -274,15 +345,16 @@ namespace NKikimr::NDDisk {
         NPDisk::TCommitRecord cr;
         cr.FirstLsnToKeep = startingPointLsn ? GetFirstLsnToKeep() : 0;
         cr.IsStartingPoint = startingPointLsn != nullptr;
-        if (chunkIdxToCommit) {
-            cr.CommitChunks.push_back(chunkIdxToCommit);
-        }
+        cr.CommitChunks = std::move(chunksToCommit);
         cr.DeleteChunks = std::move(chunksToDelete);
 
         Send(BaseInfo.PDiskActorID, new NPDisk::TEvLog(PDiskParams->Owner, PDiskParams->OwnerRound, signature, cr,
             TRcBuf(std::move(buffer)), {lsn, lsn}, nullptr, TWriteSource::DDiskBoot));
 
-        LogCallbacks.emplace(lsn, std::move(callback));
+        LogCallbacks.emplace(lsn, TLogCallback{
+            .Callback = std::move(callback),
+            .IsDDisk = signature == TLogSignature::SignatureDDiskChunkMap,
+        });
     }
 
     void TDDiskActor::Handle(NPDisk::TEvLogResult::TPtr ev) {
@@ -297,12 +369,15 @@ namespace NKikimr::NDDisk {
         }
 
         for (const auto& result : msg.Results) {
-            const auto it = LogCallbacks.find(result.Lsn);
+            auto it = LogCallbacks.find(result.Lsn);
             Y_ABORT_UNLESS(it != LogCallbacks.end());
-            if (it->second) {
-                it->second();
-            }
+            // Move the callback out before erase: it may IssuePDiskLogRecord, which
+            // emplaces into LogCallbacks and would invalidate `it`.
+            TLogCallback cb = std::move(it->second);
             LogCallbacks.erase(it);
+            if ((!IsBroken() || !cb.IsDDisk) && cb.Callback) {
+                cb.Callback();
+            }
             ++*Counters.RecoveryLog.LogRecordsWritten;
         }
     }

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_chunks.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_chunks.cpp
@@ -146,18 +146,23 @@ namespace NKikimr::NDDisk {
                     queuedChunkAllocation = true;
                 },
                 [&](TIntegrityManager::TWriteIo& io) {
-                    // Integrity writes are rare (allocation-time only), so the op is heap-allocated
-                    // rather than pooled.
-                    auto integrityOp = std::make_unique<TIntegrityIoOp>(*this);
-                    integrityOp->Reinit();
-                    integrityOp->SetIoId(io.IoId);
+                    if (io.Kind == TIntegrityManager::EWriteIoKind::Pair) {
+                        Counters.Checksums.IntegrityPairWrites->Inc();
+                    }
+                    std::unique_ptr<TDirectIoOpBase> op = AllocateOp<TIntegrityIoOp>();
+                    static_cast<TIntegrityIoOp*>(op.get())->SetIoId(io.IoId);
 
                     const ui64 diskOffset = DiskFormat->Offset(io.ChunkIdx, 0, io.OffsetInBytes);
-                    const TChunkIdx chunkIdx = io.ChunkIdx;
-                    const ui32 offsetInBytes = io.OffsetInBytes;
-                    integrityOp->PrepareWrite(TRope(std::move(io.Data)), diskOffset, chunkIdx, offsetInBytes);
+                    op->PrepareWrite(TRope(std::move(io.Data)), diskOffset, io.ChunkIdx, io.OffsetInBytes);
+                    DirectUringOp(op);
+                },
+                [&](TIntegrityManager::TReadIo& io) {
+                    Counters.Checksums.IntegrityPairReads->Inc();
+                    std::unique_ptr<TDirectIoOpBase> op = AllocateOp<TIntegrityIoOp>();
+                    static_cast<TIntegrityIoOp*>(op.get())->SetIoId(io.IoId);
 
-                    std::unique_ptr<TDirectIoOpBase> op = std::move(integrityOp);
+                    const ui64 diskOffset = DiskFormat->Offset(io.ChunkIdx, 0, io.OffsetInBytes);
+                    op->PrepareRead(io.Size, diskOffset, io.ChunkIdx, io.OffsetInBytes);
                     DirectUringOp(op);
                 },
             }, action);
@@ -165,8 +170,54 @@ namespace NKikimr::NDDisk {
         return queuedChunkAllocation;
     }
 
+    void TDDiskActor::ProcessIntegrityCompletions() {
+        for (auto& result : IntegrityManager->TakeCompletedOperations()) {
+            if (result.Status == TIntegrityManager::EOperationStatus::Corrupted) {
+                Counters.Checksums.IntegrityCorruption->Inc();
+                if (result.LostWriteDetected) {
+                    Counters.Checksums.IntegrityLostWriteDetected->Inc();
+                }
+            }
+            if (result.Kind == TIntegrityManager::EOperationKind::Write) {
+                const auto writeIt = PendingClientWrites.find(result.OperationId);
+                if (writeIt != PendingClientWrites.end()) {
+                    writeIt->second.IntegrityCompleted = true;
+                    writeIt->second.IntegrityStatus = result.Status;
+                    writeIt->second.IntegrityError = std::move(result.ErrorReason);
+                    MaybeFinishClientWrite(result.OperationId);
+                    continue;
+                }
+
+                const auto syncIt = PendingSyncSegments.find(result.OperationId);
+                if (syncIt != PendingSyncSegments.end()) {
+                    syncIt->second.IntegrityCompleted = true;
+                    syncIt->second.IntegrityStatus = result.Status;
+                    syncIt->second.IntegrityError = std::move(result.ErrorReason);
+                    MaybeFinishSyncSegment(result.OperationId);
+                }
+                continue;
+            }
+
+            const auto readIt = PendingChecksumReads.find(result.OperationId);
+            if (readIt == PendingChecksumReads.end()) {
+                continue;
+            }
+            std::unique_ptr<IEventHandle> readEvent = std::move(readIt->second.Event);
+            PendingChecksumReads.erase(readIt);
+            if (result.Status == TIntegrityManager::EOperationStatus::Corrupted) {
+                const TBlockSelector selector(readEvent->Get<TEvRead>()->Record.GetSelector());
+                Counters.Interface.Read.Reply(false, selector.Size);
+                SendReply(*readEvent, std::make_unique<TEvReadResult>(
+                    NKikimrBlobStorage::NDDisk::TReplyStatus::CORRUPTED, result.ErrorReason));
+            } else {
+                StartDDiskDataRead(std::move(readEvent), std::move(result.Checksums));
+            }
+        }
+    }
+
     void TDDiskActor::DrainIntegrityManager(bool kickReserve) {
         const bool queuedChunkAllocation = ProcessIntegrityActions();
+        ProcessIntegrityCompletions();
         OpenDataChunkWritePath(IntegrityManager->TakePlacedKeys());
         if (kickReserve && queuedChunkAllocation) {
             HandleChunkReserved();
@@ -321,6 +372,8 @@ namespace NKikimr::NDDisk {
     void TDDiskActor::Handle(TEvPrivate::TEvIntegrityIoResult::TPtr ev) {
         auto& msg = *ev->Get();
 
+        // Transient OVERLOADED errors are retried in TDirectIoOpBase::OnComplete while the
+        // op still owns its buffers. Any non-OK status that reaches this handler is fatal.
         if (msg.Status != NKikimrBlobStorage::NDDisk::TReplyStatus::OK) {
             EnterBroken(msg.ErrorMessage);
             return;
@@ -329,7 +382,12 @@ namespace NKikimr::NDDisk {
             return;
         }
 
-        const auto readyKeys = IntegrityManager->OnIoCompleted(msg.IoId);
+        std::vector<TIntegrityManager::TDataChunkKey> readyKeys;
+        if (msg.IsRead) {
+            IntegrityManager->OnReadIoCompleted(msg.IoId, std::move(msg.Data));
+        } else {
+            readyKeys = IntegrityManager->OnIoCompleted(msg.IoId);
+        }
         DrainIntegrityManager();
 
         for (const auto& key : readyKeys) {
@@ -357,6 +415,17 @@ namespace NKikimr::NDDisk {
         queue.pop();
         Receive(temp);
 
+        // Receive may synchronously enter Broken while the remaining events are temporarily
+        // outside chunkRef.PendingEventsForChunk, so EnterBroken cannot see and fail them.
+        if (Y_UNLIKELY(IsBroken())) {
+            while (!queue.empty()) {
+                auto pending = queue.front().Release();
+                queue.pop();
+                FailPendingDDiskQuery(std::unique_ptr<IEventHandle>(pending.Release()));
+            }
+            return;
+        }
+
         // schedule processing another one, if needed
         if (!queue.empty()) {
             TActivationContext::Send(ev.Release());
@@ -365,6 +434,50 @@ namespace NKikimr::NDDisk {
         // put queue back in
         queue.swap(chunkRef.PendingEventsForChunk);
         Y_ABORT_UNLESS(queue.empty()); // ensure nothing more appeared during event handling
+    }
+
+    void TDDiskActor::ScheduleSerializedWrite(ui64 tabletId, ui64 vChunkIndex) {
+        TChunkRef& chunkRef = ChunkRefs.at(tabletId).at(vChunkIndex);
+        if (Y_UNLIKELY(IsBroken()) || chunkRef.IntegrityExtentWriteInFlight
+                || chunkRef.SerializedWriteResumeScheduled
+                || chunkRef.PendingSerializedWrites.empty()) {
+            return;
+        }
+        chunkRef.SerializedWriteResumeScheduled = true;
+        Send(SelfId(), new TEvPrivate::TEvHandleSerializedWriteForChunk(tabletId, vChunkIndex));
+    }
+
+    void TDDiskActor::ReleaseIntegrityExtentWrite(ui64 tabletId, ui64 vChunkIndex) {
+        TChunkRef& chunkRef = ChunkRefs.at(tabletId).at(vChunkIndex);
+        Y_ABORT_UNLESS(chunkRef.IntegrityExtentWriteInFlight);
+        chunkRef.IntegrityExtentWriteInFlight = false;
+        ScheduleSerializedWrite(tabletId, vChunkIndex);
+    }
+
+    void TDDiskActor::Handle(TEvPrivate::TEvHandleSerializedWriteForChunk::TPtr ev) {
+        auto& msg = *ev->Get();
+        // EnterBroken clears SerializedWriteResumeScheduled but cannot recall a
+        // self-message already in the mailbox. Bail out before the flag assert.
+        if (Y_UNLIKELY(IsBroken())) {
+            return;
+        }
+
+        TChunkRef& chunkRef = ChunkRefs.at(msg.TabletId).at(msg.VChunkIndex);
+        Y_ABORT_UNLESS(chunkRef.SerializedWriteResumeScheduled);
+        chunkRef.SerializedWriteResumeScheduled = false;
+
+        if (chunkRef.IntegrityExtentWriteInFlight
+                || chunkRef.PendingSerializedWrites.empty()) {
+            return;
+        }
+
+        auto pending = chunkRef.PendingSerializedWrites.front().Release();
+        chunkRef.PendingSerializedWrites.pop();
+        Receive(pending);
+
+        // The resumed event may have become obsolete while parked and therefore not acquire the
+        // extent. Continue the FIFO in that case.
+        ScheduleSerializedWrite(msg.TabletId, msg.VChunkIndex);
     }
 
     void TDDiskActor::Handle(NPDisk::TEvCutLog::TPtr ev) {
@@ -534,6 +647,13 @@ namespace NKikimr::NDDisk {
             }
         }
 
+        if (IntegrityManager->HasInFlightOperationsForTablet(tabletId)) {
+            SendReply(*ev, std::make_unique<TEvDeleteTabletChunksResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::BUSY,
+                "integrity I/O is in flight for tablet"));
+            return;
+        }
+
         const auto tabletIt = ChunkRefs.find(tabletId);
 
         if (tabletIt == ChunkRefs.end()) {
@@ -545,10 +665,12 @@ namespace NKikimr::NDDisk {
         // Reject if any VChunk has a pending event queue (allocation queued but not yet in log)
         // or client data I/O that still targets its physical chunk.
         for (const auto& [vChunkIndex, chunkRef] : tabletIt->second) {
-            if (!chunkRef.PendingEventsForChunk.empty()) {
+            if (!chunkRef.PendingEventsForChunk.empty()
+                    || !chunkRef.PendingSerializedWrites.empty()
+                    || chunkRef.IntegrityExtentWriteInFlight) {
                 SendReply(*ev, std::make_unique<TEvDeleteTabletChunksResult>(
                     NKikimrBlobStorage::NDDisk::TReplyStatus::BUSY,
-                    "chunk allocation is queued for tablet"));
+                    "chunk allocation or integrity-extent write is queued for tablet"));
                 return;
             }
             if (chunkRef.InFlightDataIo) {

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_chunks.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_chunks.cpp
@@ -1,5 +1,7 @@
 #include "ddisk_actor.h"
+#include "direct_io_op.h"
 
+#include <algorithm>
 #include <util/generic/overloaded.h>
 #include <ydb/core/protos/blobstorage_ddisk_internal.pb.h>
 #include <ydb/core/util/stlog.h>
@@ -10,6 +12,9 @@
 namespace NKikimr::NDDisk {
 
     void TDDiskActor::IssueChunkAllocation(ui64 tabletId, ui64 vChunkIndex) {
+        if (Y_UNLIKELY(IsBroken())) {
+            return;
+        }
         ChunkAllocateQueue.emplace(TChunkForData{tabletId, vChunkIndex});
         HandleChunkReserved();
     }
@@ -61,6 +66,11 @@ namespace NKikimr::NDDisk {
     void TDDiskActor::HandleChunkReserved() {
         Y_ABORT_UNLESS(!IsPersistentBufferActor);
         while (!ChunkAllocateQueue.empty() && !ChunkReserve.empty()) {
+            if (Y_UNLIKELY(IsBroken())
+                    && !std::holds_alternative<TChunkForPersistentBuffer>(ChunkAllocateQueue.front())) {
+                ChunkAllocateQueue.pop();
+                continue;
+            }
             const auto chunkAllocate = ChunkAllocateQueue.front();
             ChunkAllocateQueue.pop();
             const TChunkIdx chunkIdx = ChunkReserve.front();
@@ -71,26 +81,23 @@ namespace NKikimr::NDDisk {
                     const auto vChunkIndex = data.VChunkIndex;
                     Y_ABORT_UNLESS(ChunkRefs.contains(tabletId) && ChunkRefs[tabletId].contains(vChunkIndex));
 
-                    ChunkMapIncrementsInFlight.emplace(tabletId, vChunkIndex, chunkIdx);
+                    const bool inserted = DataChunkAllocationsInFlight.try_emplace(
+                        std::make_pair(tabletId, vChunkIndex), TDataChunkAllocationInFlight{.ChunkIdx = chunkIdx}).second;
+                    Y_ABORT_UNLESS(inserted);
 
-                    IssuePDiskLogRecord(TLogSignature::SignatureDDiskChunkMap, chunkIdx, CreateChunkMapIncrement(
-                            tabletId, vChunkIndex, chunkIdx), nullptr, [this, tabletId, vChunkIndex, chunkIdx] {
-                        TChunkRef& chunkRef = ChunkRefs[tabletId][vChunkIndex];
-                        Y_ABORT_UNLESS(!chunkRef.ChunkIdx);
-                        chunkRef.ChunkIdx = chunkIdx;
-
-                        if (!chunkRef.PendingEventsForChunk.empty()) {
-                            Send(SelfId(), new TEvPrivate::TEvHandleEventForChunk(tabletId, vChunkIndex));
-                        }
-
-                        const size_t numErased = ChunkMapIncrementsInFlight.erase({tabletId, vChunkIndex, chunkIdx});
-                        Y_ABORT_UNLESS(numErased == 1);
-                        ++*Counters.Chunks.ChunksOwned;
-                    });
-                    if (ChunkMapSnapshotLsn == Max<ui64>()) {
-                        IssuePDiskLogRecord(TLogSignature::SignatureDDiskChunkMap, 0, CreateChunkMapSnapshot(),
-                            &ChunkMapSnapshotLsn, {});
+                    IntegrityManager->OnDataChunkAllocated({tabletId, vChunkIndex}, chunkIdx);
+                    DrainIntegrityManager(/*kickReserve=*/ false);
+                },
+                [this, chunkIdx](const TChunkForIntegrity&) {
+                    // Demand may have vanished since this allocation was queued (a tablet deletion
+                    // can free enough slots): return the chunk to the reserve instead of formatting it.
+                    if (IntegrityManager->CancelChunkAllocationIfExcess()) {
+                        ChunkReserve.push(chunkIdx);
+                        return;
                     }
+
+                    IntegrityManager->OnIntegrityChunkAllocated(chunkIdx);
+                    DrainIntegrityManager(/*kickReserve=*/ false);
                 },
                 [this, chunkIdx](const TChunkForPersistentBuffer&) {
                     Y_DEBUG_ABORT_UNLESS(std::find(PersistentBufferChunks.begin(),
@@ -104,6 +111,13 @@ namespace NKikimr::NDDisk {
                     });
                 }
             }, chunkAllocate);
+            // Chunk-map increments (data and integrity alike) need a snapshot starting point to
+            // replay from.
+            if (!std::holds_alternative<TChunkForPersistentBuffer>(chunkAllocate)
+                    && ChunkMapSnapshotLsn == Max<ui64>()) {
+                IssuePDiskLogRecord(TLogSignature::SignatureDDiskChunkMap, 0, CreateChunkMapSnapshot(),
+                    &ChunkMapSnapshotLsn, {});
+            }
         }
         if (ChunkReserve.size() < MinChunksReserved && !ReserveInFlight) { // ask for another reservation
             YDB_LOG_DEBUG("TDDiskActor::HandleChunkReserved requesting chunk reserve",
@@ -118,7 +132,218 @@ namespace NKikimr::NDDisk {
         }
     }
 
+    bool TDDiskActor::ProcessIntegrityActions() {
+        if (Y_UNLIKELY(IsBroken())) {
+            Y_UNUSED(IntegrityManager->TakeActions());
+            return false;
+        }
+
+        bool queuedChunkAllocation = false;
+        for (auto& action : IntegrityManager->TakeActions()) {
+            std::visit(TOverloaded{
+                [&](TIntegrityManager::TAllocateIntegrityChunk&) {
+                    ChunkAllocateQueue.emplace(TChunkForIntegrity{});
+                    queuedChunkAllocation = true;
+                },
+                [&](TIntegrityManager::TWriteIo& io) {
+                    // Integrity writes are rare (allocation-time only), so the op is heap-allocated
+                    // rather than pooled.
+                    auto integrityOp = std::make_unique<TIntegrityIoOp>(*this);
+                    integrityOp->Reinit();
+                    integrityOp->SetIoId(io.IoId);
+
+                    const ui64 diskOffset = DiskFormat->Offset(io.ChunkIdx, 0, io.OffsetInBytes);
+                    const TChunkIdx chunkIdx = io.ChunkIdx;
+                    const ui32 offsetInBytes = io.OffsetInBytes;
+                    integrityOp->PrepareWrite(TRope(std::move(io.Data)), diskOffset, chunkIdx, offsetInBytes);
+
+                    std::unique_ptr<TDirectIoOpBase> op = std::move(integrityOp);
+                    DirectUringOp(op);
+                },
+            }, action);
+        }
+        return queuedChunkAllocation;
+    }
+
+    void TDDiskActor::DrainIntegrityManager(bool kickReserve) {
+        const bool queuedChunkAllocation = ProcessIntegrityActions();
+        OpenDataChunkWritePath(IntegrityManager->TakePlacedKeys());
+        if (kickReserve && queuedChunkAllocation) {
+            HandleChunkReserved();
+        }
+    }
+
+    void TDDiskActor::OpenDataChunkWritePath(std::vector<TIntegrityManager::TDataChunkKey> placedKeys) {
+        if (Y_UNLIKELY(IsBroken())) {
+            return;
+        }
+        for (const auto& key : placedKeys) {
+            const auto it = DataChunkAllocationsInFlight.find({key.TabletId, key.VChunkIndex});
+            Y_ABORT_UNLESS(it != DataChunkAllocationsInFlight.end());
+            TChunkRef& chunkRef = ChunkRefs[key.TabletId][key.VChunkIndex];
+            if (!chunkRef.ChunkIdx) {
+                chunkRef.ChunkIdx = it->second.ChunkIdx;
+            }
+            Y_ABORT_UNLESS(chunkRef.ChunkIdx == it->second.ChunkIdx);
+            if (!chunkRef.PendingEventsForChunk.empty()) {
+                Send(SelfId(), new TEvPrivate::TEvHandleEventForChunk(key.TabletId, key.VChunkIndex));
+            }
+        }
+    }
+
+    bool TDDiskActor::IsIntegrityChunkCommitted(TChunkIdx chunkIdx) const {
+        return std::any_of(CommittedIntegrityChunks.begin(), CommittedIntegrityChunks.end(),
+            [chunkIdx](const auto& entry) { return entry.ChunkIdx == chunkIdx; });
+    }
+
+    void TDDiskActor::ReclaimUnusedIntegrityChunks(std::function<void()> completion) {
+        if (Y_UNLIKELY(IsBroken())) {
+            return;
+        }
+
+        const auto releasableChunks = IntegrityManager->TakeReleasableIntegrityChunks();
+        DrainIntegrityManager();
+
+        TVector<TChunkIdx> chunksToDelete;
+        for (const TChunkIdx chunkIdx : releasableChunks) {
+            if (IsIntegrityChunkCommitted(chunkIdx)) {
+                const size_t erased = std::erase_if(CommittedIntegrityChunks, [chunkIdx](const auto& entry) {
+                    return entry.ChunkIdx == chunkIdx;
+                });
+                Y_ABORT_UNLESS(erased == 1);
+                chunksToDelete.push_back(chunkIdx);
+            } else {
+                ChunkReserve.push(chunkIdx);
+            }
+        }
+
+        if (chunksToDelete.empty()) {
+            if (completion) {
+                completion();
+            }
+            return;
+        }
+
+        *Counters.Chunks.ChunksOwned -= chunksToDelete.size();
+        IssuePDiskLogRecord(TLogSignature::SignatureDDiskChunkMap, TChunkIdx(0), CreateChunkMapSnapshot(),
+            &ChunkMapSnapshotLsn, std::move(completion), std::move(chunksToDelete));
+    }
+
+    void TDDiskActor::IssueDataChunkIncrement(ui64 tabletId, ui64 vChunkIndex) {
+        if (Y_UNLIKELY(IsBroken())) {
+            return;
+        }
+
+        const auto it = DataChunkAllocationsInFlight.find({tabletId, vChunkIndex});
+        Y_ABORT_UNLESS(it != DataChunkAllocationsInFlight.end());
+        auto& allocation = it->second;
+        if (allocation.LogIssued) {
+            return;
+        }
+        Y_ABORT_UNLESS(IntegrityManager->IsExtentReady({tabletId, vChunkIndex}));
+        const auto* ref = IntegrityManager->FindExtentRef({tabletId, vChunkIndex});
+        Y_ABORT_UNLESS(ref);
+
+        allocation.LogIssued = true;
+        const TChunkIdx chunkIdx = allocation.ChunkIdx;
+        ChunkMapIncrementsInFlight.emplace(tabletId, vChunkIndex, chunkIdx);
+
+        TVector<TChunkIdx> commitChunks;
+        const TIntegrityManager::TMappingSnapshot::TIntegrityChunkEntry* integrityChunk = nullptr;
+        TIntegrityManager::TMappingSnapshot::TIntegrityChunkEntry integrityEntry;
+        if (!IsIntegrityChunkCommitted(ref->IntegrityChunkIdx)) {
+            integrityEntry = {
+                .ChunkIdx = ref->IntegrityChunkIdx,
+                .Generation = IntegrityManager->GetIntegrityChunkGeneration(ref->IntegrityChunkIdx),
+            };
+            CommittedIntegrityChunks.push_back(integrityEntry);
+            integrityChunk = &CommittedIntegrityChunks.back();
+            commitChunks.push_back(ref->IntegrityChunkIdx);
+        }
+        commitChunks.push_back(chunkIdx);
+        allocation.NewlyCommittedChunks = commitChunks.size();
+
+        IssuePDiskLogRecord(TLogSignature::SignatureDDiskChunkMap, std::move(commitChunks),
+            CreateChunkMapIncrement(tabletId, vChunkIndex, chunkIdx, *ref, integrityChunk),
+            nullptr, [this, tabletId, vChunkIndex] {
+                CompleteDataChunkAllocation(tabletId, vChunkIndex);
+            });
+    }
+
+    void TDDiskActor::FlushParkedAllocationReplies(TDataChunkAllocationInFlight& allocation) {
+        for (auto& parked : allocation.ParkedWriteResults) {
+            const bool isOk = parked.Status == NKikimrBlobStorage::NDDisk::TReplyStatus::OK;
+            std::optional<TString> errorReason;
+            if (parked.ErrorMessage) {
+                errorReason.emplace(std::move(parked.ErrorMessage));
+            }
+            auto reply = std::make_unique<TEvWriteResult>(parked.Status, errorReason);
+            Counters.Interface.Write.Reply(isOk, parked.TotalSize, parked.RequestTimeMs);
+            auto h = std::make_unique<IEventHandle>(parked.OriginalRequester, SelfId(), reply.release(),
+                0, parked.Cookie, nullptr, parked.Span.GetTraceId());
+            if (parked.InterconnectSession) {
+                h->Rewrite(TEvInterconnect::EvForward, parked.InterconnectSession);
+            }
+            parked.Span.End();
+            TActivationContext::Send(h.release());
+        }
+        allocation.ParkedWriteResults.clear();
+
+        auto parkedSyncIds = std::exchange(allocation.ParkedSyncIds, {});
+        for (const ui64 syncId : parkedSyncIds) {
+            const auto syncIt = SyncsInFlight.find(syncId);
+            if (syncIt != SyncsInFlight.end()) {
+                ReplySync(syncIt);
+            }
+        }
+    }
+
+    void TDDiskActor::CompleteDataChunkAllocation(ui64 tabletId, ui64 vChunkIndex) {
+        if (Y_UNLIKELY(IsBroken())) {
+            return;
+        }
+
+        const auto it = DataChunkAllocationsInFlight.find({tabletId, vChunkIndex});
+        Y_ABORT_UNLESS(it != DataChunkAllocationsInFlight.end());
+        auto allocation = std::move(it->second);
+        DataChunkAllocationsInFlight.erase(it);
+
+        TChunkRef& chunkRef = ChunkRefs[tabletId][vChunkIndex];
+        Y_ABORT_UNLESS(chunkRef.ChunkIdx == allocation.ChunkIdx);
+
+        const size_t numErased = ChunkMapIncrementsInFlight.erase({tabletId, vChunkIndex, allocation.ChunkIdx});
+        Y_ABORT_UNLESS(numErased == 1);
+        *Counters.Chunks.ChunksOwned += allocation.NewlyCommittedChunks;
+
+        FlushParkedAllocationReplies(allocation);
+    }
+
+    void TDDiskActor::Handle(TEvPrivate::TEvIntegrityIoResult::TPtr ev) {
+        auto& msg = *ev->Get();
+
+        if (msg.Status != NKikimrBlobStorage::NDDisk::TReplyStatus::OK) {
+            EnterBroken(msg.ErrorMessage);
+            return;
+        }
+        if (Y_UNLIKELY(IsBroken())) {
+            return;
+        }
+
+        const auto readyKeys = IntegrityManager->OnIoCompleted(msg.IoId);
+        DrainIntegrityManager();
+
+        for (const auto& key : readyKeys) {
+            IssueDataChunkIncrement(key.TabletId, key.VChunkIndex);
+        }
+
+        ReclaimUnusedIntegrityChunks();
+    }
+
     void TDDiskActor::Handle(TEvPrivate::TEvHandleEventForChunk::TPtr ev) {
+        if (Y_UNLIKELY(IsBroken())) {
+            return;
+        }
+
         auto& msg = *ev->Get();
         TChunkRef& chunkRef = ChunkRefs[msg.TabletId][msg.VChunkIndex];
 
@@ -149,13 +374,29 @@ namespace NKikimr::NDDisk {
             {"DDiskId", DDiskId},
             {"msg", msg});
 
-        if (ChunkMapSnapshotLsn < msg.FreeUpToLsn) { // we have to rewrite snapshot
+        ++*Counters.RecoveryLog.CutLogMessages;
+
+        // YardInit installs the CutLog recipient before chunk-map replay is complete. Until
+        // ApplyMappingSnapshot runs, ChunkRefs may already contain restored data chunks while the
+        // integrity manager is still empty, so a snapshot here would either abort or omit replayed
+        // mappings. Coalesce early requests and process the strongest one after recovery.
+        if (!LogReplayComplete) {
+            DeferredCutLogFreeUpToLsn = Max(DeferredCutLogFreeUpToLsn.value_or(0), msg.FreeUpToLsn);
+            return;
+        }
+
+        ProcessCutLog(msg.FreeUpToLsn);
+    }
+
+    void TDDiskActor::ProcessCutLog(ui64 freeUpToLsn) {
+        Y_ABORT_UNLESS(LogReplayComplete);
+
+        if (!IsBroken() && ChunkMapSnapshotLsn < freeUpToLsn) { // we have to rewrite snapshot
             IssuePDiskLogRecord(TLogSignature::SignatureDDiskChunkMap, 0, CreateChunkMapSnapshot(), &ChunkMapSnapshotLsn, {});
         }
-        if (PersistentBufferChunkMapSnapshotLsn < msg.FreeUpToLsn) { // we have to rewrite snapshot
+        if (PersistentBufferChunkMapSnapshotLsn < freeUpToLsn) { // we have to rewrite snapshot
             IssuePDiskLogRecord(TLogSignature::SignaturePersistentBufferChunkMap, 0, CreatePersistentBufferChunkMapSnapshot(), &PersistentBufferChunkMapSnapshotLsn, {});
         }
-        ++*Counters.RecoveryLog.CutLogMessages;
     }
 
     NKikimrBlobStorage::NDDisk::NInternal::TPersistentBufferChunkMapLogRecord TDDiskActor::CreatePersistentBufferChunkMapSnapshot() {
@@ -172,14 +413,33 @@ namespace NKikimr::NDDisk {
         NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord record;
         auto *snapshot = record.MutableSnapshot();
 
+        const auto fillExtentRef = [this](auto *item, ui64 tabletId, ui64 vChunkIndex) {
+            // Non-null for every chunk with a log record: the extent is Ready by the time its
+            // increment is issued, and refs survive until the chunk is deleted.
+            const auto *ref = IntegrityManager->FindExtentRef({tabletId, vChunkIndex});
+            Y_ABORT_UNLESS(ref);
+            auto *extentRef = item->MutableExtentRef();
+            extentRef->SetIntegrityChunkIdx(ref->IntegrityChunkIdx);
+            extentRef->SetExtentSlot(ref->ExtentSlot);
+            extentRef->SetVChunkGeneration(ref->VChunkGeneration);
+        };
+
         for (const auto& [tabletId, chunks] : ChunkRefs) {
             auto *tabletRecord = snapshot->AddTabletRecords();
             tabletRecord->SetTabletId(tabletId);
 
             for (const auto& [vChunkIndex, chunkRef] : chunks) {
+                if (!chunkRef.ChunkIdx) {
+                    continue;
+                }
+                if (DataChunkAllocationsInFlight.contains({tabletId, vChunkIndex})) {
+                    // Not yet logged: issued increments are covered by ChunkMapIncrementsInFlight.
+                    continue;
+                }
                 auto *item = tabletRecord->AddChunkRefs();
                 item->SetVChunkIndex(vChunkIndex);
                 item->SetChunkIdx(chunkRef.ChunkIdx);
+                fillExtentRef(item, tabletId, vChunkIndex);
             }
 
             // check for increments in flight, they would have been committed by the time this entry gets read
@@ -189,21 +449,41 @@ namespace NKikimr::NDDisk {
                 auto *item = tabletRecord->AddChunkRefs();
                 item->SetVChunkIndex(vChunkIndex);
                 item->SetChunkIdx(chunkIdx);
+                fillExtentRef(item, tabletId, vChunkIndex);
             }
         }
+
+        for (const auto& entry : CommittedIntegrityChunks) {
+            auto *chunk = snapshot->AddIntegrityChunks();
+            chunk->SetChunkIdx(entry.ChunkIdx);
+            chunk->SetGeneration(entry.Generation);
+        }
+        snapshot->SetGenerationCounter(IntegrityManager->GetGenerationCounter());
 
         ++*Counters.RecoveryLog.NumChunkMapSnapshots;
         return record;
     }
 
     NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord TDDiskActor::CreateChunkMapIncrement(ui64 tabletId,
-            ui64 vChunkIndex, TChunkIdx chunkIdx) {
+            ui64 vChunkIndex, TChunkIdx chunkIdx, const TIntegrityManager::TExtentRef& extentRef,
+            const TIntegrityManager::TMappingSnapshot::TIntegrityChunkEntry* integrityChunk) {
         NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord record;
         auto *increment = record.MutableIncrement();
+        if (integrityChunk) {
+            auto *chunk = increment->MutableIntegrityChunk();
+            chunk->SetChunkIdx(integrityChunk->ChunkIdx);
+            chunk->SetGeneration(integrityChunk->Generation);
+        }
 
-        increment->SetTabletId(tabletId);
-        increment->SetVChunkIndex(vChunkIndex);
-        increment->SetChunkIdx(chunkIdx);
+        auto *data = increment->MutableDataChunk();
+        data->SetTabletId(tabletId);
+        data->SetVChunkIndex(vChunkIndex);
+        data->SetChunkIdx(chunkIdx);
+
+        auto *ref = data->MutableExtentRef();
+        ref->SetIntegrityChunkIdx(extentRef.IntegrityChunkIdx);
+        ref->SetExtentSlot(extentRef.ExtentSlot);
+        ref->SetVChunkGeneration(extentRef.VChunkGeneration);
 
         ++*Counters.RecoveryLog.NumChunkMapIncrements;
         return record;
@@ -222,10 +502,31 @@ namespace NKikimr::NDDisk {
             {"DDiskId", DDiskId},
             {"tabletId", tabletId});
 
-        // Reject if any chunk allocation for this tablet is in flight (log record pending)
-        {
-            auto it = ChunkMapIncrementsInFlight.lower_bound({tabletId, 0, 0});
-            if (it != ChunkMapIncrementsInFlight.end() && std::get<0>(*it) == tabletId) {
+        if (TabletChunkDeletionsInFlight.contains(tabletId)) {
+            SendReply(*ev, std::make_unique<TEvDeleteTabletChunksResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::BUSY,
+                "tablet chunk deletion is in flight"));
+            return;
+        }
+
+        // Source reads and target writes of an in-flight sync may not have reached the target
+        // chunk yet. Deleting now could free the physical chunk underneath a write or let a late
+        // source result recreate the just-deleted mapping.
+        for (const auto& [syncId, sync] : SyncsInFlight) {
+            Y_UNUSED(syncId);
+            if (sync.Creds.TabletId == tabletId) {
+                SendReply(*ev, std::make_unique<TEvDeleteTabletChunksResult>(
+                    NKikimrBlobStorage::NDDisk::TReplyStatus::BUSY,
+                    "sync is in flight for tablet"));
+                return;
+            }
+        }
+
+        // Reject if any chunk allocation for this tablet is in flight (covers both allocations
+        // whose increment log record is pending and those still waiting for an extent ref).
+        for (const auto& [key, allocation] : DataChunkAllocationsInFlight) {
+            Y_UNUSED(allocation);
+            if (key.first == tabletId) {
                 SendReply(*ev, std::make_unique<TEvDeleteTabletChunksResult>(
                     NKikimrBlobStorage::NDDisk::TReplyStatus::BUSY,
                     "chunk allocation is in flight for tablet"));
@@ -251,19 +552,27 @@ namespace NKikimr::NDDisk {
             }
         }
 
-        // Collect physical chunk IDs and erase the tablet from the in-memory chunk map
+        // Collect physical data chunk IDs.
         TVector<TChunkIdx> chunksToDelete;
         for (const auto& [vChunkIndex, chunkRef] : tabletIt->second) {
             if (chunkRef.ChunkIdx) {
                 chunksToDelete.push_back(chunkRef.ChunkIdx);
             }
         }
-        ChunkRefs.erase(tabletIt);
 
         if (chunksToDelete.empty()) {
+            ChunkRefs.erase(tabletIt);
             SendReply(*ev, std::make_unique<TEvDeleteTabletChunksResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK));
             return;
         }
+
+        // Remove the logical mapping from the snapshot now, but quarantine the corresponding
+        // integrity slots until this removal record commits. Formatting a reused slot earlier
+        // could overwrite metadata that recovery still maps to this tablet after a crash.
+        const bool inserted = TabletChunkDeletionsInFlight.insert(tabletId).second;
+        Y_ABORT_UNLESS(inserted);
+        IntegrityManager->PrepareTabletChunksDeletion(tabletId);
+        ChunkRefs.erase(tabletIt);
 
         *Counters.Chunks.ChunksOwned -= chunksToDelete.size();
 
@@ -271,19 +580,38 @@ namespace NKikimr::NDDisk {
         const TActorId replyTo = ev->Sender;
         const ui64 replyCookie = ev->Cookie;
         const TActorId replySession = ev->InterconnectSession;
+        const bool replyInserted = TabletChunkDeletionReplies.emplace(tabletId,
+            TTabletChunkDeletionReply{
+                .ReplyTo = replyTo,
+                .Cookie = replyCookie,
+                .InterconnectSession = replySession,
+            }).second;
+        Y_ABORT_UNLESS(replyInserted);
 
-        // Write a snapshot (without the freed tablet chunks) to the PDisk log.
-        // The DeleteChunks field in the commit record tells PDisk to release the physical chunks.
+        // The first snapshot removes and deallocates only the data chunks. Integrity chunks stay
+        // owned because their deleted extents are not reusable until this snapshot is durable.
         IssuePDiskLogRecord(TLogSignature::SignatureDDiskChunkMap, 0, CreateChunkMapSnapshot(),
             &ChunkMapSnapshotLsn,
-            [this, replyTo, replyCookie, replySession]() {
-                auto h = std::make_unique<IEventHandle>(replyTo, SelfId(),
-                    new TEvDeleteTabletChunksResult(NKikimrBlobStorage::NDDisk::TReplyStatus::OK),
-                    0, replyCookie);
-                if (replySession) {
-                    h->Rewrite(TEvInterconnect::EvForward, replySession);
-                }
-                TActivationContext::Send(h.release());
+            [this, tabletId]() {
+                const size_t erased = TabletChunkDeletionsInFlight.erase(tabletId);
+                Y_ABORT_UNLESS(erased == 1);
+                IntegrityManager->CommitTabletChunksDeletion(tabletId);
+
+                // Freed slots serve pending allocations first. Any integrity chunks left empty are
+                // removed by a second snapshot; acknowledge deletion only after that record lands.
+                ReclaimUnusedIntegrityChunks([this, tabletId]() {
+                    const auto replyIt = TabletChunkDeletionReplies.find(tabletId);
+                    Y_ABORT_UNLESS(replyIt != TabletChunkDeletionReplies.end());
+                    const auto& reply = replyIt->second;
+                    auto h = std::make_unique<IEventHandle>(reply.ReplyTo, SelfId(),
+                        new TEvDeleteTabletChunksResult(NKikimrBlobStorage::NDDisk::TReplyStatus::OK),
+                        0, reply.Cookie);
+                    if (reply.InterconnectSession) {
+                        h->Rewrite(TEvInterconnect::EvForward, reply.InterconnectSession);
+                    }
+                    TActivationContext::Send(h.release());
+                    TabletChunkDeletionReplies.erase(replyIt);
+                });
             },
             std::move(chunksToDelete));
     }

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_chunks.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_chunks.cpp
@@ -543,11 +543,18 @@ namespace NKikimr::NDDisk {
         }
 
         // Reject if any VChunk has a pending event queue (allocation queued but not yet in log)
+        // or client data I/O that still targets its physical chunk.
         for (const auto& [vChunkIndex, chunkRef] : tabletIt->second) {
             if (!chunkRef.PendingEventsForChunk.empty()) {
                 SendReply(*ev, std::make_unique<TEvDeleteTabletChunksResult>(
                     NKikimrBlobStorage::NDDisk::TReplyStatus::BUSY,
                     "chunk allocation is queued for tablet"));
+                return;
+            }
+            if (chunkRef.InFlightDataIo) {
+                SendReply(*ev, std::make_unique<TEvDeleteTabletChunksResult>(
+                    NKikimrBlobStorage::NDDisk::TReplyStatus::BUSY,
+                    "data chunk I/O is in flight for tablet"));
                 return;
             }
         }

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_persistent_buffer.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_persistent_buffer.cpp
@@ -1265,6 +1265,17 @@ namespace NKikimr::NDDisk {
         const TQueryCredentials creds(record.GetCredentials());
         const TBlockSelector selector(record.GetSelector());
         const ui64 lsn = record.GetLsn();
+        if (!HasRequiredBlockChecksums(record.ChecksumsSize(), selector.OffsetInBytes, selector.Size)) {
+            if (record.ChecksumsSize() == 0) {
+                Counters.Checksums.WritesWithoutChecksums->Inc();
+            }
+            Counters.Interface.WritePersistentBuffer.Request(selector.Size);
+            Counters.Interface.WritePersistentBuffer.Reply(false, selector.Size);
+            SendReply(*ev, std::make_unique<TEvWritePersistentBufferResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::INCORRECT_REQUEST,
+                "one checksum per aligned 4 KiB block is required"));
+            return;
+        }
         if (selector.Size > TPersistentBufferLsnRecordHeader::MaxSectorsPerBufferRecord * SectorSize) {
             Counters.Interface.WritePersistentBuffer.Request(selector.Size);
             Counters.Interface.WritePersistentBuffer.Reply(false, selector.Size);
@@ -1279,37 +1290,32 @@ namespace NKikimr::NDDisk {
                     << selector.Size << " bytes"));
             return;
         }
-        if (record.ChecksumsSize() == 0) {
-            if (!creds.IsInternal()) {
-                Counters.Checksums.WritesWithoutChecksums->Inc();
+
+        // Checksums are validated here, before any sector allocation or disk I/O.
+        const TWriteInstruction instr(record.GetInstruction());
+        Y_ABORT_UNLESS(instr.PayloadId, "TEvWritePersistentBuffer without a payload, but with checksums");
+        const TRope& payload = ev->Get()->GetPayload(*instr.PayloadId);
+        if (const auto result = ValidatePayloadChecksums(record, payload)) {
+            const bool isCorrupted = result->Status == NKikimrBlobStorage::NDDisk::TReplyStatus::CORRUPTED;
+            Counters.Interface.WritePersistentBuffer.Request(selector.Size);
+            Counters.Interface.WritePersistentBuffer.Reply(false, selector.Size);
+            if (isCorrupted) {
+                Counters.Checksums.ChecksumMismatch->Inc();
             }
-        } else {
-            // Checksums are validated here, before any sector allocation or disk I/O
-            const TWriteInstruction instr(record.GetInstruction());
-            Y_ABORT_UNLESS(instr.PayloadId, "TEvWritePersistentBuffer without a payload, but with checksums");
-            const TRope& payload = ev->Get()->GetPayload(*instr.PayloadId);
-            if (const auto result = ValidatePayloadChecksums(record, payload)) {
-                const bool isCorrupted = result->Status == NKikimrBlobStorage::NDDisk::TReplyStatus::CORRUPTED;
-                Counters.Interface.WritePersistentBuffer.Request(selector.Size);
-                Counters.Interface.WritePersistentBuffer.Reply(false, selector.Size);
-                if (isCorrupted) {
-                    Counters.Checksums.ChecksumMismatch->Inc();
-                }
-                YDB_LOG_ERROR_COMP(NKikimrServices::BS_PERSISTENT_BUFFER,
-                    (isCorrupted
-                        ? "TDDiskActor::Handle(TEvWritePersistentBuffer) checksum mismatch"
-                        : "TDDiskActor::Handle(TEvWritePersistentBuffer) checksum count mismatch"),
-                    {"marker", "BSPB"},
-                    {"PBufferId", SelfId()},
-                    {"tabletId", creds.TabletId},
-                    {"generation", creds.Generation},
-                    {"lsn", lsn},
-                    {"checksumCount", result->ChecksumCount},
-                    {"selectorSize", selector.Size},
-                    {"blockIdx", result->MismatchedBlockIdx ? static_cast<i64>(*result->MismatchedBlockIdx) : -1});
-                SendReply(*ev, std::make_unique<TEvWritePersistentBufferResult>(result->Status, result->ErrorReason));
-                return;
-            }
+            YDB_LOG_ERROR_COMP(NKikimrServices::BS_PERSISTENT_BUFFER,
+                (isCorrupted
+                    ? "TDDiskActor::Handle(TEvWritePersistentBuffer) checksum mismatch"
+                    : "TDDiskActor::Handle(TEvWritePersistentBuffer) checksum count mismatch"),
+                {"marker", "BSPB"},
+                {"PBufferId", SelfId()},
+                {"tabletId", creds.TabletId},
+                {"generation", creds.Generation},
+                {"lsn", lsn},
+                {"checksumCount", result->ChecksumCount},
+                {"selectorSize", selector.Size},
+                {"blockIdx", result->MismatchedBlockIdx ? static_cast<i64>(*result->MismatchedBlockIdx) : -1});
+            SendReply(*ev, std::make_unique<TEvWritePersistentBufferResult>(result->Status, result->ErrorReason));
+            return;
         }
         if (!PersistentBufferReady) {
             if (PendingPersistentBufferEvents.size() >= PersistentBufferFormat.MaxPendingEventsQueueSize) {
@@ -1506,7 +1512,7 @@ namespace NKikimr::NDDisk {
                     // Persisted checksums cover [pr.OffsetInBytes, pr.OffsetInBytes + pr.Size) one entry
                     // per MinSectorSize block, same order as the trimmed data above - slice out the
                     // sub-range the selector actually asked for. Returned as-is (never recomputed from
-                    // on-disk bytes), matching the write path's opt-in, pre-signature-correction values.
+                    // on-disk bytes): the same pure-data checksums the writer attached.
                     Y_ABORT_UNLESS(pr.PayloadChecksums.size() == pr.Size / SectorSize);
                     const ui32 firstBlock = (inflightRecord.OffsetInBytes - pr.OffsetInBytes) / SectorSize;
                     const ui32 blockCount = inflightRecord.Size / SectorSize;

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_persistent_buffer.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_persistent_buffer.cpp
@@ -248,7 +248,7 @@ namespace NKikimr::NDDisk {
     std::vector<std::tuple<ui32, ui32, TRope>> TDDiskActor::SlicePersistentBuffer(
         ui64 tabletId, ui32 generation, ui64 vchunkIndex, ui64 lsn, ui32 offsetInBytes, ui32 sizeInBytes,
         TRcBuf&& payloadWithHeader, std::vector<TPersistentBufferSectorInfo>& sectors,
-        const std::vector<ui64>& payloadChecksums)
+        const std::vector<ui64>& payloadChecksums, ui8 directBlockGroupIndex)
     {
         TRope fullData(std::move(payloadWithHeader));
 
@@ -299,6 +299,7 @@ namespace NKikimr::NDDisk {
         lsnRecordHeader->OffsetInBytes = offsetInBytes;
         lsnRecordHeader->Size = sizeInBytes;
         lsnRecordHeader->Lsn = lsn;
+        lsnRecordHeader->DirectBlockGroupIndex = directBlockGroupIndex;
         const bool hasPayloadChecksums = !payloadChecksums.empty();
         lsnRecordHeader->Flags = hasPayloadChecksums ? TPersistentBufferLsnRecordHeader::HAS_PAYLOAD_CHECKSUMS : TPersistentBufferLsnRecordHeader::NONE;
         header->Version = hasPayloadChecksums ? 1 : 0;
@@ -386,7 +387,20 @@ namespace NKikimr::NDDisk {
         const TBlockSelector selector(record.GetSelector());
         const ui64 lsn = record.GetLsn();
 
-        auto barrierRecord = PersistentBufferBarriersManager.GetBarrier(creds.TabletId);
+        // DirectBlockGroupIndex is stored on disk as ui8; reject out-of-range values explicitly
+        // instead of silently truncating them (which could collide with an existing namespace).
+        if (creds.DirectBlockGroupIndex > Max<ui8>()) {
+            YDB_LOG_DEBUG_COMP(BS_DDISK, "TDDiskActor::PreprocessPersistentBufferWrite DirectBlockGroupIndex out of range",
+                {"marker", "BSDD41"},
+                {"tabletId", creds.TabletId},
+                {"directBlockGroupIndex", creds.DirectBlockGroupIndex});
+            SendReply(ev, std::make_unique<TEvWritePersistentBufferResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::INCORRECT_REQUEST,
+                TStringBuilder() << "directBlockGroupIndex# " << creds.DirectBlockGroupIndex << " out of range"));
+            return false;
+        }
+
+        auto barrierRecord = PersistentBufferBarriersManager.GetBarrier(creds.TabletId, static_cast<ui8>(creds.DirectBlockGroupIndex));
         if (barrierRecord.Generation > creds.Generation
             || (barrierRecord.Generation == creds.Generation && lsn <= barrierRecord.Lsn)) {
             YDB_LOG_DEBUG_COMP(BS_DDISK, "TDDiskActor::PreprocessPersistentBufferWrite write before barrier",
@@ -438,7 +452,7 @@ namespace NKikimr::NDDisk {
             }
             return true;
         };
-        if (auto it = PersistentBuffers.find({creds.TabletId, creds.Generation}); it != PersistentBuffers.end()) {
+        if (auto it = PersistentBuffers.find({creds.TabletId, creds.Generation, static_cast<ui8>(creds.DirectBlockGroupIndex)}); it != PersistentBuffers.end()) {
             if (auto recordIt = it->second.Records.find(lsn); recordIt != it->second.Records.end()) {
                 auto& record = recordIt->second;
                 if (!checkIsSameRequest(record)) {
@@ -470,7 +484,7 @@ namespace NKikimr::NDDisk {
                 return false;
             }
         }
-        if (auto it = PersistentBufferWriteInflightsByRecord.find({creds.TabletId, creds.Generation, lsn}); it != PersistentBufferWriteInflightsByRecord.end()) {
+        if (auto it = PersistentBufferWriteInflightsByRecord.find({creds.TabletId, creds.Generation, lsn, static_cast<ui8>(creds.DirectBlockGroupIndex)}); it != PersistentBufferWriteInflightsByRecord.end()) {
             Y_ABORT_UNLESS(!it->second.empty());
 
             auto inflightIt = PersistentBufferDiskOperationInflight.find(std::get<0>(*it->second.begin()));
@@ -587,8 +601,8 @@ namespace NKikimr::NDDisk {
                 auto* pos = headerRope.Begin().ContiguousDataMut() + sizeof(TPersistentBufferHeader);
                 for (ui32 batchIdx = 0; batchIdx < header->BatchSize; ++batchIdx) {
                     TPersistentBufferLsnRecordHeader* recordHeader = reinterpret_cast<TPersistentBufferLsnRecordHeader*>(pos);
-                    pbh.insert({recordHeader->TabletId, recordHeader->Generation, recordHeader->Lsn});
-                    auto& buffer = PersistentBuffers[{recordHeader->TabletId, recordHeader->Generation}];
+                    pbh.insert({recordHeader->TabletId, recordHeader->Generation, recordHeader->Lsn, recordHeader->DirectBlockGroupIndex});
+                    auto& buffer = PersistentBuffers[{recordHeader->TabletId, recordHeader->Generation, recordHeader->DirectBlockGroupIndex}];
                     auto [it, inserted] = buffer.Records.try_emplace(recordHeader->Lsn);
                     if (!inserted) {
                         YDB_LOG_DEBUG_COMP(NKikimrServices::BS_PERSISTENT_BUFFER, "TDDiskActor::StartRestorePersistentBuffer duplicated lsn for tablet in persistent buffer",
@@ -706,7 +720,7 @@ namespace NKikimr::NDDisk {
         Y_ABORT_UNLESS(inflight.Records.size() == 1);
         auto& inflightRecord = inflight.Records[0];
 
-        auto it = PersistentBuffers.find({inflightRecord.TabletId, inflightRecord.Generation});
+        auto it = PersistentBuffers.find({inflightRecord.TabletId, inflightRecord.Generation, inflightRecord.DirectBlockGroupIndex});
         if (it == PersistentBuffers.end()) {
             inflight.Status = NKikimrBlobStorage::NDDisk::TReplyStatus::MISSING_RECORD;
         } else {
@@ -726,7 +740,7 @@ namespace NKikimr::NDDisk {
                         PersistentBufferInMemoryCacheSize += pr.Size;
                         *Counters.PersistentBuffer.InMemoryCacheSize = PersistentBufferInMemoryCacheSize;
 
-                        auto [_, inserted2] = PersistentBuffersInMemoryCacheUptime[pr.Timestamp].emplace(inflightRecord.TabletId, inflightRecord.Generation, inflightRecord.Lsn);
+                        auto [_, inserted2] = PersistentBuffersInMemoryCacheUptime[pr.Timestamp].emplace(inflightRecord.TabletId, inflightRecord.Generation, inflightRecord.Lsn, inflightRecord.DirectBlockGroupIndex);
                         Y_ABORT_UNLESS(inserted2);
                         ReplyReadPersistentBuffer(pr, inflight.Status, inflight.ErrorMessage);
                     }
@@ -748,7 +762,7 @@ namespace NKikimr::NDDisk {
             Counters.PersistentBuffer.WriteBatchSize->Collect(inflight.Records.size());
             if (!inflight.ErrorMessage) {
                 for (auto& record : inflight.Records) {
-                    auto& buffer = PersistentBuffers[{record.TabletId, record.Generation}];
+                    auto& buffer = PersistentBuffers[{record.TabletId, record.Generation, record.DirectBlockGroupIndex}];
                     auto [it, inserted] = buffer.Records.try_emplace(record.Lsn);
                     TPersistentBuffer::TRecord& pr = it->second;
                     Y_ABORT_UNLESS(record.DataParts.size() == 1 && record.PartsCount == 1);
@@ -763,13 +777,13 @@ namespace NKikimr::NDDisk {
                     };
 
                     auto& pbh = PersistentBufferHeaders[{pr.Sectors[0].ChunkIdx, pr.Sectors[0].SectorIdx}];
-                    pbh.insert({record.TabletId, record.Generation, record.Lsn});
+                    pbh.insert({record.TabletId, record.Generation, record.Lsn, record.DirectBlockGroupIndex});
 
                     buffer.Size += pr.Size;
                     pr.Data = std::move(record.DataParts.begin()->second);
                     PersistentBufferInMemoryCacheSize += pr.Size;
                     *Counters.PersistentBuffer.InMemoryCacheSize = PersistentBufferInMemoryCacheSize;
-                    auto [_, inserted2] = PersistentBuffersInMemoryCacheUptime[pr.Timestamp].emplace(record.TabletId, record.Generation, record.Lsn);
+                    auto [_, inserted2] = PersistentBuffersInMemoryCacheUptime[pr.Timestamp].emplace(record.TabletId, record.Generation, record.Lsn, record.DirectBlockGroupIndex);
                     Y_ABORT_UNLESS(inserted2);
                 }
                 SanitizePersistentBufferInMemoryCache();
@@ -782,7 +796,7 @@ namespace NKikimr::NDDisk {
 
             // process duplicated write requests and clear PersistentBufferWriteInflightsByRecord
             for (auto& record : inflight.Records) {
-                auto it = PersistentBufferWriteInflightsByRecord.find({record.TabletId, record.Generation, record.Lsn});
+                auto it = PersistentBufferWriteInflightsByRecord.find({record.TabletId, record.Generation, record.Lsn, record.DirectBlockGroupIndex});
                 Y_ABORT_UNLESS(it != PersistentBufferWriteInflightsByRecord.end());
                 Y_ABORT_UNLESS(!it->second.empty());
                 for (auto [replyCookie, pos] : it->second) {
@@ -886,7 +900,7 @@ namespace NKikimr::NDDisk {
             auto itErase = inflight.Erases.find(partCookie);
             Y_ABORT_UNLESS(itErase != inflight.Erases.end());
             for (auto& e : itErase->second) {
-                auto it = PersistentBufferEraseInflightsByRecord.find(TPersistentBufferRecordId{inflightRecord.TabletId, e.Generation, e.Lsn});
+                auto it = PersistentBufferEraseInflightsByRecord.find(TPersistentBufferRecordId{inflightRecord.TabletId, e.Generation, e.Lsn, inflightRecord.DirectBlockGroupIndex});
                 if (it == PersistentBufferEraseInflightsByRecord.end()) {
                     continue;
                 }
@@ -999,7 +1013,7 @@ namespace NKikimr::NDDisk {
 
         auto parts = SlicePersistentBuffer(creds.TabletId, creds.Generation,
             selector.VChunkIndex, lsn, selector.OffsetInBytes, selector.Size, std::move(payloadWithHeader), sectors,
-            payloadChecksums);
+            payloadChecksums, static_cast<ui8>(creds.DirectBlockGroupIndex));
 
         auto opCookie = NextCookie++;
         auto& inflightRecord = PersistentBufferDiskOperationInflight[opCookie];
@@ -1025,8 +1039,9 @@ namespace NKikimr::NDDisk {
             // payloadChecksums was only read (never mutated) above by SlicePersistentBuffer; safe to
             // move into the inflight record now that this is its last use.
             .PayloadChecksums = std::move(payloadChecksums),
+            .DirectBlockGroupIndex = static_cast<ui8>(creds.DirectBlockGroupIndex),
         });
-        PersistentBufferWriteInflightsByRecord[TPersistentBufferRecordId{creds.TabletId, creds.Generation, lsn}].emplace_back(
+        PersistentBufferWriteInflightsByRecord[TPersistentBufferRecordId{creds.TabletId, creds.Generation, lsn, static_cast<ui8>(creds.DirectBlockGroupIndex)}].emplace_back(
             opCookie,
             inflightRecord.Records.size() - 1
         );
@@ -1134,6 +1149,7 @@ namespace NKikimr::NDDisk {
             .DataParts = {{0, payload}},
             .PartsCount = 1,
             .PayloadChecksums = std::move(payloadChecksums),
+            .DirectBlockGroupIndex = static_cast<ui8>(creds.DirectBlockGroupIndex),
         });
 
         auto& r = inflight.Records.back();
@@ -1153,7 +1169,7 @@ namespace NKikimr::NDDisk {
             sectorsIt->Checksum = r.Sectors[i + 1].Checksum;
             ++sectorsIt;
         }
-        PersistentBufferWriteInflightsByRecord[TPersistentBufferRecordId{creds.TabletId, creds.Generation, lsn}].emplace_back(
+        PersistentBufferWriteInflightsByRecord[TPersistentBufferRecordId{creds.TabletId, creds.Generation, lsn, static_cast<ui8>(creds.DirectBlockGroupIndex)}].emplace_back(
             PersistentBufferBatchWriteCookie,
             inflight.Records.size() - 1
         );
@@ -1200,6 +1216,7 @@ namespace NKikimr::NDDisk {
             lsnRecordHeader->OffsetInBytes = record.OffsetInBytes;
             lsnRecordHeader->Size = record.Size;
             lsnRecordHeader->Lsn = record.Lsn;
+            lsnRecordHeader->DirectBlockGroupIndex = record.DirectBlockGroupIndex;
             const bool hasPayloadChecksums = !record.PayloadChecksums.empty();
             lsnRecordHeader->Flags = hasPayloadChecksums ? TPersistentBufferLsnRecordHeader::HAS_PAYLOAD_CHECKSUMS : TPersistentBufferLsnRecordHeader::NONE;
             anyPayloadChecksums = anyPayloadChecksums || hasPayloadChecksums;
@@ -1379,7 +1396,7 @@ namespace NKikimr::NDDisk {
             .Attribute("size", selector.Size)
             .Attribute("lsn", static_cast<i64>(lsn));
 
-        auto it = PersistentBuffers.find({creds.TabletId, generation});
+        auto it = PersistentBuffers.find({creds.TabletId, generation, static_cast<ui8>(creds.DirectBlockGroupIndex)});
         if (it == PersistentBuffers.end()) {
             Counters.Interface.ReadPersistentBuffer.Reply(false, selector.Size);
             span.End();
@@ -1432,6 +1449,7 @@ namespace NKikimr::NDDisk {
             .OffsetInBytes = selector.OffsetInBytes,
             .Size = selector.Size,
             .PartsCount = 0,
+            .DirectBlockGroupIndex = static_cast<ui8>(creds.DirectBlockGroupIndex),
         });
         pr.ReadInflight.insert(operationCookie);
         if (pr.ReadInflight.size() > 1) {
@@ -1553,7 +1571,7 @@ namespace NKikimr::NDDisk {
             Y_ABORT_UNLESS(recordIt != PersistentBuffersInMemoryCacheUptime.end());
             auto lsnIt = recordIt->second.begin();
             Y_ABORT_UNLESS(lsnIt != recordIt->second.end());
-            auto& pb = PersistentBuffers.at({lsnIt->TabletId, lsnIt->Generation});
+            auto& pb = PersistentBuffers.at({lsnIt->TabletId, lsnIt->Generation, lsnIt->DirectBlockGroupIndex});
             auto& pr = pb.Records.at(lsnIt->Lsn);
             Y_ABORT_UNLESS(pr.Data.size() == pr.Size);
             PersistentBufferInMemoryCacheSize -= pr.Size;
@@ -1566,7 +1584,7 @@ namespace NKikimr::NDDisk {
         }
     }
 
-    void TDDiskActor::SanitizePersistentBufferInMemoryCache(ui64 tabletId, ui32 generation, ui64 lsn, TPersistentBuffer::TRecord& record) {
+    void TDDiskActor::SanitizePersistentBufferInMemoryCache(ui64 tabletId, ui32 generation, ui64 lsn, TPersistentBuffer::TRecord& record, ui8 directBlockGroupIndex) {
         if (!record.Data.empty()) {
             Y_ABORT_UNLESS(record.Data.size() == record.Size);
             Y_DEBUG_ABORT_UNLESS(PersistentBufferInMemoryCacheSize == CalcPersistentBufferInMemoryCacheSize());
@@ -1575,7 +1593,7 @@ namespace NKikimr::NDDisk {
             *Counters.PersistentBuffer.InMemoryCacheSize = PersistentBufferInMemoryCacheSize;
             auto icuIt = PersistentBuffersInMemoryCacheUptime.find(record.Timestamp);
             Y_ABORT_UNLESS(icuIt != PersistentBuffersInMemoryCacheUptime.end());
-            auto count = icuIt->second.erase(TPersistentBufferRecordId{tabletId, generation, lsn});
+            auto count = icuIt->second.erase(TPersistentBufferRecordId{tabletId, generation, lsn, directBlockGroupIndex});
             Y_ABORT_UNLESS(count == 1);
             if (icuIt->second.empty()) {
                 PersistentBuffersInMemoryCacheUptime.erase(icuIt);
@@ -1624,11 +1642,12 @@ namespace NKikimr::NDDisk {
             .Session = queryEv.InterconnectSession,
             .Span = std::move(span),
             .TabletId = creds.TabletId,
+            .DirectBlockGroupIndex = static_cast<ui8>(creds.DirectBlockGroupIndex),
         });
 
         const auto sectors = PersistentBufferSpaceAllocator.Occupy(1);
         Y_ABORT_UNLESS(sectors.size() == 1);
-        auto [oldChunkIdx, oldSectorIdx, barrier] = PersistentBufferBarriersManager.MoveBarrier(creds.TabletId, creds.Generation, lsn, sectors[0]);
+        auto [oldChunkIdx, oldSectorIdx, barrier] = PersistentBufferBarriersManager.MoveBarrier(creds.TabletId, creds.Generation, lsn, sectors[0], static_cast<ui8>(creds.DirectBlockGroupIndex));
 
         if (oldChunkIdx != Max<ui32>()) {
             inflightRecord->second.Records[0].Sectors.push_back({.ChunkIdx = oldChunkIdx, .SectorIdx = oldSectorIdx});
@@ -1674,6 +1693,7 @@ namespace NKikimr::NDDisk {
             .Session = queryEv.InterconnectSession,
             .Span = std::move(span),
             .TabletId = creds.TabletId,
+            .DirectBlockGroupIndex = static_cast<ui8>(creds.DirectBlockGroupIndex),
         });
         Y_ABORT_UNLESS(inserted);
 
@@ -1688,12 +1708,12 @@ namespace NKikimr::NDDisk {
                 {"lsn", lsn},
                 {"generation", generation});
 
-            const auto it = PersistentBuffers.find({creds.TabletId, generation});
+            const auto it = PersistentBuffers.find({creds.TabletId, generation, static_cast<ui8>(creds.DirectBlockGroupIndex)});
             TPersistentBuffer& buffer = it->second;
             const auto jt = buffer.Records.find(lsn);
             TPersistentBuffer::TRecord& pr = jt->second;
 
-            auto &itErase = PersistentBufferEraseInflightsByRecord[TPersistentBufferRecordId{creds.TabletId, generation, lsn}];
+            auto &itErase = PersistentBufferEraseInflightsByRecord[TPersistentBufferRecordId{creds.TabletId, generation, lsn, static_cast<ui8>(creds.DirectBlockGroupIndex)}];
             if (!itErase.OperationsCookie.empty()) {
                 inflightRecord->second.OperationCookies.insert(itErase.EraseCookie);
                 inflightRecord->second.Erases[itErase.EraseCookie].push_back(e);
@@ -1748,6 +1768,7 @@ namespace NKikimr::NDDisk {
             .Session = queryEv.InterconnectSession,
             .Span = std::move(span),
             .TabletId = creds.TabletId,
+            .DirectBlockGroupIndex = static_cast<ui8>(creds.DirectBlockGroupIndex),
         });
 
         if (fastErase.OldChunkIdx != Max<ui32>()) {
@@ -1794,7 +1815,7 @@ namespace NKikimr::NDDisk {
                 {"lsn", lsn},
                 {"generation", generation});
 
-            const auto it = PersistentBuffers.find({inflightRecord.TabletId, generation});
+            const auto it = PersistentBuffers.find({inflightRecord.TabletId, generation, inflightRecord.DirectBlockGroupIndex});
             if (it == PersistentBuffers.end()) {
                 continue;
             }
@@ -1804,12 +1825,12 @@ namespace NKikimr::NDDisk {
                 continue;
             }
             TPersistentBuffer::TRecord& pr = jt->second;
-            SanitizePersistentBufferInMemoryCache(inflightRecord.TabletId, generation, lsn, pr);
+            SanitizePersistentBufferInMemoryCache(inflightRecord.TabletId, generation, lsn, pr, inflightRecord.DirectBlockGroupIndex);
 
             auto pbhIt = PersistentBufferHeaders.find({pr.Sectors[0].ChunkIdx, pr.Sectors[0].SectorIdx});
             Y_ABORT_UNLESS(pbhIt != PersistentBufferHeaders.end());
             auto& pbh = pbhIt->second;
-            pbh.erase({inflightRecord.TabletId, generation, lsn});
+            pbh.erase({inflightRecord.TabletId, generation, lsn, inflightRecord.DirectBlockGroupIndex});
             if (pbh.empty()) {
                 PersistentBufferHeaders.erase(pbhIt);
                 PersistentBufferSpaceAllocator.Free(pr.Sectors);
@@ -1864,9 +1885,22 @@ namespace NKikimr::NDDisk {
         const auto& record = ev->Get()->Record;
         const TQueryCredentials creds(record.GetCredentials());
 
+        // DirectBlockGroupIndex is stored on disk as ui8; reject out-of-range values explicitly
+        // instead of silently truncating them (which could collide with an existing namespace).
+        if (creds.DirectBlockGroupIndex > Max<ui8>()) {
+            YDB_LOG_DEBUG_COMP(NKikimrServices::BS_PERSISTENT_BUFFER, "TDDiskActor::Handle(TEvBatchErasePersistentBuffer) DirectBlockGroupIndex out of range",
+                {"marker", "BSDD42"},
+                {"tabletId", creds.TabletId},
+                {"directBlockGroupIndex", creds.DirectBlockGroupIndex});
+            SendReply(*ev, std::make_unique<TEvErasePersistentBufferResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::INCORRECT_REQUEST,
+                TStringBuilder() << "directBlockGroupIndex# " << creds.DirectBlockGroupIndex << " out of range"));
+            return;
+        }
+
         std::vector<TEraseLsnId> erases;
         std::vector<ui64> fastErases;
-        bool canFastErase = PersistentBufferBarriersManager.CanFastErase(creds.TabletId, creds.Generation);
+        bool canFastErase = PersistentBufferBarriersManager.CanFastErase(creds.TabletId, creds.Generation, static_cast<ui8>(creds.DirectBlockGroupIndex));
         fastErases.reserve(record.ErasesSize());
         for (auto& e : record.GetErases()) {
             auto lsn = e.GetLsn();
@@ -1874,7 +1908,7 @@ namespace NKikimr::NDDisk {
             if (generation != creds.Generation) {
                 canFastErase = false;
             }
-            const auto it = PersistentBuffers.find({creds.TabletId, generation});
+            const auto it = PersistentBuffers.find({creds.TabletId, generation, static_cast<ui8>(creds.DirectBlockGroupIndex)});
             if (it != PersistentBuffers.end() && it->second.Records.find(lsn) != it->second.Records.end()) {
                 erases.emplace_back(generation, lsn);
                 if (canFastErase && PersistentBufferFormat.EnableFastErases) {
@@ -1892,7 +1926,7 @@ namespace NKikimr::NDDisk {
             ErasePersistentBuffer(*ev, creds, erases);
             return;
         }
-        if (auto fastErase = PersistentBufferBarriersManager.Erase(creds.TabletId, creds.Generation, fastErases, PersistentBufferSpaceAllocator); fastErase) {
+        if (auto fastErase = PersistentBufferBarriersManager.Erase(creds.TabletId, creds.Generation, fastErases, PersistentBufferSpaceAllocator, static_cast<ui8>(creds.DirectBlockGroupIndex)); fastErase) {
             FastErasePersistentBuffer(*ev, creds, erases, fastErase.value());
         } else {
             ErasePersistentBuffer(*ev, creds, erases);
@@ -1929,10 +1963,29 @@ namespace NKikimr::NDDisk {
         const TQueryCredentials creds(record.GetCredentials());
         const ui64 lsn = record.GetLsn();
 
+        // DirectBlockGroupIndex is stored on disk as ui8; reject out-of-range values explicitly
+        // instead of silently truncating them (which could collide with an existing namespace).
+        if (creds.DirectBlockGroupIndex > Max<ui8>()) {
+            YDB_LOG_DEBUG_COMP(NKikimrServices::BS_PERSISTENT_BUFFER, "TDDiskActor::Handle(TEvErasePersistentBuffer) DirectBlockGroupIndex out of range",
+                {"marker", "BSDD43"},
+                {"tabletId", creds.TabletId},
+                {"directBlockGroupIndex", creds.DirectBlockGroupIndex});
+            SendReply(*ev, std::make_unique<TEvErasePersistentBufferResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::INCORRECT_REQUEST,
+                TStringBuilder() << "directBlockGroupIndex# " << creds.DirectBlockGroupIndex << " out of range"));
+            return;
+        }
+
         std::vector<TEraseLsnId> erases;
 
+        // Persistent buffer keys are ordered (TabletId, Generation, DirectBlockGroupIndex), so a
+        // plain TabletId range mixes together entries from every direct block group under this
+        // tablet; filter to the caller's DirectBlockGroupIndex explicitly.
         for (auto it = PersistentBuffers.lower_bound({creds.TabletId, 0}); it != PersistentBuffers.end() &&
                 it->first.TabletId == creds.TabletId; ++it) {
+            if (it->first.DirectBlockGroupIndex != creds.DirectBlockGroupIndex) {
+                continue;
+            }
             const TPersistentBuffer& buffer = it->second;
             auto recordIt = buffer.Records.begin();
             while (recordIt != buffer.Records.end()
@@ -1947,7 +2000,7 @@ namespace NKikimr::NDDisk {
                 NKikimrBlobStorage::NDDisk::TReplyStatus::OVERFILL, "not enough free space to move barrier"));
             return;
         }
-        if (!PersistentBufferBarriersManager.CanMoveBarrier(creds.TabletId, PersistentBufferFormat.MaxBarriersLimit)) {
+        if (!PersistentBufferBarriersManager.CanMoveBarrier(creds.TabletId, PersistentBufferFormat.MaxBarriersLimit, static_cast<ui8>(creds.DirectBlockGroupIndex))) {
             SendReply(*ev, std::make_unique<TEvErasePersistentBufferResult>(
                 NKikimrBlobStorage::NDDisk::TReplyStatus::OVERFILL, "barrier can not be moved"));
             return;
@@ -2071,7 +2124,8 @@ namespace NKikimr::NDDisk {
                     v.Records.begin()->first, v.Records.rbegin()->first,
                     v.Records.begin()->second.Timestamp, v.Records.rbegin()->second.Timestamp,
                     v.Records.size(), v.Size,
-                    PersistentBufferBarriersManager.GetErasesCount(k.TabletId));
+                    PersistentBufferBarriersManager.GetErasesCount(k.TabletId, k.DirectBlockGroupIndex),
+                    k.DirectBlockGroupIndex);
             }
             reply->EraseBarriers = PersistentBufferBarriersManager.GetBarriers();
         }
@@ -2104,9 +2158,14 @@ namespace NKikimr::NDDisk {
 
         auto reply = std::make_unique<TEvListPersistentBufferResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
         auto& rr = reply->Record;
-        rr.SetBarrierLsn(PersistentBufferBarriersManager.GetBarrier(creds.TabletId).Lsn);
+        rr.SetBarrierLsn(PersistentBufferBarriersManager.GetBarrier(creds.TabletId, static_cast<ui8>(creds.DirectBlockGroupIndex)).Lsn);
+        // Persistent buffer keys are ordered (TabletId, Generation, DirectBlockGroupIndex), so filter
+        // to the caller's DirectBlockGroupIndex explicitly instead of relying on a contiguous range.
         for (auto it = PersistentBuffers.lower_bound({creds.TabletId, 0}); it != PersistentBuffers.end() &&
                 it->first.TabletId == creds.TabletId; ++it) {
+            if (it->first.DirectBlockGroupIndex != creds.DirectBlockGroupIndex) {
+                continue;
+            }
             const TPersistentBuffer& buffer = it->second;
             for (const auto& [lsn, pr] : buffer.Records) {
                 auto *pb = rr.AddRecords();
@@ -2192,7 +2251,7 @@ namespace NKikimr::NDDisk {
         TStringBuilder sb;
         sb << "PersistentBuffer size:" << PersistentBuffers.size() << "\n";
         for (auto [k, v] : PersistentBuffers) {
-            sb << "  TabletId:" << k.TabletId << "\n";
+            sb << "  TabletId:" << k.TabletId << " DirectBlockGroupIndex:" << (ui32)k.DirectBlockGroupIndex << "\n";
             for (auto [lsn, pr] : v.Records) {
                 sb << "    Lsn:" << lsn << " Offset:" << pr.OffsetInBytes << " Size:" << pr.Size << " Sectors: ";
                 for (auto sector : pr.Sectors) {

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_read_write.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_read_write.cpp
@@ -63,8 +63,8 @@ namespace NKikimr::NDDisk {
         const TWriteInstruction instr(record.GetInstruction());
 
         if (TabletChunkDeletionsInFlight.contains(creds.TabletId)) {
-            Counters.Interface.Write.Request(0);
-            Counters.Interface.Write.Reply(false);
+            Counters.Interface.Write.Request(selector.Size);
+            Counters.Interface.Write.Reply(false, selector.Size);
             SendReply(*ev, std::make_unique<TEvWriteResult>(
                 NKikimrBlobStorage::NDDisk::TReplyStatus::BUSY,
                 "tablet chunk deletion is in flight"));
@@ -92,43 +92,50 @@ namespace NKikimr::NDDisk {
                 SendReply(*ev, std::make_unique<TEvWriteResult>(
                     NKikimrBlobStorage::NDDisk::TReplyStatus::INCORRECT_REQUEST,
                     ss.Str()));
-                Counters.Interface.Write.Request(0);
-                Counters.Interface.Write.Reply(false);
+                Counters.Interface.Write.Request(selector.Size);
+                Counters.Interface.Write.Reply(false, selector.Size);
                 return;
             }
         }
 
-        // Unlike TEvWritePersistentBuffer, TEvWrite's checksums (if any) are validated here but never
-        // persisted: TEvWrite goes straight to the final DDisk chunk, which has no per-record metadata
-        // slot to carry them (see RFC 006). Note this validation intentionally runs again for events
-        // that get parked in PendingEventsForChunk below and re-dispatched to this same handler once
-        // their chunk allocation completes -- harmless (checksums don't change), just redundant.
-        if (record.ChecksumsSize() > 0) {
-            Y_ABORT_UNLESS(instr.PayloadId, "TEvWrite without a payload, but with checksums");
-
-            const TRope& payload = ev->Get()->GetPayload(*instr.PayloadId);
-            if (const auto result = ValidatePayloadChecksums(record, payload)) {
-                const bool isCorrupted = result->Status == NKikimrBlobStorage::NDDisk::TReplyStatus::CORRUPTED;
-                Counters.Interface.Write.Request(0);
-                Counters.Interface.Write.Reply(false);
-                if (isCorrupted) {
-                    Counters.Checksums.ChecksumMismatch->Inc();
-                }
-                YDB_LOG_ERROR_COMP(NKikimrServices::BS_DDISK,
-                    (isCorrupted
-                        ? "TDDiskActor::Handle(TEvWrite) checksum mismatch"
-                        : "TDDiskActor::Handle(TEvWrite) checksum count mismatch"),
-                    {"marker", "BSDD52"},
-                    {"DDiskId", DDiskId},
-                    {"tabletId", creds.TabletId},
-                    {"vChunkIndex", selector.VChunkIndex},
-                    {"offsetInBytes", selector.OffsetInBytes},
-                    {"checksumCount", result->ChecksumCount},
-                    {"selectorSize", selector.Size},
-                    {"blockIdx", result->MismatchedBlockIdx ? static_cast<i64>(*result->MismatchedBlockIdx) : -1});
-                SendReply(*ev, std::make_unique<TEvWriteResult>(result->Status, result->ErrorReason));
-                return;
+        if (!HasRequiredBlockChecksums(record.ChecksumsSize(), selector.OffsetInBytes, selector.Size)) {
+            if (record.ChecksumsSize() == 0) {
+                Counters.Checksums.WritesWithoutChecksums->Inc();
             }
+            Counters.Interface.Write.Request(selector.Size);
+            Counters.Interface.Write.Reply(false, selector.Size);
+            SendReply(*ev, std::make_unique<TEvWriteResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::INCORRECT_REQUEST,
+                "one checksum per aligned 4 KiB block is required"));
+            return;
+        }
+
+        // Validate before chunk allocation or data/integrity I/O. Parked events pass through this
+        // check again when re-dispatched; the redundant validation is harmless.
+        Y_ABORT_UNLESS(instr.PayloadId, "TEvWrite without a payload, but with checksums");
+
+        const TRope& payload = ev->Get()->GetPayload(*instr.PayloadId);
+        if (const auto result = ValidatePayloadChecksums(record, payload)) {
+            const bool isCorrupted = result->Status == NKikimrBlobStorage::NDDisk::TReplyStatus::CORRUPTED;
+            Counters.Interface.Write.Request(selector.Size);
+            Counters.Interface.Write.Reply(false, selector.Size);
+            if (isCorrupted) {
+                Counters.Checksums.ChecksumMismatch->Inc();
+            }
+            YDB_LOG_ERROR_COMP(NKikimrServices::BS_DDISK,
+                (isCorrupted
+                    ? "TDDiskActor::Handle(TEvWrite) checksum mismatch"
+                    : "TDDiskActor::Handle(TEvWrite) checksum count mismatch"),
+                {"marker", "BSDD52"},
+                {"DDiskId", DDiskId},
+                {"tabletId", creds.TabletId},
+                {"vChunkIndex", selector.VChunkIndex},
+                {"offsetInBytes", selector.OffsetInBytes},
+                {"checksumCount", result->ChecksumCount},
+                {"selectorSize", selector.Size},
+                {"blockIdx", result->MismatchedBlockIdx ? static_cast<i64>(*result->MismatchedBlockIdx) : -1});
+            SendReply(*ev, std::make_unique<TEvWriteResult>(result->Status, result->ErrorReason));
+            return;
         }
 
         TChunkRef& chunkRef = ChunkRefs[creds.TabletId][selector.VChunkIndex];
@@ -143,7 +150,14 @@ namespace NKikimr::NDDisk {
             return;
         }
 
+        if (chunkRef.IntegrityExtentWriteInFlight) {
+            chunkRef.PendingSerializedWrites.emplace(ev, "WaitIntegrityExtentWrite");
+            return;
+        }
+        chunkRef.IntegrityExtentWriteInFlight = true;
+
         Counters.Interface.Write.Request(selector.Size);
+        const auto requestStartTs = HPNow();
 
         auto span = NWilson::TSpan(TWilson::DDiskTopLevel, std::move(ev->TraceId), "DDisk.Write",
                 NWilson::EFlags::NONE, TActivationContext::ActorSystem());
@@ -161,22 +175,36 @@ namespace NKikimr::NDDisk {
 
         Y_ABORT_UNLESS(data.size() == selector.Size);
 
-        // Track the written blocks (and their checksums, when supplied and block-aligned) at
-        // submission time: the protocol guarantees no reads of ranges with writes in flight.
-        {
-            std::vector<ui64> checksums;
-            if (record.ChecksumsSize() > 0 &&
-                    selector.OffsetInBytes % IntegrityUnitSize == 0 && selector.Size % IntegrityUnitSize == 0) {
-                checksums.assign(record.GetChecksums().begin(), record.GetChecksums().end());
-            }
-            IntegrityManager->OnBlocksWritten({creds.TabletId, selector.VChunkIndex},
-                selector.OffsetInBytes, selector.Size, checksums);
+        std::vector<ui64> checksums(record.GetChecksums().begin(), record.GetChecksums().end());
+        const ui64 integrityOperationId = IntegrityManager->BeginBlocksWrite(
+            {creds.TabletId, selector.VChunkIndex}, selector.OffsetInBytes, selector.Size, checksums);
+        const bool inserted = PendingClientWrites.try_emplace(integrityOperationId).second;
+        Y_ABORT_UNLESS(inserted);
+        DrainIntegrityManager();
+        const auto pendingIt = PendingClientWrites.find(integrityOperationId);
+        if (pendingIt != PendingClientWrites.end() && pendingIt->second.IntegrityCompleted
+                && pendingIt->second.IntegrityStatus == TIntegrityManager::EOperationStatus::Corrupted) {
+            pendingIt->second.DataResult.emplace(TParkedWriteReply{
+                .Status = NKikimrBlobStorage::NDDisk::TReplyStatus::OK,
+                .OriginalRequester = ev->Sender,
+                .InterconnectSession = ev->InterconnectSession,
+                .Cookie = ev->Cookie,
+                .Span = std::move(span),
+                .TotalSize = selector.Size,
+                .RequestTimeMs = HPMilliSecondsFloat(HPNow() - requestStartTs),
+                .TabletId = creds.TabletId,
+                .VChunkIndex = selector.VChunkIndex,
+            });
+            MaybeFinishClientWrite(integrityOperationId);
+            return;
         }
 
         auto offset = DiskFormat->Offset(chunkRef.ChunkIdx, 0, selector.OffsetInBytes);
 
         std::unique_ptr<TDirectIoOpBase> op = AllocateOp<TDDiskIoOp>(ev.Get());
-        static_cast<TDDiskIoOp*>(op.get())->SetChunkKey(creds.TabletId, selector.VChunkIndex);
+        auto* ddiskOp = static_cast<TDDiskIoOp*>(op.get());
+        ddiskOp->SetChunkKey(creds.TabletId, selector.VChunkIndex);
+        ddiskOp->SetIntegrityOperationId(integrityOperationId);
         op->SetSpan(std::move(span));
         op->PrepareWrite(std::move(data), offset, chunkRef.ChunkIdx, selector.OffsetInBytes);
 
@@ -245,16 +273,24 @@ namespace NKikimr::NDDisk {
         const TQueryCredentials creds(record.GetCredentials());
         const TBlockSelector selector(record.GetSelector());
 
+        if (selector.OffsetInBytes % IntegrityUnitSize != 0
+                || selector.Size % IntegrityUnitSize != 0) {
+            Counters.Interface.Read.Request(selector.Size);
+            Counters.Interface.Read.Reply(false, selector.Size);
+            SendReply(*ev, std::make_unique<TEvReadResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::INCORRECT_REQUEST,
+                "read offset and size must be aligned to the 4 KiB integrity unit"));
+            return;
+        }
+
         if (TabletChunkDeletionsInFlight.contains(creds.TabletId)) {
-            Counters.Interface.Read.Request(0);
-            Counters.Interface.Read.Reply(false);
+            Counters.Interface.Read.Request(selector.Size);
+            Counters.Interface.Read.Reply(false, selector.Size);
             SendReply(*ev, std::make_unique<TEvReadResult>(
                 NKikimrBlobStorage::NDDisk::TReplyStatus::BUSY,
                 "tablet chunk deletion is in flight"));
             return;
         }
-
-        TRope result;
 
         TChunkRef& chunkRef = ChunkRefs[creds.TabletId][selector.VChunkIndex];
         if (!chunkRef.PendingEventsForChunk.empty()) {
@@ -264,8 +300,36 @@ namespace NKikimr::NDDisk {
 
         Counters.Interface.Read.Request(selector.Size);
 
+        // No chunk allocated: the whole range was never written.
+        if (!chunkRef.ChunkIdx) {
+            auto zero = TRcBuf::Uninitialized(selector.Size);
+            memset(zero.GetDataMut(), 0, zero.size());
+            TRope result(std::move(zero));
+            const std::vector<ui64> checksums(selector.Size / IntegrityUnitSize, GetZeroBlockChecksum());
+            Counters.Interface.Read.Reply(true, selector.Size, 0);
+            SendReply(*ev, std::make_unique<TEvReadResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::OK, std::nullopt,
+                std::move(result), checksums));
+            return;
+        }
+
+        const ui64 integrityOperationId = IntegrityManager->BeginChecksumRead(
+            {creds.TabletId, selector.VChunkIndex}, selector.OffsetInBytes, selector.Size);
+        const bool inserted = PendingChecksumReads.emplace(integrityOperationId,
+            TPendingChecksumRead{std::unique_ptr<IEventHandle>(ev.Release())}).second;
+        Y_ABORT_UNLESS(inserted);
+        DrainIntegrityManager();
+    }
+
+    void TDDiskActor::StartDDiskDataRead(std::unique_ptr<IEventHandle> ev,
+            std::vector<ui64> checksums) {
+        const auto& record = ev->Get<TEvRead>()->Record;
+        const TQueryCredentials creds(record.GetCredentials());
+        const TBlockSelector selector(record.GetSelector());
+        TChunkRef& chunkRef = ChunkRefs.at(creds.TabletId).at(selector.VChunkIndex);
+
         auto span = NWilson::TSpan(TWilson::DDiskTopLevel, std::move(ev->TraceId), "DDisk.Read",
-                NWilson::EFlags::NONE, TActivationContext::ActorSystem());
+            NWilson::EFlags::NONE, TActivationContext::ActorSystem());
         NPrivate::AddMessageWaitAttributes(span);
         span
             .Attribute("tablet_id", static_cast<i64>(creds.TabletId))
@@ -273,36 +337,26 @@ namespace NKikimr::NDDisk {
             .Attribute("offset_in_bytes", selector.OffsetInBytes)
             .Attribute("size", selector.Size);
 
-        auto replyZeros = [&] {
-            auto zero = TRcBuf::Uninitialized(selector.Size);
-            memset(zero.GetDataMut(), 0, zero.size());
-            result.Insert(result.End(), std::move(zero));
-            Counters.Interface.Read.Reply(true, selector.Size, 0);
-            span.End();
-            SendReply(*ev, std::make_unique<TEvReadResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK, std::nullopt,
-                std::move(result)));
-        };
-
-        // No chunk allocated: the whole range was never written.
-        if (!chunkRef.ChunkIdx) {
-            replyZeros();
-            return;
-        }
-
-        // A chunk exists, but some (or all) of its blocks may never have been written: consult the
-        // integrity manager so that such blocks read as zeros rather than as whatever the reused
-        // physical chunk contains. Untracked (boot-restored) chunks yield Passthrough.
         auto plan = IntegrityManager->MakeReadPlan({creds.TabletId, selector.VChunkIndex},
             selector.OffsetInBytes, selector.Size);
         if (plan.Kind == TIntegrityManager::TReadPlan::AllZero) {
-            replyZeros();
+            auto zero = TRcBuf::Uninitialized(selector.Size);
+            memset(zero.GetDataMut(), 0, zero.size());
+            TRope result(std::move(zero));
+            Counters.Interface.Read.Reply(true, selector.Size, 0);
+            span.End();
+            SendReply(*ev, std::make_unique<TEvReadResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::OK, std::nullopt,
+                std::move(result), checksums));
             return;
         }
 
         auto offset = DiskFormat->Offset(chunkRef.ChunkIdx, 0, selector.OffsetInBytes);
 
-        std::unique_ptr<TDirectIoOpBase> op = AllocateOp<TDDiskIoOp>(ev.Get());
-        static_cast<TDDiskIoOp*>(op.get())->SetChunkKey(creds.TabletId, selector.VChunkIndex);
+        std::unique_ptr<TDirectIoOpBase> op = AllocateOp<TDDiskIoOp>(ev.get());
+        auto* ddiskOp = static_cast<TDDiskIoOp*>(op.get());
+        ddiskOp->SetChunkKey(creds.TabletId, selector.VChunkIndex);
+        ddiskOp->SetReadChecksums(std::move(checksums));
         op->SetSpan(std::move(span));
         op->PrepareRead(selector.Size, offset, chunkRef.ChunkIdx, selector.OffsetInBytes);
         if (plan.Kind == TIntegrityManager::TReadPlan::Mixed) {
@@ -330,7 +384,28 @@ namespace NKikimr::NDDisk {
         if (Y_UNLIKELY(IsBroken())) {
             status = NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR;
             errorMessage = GetBrokenReason();
-        } else if (msg.OperationType == NPDisk::TUringOperationBase::EWRITE && msg.HasChunkKey) {
+        }
+
+        if (msg.OperationType == NPDisk::TUringOperationBase::EWRITE && msg.IntegrityOperationId) {
+            const auto pendingIt = PendingClientWrites.find(msg.IntegrityOperationId);
+            Y_ABORT_UNLESS(pendingIt != PendingClientWrites.end());
+            pendingIt->second.DataResult.emplace(TParkedWriteReply{
+                .Status = status,
+                .ErrorMessage = std::move(errorMessage),
+                .OriginalRequester = msg.OriginalRequester,
+                .InterconnectSession = msg.InterconnectSession,
+                .Cookie = msg.Cookie,
+                .Span = std::move(msg.Span),
+                .TotalSize = msg.TotalSize,
+                .RequestTimeMs = msg.RequestTimeMs,
+                .TabletId = msg.TabletId,
+                .VChunkIndex = msg.VChunkIndex,
+            });
+            MaybeFinishClientWrite(msg.IntegrityOperationId);
+            return;
+        }
+
+        if (msg.OperationType == NPDisk::TUringOperationBase::EWRITE && msg.HasChunkKey) {
             const auto it = DataChunkAllocationsInFlight.find({msg.TabletId, msg.VChunkIndex});
             if (it != DataChunkAllocationsInFlight.end()) {
                 it->second.ParkedWriteResults.push_back(TParkedWriteReply{
@@ -342,6 +417,8 @@ namespace NKikimr::NDDisk {
                     .Span = std::move(msg.Span),
                     .TotalSize = msg.TotalSize,
                     .RequestTimeMs = msg.RequestTimeMs,
+                    .TabletId = msg.TabletId,
+                    .VChunkIndex = msg.VChunkIndex,
                 });
                 return;
             }
@@ -357,7 +434,8 @@ namespace NKikimr::NDDisk {
         switch (msg.OperationType) {
             case NPDisk::TUringOperationBase::EREAD:
                 reply = std::make_unique<TEvReadResult>(
-                    status, errorReason, isOk ? std::move(msg.Data) : TRope{});
+                    status, errorReason, isOk ? std::move(msg.Data) : TRope{},
+                    isOk ? msg.Checksums : std::vector<ui64>{});
                 Counters.Interface.Read.Reply(isOk, msg.TotalSize, msg.RequestTimeMs);
                 break;
             case NPDisk::TUringOperationBase::EWRITE:
@@ -374,6 +452,51 @@ namespace NKikimr::NDDisk {
             h->Rewrite(TEvInterconnect::EvForward, msg.InterconnectSession);
         }
         msg.Span.End();
+        TActivationContext::Send(h.release());
+    }
+
+    void TDDiskActor::MaybeFinishClientWrite(ui64 operationId) {
+        const auto it = PendingClientWrites.find(operationId);
+        if (it == PendingClientWrites.end() || !it->second.DataResult
+                || !it->second.IntegrityCompleted) {
+            return;
+        }
+
+        TParkedWriteReply result = std::move(*it->second.DataResult);
+        if (Y_UNLIKELY(IsBroken())) {
+            result.Status = NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR;
+            result.ErrorMessage = GetBrokenReason();
+        } else if (it->second.IntegrityStatus == TIntegrityManager::EOperationStatus::Corrupted
+                && result.Status == NKikimrBlobStorage::NDDisk::TReplyStatus::OK) {
+            result.Status = NKikimrBlobStorage::NDDisk::TReplyStatus::CORRUPTED;
+            result.ErrorMessage = std::move(it->second.IntegrityError);
+        }
+        PendingClientWrites.erase(it);
+        ReleaseIntegrityExtentWrite(result.TabletId, result.VChunkIndex);
+        FinishClientWrite(std::move(result));
+    }
+
+    void TDDiskActor::FinishClientWrite(TParkedWriteReply result) {
+        const auto allocationIt = DataChunkAllocationsInFlight.find({
+            result.TabletId, result.VChunkIndex});
+        if (allocationIt != DataChunkAllocationsInFlight.end()) {
+            allocationIt->second.ParkedWriteResults.push_back(std::move(result));
+            return;
+        }
+
+        const bool isOk = result.Status == NKikimrBlobStorage::NDDisk::TReplyStatus::OK;
+        std::optional<TString> errorReason;
+        if (result.ErrorMessage) {
+            errorReason.emplace(std::move(result.ErrorMessage));
+        }
+        auto reply = std::make_unique<TEvWriteResult>(result.Status, errorReason);
+        Counters.Interface.Write.Reply(isOk, result.TotalSize, result.RequestTimeMs);
+        auto h = std::make_unique<IEventHandle>(result.OriginalRequester, SelfId(), reply.release(),
+            0, result.Cookie, nullptr, result.Span.GetTraceId());
+        if (result.InterconnectSession) {
+            h->Rewrite(TEvInterconnect::EvForward, result.InterconnectSession);
+        }
+        result.Span.End();
         TActivationContext::Send(h.release());
     }
 
@@ -398,8 +521,19 @@ namespace NKikimr::NDDisk {
             return;
         }
 
-        if (!CheckPDiskReply(msg.Status, msg.ErrorReason, "Handle(TEvChunkReadRawResult)")) {
-            return;
+        if (msg.Status != NKikimrProto::OK) {
+            if (it->second.Op->IsIntegrityIo()) {
+                // Complete fallback integrity reads through the same path as an io_uring EIO.
+                // TEvIntegrityIoResult will latch Broken and fail every joined client request.
+                std::unique_ptr<TDirectIoOpBase> op = std::move(it->second.Op);
+                ReadCallbacks.erase(it);
+                op->SetResult(-EIO);
+                op.release()->OnComplete(TActorContext::ActorSystem());
+                return;
+            }
+            if (!CheckPDiskReply(msg.Status, msg.ErrorReason, "Handle(TEvChunkReadRawResult)")) {
+                return;
+            }
         }
 
         std::unique_ptr<TDirectIoOpBase> op = std::move(it->second.Op);

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_read_write.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_read_write.cpp
@@ -62,6 +62,15 @@ namespace NKikimr::NDDisk {
         const TBlockSelector selector(record.GetSelector());
         const TWriteInstruction instr(record.GetInstruction());
 
+        if (TabletChunkDeletionsInFlight.contains(creds.TabletId)) {
+            Counters.Interface.Write.Request(0);
+            Counters.Interface.Write.Reply(false);
+            SendReply(*ev, std::make_unique<TEvWriteResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::BUSY,
+                "tablet chunk deletion is in flight"));
+            return;
+        }
+
         if (instr.PayloadId) {
             const TRope& data = ev->Get()->GetPayload(*instr.PayloadId);
             auto dataIter = data.Begin();
@@ -124,10 +133,13 @@ namespace NKikimr::NDDisk {
 
         TChunkRef& chunkRef = ChunkRefs[creds.TabletId][selector.VChunkIndex];
         if (!chunkRef.PendingEventsForChunk.empty() || !chunkRef.ChunkIdx) {
-            if (chunkRef.PendingEventsForChunk.empty() && !chunkRef.ChunkIdx) {
+            // Park first: IssueChunkAllocation may place the extent synchronously from the
+            // reserve and OpenDataChunkWritePath only drains already-queued events.
+            const bool startAllocation = chunkRef.PendingEventsForChunk.empty() && !chunkRef.ChunkIdx;
+            chunkRef.PendingEventsForChunk.emplace(ev, "WaitChunkAllocation");
+            if (startAllocation) {
                 IssueChunkAllocation(creds.TabletId, selector.VChunkIndex);
             }
-            chunkRef.PendingEventsForChunk.emplace(ev, "WaitChunkAllocation");
             return;
         }
 
@@ -149,9 +161,22 @@ namespace NKikimr::NDDisk {
 
         Y_ABORT_UNLESS(data.size() == selector.Size);
 
+        // Track the written blocks (and their checksums, when supplied and block-aligned) at
+        // submission time: the protocol guarantees no reads of ranges with writes in flight.
+        {
+            std::vector<ui64> checksums;
+            if (record.ChecksumsSize() > 0 &&
+                    selector.OffsetInBytes % IntegrityUnitSize == 0 && selector.Size % IntegrityUnitSize == 0) {
+                checksums.assign(record.GetChecksums().begin(), record.GetChecksums().end());
+            }
+            IntegrityManager->OnBlocksWritten({creds.TabletId, selector.VChunkIndex},
+                selector.OffsetInBytes, selector.Size, checksums);
+        }
+
         auto offset = DiskFormat->Offset(chunkRef.ChunkIdx, 0, selector.OffsetInBytes);
 
         std::unique_ptr<TDirectIoOpBase> op = AllocateOp<TDDiskIoOp>(ev.Get());
+        static_cast<TDDiskIoOp*>(op.get())->SetChunkKey(creds.TabletId, selector.VChunkIndex);
         op->SetSpan(std::move(span));
         op->PrepareWrite(std::move(data), offset, chunkRef.ChunkIdx, selector.OffsetInBytes);
 
@@ -165,12 +190,35 @@ namespace NKikimr::NDDisk {
             {"DDiskId", DDiskId},
             {"msg", msg});
 
-        if (!CheckPDiskReply(msg.Status, msg.ErrorReason, "Handle(TEvChunkWriteRawResult)")) {
+        auto it = WriteCallbacks.find(ev->Cookie);
+        if (it == WriteCallbacks.end()) {
+            Y_ABORT_UNLESS(IsBroken());
             return;
         }
 
-        auto it = WriteCallbacks.find(ev->Cookie);
-        Y_ABORT_UNLESS(it != WriteCallbacks.end());
+        if (Y_UNLIKELY(IsBroken())) {
+            std::unique_ptr<TDirectIoOpBase> op = std::move(it->second.Op);
+            WriteCallbacks.erase(it);
+            op->SetResult(-EIO);
+            op.release()->OnComplete(TActorContext::ActorSystem());
+            return;
+        }
+
+        if (msg.Status != NKikimrProto::OK) {
+            if (it->second.Op->IsIntegrityIo()) {
+                // A fallback integrity write is a DDisk integrity failure, not a reason to enter
+                // the passive PDisk-session termination state. Finish it through the same op path
+                // as an io_uring EIO so the health latch is published before any success reply.
+                std::unique_ptr<TDirectIoOpBase> op = std::move(it->second.Op);
+                WriteCallbacks.erase(it);
+                op->SetResult(-EIO);
+                op.release()->OnComplete(TActorContext::ActorSystem());
+                return;
+            }
+            if (!CheckPDiskReply(msg.Status, msg.ErrorReason, "Handle(TEvChunkWriteRawResult)")) {
+                return;
+            }
+        }
 
         std::unique_ptr<TDirectIoOpBase> op = std::move(it->second.Op);
         WriteCallbacks.erase(it);
@@ -196,6 +244,15 @@ namespace NKikimr::NDDisk {
         const TQueryCredentials creds(record.GetCredentials());
         const TBlockSelector selector(record.GetSelector());
 
+        if (TabletChunkDeletionsInFlight.contains(creds.TabletId)) {
+            Counters.Interface.Read.Request(0);
+            Counters.Interface.Read.Reply(false);
+            SendReply(*ev, std::make_unique<TEvReadResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::BUSY,
+                "tablet chunk deletion is in flight"));
+            return;
+        }
+
         TRope result;
 
         TChunkRef& chunkRef = ChunkRefs[creds.TabletId][selector.VChunkIndex];
@@ -215,7 +272,7 @@ namespace NKikimr::NDDisk {
             .Attribute("offset_in_bytes", selector.OffsetInBytes)
             .Attribute("size", selector.Size);
 
-        if (!chunkRef.ChunkIdx) {
+        auto replyZeros = [&] {
             auto zero = TRcBuf::Uninitialized(selector.Size);
             memset(zero.GetDataMut(), 0, zero.size());
             result.Insert(result.End(), std::move(zero));
@@ -223,6 +280,21 @@ namespace NKikimr::NDDisk {
             span.End();
             SendReply(*ev, std::make_unique<TEvReadResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK, std::nullopt,
                 std::move(result)));
+        };
+
+        // No chunk allocated: the whole range was never written.
+        if (!chunkRef.ChunkIdx) {
+            replyZeros();
+            return;
+        }
+
+        // A chunk exists, but some (or all) of its blocks may never have been written: consult the
+        // integrity manager so that such blocks read as zeros rather than as whatever the reused
+        // physical chunk contains. Untracked (boot-restored) chunks yield Passthrough.
+        auto plan = IntegrityManager->MakeReadPlan({creds.TabletId, selector.VChunkIndex},
+            selector.OffsetInBytes, selector.Size);
+        if (plan.Kind == TIntegrityManager::TReadPlan::AllZero) {
+            replyZeros();
             return;
         }
 
@@ -231,8 +303,67 @@ namespace NKikimr::NDDisk {
         std::unique_ptr<TDirectIoOpBase> op = AllocateOp<TDDiskIoOp>(ev.Get());
         op->SetSpan(std::move(span));
         op->PrepareRead(selector.Size, offset, chunkRef.ChunkIdx, selector.OffsetInBytes);
+        if (plan.Kind == TIntegrityManager::TReadPlan::Mixed) {
+            // The unused blocks are zero-filled right before the reply, on the uring completion
+            // thread, so the mask travels inside the op.
+            op->SetReadUsedBlocksMask(std::move(plan.UsedBlocks));
+        }
 
         DirectUringOp(op);
+    }
+
+    void TDDiskActor::Handle(TEvPrivate::TEvDDiskIoResult::TPtr ev) {
+        auto& msg = *ev->Get();
+        auto status = msg.Status;
+        TString errorMessage = std::move(msg.ErrorMessage);
+        if (Y_UNLIKELY(IsBroken())) {
+            status = NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR;
+            errorMessage = GetBrokenReason();
+        } else if (msg.OperationType == NPDisk::TUringOperationBase::EWRITE && msg.HasChunkKey) {
+            const auto it = DataChunkAllocationsInFlight.find({msg.TabletId, msg.VChunkIndex});
+            if (it != DataChunkAllocationsInFlight.end()) {
+                it->second.ParkedWriteResults.push_back(TParkedWriteReply{
+                    .Status = status,
+                    .ErrorMessage = std::move(errorMessage),
+                    .OriginalRequester = msg.OriginalRequester,
+                    .InterconnectSession = msg.InterconnectSession,
+                    .Cookie = msg.Cookie,
+                    .Span = std::move(msg.Span),
+                    .TotalSize = msg.TotalSize,
+                    .RequestTimeMs = msg.RequestTimeMs,
+                });
+                return;
+            }
+        }
+
+        const bool isOk = status == NKikimrBlobStorage::NDDisk::TReplyStatus::OK;
+        std::optional<TString> errorReason;
+        if (errorMessage) {
+            errorReason.emplace(std::move(errorMessage));
+        }
+
+        std::unique_ptr<IEventBase> reply;
+        switch (msg.OperationType) {
+            case NPDisk::TUringOperationBase::EREAD:
+                reply = std::make_unique<TEvReadResult>(
+                    status, errorReason, isOk ? std::move(msg.Data) : TRope{});
+                Counters.Interface.Read.Reply(isOk, msg.TotalSize, msg.RequestTimeMs);
+                break;
+            case NPDisk::TUringOperationBase::EWRITE:
+                reply = std::make_unique<TEvWriteResult>(status, errorReason);
+                Counters.Interface.Write.Reply(isOk, msg.TotalSize, msg.RequestTimeMs);
+                break;
+            default:
+                Y_ABORT("Unknown OperationType");
+        }
+
+        auto h = std::make_unique<IEventHandle>(msg.OriginalRequester, SelfId(), reply.release(),
+            0, msg.Cookie, nullptr, msg.Span.GetTraceId());
+        if (msg.InterconnectSession) {
+            h->Rewrite(TEvInterconnect::EvForward, msg.InterconnectSession);
+        }
+        msg.Span.End();
+        TActivationContext::Send(h.release());
     }
 
 	void TDDiskActor::Handle(NPDisk::TEvChunkReadRawResult::TPtr ev) {
@@ -242,12 +373,23 @@ namespace NKikimr::NDDisk {
             {"DDiskId", DDiskId},
             {"msg", msg});
 
-        if (!CheckPDiskReply(msg.Status, msg.ErrorReason, "Handle(TEvChunkReadRawResult)")) {
+        auto it = ReadCallbacks.find(ev->Cookie);
+        if (it == ReadCallbacks.end()) {
+            Y_ABORT_UNLESS(IsBroken());
             return;
         }
 
-        auto it = ReadCallbacks.find(ev->Cookie);
-        Y_ABORT_UNLESS(it != ReadCallbacks.end());
+        if (Y_UNLIKELY(IsBroken())) {
+            std::unique_ptr<TDirectIoOpBase> op = std::move(it->second.Op);
+            ReadCallbacks.erase(it);
+            op->SetResult(-EIO);
+            op.release()->OnComplete(TActorContext::ActorSystem());
+            return;
+        }
+
+        if (!CheckPDiskReply(msg.Status, msg.ErrorReason, "Handle(TEvChunkReadRawResult)")) {
+            return;
+        }
 
         std::unique_ptr<TDirectIoOpBase> op = std::move(it->second.Op);
         ReadCallbacks.erase(it);
@@ -295,6 +437,25 @@ namespace NKikimr::NDDisk {
     }
 
     void TDDiskActor::DirectUringOp(std::unique_ptr<TDirectIoOpBase>& op, bool flush, bool isShort) {
+        if (Y_UNLIKELY(IsBroken())) {
+            if (isShort) {
+                switch (op->GetOperationType()) {
+                    case NPDisk::TUringOperationBase::EREAD:
+                        Counters.DirectIO.Read.Done(op->GetTotalSize());
+                        break;
+                    case NPDisk::TUringOperationBase::EWRITE:
+                        Counters.DirectIO.Write.Done(op->GetTotalSize());
+                        break;
+                    default:
+                        Y_ABORT("Unknown OperationType");
+                }
+            }
+            op->Reply(TActivationContext::ActorSystem(),
+                NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR, GetBrokenReason());
+            op.reset();
+            return;
+        }
+
         if (Y_LIKELY(!isShort)) {
             switch (op->GetOperationType()) {
             case NPDisk::TUringOperationBase::EREAD:
@@ -383,6 +544,15 @@ namespace NKikimr::NDDisk {
     void TDDiskActor::ProcessIoSubmitQueue() {
 #if defined(__linux__)
         Y_ABORT_UNLESS(UringRouter);
+
+        if (Y_UNLIKELY(IsBroken())) {
+            while (!DirectIoQueue.empty()) {
+                auto op = std::move(DirectIoQueue.front());
+                DirectIoQueue.pop();
+                FailDirectIoOp(std::move(op), false);
+            }
+            return;
+        }
 
         while (!DirectIoQueue.empty()) {
             auto& op = DirectIoQueue.front();

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_read_write.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_read_write.cpp
@@ -180,6 +180,7 @@ namespace NKikimr::NDDisk {
         op->SetSpan(std::move(span));
         op->PrepareWrite(std::move(data), offset, chunkRef.ChunkIdx, selector.OffsetInBytes);
 
+        ++chunkRef.InFlightDataIo;
         DirectUringOp(op);
     }
 
@@ -301,6 +302,7 @@ namespace NKikimr::NDDisk {
         auto offset = DiskFormat->Offset(chunkRef.ChunkIdx, 0, selector.OffsetInBytes);
 
         std::unique_ptr<TDirectIoOpBase> op = AllocateOp<TDDiskIoOp>(ev.Get());
+        static_cast<TDDiskIoOp*>(op.get())->SetChunkKey(creds.TabletId, selector.VChunkIndex);
         op->SetSpan(std::move(span));
         op->PrepareRead(selector.Size, offset, chunkRef.ChunkIdx, selector.OffsetInBytes);
         if (plan.Kind == TIntegrityManager::TReadPlan::Mixed) {
@@ -309,11 +311,20 @@ namespace NKikimr::NDDisk {
             op->SetReadUsedBlocksMask(std::move(plan.UsedBlocks));
         }
 
+        ++chunkRef.InFlightDataIo;
         DirectUringOp(op);
     }
 
     void TDDiskActor::Handle(TEvPrivate::TEvDDiskIoResult::TPtr ev) {
         auto& msg = *ev->Get();
+        Y_ABORT_UNLESS(msg.HasChunkKey);
+        const auto tabletIt = ChunkRefs.find(msg.TabletId);
+        Y_ABORT_UNLESS(tabletIt != ChunkRefs.end());
+        const auto chunkIt = tabletIt->second.find(msg.VChunkIndex);
+        Y_ABORT_UNLESS(chunkIt != tabletIt->second.end());
+        Y_ABORT_UNLESS(chunkIt->second.InFlightDataIo > 0);
+        --chunkIt->second.InFlightDataIo;
+
         auto status = msg.Status;
         TString errorMessage = std::move(msg.ErrorMessage);
         if (Y_UNLIKELY(IsBroken())) {

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_sync.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_sync.cpp
@@ -128,10 +128,10 @@ namespace NKikimr::NDDisk {
         sync.Requests.reserve(segmentCount);
 
         auto validateSelector = [&](const TBlockSelector& selector, TStringBuf selectorName) {
-            if (selector.OffsetInBytes % DiskFormat->SectorSize || selector.Size % DiskFormat->SectorSize || !selector.Size) {
+            if (selector.OffsetInBytes % IntegrityUnitSize || selector.Size % IntegrityUnitSize || !selector.Size) {
                 reject(NKikimrBlobStorage::NDDisk::TReplyStatus::INCORRECT_REQUEST,
                     TStringBuilder() << selectorName
-                        << " offset and size must be multiple of sector size and size must be nonzero");
+                        << " offset and size must be multiple of the 4 KiB integrity unit and size must be nonzero");
                 return false;
             }
 
@@ -307,6 +307,34 @@ namespace NKikimr::NDDisk {
             return;
         }
 
+        TRope data = ev->Get()->GetPayload(0);
+        if (!HasRequiredBlockChecksums(record.ChecksumsSize(),
+                request.Selector.OffsetInBytes, request.Selector.Size)) {
+            SyncReadCookiesInFlight.erase(ev->Cookie);
+            request.Status = NKikimrBlobStorage::NDDisk::TReplyStatus::INCORRECT_REQUEST;
+            request.ErrorReason << "source read must return one checksum per aligned 4 KiB block";
+            sync.ErrorReason << "[request_idx=" << ev->Cookie - sync.FirstRequestId
+                << "] source read has no complete checksum list; ";
+            if (--sync.RequestsInFlight == 0) {
+                MaybeReplySync(it);
+            }
+            return;
+        }
+        if (const auto validation = ValidatePayloadChecksums(record, data)) {
+            SyncReadCookiesInFlight.erase(ev->Cookie);
+            request.Status = validation->Status;
+            request.ErrorReason << validation->ErrorReason;
+            sync.ErrorReason << "[request_idx=" << ev->Cookie - sync.FirstRequestId
+                << "] source payload checksum mismatch; ";
+            if (validation->Status == NKikimrBlobStorage::NDDisk::TReplyStatus::CORRUPTED) {
+                Counters.Checksums.ChecksumMismatch->Inc();
+            }
+            if (--sync.RequestsInFlight == 0) {
+                MaybeReplySync(it);
+            }
+            return;
+        }
+
         TChunkRef& chunkRef = ChunkRefs[sync.Creds.TabletId][sync.VChunkIndex];
         if (!chunkRef.PendingEventsForChunk.empty() || !chunkRef.ChunkIdx) {
             // Park first: IssueChunkAllocation may place the extent synchronously from the
@@ -319,12 +347,16 @@ namespace NKikimr::NDDisk {
             return;
         }
 
+        if (chunkRef.IntegrityExtentWriteInFlight) {
+            chunkRef.PendingSerializedWrites.emplace(ev, "WaitIntegrityExtentWrite");
+            return;
+        }
+        chunkRef.IntegrityExtentWriteInFlight = true;
+
         std::vector<TSegmentManager::TSegment> segments;
         SegmentManager.PopRequest(ev->Cookie, &segments);
         SyncReadCookiesInFlight.erase(ev->Cookie);
         Y_VERIFY(segments.size());
-
-        TRope data = ev->Get()->GetPayload(0);
 
         std::sort(segments.begin(), segments.end());
         ui64 cuttedFromData = request.Selector.OffsetInBytes;
@@ -347,23 +379,28 @@ namespace NKikimr::NDDisk {
             data.ExtractFront(end - begin, &segmentData);
             cuttedFromData = end;
 
-            // Track the written blocks at submission time. The source read result may carry
-            // per-4KiB-block checksums of the whole requested range; slice out this segment's part.
-            {
-                std::vector<ui64> segmentChecksums;
-                const ui64 selectorOffset = request.Selector.OffsetInBytes;
-                if (record.ChecksumsSize() > 0 &&
-                        static_cast<ui64>(record.ChecksumsSize()) * IntegrityUnitSize == request.Selector.Size &&
-                        selectorOffset % IntegrityUnitSize == 0 &&
-                        begin % IntegrityUnitSize == 0 && end % IntegrityUnitSize == 0) {
-                    const auto& checksums = record.GetChecksums();
-                    const size_t first = (begin - selectorOffset) / IntegrityUnitSize;
-                    const size_t count = (end - begin) / IntegrityUnitSize;
-                    segmentChecksums.assign(checksums.begin() + first, checksums.begin() + first + count);
-                }
-                IntegrityManager->OnBlocksWritten({sync.Creds.TabletId, sync.VChunkIndex},
-                    static_cast<ui32>(begin), static_cast<ui32>(end - begin), segmentChecksums);
-            }
+            std::vector<ui64> segmentChecksums;
+            const ui64 selectorOffset = request.Selector.OffsetInBytes;
+            Y_ABORT_UNLESS(selectorOffset % IntegrityUnitSize == 0
+                && begin % IntegrityUnitSize == 0 && end % IntegrityUnitSize == 0);
+            const auto& checksums = record.GetChecksums();
+            const size_t first = (begin - selectorOffset) / IntegrityUnitSize;
+            const size_t count = (end - begin) / IntegrityUnitSize;
+            segmentChecksums.assign(checksums.begin() + first, checksums.begin() + first + count);
+            const ui64 integrityOperationId = IntegrityManager->BeginBlocksWrite(
+                {sync.Creds.TabletId, sync.VChunkIndex}, static_cast<ui32>(begin),
+                static_cast<ui32>(end - begin), segmentChecksums);
+            const bool inserted = PendingSyncSegments.emplace(integrityOperationId, TPendingSyncSegment{
+                .SyncId = syncId,
+                .RequestId = ev->Cookie,
+                .Begin = begin,
+                .End = end,
+            }).second;
+            Y_ABORT_UNLESS(inserted);
+            // Keep metadata ahead of data on both uring and PDisk-fallback paths. The client still
+            // waits for both completions, but fallback consumers cannot strand a later pair write
+            // while waiting for the sync result.
+            DrainIntegrityManager();
 
             auto diskOffset = DiskFormat->Offset(chunkRef.ChunkIdx, 0, begin);
             std::unique_ptr<TDirectIoOpBase> op = AllocateOp<TInternalSyncWriteOp>();
@@ -371,6 +408,7 @@ namespace NKikimr::NDDisk {
             syncWriteOp->SetSyncId(syncId);
             syncWriteOp->SetRequestId(ev->Cookie);
             syncWriteOp->SetSegment(begin, end);
+            syncWriteOp->SetIntegrityOperationId(integrityOperationId);
             syncWriteOp->PrepareWrite(std::move(segmentData), diskOffset, chunkRef.ChunkIdx, begin);
 
             DirectUringOp(op);
@@ -386,36 +424,59 @@ namespace NKikimr::NDDisk {
     }
 
     void TDDiskActor::Handle(TEvPrivate::TEvInternalSyncWriteResult::TPtr ev) {
-        auto it = SyncsInFlight.find(ev->Get()->SyncId);
+        const auto segmentIt = PendingSyncSegments.find(ev->Get()->IntegrityOperationId);
+        if (segmentIt == PendingSyncSegments.end()) {
+            return;
+        }
+        segmentIt->second.DataCompleted = true;
+        segmentIt->second.DataStatus = ev->Get()->Status;
+        segmentIt->second.DataError = std::move(ev->Get()->ErrorMessage);
+        MaybeFinishSyncSegment(ev->Get()->IntegrityOperationId);
+    }
+
+    void TDDiskActor::MaybeFinishSyncSegment(ui64 integrityOperationId) {
+        const auto segmentIt = PendingSyncSegments.find(integrityOperationId);
+        if (segmentIt == PendingSyncSegments.end() || !segmentIt->second.DataCompleted
+                || !segmentIt->second.IntegrityCompleted) {
+            return;
+        }
+        TPendingSyncSegment segment = std::move(segmentIt->second);
+        PendingSyncSegments.erase(segmentIt);
+
+        auto it = SyncsInFlight.find(segment.SyncId);
         if (it == SyncsInFlight.end()) {
             return;
         }
         auto& sync = it->second;
 
-        const ui64 requestId = ev->Get()->RequestId;
+        const ui64 requestId = segment.RequestId;
         if (requestId < sync.FirstRequestId || requestId >= sync.FirstRequestId + sync.Requests.size()) {
             return;
         }
         auto& request = sync.Requests[requestId - sync.FirstRequestId];
 
-        if (request.Status != NKikimrBlobStorage::NDDisk::TReplyStatus::UNKNOWN) {
-            return;
+        NKikimrBlobStorage::NDDisk::TReplyStatus::E status = segment.DataStatus;
+        TString errorReason = std::move(segment.DataError);
+        if (status == NKikimrBlobStorage::NDDisk::TReplyStatus::OK
+                && segment.IntegrityStatus == TIntegrityManager::EOperationStatus::Corrupted) {
+            status = NKikimrBlobStorage::NDDisk::TReplyStatus::CORRUPTED;
+            errorReason = std::move(segment.IntegrityError);
         }
 
-        const ui64 begin = ev->Get()->SegmentBegin;
-        const ui64 end = ev->Get()->SegmentEnd;
-        if (ev->Get()->Status != NKikimrBlobStorage::NDDisk::TReplyStatus::OK) {
-            request.Status = NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR;
-            request.ErrorReason << "[" << begin << ";" << end << ") failed to write; reason: " << ev->Get()->ErrorMessage << "; ";
+        if (status != NKikimrBlobStorage::NDDisk::TReplyStatus::OK
+                && request.Status == NKikimrBlobStorage::NDDisk::TReplyStatus::UNKNOWN) {
+            request.Status = status;
+            request.ErrorReason << "[" << segment.Begin << ";" << segment.End
+                << ") failed to write; reason: " << errorReason << "; ";
             sync.ErrorReason << "[request_idx=" << requestId - sync.FirstRequestId << "] failed to write; ";
-            if (--sync.RequestsInFlight == 0) {
-                MaybeReplySync(it);
-            }
-            return;
         }
 
+        Y_ABORT_UNLESS(request.SegmentsInFlight > 0);
         if (--request.SegmentsInFlight == 0) {
-            request.Status = NKikimrBlobStorage::NDDisk::TReplyStatus::OK;
+            if (request.Status == NKikimrBlobStorage::NDDisk::TReplyStatus::UNKNOWN) {
+                request.Status = NKikimrBlobStorage::NDDisk::TReplyStatus::OK;
+            }
+            ReleaseIntegrityExtentWrite(sync.Creds.TabletId, sync.VChunkIndex);
             if (--sync.RequestsInFlight == 0) {
                 MaybeReplySync(it);
             }

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_sync.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_sync.cpp
@@ -24,6 +24,14 @@ namespace NKikimr::NDDisk {
         TSyncIt syncIt = SyncsInFlight.end();
         counters.Request(0);
 
+        if (TabletChunkDeletionsInFlight.contains(creds.TabletId)) {
+            counters.Reply(false);
+            SendReply(*ev, std::make_unique<TEvSyncResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::BUSY,
+                "tablet chunk deletion is in flight"));
+            return;
+        }
+
         auto cleanupSyncState = [&] {
             if (syncIt == SyncsInFlight.end()) {
                 return;
@@ -195,7 +203,7 @@ namespace NKikimr::NDDisk {
                     const auto prevStatus = std::exchange(request.Status, NKikimrBlobStorage::NDDisk::TReplyStatus::OUTDATED);
                     if (prevStatus == NKikimrBlobStorage::NDDisk::TReplyStatus::UNKNOWN) {
                         if (--outdatedSync.RequestsInFlight == 0) {
-                            ReplySync(outdatedIt);
+                            MaybeReplySync(outdatedIt);
                         }
                     }
                 }
@@ -294,17 +302,20 @@ namespace NKikimr::NDDisk {
                 {"status", static_cast<int>(record.GetStatus())},
                 {"errorReason", record.GetErrorReason()});
             if (--sync.RequestsInFlight == 0) {
-                ReplySync(it);
+                MaybeReplySync(it);
             }
             return;
         }
 
         TChunkRef& chunkRef = ChunkRefs[sync.Creds.TabletId][sync.VChunkIndex];
         if (!chunkRef.PendingEventsForChunk.empty() || !chunkRef.ChunkIdx) {
-            if (chunkRef.PendingEventsForChunk.empty() && !chunkRef.ChunkIdx) {
+            // Park first: IssueChunkAllocation may place the extent synchronously from the
+            // reserve and OpenDataChunkWritePath only drains already-queued events.
+            const bool startAllocation = chunkRef.PendingEventsForChunk.empty() && !chunkRef.ChunkIdx;
+            chunkRef.PendingEventsForChunk.emplace(ev, "WaitChunkAllocation");
+            if (startAllocation) {
                 IssueChunkAllocation(sync.Creds.TabletId, sync.VChunkIndex);
             }
-            chunkRef.PendingEventsForChunk.emplace(ev, "WaitChunkAllocation");
             return;
         }
 
@@ -335,6 +346,24 @@ namespace NKikimr::NDDisk {
             TRope segmentData;
             data.ExtractFront(end - begin, &segmentData);
             cuttedFromData = end;
+
+            // Track the written blocks at submission time. The source read result may carry
+            // per-4KiB-block checksums of the whole requested range; slice out this segment's part.
+            {
+                std::vector<ui64> segmentChecksums;
+                const ui64 selectorOffset = request.Selector.OffsetInBytes;
+                if (record.ChecksumsSize() > 0 &&
+                        static_cast<ui64>(record.ChecksumsSize()) * IntegrityUnitSize == request.Selector.Size &&
+                        selectorOffset % IntegrityUnitSize == 0 &&
+                        begin % IntegrityUnitSize == 0 && end % IntegrityUnitSize == 0) {
+                    const auto& checksums = record.GetChecksums();
+                    const size_t first = (begin - selectorOffset) / IntegrityUnitSize;
+                    const size_t count = (end - begin) / IntegrityUnitSize;
+                    segmentChecksums.assign(checksums.begin() + first, checksums.begin() + first + count);
+                }
+                IntegrityManager->OnBlocksWritten({sync.Creds.TabletId, sync.VChunkIndex},
+                    static_cast<ui32>(begin), static_cast<ui32>(end - begin), segmentChecksums);
+            }
 
             auto diskOffset = DiskFormat->Offset(chunkRef.ChunkIdx, 0, begin);
             std::unique_ptr<TDirectIoOpBase> op = AllocateOp<TInternalSyncWriteOp>();
@@ -380,7 +409,7 @@ namespace NKikimr::NDDisk {
             request.ErrorReason << "[" << begin << ";" << end << ") failed to write; reason: " << ev->Get()->ErrorMessage << "; ";
             sync.ErrorReason << "[request_idx=" << requestId - sync.FirstRequestId << "] failed to write; ";
             if (--sync.RequestsInFlight == 0) {
-                ReplySync(it);
+                MaybeReplySync(it);
             }
             return;
         }
@@ -388,7 +417,7 @@ namespace NKikimr::NDDisk {
         if (--request.SegmentsInFlight == 0) {
             request.Status = NKikimrBlobStorage::NDDisk::TReplyStatus::OK;
             if (--sync.RequestsInFlight == 0) {
-                ReplySync(it);
+                MaybeReplySync(it);
             }
         }
     }
@@ -422,5 +451,17 @@ namespace NKikimr::NDDisk {
         sync.Span.End();
         TActivationContext::Send(h.release());
         SyncsInFlight.erase(it);
+    }
+
+    void TDDiskActor::MaybeReplySync(TSyncIt it) {
+        Y_VERIFY(it != SyncsInFlight.end());
+        const ui64 syncId = it->first;
+        auto& sync = it->second;
+        const auto allocIt = DataChunkAllocationsInFlight.find({sync.Creds.TabletId, sync.VChunkIndex});
+        if (allocIt != DataChunkAllocationsInFlight.end()) {
+            allocIt->second.ParkedSyncIds.push_back(syncId);
+            return;
+        }
+        ReplySync(it);
     }
 }

--- a/ydb/core/blobstorage/ddisk/ddisk_checksums.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_checksums.cpp
@@ -5,6 +5,9 @@
 #define XXH_INLINE_ALL
 #include <contrib/libs/xxhash/xxhash.h>
 
+#include <array>
+#include <cstddef>
+
 namespace NKikimr::NDDisk {
 
 ui64 CalculateBlockChecksum(TRope::TConstIterator it, size_t numBytes) {
@@ -50,6 +53,31 @@ ui64 CalculateRawChecksum(const void* data, size_t size) {
     return XXH3_64bits(data, size);
 }
 
+namespace {
+
+// XXH3_64 over [data, data+size) with [fieldOffset, fieldOffset+fieldSize) hashed as zeros.
+// Used so integrity-block self-checksums can be verified without copying the 4 KiB block.
+ui64 CalculateRawChecksumZeroedField(const void* data, size_t size, size_t fieldOffset, size_t fieldSize) {
+    Y_ABORT_UNLESS(fieldOffset + fieldSize <= size);
+    const char* bytes = static_cast<const char*>(data);
+
+    XXH3_state_t state;
+    XXH3_64bits_reset(&state);
+    if (fieldOffset) {
+        XXH3_64bits_update(&state, bytes, fieldOffset);
+    }
+    ui8 zeros[16] = {};
+    Y_ABORT_UNLESS(fieldSize <= sizeof(zeros));
+    XXH3_64bits_update(&state, zeros, fieldSize);
+    const size_t tailOffset = fieldOffset + fieldSize;
+    if (tailOffset < size) {
+        XXH3_64bits_update(&state, bytes + tailOffset, size - tailOffset);
+    }
+    return XXH3_64bits_digest(&state);
+}
+
+} // anonymous
+
 ui64 Contribution(ui64 vchunkGeneration, ui64 blockIdx, ui64 blockChecksum) {
     ui64 parts[3] = {vchunkGeneration, blockIdx, blockChecksum};
     return XXH3_64bits(parts, sizeof(parts));
@@ -58,6 +86,63 @@ ui64 Contribution(ui64 vchunkGeneration, ui64 blockIdx, ui64 blockChecksum) {
 void UpdateRoot(ui64& integrityBlockDigest, ui64 vchunkGeneration, ui64 idx, ui64 oldCsum, ui64 newCsum) {
     integrityBlockDigest ^= Contribution(vchunkGeneration, idx, oldCsum);
     integrityBlockDigest ^= Contribution(vchunkGeneration, idx, newCsum);
+}
+
+ui64 CalculateChecksumIdentitySalt(ui64 ddiskId, ui64 pdiskGuid, ui64 tabletId,
+        ui64 vChunkIndex, ui64 blockIdx) {
+    const ui64 parts[] = {ddiskId, pdiskGuid, tabletId, vChunkIndex, blockIdx};
+    return XXH3_64bits(parts, sizeof(parts));
+}
+
+ui64 SealBlockChecksum(ui64 pureChecksum, ui64 ddiskId, ui64 pdiskGuid, ui64 tabletId,
+        ui64 vChunkIndex, ui64 blockIdx) {
+    return pureChecksum
+        ^ CalculateChecksumIdentitySalt(ddiskId, pdiskGuid, tabletId, vChunkIndex, blockIdx);
+}
+
+ui64 UnsealBlockChecksum(ui64 storedChecksum, ui64 ddiskId, ui64 pdiskGuid, ui64 tabletId,
+        ui64 vChunkIndex, ui64 blockIdx) {
+    return SealBlockChecksum(storedChecksum, ddiskId, pdiskGuid, tabletId, vChunkIndex, blockIdx);
+}
+
+ui64 GetZeroBlockChecksum() {
+    static const ui64 checksum = [] {
+        const std::array<ui8, IntegrityUnitSize> zero{};
+        return XXH3_64bits(zero.data(), zero.size());
+    }();
+    return checksum;
+}
+
+bool ValidateIntegrityBlock(const TIntegrityBlock& block, const TIntegrityBlockIdentity& expected) {
+    const ui64 expectedChecksum = CalculateRawChecksumZeroedField(
+        &block, sizeof(block), offsetof(TIntegrityBlockHeader, BlockChecksum), sizeof(block.Header.BlockChecksum));
+    if (block.Header.BlockChecksum != expectedChecksum) {
+        return false;
+    }
+
+    const TIntegrityBlockHeader& header = block.Header;
+    return header.Magic == MagicIntegrityBlock
+        && header.FormatVersion == static_cast<ui16>(EIntegrityFormatVersion::BaseAwupf4KiB)
+        && header.ChecksumBlockIdx == expected.ChecksumBlockIdx
+        && header.OwnerId == expected.OwnerId
+        && header.VChunkId == expected.VChunkId
+        && header.VChunkGeneration == expected.VChunkGeneration
+        && header.IntegrityChunkId == expected.IntegrityChunkId
+        && header.IntegrityExtentId == expected.IntegrityExtentId
+        && header.IntegrityChunkGeneration == expected.IntegrityChunkGeneration;
+}
+
+i32 SelectIntegrityBlockWinner(const TIntegrityBlock (&slots)[IntegrityPairSlots],
+        const TIntegrityBlockIdentity& expected) {
+    const bool validA = ValidateIntegrityBlock(slots[0], expected);
+    const bool validB = ValidateIntegrityBlock(slots[1], expected);
+    if (!validA) {
+        return validB ? 1 : -1;
+    }
+    if (!validB) {
+        return 0;
+    }
+    return slots[1].Header.PairSequenceNumber >= slots[0].Header.PairSequenceNumber ? 1 : 0;
 }
 
 } // namespace NKikimr::NDDisk

--- a/ydb/core/blobstorage/ddisk/ddisk_checksums.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_checksums.cpp
@@ -46,6 +46,10 @@ std::vector<ui64> CalculatePayloadChecksums(const TRope& payload) {
     return checksums;
 }
 
+ui64 CalculateRawChecksum(const void* data, size_t size) {
+    return XXH3_64bits(data, size);
+}
+
 ui64 Contribution(ui64 vchunkGeneration, ui64 blockIdx, ui64 blockChecksum) {
     ui64 parts[3] = {vchunkGeneration, blockIdx, blockChecksum};
     return XXH3_64bits(parts, sizeof(parts));

--- a/ydb/core/blobstorage/ddisk/ddisk_checksums.h
+++ b/ydb/core/blobstorage/ddisk/ddisk_checksums.h
@@ -11,6 +11,7 @@ namespace NKikimr::NDDisk {
 // Checksum unit size (4 KiB), independent of LBA format. Matches MinSectorSize / DataAlignment.
 constexpr size_t IntegrityUnitSize = 4096;
 constexpr size_t IntegritySubBlockSize = 512;
+constexpr ui32 IntegrityPairSlots = 2;
 
 // DataChunk / IntegrityChunk are PDisk chunks whose size comes from the PDisk format at runtime.
 // IntegrityChunk reserves a fixed 128 KiB region at the front for its own metadata
@@ -46,6 +47,19 @@ std::vector<ui64> CalculatePayloadChecksums(const TRope& payload);
 // XORs in the new one.
 ui64 Contribution(ui64 vchunkGeneration, ui64 blockIdx, ui64 blockChecksum);
 void UpdateRoot(ui64& integrityBlockDigest, ui64 vchunkGeneration, ui64 idx, ui64 oldCsum, ui64 newCsum);
+
+// On-disk checksums are salted with their logical identity. The wire protocol and the in-memory
+// cache always carry pure XXH3_64(data) values; sealing/unsealing happens only at the integrity
+// block boundary. XOR makes the operation reversible without recomputing data checksums.
+ui64 CalculateChecksumIdentitySalt(ui64 ddiskId, ui64 pdiskGuid, ui64 tabletId,
+    ui64 vChunkIndex, ui64 blockIdx);
+ui64 SealBlockChecksum(ui64 pureChecksum, ui64 ddiskId, ui64 pdiskGuid, ui64 tabletId,
+    ui64 vChunkIndex, ui64 blockIdx);
+ui64 UnsealBlockChecksum(ui64 storedChecksum, ui64 ddiskId, ui64 pdiskGuid, ui64 tabletId,
+    ui64 vChunkIndex, ui64 blockIdx);
+
+// Pure checksum returned for a never-written data block.
+ui64 GetZeroBlockChecksum();
 
 #pragma pack(push, 1)
 
@@ -91,6 +105,25 @@ struct TIntegrityBlock {
 
 static_assert(sizeof(TIntegrityBlock) == IntegrityUnitSize);
 
+struct TIntegrityBlockIdentity {
+    ui64 OwnerId = 0;
+    ui64 VChunkId = 0;
+    ui64 VChunkGeneration = 0;
+    ui64 IntegrityChunkId = 0;
+    ui64 IntegrityExtentId = 0;
+    ui64 IntegrityChunkGeneration = 0;
+    ui32 ChecksumBlockIdx = 0;
+};
+
+// Validates a single slot without trusting any of its fields first. The self-checksum is checked
+// before identity/generation fields are used for winner selection.
+bool ValidateIntegrityBlock(const TIntegrityBlock& block, const TIntegrityBlockIdentity& expected);
+
+// Returns the winning slot index (0 for A, 1 for B), or -1 when neither slot is valid. A valid
+// slot with the larger PairSequenceNumber wins; equal sequence numbers deterministically prefer B.
+i32 SelectIntegrityBlockWinner(const TIntegrityBlock (&slots)[IntegrityPairSlots],
+    const TIntegrityBlockIdentity& expected);
+
 struct TIntegritySubBlockHeader {
     ui64 Magic;
     ui64 SubBlockChecksum; // XXH3_64 over this 512 B sub-block with this field zeroed
@@ -129,7 +162,6 @@ static_assert(sizeof(TIntegritySubBlock) == IntegritySubBlockSize);
 
 // On disk every TIntegrityBlock lives in a ping-pong pair of adjacent 4 KiB slots (A/B, read
 // together as one 8 KiB I/O; never rewritten in place because we do not rely on AWUPF).
-constexpr ui32 IntegrityPairSlots = 2;
 
 struct TIntegrityChunkHeader {
     ui64 Magic;

--- a/ydb/core/blobstorage/ddisk/ddisk_checksums.h
+++ b/ydb/core/blobstorage/ddisk/ddisk_checksums.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "defs.h"
-
 #include <ydb/library/actors/util/rope.h>
+
+#include <util/generic/size_literals.h>
 
 #include <vector>
 
@@ -12,11 +12,10 @@ namespace NKikimr::NDDisk {
 constexpr size_t IntegrityUnitSize = 4096;
 constexpr size_t IntegritySubBlockSize = 512;
 
-// DataChunk / IntegrityChunk are PDisk chunks (default 128 MiB). IntegrityChunk reserves
-// 128 KiB at the front for its own metadata (TIntegrityChunkHeader replicas, etc.).
-constexpr size_t IntegrityChunkSize = 128_MB;
+// DataChunk / IntegrityChunk are PDisk chunks whose size comes from the PDisk format at runtime.
+// IntegrityChunk reserves a fixed 128 KiB region at the front for its own metadata
+// (TIntegrityChunkHeader replicas, etc.).
 constexpr size_t IntegrityChunkHeaderRegionSize = 128_KB;
-constexpr ui32 DataBlocksPerChunk = IntegrityChunkSize / IntegrityUnitSize;
 
 // Placeholder magics (PDisk-style unique values); not yet finalized for production format.
 constexpr ui64 MagicIntegrityBlock = 0x1B71E6A7B10C4E55ull;
@@ -32,6 +31,11 @@ enum class EIntegrityFormatVersion : ui16 {
 // value, so the caller's own iterator is not advanced. This is a raw data checksum with no identity
 // or salt mixed in.
 ui64 CalculateBlockChecksum(TRope::TConstIterator it, size_t numBytes);
+
+// Raw XXH3-64 over a contiguous buffer. Unlike the TRope variant above there are no alignment or
+// size restrictions; used for self-checksums of integrity metadata blocks (BlockChecksum /
+// HeaderChecksum fields computed with the field itself zeroed).
+ui64 CalculateRawChecksum(const void* data, size_t size);
 
 // Splits payload into IntegrityUnitSize (4 KiB) blocks and computes a checksum for each block, in order.
 // payload.size() must be a non-zero multiple of IntegrityUnitSize (same as MinSectorSize).
@@ -64,16 +68,21 @@ struct TIntegrityBlockHeader {
 
     ui64 IntegrityBlockDigest; // Incremental checksum of data block checksums
 
-    ui8 UsedBlocksBitmap[2]; // which of 500 blocks are used
-    ui8 Reserved[14]; // pad so packed sizeof == 96
+    ui64 PairSequenceNumber; // per-pair monotonic sequence number (ping-pong slots): write max(seqA, seqB) + 1
+
+    ui8 UsedBlocksBitmap[62]; // 496 bits: which of the covered data blocks are used (492 in base format)
+    ui8 Reserved[10]; // pad so packed sizeof == 160
 };
 
-static_assert(sizeof(TIntegrityBlockHeader) == 96);
+static_assert(sizeof(TIntegrityBlockHeader) == 160);
 
 // Base format (AWUPF >= 4 KiB): how many data-block checksums fit after the header in one unit.
 constexpr ui32 ChecksumsPerIntegrityBlock =
     (IntegrityUnitSize - sizeof(TIntegrityBlockHeader)) / sizeof(ui64);
-static_assert(ChecksumsPerIntegrityBlock == 500);
+static_assert(ChecksumsPerIntegrityBlock == 492);
+
+// The bitmap must have a bit for every checksum slot of the block.
+static_assert(sizeof(TIntegrityBlockHeader::UsedBlocksBitmap) * 8 >= ChecksumsPerIntegrityBlock);
 
 struct TIntegrityBlock {
     TIntegrityBlockHeader Header;
@@ -104,12 +113,12 @@ static_assert(ChecksumsPerIntegritySubBlock == 60);
 
 constexpr ui32 ChecksumsInIntegrityBlockHeaderSubBlock =
     (IntegritySubBlockSize - sizeof(TIntegrityBlockHeader)) / sizeof(ui64);
-static_assert(ChecksumsInIntegrityBlockHeaderSubBlock == 52);
+static_assert(ChecksumsInIntegrityBlockHeaderSubBlock == 44);
 
 constexpr ui32 ChecksumsPerIntegrityBlockAwupf512 =
     ChecksumsInIntegrityBlockHeaderSubBlock
     + (IntegritySubBlocksPerBlock - 1) * ChecksumsPerIntegritySubBlock;
-static_assert(ChecksumsPerIntegrityBlockAwupf512 == 472);
+static_assert(ChecksumsPerIntegrityBlockAwupf512 == 464);
 
 struct TIntegritySubBlock {
     TIntegritySubBlockHeader Header;
@@ -118,25 +127,9 @@ struct TIntegritySubBlock {
 
 static_assert(sizeof(TIntegritySubBlock) == IntegritySubBlockSize);
 
-// IntegrityExtent covers one DataChunk: ceil(data blocks / checksums per integrity block).
-constexpr ui32 IntegrityBlocksPerExtent =
-    (DataBlocksPerChunk + ChecksumsPerIntegrityBlock - 1) / ChecksumsPerIntegrityBlock;
-static_assert(IntegrityBlocksPerExtent == 66);
-
-constexpr ui32 IntegrityBlocksPerExtentAwupf512 =
-    (DataBlocksPerChunk + ChecksumsPerIntegrityBlockAwupf512 - 1) / ChecksumsPerIntegrityBlockAwupf512;
-static_assert(IntegrityBlocksPerExtentAwupf512 == 70);
-
-constexpr size_t IntegrityExtentSize = IntegrityBlocksPerExtent * IntegrityUnitSize;
-constexpr size_t IntegrityExtentSizeAwupf512 = IntegrityBlocksPerExtentAwupf512 * IntegrityUnitSize;
-
-constexpr ui32 IntegrityExtentsPerChunk =
-    (IntegrityChunkSize - IntegrityChunkHeaderRegionSize) / IntegrityExtentSize;
-static_assert(IntegrityExtentsPerChunk == 496);
-
-constexpr ui32 IntegrityExtentsPerChunkAwupf512 =
-    (IntegrityChunkSize - IntegrityChunkHeaderRegionSize) / IntegrityExtentSizeAwupf512;
-static_assert(IntegrityExtentsPerChunkAwupf512 == 467);
+// On disk every TIntegrityBlock lives in a ping-pong pair of adjacent 4 KiB slots (A/B, read
+// together as one 8 KiB I/O; never rewritten in place because we do not rely on AWUPF).
+constexpr ui32 IntegrityPairSlots = 2;
 
 struct TIntegrityChunkHeader {
     ui64 Magic;
@@ -160,7 +153,5 @@ struct TIntegrityChunkHeader {
 static_assert(sizeof(TIntegrityChunkHeader) == IntegrityUnitSize);
 
 #pragma pack(pop)
-
-static_assert(DataBlocksPerChunk == 32768);
 
 } // namespace NKikimr::NDDisk

--- a/ydb/core/blobstorage/ddisk/ddisk_config.h
+++ b/ydb/core/blobstorage/ddisk/ddisk_config.h
@@ -1,11 +1,17 @@
 #pragma once
 
+#include <util/system/types.h>
+
 namespace NKikimr::NDDisk {
 
 struct TDDiskConfig {
     bool UseSQPoll = false;
     bool UseIOPoll = false;
     bool ForcePDiskFallback = false;
+    // Bounds the memory TIntegrityManager spends on cached data block checksums / digests
+    // (see the memory note in integrity_manager.h). Must match
+    // TIntegrityManager::DefaultChecksumCacheBytes by default.
+    ui64 IntegrityChecksumCacheBytes = 64ull << 20;
 };
 
 } // NKikimr::NDDisk

--- a/ydb/core/blobstorage/ddisk/direct_io_op.cpp
+++ b/ydb/core/blobstorage/ddisk/direct_io_op.cpp
@@ -84,6 +84,16 @@ void TDDiskActor::TDirectIoOpBase::OnComplete(NActors::TActorSystem* actorSystem
         bytesProcessed = static_cast<ui32>(result);
     }
 
+    // EAGAIN/ENOMEM/ENOSPC on integrity I/O must not brick the DDisk: retry the same op
+    // (buffers still owned here) through the short-I/O path. Defer Done() until the retry
+    // completes or a hard error is reported.
+    if (Y_UNLIKELY(result < 0 && IsIntegrityIo()
+            && UringErrorToStatus(result, opType) == TReplyStatus::OVERLOADED)) {
+        auto ev = std::make_unique<TDDiskActor::TEvPrivate::TEvShortIO>(std::move(guard));
+        actorSystem->Send(new IEventHandle(DDiskId, {}, ev.release()));
+        return;
+    }
+
     if (result < 0 || bytesProcessed == operationBytes) {
         switch (opType) {
         case TUringOperationBase::EREAD:
@@ -299,7 +309,8 @@ void TDDiskActor::TDDiskIoOp::Reply(NActors::TActorSystem* actorSystem, TReplySt
     actorSystem->Send(DDiskId, new TEvPrivate::TEvDDiskIoResult(
         GetOperationType(), status, std::move(reason), std::move(data),
         GetOriginalRequester(), GetInterconnectSession(), GetCookie(), ExtractSpan(),
-        GetTotalSize(), requestTimeMs, TabletId, VChunkIndex, HasChunkKey));
+        GetTotalSize(), requestTimeMs, TabletId, VChunkIndex, HasChunkKey,
+        IntegrityOperationId, std::move(Checksums)));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -385,6 +396,8 @@ void TDDiskActor::TDDiskIoOp::ClearForRecycle() noexcept {
     TabletId = 0;
     VChunkIndex = 0;
     HasChunkKey = false;
+    IntegrityOperationId = 0;
+    Checksums.clear();
     TDirectIoOpBase::ClearForRecycle();
 }
 
@@ -404,10 +417,20 @@ void TDDiskActor::TInternalSyncWriteOp::ClearForRecycle() noexcept {
     RequestId = 0;
     SegmentBegin = 0;
     SegmentEnd = 0;
+    IntegrityOperationId = 0;
     TDirectIoOpBase::ClearForRecycle();
 }
 
 void TDDiskActor::TInternalSyncWriteOp::SelfRecycle() noexcept {
+    Actor.ReturnOp(this);
+}
+
+void TDDiskActor::TIntegrityIoOp::ClearForRecycle() noexcept {
+    IoId = 0;
+    TDirectIoOpBase::ClearForRecycle();
+}
+
+void TDDiskActor::TIntegrityIoOp::SelfRecycle() noexcept {
     Actor.ReturnOp(this);
 }
 
@@ -442,6 +465,7 @@ void TDDiskActor::TInternalSyncWriteOp::Reply(NActors::TActorSystem* actorSystem
             RequestId,
             SegmentBegin,
             SegmentEnd,
+            IntegrityOperationId,
             status,
             std::move(reason)));
 }
@@ -453,18 +477,23 @@ void TDDiskActor::TInternalSyncWriteOp::Reply(NActors::TActorSystem* actorSystem
 void TDDiskActor::TIntegrityIoOp::Reply(NActors::TActorSystem* actorSystem, TReplyStatus::E status,
         TString reason) noexcept {
     const i32 result = GetResult();
+    TRope data;
 
     if (status != TReplyStatus::OK && !reason) {
         if (result < 0) {
             reason = TStringBuilder()
-                << "integrity write failed: " << strerror(-result)
+                << "integrity I/O failed: " << strerror(-result)
                 << " (errno " << (-result) << ")";
         } else {
-            reason = "integrity write failed";
+            reason = "integrity I/O failed";
         }
+    } else if (status == TReplyStatus::OK && GetOperationType() == TUringOperationBase::EREAD) {
+        data = ExtractData();
     }
 
-    actorSystem->Send(DDiskId, new TEvPrivate::TEvIntegrityIoResult(IoId, status, std::move(reason)));
+    actorSystem->Send(DDiskId, new TEvPrivate::TEvIntegrityIoResult(
+        IoId, status, std::move(reason), std::move(data),
+        GetOperationType() == TUringOperationBase::EREAD));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -478,6 +507,8 @@ std::unique_ptr<T> TDDiskActor::AllocateOp(const IEventHandle* ev) {
             return self.DdiskIoOpPool;
         } else if constexpr (std::is_same_v<T, TPersistentBufferPartIoOp>) {
             return self.PersistentBufferPartIoOpPool;
+        } else if constexpr (std::is_same_v<T, TIntegrityIoOp>) {
+            return self.IntegrityIoOpPool;
         } else {
             static_assert(std::is_same_v<T, TInternalSyncWriteOp>);
             return self.InternalSyncWriteOpPool;
@@ -501,6 +532,9 @@ TDDiskActor::AllocateOp<TDDiskActor::TPersistentBufferPartIoOp>(const IEventHand
 template std::unique_ptr<TDDiskActor::TInternalSyncWriteOp>
 TDDiskActor::AllocateOp<TDDiskActor::TInternalSyncWriteOp>(const IEventHandle*);
 
+template std::unique_ptr<TDDiskActor::TIntegrityIoOp>
+TDDiskActor::AllocateOp<TDDiskActor::TIntegrityIoOp>(const IEventHandle*);
+
 void TDDiskActor::ReturnOp(TDDiskIoOp* op) {
     op->ClearForRecycle();
     if (!DdiskIoOpPool.TryPush(std::unique_ptr<TDDiskIoOp>(op))) {
@@ -522,6 +556,13 @@ void TDDiskActor::ReturnOp(TInternalSyncWriteOp* op) {
     }
 }
 
+void TDDiskActor::ReturnOp(TIntegrityIoOp* op) {
+    op->ClearForRecycle();
+    if (!IntegrityIoOpPool.TryPush(std::unique_ptr<TIntegrityIoOp>(op))) {
+        // unique_ptr destructor deletes anyway
+    }
+}
+
 template <typename T>
 void TDDiskActor::FillPool(TSpscCircularQueue<std::unique_ptr<T>>& pool) {
     for (ui32 i = 0; i < IoOpPoolCapacity; ++i) {
@@ -532,5 +573,6 @@ void TDDiskActor::FillPool(TSpscCircularQueue<std::unique_ptr<T>>& pool) {
 template void TDDiskActor::FillPool<TDDiskActor::TDDiskIoOp>(TSpscCircularQueue<std::unique_ptr<TDDiskActor::TDDiskIoOp>>&);
 template void TDDiskActor::FillPool<TDDiskActor::TPersistentBufferPartIoOp>(TSpscCircularQueue<std::unique_ptr<TDDiskActor::TPersistentBufferPartIoOp>>&);
 template void TDDiskActor::FillPool<TDDiskActor::TInternalSyncWriteOp>(TSpscCircularQueue<std::unique_ptr<TDDiskActor::TInternalSyncWriteOp>>&);
+template void TDDiskActor::FillPool<TDDiskActor::TIntegrityIoOp>(TSpscCircularQueue<std::unique_ptr<TDDiskActor::TIntegrityIoOp>>&);
 
 } // NKikimr::NDDisk

--- a/ydb/core/blobstorage/ddisk/direct_io_op.cpp
+++ b/ydb/core/blobstorage/ddisk/direct_io_op.cpp
@@ -1,4 +1,5 @@
 #include "ddisk_actor.h"
+#include "ddisk_checksums.h"
 #include "direct_io_op.h"
 
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_data.h>
@@ -246,6 +247,23 @@ TRope TDDiskActor::TDirectIoOpBase::ExtractData() {
     return TRope(std::move(AlignedDataHolder));
 }
 
+void TDDiskActor::TDirectIoOpBase::ApplyReadUsedBlocksMask(TRope& data) noexcept {
+    if (!ReadUsedBlocksMask) {
+        return;
+    }
+
+    // The buffer was just read from disk and is exclusively ours, so mutating without COW is safe.
+    // On the uring path it is a single contiguous TRcBuf (AlignedDataHolder); on the PDisk fallback
+    // path a non-contiguous rope would be compacted here (rare and small).
+    auto span = data.UnsafeGetContiguousSpanMut();
+    const size_t numBlocks = span.size() / IntegrityUnitSize;
+    for (size_t i = 0; i < numBlocks; ++i) {
+        if (!ReadUsedBlocksMask->Get(i)) {
+            memset(span.data() + i * IntegrityUnitSize, 0, IntegrityUnitSize);
+        }
+    }
+}
+
 double TDDiskActor::TDirectIoOpBase::TimePassed() const {
     return HPMilliSecondsFloat(HPNow() - StartTs);
 }
@@ -262,43 +280,26 @@ void TDDiskActor::TDirectIoOpBase::SetResult(i32 result, TRope&& data) {
 void TDDiskActor::TDDiskIoOp::Reply(NActors::TActorSystem* actorSystem, TReplyStatus::E status,
         TString reason) noexcept {
     const double requestTimeMs = TimePassed();
-
-    std::unique_ptr<IEventBase> reply;
     TRope data;
-    bool isOk = status == TReplyStatus::OK;
-    std::optional<TString> errorReason;
-    if (reason) {
-        errorReason = std::move(reason);
-    }
 
     switch (GetOperationType()) {
     case TUringOperationBase::EREAD: {
         if (status == TReplyStatus::OK) {
             data = ExtractData();
+            ApplyReadUsedBlocksMask(data);
         }
-        reply = std::make_unique<TEvReadResult>(status, errorReason, std::move(data));
-        Actor.Counters.Interface.Read.Reply(isOk, GetTotalSize(), requestTimeMs);
         break;
     }
-    case TUringOperationBase::EWRITE: {
-        reply = std::make_unique<TEvWriteResult>(status, errorReason);
-        Actor.Counters.Interface.Write.Reply(isOk, GetTotalSize(), requestTimeMs);
+    case TUringOperationBase::EWRITE:
         break;
-    }
     default:
         Y_ABORT("Unknown OperationType");
     }
 
-    NWilson::TSpan& span = GetSpan();
-
-    auto h = std::make_unique<IEventHandle>(GetOriginalRequester(), DDiskId, reply.release(),
-        0, GetCookie(), nullptr, span.GetTraceId());
-    const auto& session = GetInterconnectSession();
-    if (session) {
-        h->Rewrite(TEvInterconnect::EvForward, session);
-    }
-    span.End();
-    actorSystem->Send(h.release());
+    actorSystem->Send(DDiskId, new TEvPrivate::TEvDDiskIoResult(
+        GetOperationType(), status, std::move(reason), std::move(data),
+        GetOriginalRequester(), GetInterconnectSession(), GetCookie(), ExtractSpan(),
+        GetTotalSize(), requestTimeMs, TabletId, VChunkIndex, HasChunkKey));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -366,16 +367,25 @@ void TDDiskActor::TDirectIoOpBase::Reinit(const IEventHandle* ev) {
     }
     ChunkIdx = 0;
     ChunkOffsetInBytes = 0;
+    ReadUsedBlocksMask.reset();
 }
 
 void TDDiskActor::TDirectIoOpBase::ClearForRecycle() noexcept {
     AlignedDataHolder = {};
     Data.reset();
     Span = {};
+    ReadUsedBlocksMask.reset();
 }
 
 void TDDiskActor::TDDiskIoOp::SelfRecycle() noexcept {
     Actor.ReturnOp(this);
+}
+
+void TDDiskActor::TDDiskIoOp::ClearForRecycle() noexcept {
+    TabletId = 0;
+    VChunkIndex = 0;
+    HasChunkKey = false;
+    TDirectIoOpBase::ClearForRecycle();
 }
 
 void TDDiskActor::TPersistentBufferPartIoOp::ClearForRecycle() noexcept {
@@ -434,6 +444,27 @@ void TDDiskActor::TInternalSyncWriteOp::Reply(NActors::TActorSystem* actorSystem
             SegmentEnd,
             status,
             std::move(reason)));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// TDDiskActor::TIntegrityIoOp
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void TDDiskActor::TIntegrityIoOp::Reply(NActors::TActorSystem* actorSystem, TReplyStatus::E status,
+        TString reason) noexcept {
+    const i32 result = GetResult();
+
+    if (status != TReplyStatus::OK && !reason) {
+        if (result < 0) {
+            reason = TStringBuilder()
+                << "integrity write failed: " << strerror(-result)
+                << " (errno " << (-result) << ")";
+        } else {
+            reason = "integrity write failed";
+        }
+    }
+
+    actorSystem->Send(DDiskId, new TEvPrivate::TEvIntegrityIoResult(IoId, status, std::move(reason)));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/ddisk/direct_io_op.h
+++ b/ydb/core/blobstorage/ddisk/direct_io_op.h
@@ -124,10 +124,20 @@ public:
         HasChunkKey = true;
     }
 
+    void SetIntegrityOperationId(ui64 operationId) {
+        IntegrityOperationId = operationId;
+    }
+
+    void SetReadChecksums(std::vector<ui64> checksums) {
+        Checksums = std::move(checksums);
+    }
+
 private:
     ui64 TabletId = 0;
     ui64 VChunkIndex = 0;
     bool HasChunkKey = false;
+    ui64 IntegrityOperationId = 0;
+    std::vector<ui64> Checksums;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -191,20 +201,24 @@ public:
         SyncId = syncId;
     }
 
+    void SetIntegrityOperationId(ui64 operationId) {
+        IntegrityOperationId = operationId;
+    }
+
 private:
     ui64 SyncId = 0;
     ui64 RequestId = 0;
     ui64 SegmentBegin = 0;
     ui64 SegmentEnd = 0;
+    ui64 IntegrityOperationId = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TDDiskActor::TIntegrityIoOp
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Executes one TIntegrityManager::TWriteIo (chunk header replica / extent format write) and posts
-// TEvPrivate::TEvIntegrityIoResult{IoId, Status} back to the actor. Integrity I/O only happens at
-// chunk allocation time, so these ops are not pooled: SelfRecycle simply deletes.
+// Executes one TIntegrityManager TWriteIo / TReadIo and posts TEvPrivate::TEvIntegrityIoResult
+// back to the actor.
 class TDDiskActor::TIntegrityIoOp final : public TDDiskActor::TDirectIoOpBase {
 public:
     explicit TIntegrityIoOp(TDDiskActor& actor)
@@ -215,6 +229,9 @@ public:
         NActors::TActorSystem* actorSystem, NKikimrBlobStorage::NDDisk::TReplyStatus::E status,
         TString reason = {}) noexcept override;
     bool IsIntegrityIo() const noexcept override { return true; }
+
+    void ClearForRecycle() noexcept override;
+    void SelfRecycle() noexcept override;
 
     void SetIoId(ui64 ioId) {
         IoId = ioId;

--- a/ydb/core/blobstorage/ddisk/direct_io_op.h
+++ b/ydb/core/blobstorage/ddisk/direct_io_op.h
@@ -33,6 +33,7 @@ public:
     virtual void Reply(
         NActors::TActorSystem* actorSystem, NKikimrBlobStorage::NDDisk::TReplyStatus::E status,
         TString reason = {}) noexcept = 0;
+    virtual bool IsIntegrityIo() const noexcept { return false; }
 
     virtual void ClearForRecycle() noexcept;
 
@@ -43,9 +44,15 @@ public:
 
     void SetSpan(NWilson::TSpan&& span) { Span = std::move(span); }
     NWilson::TSpan& GetSpan() { return Span; }
+    NWilson::TSpan ExtractSpan() { return std::move(Span); }
 
     void SetCookie(ui64 cookie) { Cookie = cookie; }
     ui64 GetCookie() const { return Cookie; }
+
+    // Read-path integrity zero mask (TIntegrityManager::TReadPlan::Mixed): bit i covers the i-th
+    // IntegrityUnitSize block of the read range; unset bits are zero-filled before replying. Must
+    // live in the op because the reply happens on the uring completion thread.
+    void SetReadUsedBlocksMask(TDynBitMap&& usedBlocks) { ReadUsedBlocksMask.emplace(std::move(usedBlocks)); }
 
     const TActorId& GetDDiskId() const { return DDiskId; }
     const TActorId& GetOriginalRequester() const { return OriginalRequester; }
@@ -71,6 +78,9 @@ protected:
 
     virtual void SelfRecycle() noexcept { delete this; }
 
+    // Zero-fills the blocks of freshly read data whose ReadUsedBlocksMask bits are unset.
+    void ApplyReadUsedBlocksMask(TRope& data) noexcept;
+
 private:
     NHPTimer::STime StartTs;
 
@@ -87,6 +97,8 @@ private:
 
     TRcBuf AlignedDataHolder;
     std::optional<TRope> Data;
+
+    std::optional<TDynBitMap> ReadUsedBlocksMask;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -103,7 +115,19 @@ public:
         NActors::TActorSystem* actorSystem, NKikimrBlobStorage::NDDisk::TReplyStatus::E status,
         TString reason = {}) noexcept override;
 
+    void ClearForRecycle() noexcept override;
     void SelfRecycle() noexcept override;
+
+    void SetChunkKey(ui64 tabletId, ui64 vChunkIndex) {
+        TabletId = tabletId;
+        VChunkIndex = vChunkIndex;
+        HasChunkKey = true;
+    }
+
+private:
+    ui64 TabletId = 0;
+    ui64 VChunkIndex = 0;
+    bool HasChunkKey = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -172,6 +196,32 @@ private:
     ui64 RequestId = 0;
     ui64 SegmentBegin = 0;
     ui64 SegmentEnd = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// TDDiskActor::TIntegrityIoOp
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Executes one TIntegrityManager::TWriteIo (chunk header replica / extent format write) and posts
+// TEvPrivate::TEvIntegrityIoResult{IoId, Status} back to the actor. Integrity I/O only happens at
+// chunk allocation time, so these ops are not pooled: SelfRecycle simply deletes.
+class TDDiskActor::TIntegrityIoOp final : public TDDiskActor::TDirectIoOpBase {
+public:
+    explicit TIntegrityIoOp(TDDiskActor& actor)
+        : TDirectIoOpBase(actor)
+    {}
+
+    void Reply(
+        NActors::TActorSystem* actorSystem, NKikimrBlobStorage::NDDisk::TReplyStatus::E status,
+        TString reason = {}) noexcept override;
+    bool IsIntegrityIo() const noexcept override { return true; }
+
+    void SetIoId(ui64 ioId) {
+        IoId = ioId;
+    }
+
+private:
+    ui64 IoId = 0;
 };
 
 } // namespace NKikimr::NDDisk

--- a/ydb/core/blobstorage/ddisk/integrity_manager.cpp
+++ b/ydb/core/blobstorage/ddisk/integrity_manager.cpp
@@ -56,6 +56,13 @@ void TIntegrityManager::OnDataChunkAllocated(TDataChunkKey key, TChunkIdx dataCh
     TExtentInfo& extent = it->second;
     extent.DataChunkIdx = dataChunkIdx;
     extent.Ref.VChunkGeneration = AllocateGeneration();
+    extent.Pairs.resize(BlocksPerExtentCount);
+    for (TPairMeta& pair : extent.Pairs) {
+        pair.DigestKnown = true;
+        pair.BitmapKnown = true;
+        pair.Resident = true; // a freshly formatted pair is known to contain no used blocks
+        pair.CurrentSlot = EPairSlot::B;
+    }
 
     PendingExtents.push_back(key);
     EnsureChunkCapacity();
@@ -98,6 +105,39 @@ void TIntegrityManager::CommitTabletChunksDeletion(ui64 tabletId) {
 }
 
 void TIntegrityManager::FreeExtent(TDataChunkKey key, TExtentInfo& extent) {
+    std::vector<ui64> operationIds;
+    for (const auto& [operationId, operation] : PendingOperations) {
+        if (operation.Key == key) {
+            operationIds.push_back(operationId);
+        }
+    }
+    for (const ui64 operationId : operationIds) {
+        CompleteOperation(operationId, EOperationStatus::Corrupted, "integrity extent was deleted");
+    }
+
+    auto cancelQueuedIo = [&](ui64 ioId) {
+        if (!ioId) {
+            return;
+        }
+        const size_t oldSize = Actions.size();
+        std::erase_if(Actions, [ioId](const TAction& action) {
+            return std::visit(TOverloaded{
+                [](const TAllocateIntegrityChunk&) { return false; },
+                [ioId](const TWriteIo& io) { return io.IoId == ioId; },
+                [ioId](const TReadIo& io) { return io.IoId == ioId; },
+            }, action);
+        });
+        Y_ABORT_UNLESS(Actions.size() + 1 == oldSize,
+            "attempt to delete an extent with submitted pair I/O, IoId# %" PRIu64, ioId);
+        Y_ABORT_UNLESS(IosInFlight.erase(ioId) == 1);
+    };
+    for (const auto& [pairIdx, runtime] : extent.PairRuntime) {
+        Y_UNUSED(pairIdx);
+        cancelQueuedIo(runtime.ReadIoId);
+        cancelQueuedIo(runtime.WriteIoId);
+    }
+    extent.PairRuntime.clear();
+
     DropBlockStates(extent);
     switch (extent.State) {
         case EExtentState::Pending:
@@ -205,7 +245,13 @@ void TIntegrityManager::QueueChunkHeaderWrite(TChunkIdx chunkIdx, ui32 replica) 
 
     const ui64 ioId = NextIoId++;
     IosInFlight.emplace(ioId, THeaderWriteRef{chunkIdx, replica});
-    Actions.emplace_back(TWriteIo{ioId, chunkIdx, ChunkHeaderReplicaOffset(replica), std::move(data)});
+    Actions.emplace_back(TWriteIo{
+        .IoId = ioId,
+        .ChunkIdx = chunkIdx,
+        .OffsetInBytes = ChunkHeaderReplicaOffset(replica),
+        .Data = std::move(data),
+        .Kind = EWriteIoKind::ChunkHeader,
+    });
 }
 
 std::vector<TChunkIdx> TIntegrityManager::TakeReleasableIntegrityChunks() {
@@ -291,8 +337,13 @@ void TIntegrityManager::QueueExtentFormatWrite(TDataChunkKey key, TExtentInfo& e
     const ui64 ioId = NextIoId++;
     extent.FormatIoId = ioId;
     IosInFlight.emplace(ioId, TExtentFormatRef{key});
-    Actions.emplace_back(TWriteIo{ioId, extent.Ref.IntegrityChunkIdx, ExtentOffset(extent.Ref.ExtentSlot),
-        std::move(data)});
+    Actions.emplace_back(TWriteIo{
+        .IoId = ioId,
+        .ChunkIdx = extent.Ref.IntegrityChunkIdx,
+        .OffsetInBytes = ExtentOffset(extent.Ref.ExtentSlot),
+        .Data = std::move(data),
+        .Kind = EWriteIoKind::ExtentFormat,
+    });
 }
 
 void TIntegrityManager::MaybeCompleteExtent(TDataChunkKey key, TExtentInfo& extent,
@@ -308,6 +359,12 @@ void TIntegrityManager::MaybeCompleteExtent(TDataChunkKey key, TExtentInfo& exte
     extent.State = EExtentState::Ready;
     if (!extent.DeletionPending) {
         readyKeys.push_back(key);
+    }
+    for (ui32 pairIdx = 0; pairIdx < extent.Pairs.size(); ++pairIdx) {
+        const auto runtimeIt = extent.PairRuntime.find(pairIdx);
+        if (runtimeIt != extent.PairRuntime.end() && runtimeIt->second.Dirty) {
+            QueuePairWrite(key, extent, pairIdx);
+        }
     }
 }
 
@@ -354,9 +411,255 @@ std::vector<TIntegrityManager::TDataChunkKey> TIntegrityManager::OnIoCompleted(u
             ReleaseSlot(orphanRef.ChunkIdx, orphanRef.ExtentSlot);
             TryAssignExtents();
         },
+        [&](const TPairReadRef&) {
+            Y_ABORT("read integrity I/O completed through the write completion path");
+        },
+        [&](const TPairWriteRef& writeRef) {
+            const auto it = Extents.find(writeRef.Key);
+            if (it == Extents.end()) {
+                return;
+            }
+            TExtentInfo& extent = it->second;
+            TPairMeta& pair = extent.Pairs.at(writeRef.PairIdx);
+            TPairRuntime& runtime = extent.PairRuntime.at(writeRef.PairIdx);
+            Y_ABORT_UNLESS(runtime.WriteIoId == ioId);
+            runtime.WriteIoId = 0;
+            pair.CurrentSlot = writeRef.Slot;
+            TIntegrityBlockState* state = FindBlockState(extent, writeRef.PairIdx);
+            Y_ABORT_UNLESS(state);
+            ++state->PairSequenceNumber;
+            runtime.DurableVersion = Max(runtime.DurableVersion, writeRef.Version);
+            NotifyPairDurable(writeRef.Key, extent, writeRef.PairIdx);
+            if (const auto runtimeIt = extent.PairRuntime.find(writeRef.PairIdx);
+                    runtimeIt != extent.PairRuntime.end() && runtimeIt->second.Dirty) {
+                QueuePairWrite(writeRef.Key, extent, writeRef.PairIdx);
+            }
+            MaybeDropPairRuntime(extent, writeRef.PairIdx);
+            EvictBlockStatesOverBudget();
+        },
     }, ref);
 
     return readyKeys;
+}
+
+void TIntegrityManager::NotifyPairDurable(TDataChunkKey key, TExtentInfo& extent, ui32 pairIdx) {
+    Y_UNUSED(key);
+    TPairRuntime& runtime = extent.PairRuntime.at(pairIdx);
+    std::vector<std::pair<ui64, ui64>> remaining;
+    std::vector<ui64> durableOperations;
+    for (const auto& [operationId, requiredVersion] : runtime.DurabilityWaiters) {
+        if (requiredVersion > runtime.DurableVersion) {
+            remaining.emplace_back(operationId, requiredVersion);
+            continue;
+        }
+        durableOperations.push_back(operationId);
+    }
+    runtime.DurabilityWaiters = std::move(remaining);
+
+    for (const ui64 operationId : durableOperations) {
+        const auto operationIt = PendingOperations.find(operationId);
+        if (operationIt == PendingOperations.end()) {
+            continue;
+        }
+        TPendingOperation& operation = operationIt->second;
+        Y_ABORT_UNLESS(operation.PendingDurability > 0);
+        if (--operation.PendingDurability == 0) {
+            CompleteOperation(operationId);
+        }
+    }
+}
+
+void TIntegrityManager::CompleteOperation(ui64 operationId, EOperationStatus status,
+        TString errorReason, bool lostWriteDetected) {
+    const auto it = PendingOperations.find(operationId);
+    if (it == PendingOperations.end()) {
+        return;
+    }
+
+    TPendingOperation& operation = it->second;
+    TOperationResult result{
+        .OperationId = operationId,
+        .Kind = operation.Kind,
+        .Status = status,
+        .ErrorReason = std::move(errorReason),
+        .LostWriteDetected = lostWriteDetected,
+    };
+
+    if (status == EOperationStatus::Ok && operation.Kind == EOperationKind::Read) {
+        const ui32 firstBlock = operation.OffsetInBytes / IntegrityUnitSize;
+        const ui32 numBlocks = operation.Size / IntegrityUnitSize;
+        result.Checksums.reserve(numBlocks);
+        const auto extentIt = Extents.find(operation.Key);
+        if (extentIt == Extents.end()) {
+            result.Status = EOperationStatus::Corrupted;
+            result.ErrorReason = "integrity extent is missing for an allocated data chunk";
+            CompletedOperations.push_back(std::move(result));
+            PendingOperations.erase(it);
+            return;
+        }
+        const TExtentInfo& extent = extentIt->second;
+        for (ui32 blockIdx = firstBlock; blockIdx < firstBlock + numBlocks; ++blockIdx) {
+            const ui32 pairIdx = blockIdx / ChecksumsPerIntegrityBlock;
+            const ui32 slot = blockIdx % ChecksumsPerIntegrityBlock;
+            if (!extent.UsedBlocks.Get(blockIdx)) {
+                result.Checksums.push_back(GetZeroBlockChecksum());
+                continue;
+            }
+            const auto stateIt = extent.BlockStates.find(pairIdx);
+            if (stateIt == extent.BlockStates.end() || !stateIt->second->Known.Get(slot)) {
+                result.Status = EOperationStatus::Corrupted;
+                result.ErrorReason = TStringBuilder()
+                    << "checksum is missing for used data block " << blockIdx;
+                result.Checksums.clear();
+                break;
+            }
+            result.Checksums.push_back(stateIt->second->Checksums[slot]);
+        }
+    }
+
+    if (operation.PairsPinned) {
+        const auto extentIt = Extents.find(operation.Key);
+        Y_ABORT_UNLESS(extentIt != Extents.end());
+        TExtentInfo& extent = extentIt->second;
+        for (ui32 pairIdx = FirstPair(operation.OffsetInBytes);
+                pairIdx < EndPair(operation.OffsetInBytes, operation.Size); ++pairIdx) {
+            TPairMeta& pair = extent.Pairs.at(pairIdx);
+            Y_ABORT_UNLESS(pair.OperationPins > 0);
+            --pair.OperationPins;
+            MaybeDropPairRuntime(extent, pairIdx);
+        }
+        operation.PairsPinned = false;
+    }
+
+    CompletedOperations.push_back(std::move(result));
+    PendingOperations.erase(it);
+}
+
+void TIntegrityManager::CompleteReadOperation(ui64 operationId, TPendingOperation& operation) {
+    Y_ABORT_UNLESS(operation.Kind == EOperationKind::Read && operation.PendingLoads == 0);
+    CompleteOperation(operationId);
+}
+
+void TIntegrityManager::NotifyPairLoaded(TDataChunkKey key, TExtentInfo& extent, ui32 pairIdx) {
+    TPairMeta& pair = extent.Pairs.at(pairIdx);
+    TPairRuntime& runtime = extent.PairRuntime.at(pairIdx);
+    auto waiters = std::exchange(runtime.LoadWaiters, {});
+    const TString corruptionReason = runtime.CorruptionReason;
+    const bool lostWriteCorruption = runtime.LostWriteCorruption;
+    for (const ui64 operationId : waiters) {
+        const auto operationIt = PendingOperations.find(operationId);
+        if (operationIt == PendingOperations.end()) {
+            continue;
+        }
+        TPendingOperation& operation = operationIt->second;
+        if (pair.Corrupted) {
+            CompleteOperation(operationId, EOperationStatus::Corrupted, corruptionReason,
+                lostWriteCorruption);
+            continue;
+        }
+        Y_ABORT_UNLESS(operation.PendingLoads > 0);
+        if (--operation.PendingLoads != 0) {
+            continue;
+        }
+        if (operation.Kind == EOperationKind::Write) {
+            ApplyWriteOperation(operationId, operation);
+        } else {
+            CompleteReadOperation(operationId, operation);
+        }
+    }
+    Y_UNUSED(key);
+}
+
+bool TIntegrityManager::LoadPairImage(TDataChunkKey key, TExtentInfo& extent, ui32 pairIdx,
+        const TRope& data, TString* errorReason, bool* lostWriteDetected) {
+    *lostWriteDetected = false;
+    if (data.size() != IntegrityPairSlots * sizeof(TIntegrityBlock)) {
+        *errorReason = TStringBuilder() << "short integrity pair read: expected "
+            << IntegrityPairSlots * sizeof(TIntegrityBlock) << " bytes, got " << data.size();
+        return false;
+    }
+
+    TIntegrityBlock slots[IntegrityPairSlots];
+    data.Begin().ExtractPlainDataAndAdvance(slots, sizeof(slots));
+    const i32 winner = SelectIntegrityBlockWinner(slots, MakeBlockIdentity(key, extent, pairIdx));
+    if (winner < 0) {
+        *errorReason = TStringBuilder() << "both integrity slots are invalid for pair " << pairIdx;
+        return false;
+    }
+
+    const TIntegrityBlock& block = slots[winner];
+    TPairMeta& pair = extent.Pairs.at(pairIdx);
+    if (pair.DigestKnown && pair.Digest != block.Header.IntegrityBlockDigest) {
+        *errorReason = TStringBuilder() << "integrity digest mismatch for pair " << pairIdx
+            << ": expected " << pair.Digest << ", got " << block.Header.IntegrityBlockDigest;
+        *lostWriteDetected = true;
+        return false;
+    }
+
+    pair.Digest = block.Header.IntegrityBlockDigest;
+    pair.DigestKnown = true;
+    pair.BitmapKnown = true;
+    pair.Resident = true;
+    pair.CurrentSlot = winner == 0 ? EPairSlot::A : EPairSlot::B;
+
+    TIntegrityBlockState& state = GetOrCreateBlockState(key, extent, pairIdx);
+    state.PairSequenceNumber = block.Header.PairSequenceNumber;
+    state.Known.Clear();
+    state.Known.Reserve(ChecksumsPerIntegrityBlock);
+    std::fill(state.Checksums.begin(), state.Checksums.end(), 0);
+
+    const ui32 firstBlock = pairIdx * ChecksumsPerIntegrityBlock;
+    const ui32 endBlock = Min(DataBlocksPerChunkCount, firstBlock + ChecksumsPerIntegrityBlock);
+    for (ui32 blockIdx = firstBlock; blockIdx < endBlock; ++blockIdx) {
+        const ui32 slot = blockIdx - firstBlock;
+        const bool used = block.Header.UsedBlocksBitmap[slot / 8] & ui8(1u << (slot % 8));
+        if (!used) {
+            continue;
+        }
+        extent.UsedBlocks.Set(blockIdx);
+        state.Known.Set(slot);
+        state.Checksums[slot] = UnsealBlockChecksum(block.Checksums[slot], DDiskId,
+            PDiskGuid, key.TabletId, key.VChunkIndex, blockIdx);
+    }
+    return true;
+}
+
+void TIntegrityManager::OnReadIoCompleted(ui64 ioId, TRope data) {
+    const auto ioIt = IosInFlight.find(ioId);
+    Y_ABORT_UNLESS(ioIt != IosInFlight.end(), "unknown read IoId# %" PRIu64, ioId);
+    const auto* readRef = std::get_if<TPairReadRef>(&ioIt->second);
+    Y_ABORT_UNLESS(readRef);
+    const TPairReadRef ref = *readRef;
+    IosInFlight.erase(ioIt);
+
+    const auto extentIt = Extents.find(ref.Key);
+    if (extentIt == Extents.end()) {
+        return;
+    }
+    TExtentInfo& extent = extentIt->second;
+    TPairMeta& pair = extent.Pairs.at(ref.PairIdx);
+    {
+        TPairRuntime& runtime = extent.PairRuntime.at(ref.PairIdx);
+        Y_ABORT_UNLESS(runtime.ReadIoId == ioId);
+        runtime.ReadIoId = 0;
+
+        TString errorReason;
+        bool lostWriteDetected = false;
+        if (!LoadPairImage(ref.Key, extent, ref.PairIdx, data, &errorReason, &lostWriteDetected)) {
+            pair.Corrupted = true;
+            runtime.LostWriteCorruption = lostWriteDetected;
+            runtime.CorruptionReason = std::move(errorReason);
+        }
+    }
+    NotifyPairLoaded(ref.Key, extent, ref.PairIdx);
+    if (!pair.Corrupted) {
+        if (const auto runtimeIt = extent.PairRuntime.find(ref.PairIdx);
+                runtimeIt != extent.PairRuntime.end() && runtimeIt->second.Dirty) {
+            QueuePairWrite(ref.Key, extent, ref.PairIdx);
+        }
+    }
+    MaybeDropPairRuntime(extent, ref.PairIdx);
+    EvictBlockStatesOverBudget();
 }
 
 bool TIntegrityManager::IsExtentReady(TDataChunkKey key) const {
@@ -370,18 +673,18 @@ bool TIntegrityManager::IsExtentReady(TDataChunkKey key) const {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 TIntegrityManager::TIntegrityBlockState& TIntegrityManager::GetOrCreateBlockState(TDataChunkKey key,
-        TExtentInfo& extent, ui32 blockIdx) {
-    const auto [it, inserted] = extent.BlockStates.try_emplace(blockIdx);
+        TExtentInfo& extent, ui32 pairIdx) {
+    const auto [it, inserted] = extent.BlockStates.try_emplace(pairIdx);
     if (inserted) {
         it->second = std::make_unique<TIntegrityBlockState>();
         TIntegrityBlockState& state = *it->second;
         state.Key = key;
-        state.BlockIdx = blockIdx;
+        state.PairIdx = pairIdx;
+        state.PairSequenceNumber = extent.Pairs.at(pairIdx).CurrentSlot == EPairSlot::B ? 1 : 0;
         state.Known.Reserve(ChecksumsPerIntegrityBlock);
         state.Checksums.resize(ChecksumsPerIntegrityBlock, 0);
         BlockStateLru.PushBack(&state);
         ++BlockStateCount;
-        EvictBlockStatesOverBudget();
         return state;
     }
     TIntegrityBlockState& state = *it->second;
@@ -390,8 +693,8 @@ TIntegrityManager::TIntegrityBlockState& TIntegrityManager::GetOrCreateBlockStat
     return state;
 }
 
-TIntegrityManager::TIntegrityBlockState* TIntegrityManager::FindBlockState(TExtentInfo& extent, ui32 blockIdx) {
-    const auto it = extent.BlockStates.find(blockIdx);
+TIntegrityManager::TIntegrityBlockState* TIntegrityManager::FindBlockState(TExtentInfo& extent, ui32 pairIdx) {
+    const auto it = extent.BlockStates.find(pairIdx);
     if (it == extent.BlockStates.end()) {
         return nullptr;
     }
@@ -403,10 +706,31 @@ TIntegrityManager::TIntegrityBlockState* TIntegrityManager::FindBlockState(TExte
 
 void TIntegrityManager::EvictBlockStatesOverBudget() {
     while (BlockStateCount > MaxBlockStates) {
-        TIntegrityBlockState* victim = BlockStateLru.Front();
+        TIntegrityBlockState* victim = nullptr;
+        size_t examined = 0;
+        while (examined++ < BlockStateCount) {
+            TIntegrityBlockState* candidate = BlockStateLru.Front();
+            TExtentInfo& extent = Extents.at(candidate->Key);
+            const auto runtimeIt = extent.PairRuntime.find(candidate->PairIdx);
+            if (extent.Pairs.at(candidate->PairIdx).OperationPins == 0
+                    && (runtimeIt == extent.PairRuntime.end()
+                    || (!runtimeIt->second.ReadIoId && !runtimeIt->second.WriteIoId
+                        && !runtimeIt->second.Dirty && runtimeIt->second.LoadWaiters.empty()
+                        && runtimeIt->second.DurabilityWaiters.empty()))) {
+                victim = candidate;
+                break;
+            }
+            candidate->Unlink();
+            BlockStateLru.PushBack(candidate);
+        }
+        if (!victim) {
+            // The budget is soft while all resident states are needed by in-flight operations.
+            return;
+        }
         const auto extentIt = Extents.find(victim->Key);
         Y_ABORT_UNLESS(extentIt != Extents.end());
-        const size_t numErased = extentIt->second.BlockStates.erase(victim->BlockIdx);
+        extentIt->second.Pairs.at(victim->PairIdx).Resident = false;
+        const size_t numErased = extentIt->second.BlockStates.erase(victim->PairIdx);
         Y_ABORT_UNLESS(numErased == 1); // unlinks from the LRU via ~TIntrusiveListItem
         --BlockStateCount;
     }
@@ -417,7 +741,139 @@ void TIntegrityManager::DropBlockStates(TExtentInfo& extent) {
     extent.BlockStates.clear(); // each state unlinks from the LRU via ~TIntrusiveListItem
 }
 
-void TIntegrityManager::OnBlocksWritten(TDataChunkKey key, ui32 offsetInBytes, ui32 size,
+ui32 TIntegrityManager::FirstPair(ui32 offsetInBytes) const {
+    return (offsetInBytes / IntegrityUnitSize) / ChecksumsPerIntegrityBlock;
+}
+
+ui32 TIntegrityManager::EndPair(ui32 offsetInBytes, ui32 size) const {
+    const ui32 endBlock = (offsetInBytes + size + IntegrityUnitSize - 1) / IntegrityUnitSize;
+    return (endBlock + ChecksumsPerIntegrityBlock - 1) / ChecksumsPerIntegrityBlock;
+}
+
+TIntegrityBlockIdentity TIntegrityManager::MakeBlockIdentity(TDataChunkKey key,
+        const TExtentInfo& extent, ui32 pairIdx) const {
+    return {
+        .OwnerId = key.TabletId,
+        .VChunkId = key.VChunkIndex,
+        .VChunkGeneration = extent.Ref.VChunkGeneration,
+        .IntegrityChunkId = extent.Ref.IntegrityChunkIdx,
+        .IntegrityExtentId = extent.Ref.ExtentSlot,
+        .IntegrityChunkGeneration = IntegrityChunks.at(extent.Ref.IntegrityChunkIdx).Generation,
+        .ChecksumBlockIdx = pairIdx,
+    };
+}
+
+TIntegrityManager::TPairRuntime& TIntegrityManager::GetPairRuntime(
+        TExtentInfo& extent, ui32 pairIdx) {
+    return extent.PairRuntime[pairIdx];
+}
+
+void TIntegrityManager::MaybeDropPairRuntime(TExtentInfo& extent, ui32 pairIdx) {
+    const auto it = extent.PairRuntime.find(pairIdx);
+    if (it == extent.PairRuntime.end()) {
+        return;
+    }
+    const TPairRuntime& runtime = it->second;
+    const TPairMeta& pair = extent.Pairs.at(pairIdx);
+    if (!pair.Corrupted && pair.OperationPins == 0 && !runtime.ReadIoId && !runtime.WriteIoId
+            && !runtime.Dirty && runtime.LoadWaiters.empty()
+            && runtime.DurabilityWaiters.empty()) {
+        extent.PairRuntime.erase(it);
+    }
+}
+
+void TIntegrityManager::QueuePairRead(TDataChunkKey key, TExtentInfo& extent, ui32 pairIdx) {
+    TPairMeta& pair = extent.Pairs.at(pairIdx);
+    TPairRuntime& runtime = GetPairRuntime(extent, pairIdx);
+    if (runtime.ReadIoId || pair.Resident || pair.Corrupted) {
+        return;
+    }
+
+    const ui64 ioId = NextIoId++;
+    runtime.ReadIoId = ioId;
+    IosInFlight.emplace(ioId, TPairReadRef{key, pairIdx});
+    Actions.emplace_back(TReadIo{
+        .IoId = ioId,
+        .ChunkIdx = extent.Ref.IntegrityChunkIdx,
+        .OffsetInBytes = ExtentOffset(extent.Ref.ExtentSlot)
+            + pairIdx * IntegrityPairSlots * static_cast<ui32>(IntegrityUnitSize),
+        .Size = IntegrityPairSlots * static_cast<ui32>(IntegrityUnitSize),
+    });
+}
+
+bool TIntegrityManager::PairHasAllUsedChecksums(const TExtentInfo& extent, ui32 pairIdx,
+        const TIntegrityBlockState& state) const {
+    const ui32 firstBlock = pairIdx * ChecksumsPerIntegrityBlock;
+    const ui32 endBlock = Min(DataBlocksPerChunkCount, firstBlock + ChecksumsPerIntegrityBlock);
+    for (ui32 block = firstBlock; block < endBlock; ++block) {
+        if (extent.UsedBlocks.Get(block) && !state.Known.Get(block - firstBlock)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void TIntegrityManager::QueuePairWrite(TDataChunkKey key, TExtentInfo& extent, ui32 pairIdx) {
+    TPairMeta& pair = extent.Pairs.at(pairIdx);
+    TPairRuntime& runtime = GetPairRuntime(extent, pairIdx);
+    if (extent.State != EExtentState::Ready || runtime.ReadIoId || runtime.WriteIoId
+            || !pair.Resident || pair.Corrupted || !runtime.Dirty) {
+        return;
+    }
+
+    TIntegrityBlockState& state = GetOrCreateBlockState(key, extent, pairIdx);
+    Y_ABORT_UNLESS(PairHasAllUsedChecksums(extent, pairIdx, state),
+        "used data block without a checksum in pair# %" PRIu32, pairIdx);
+
+    auto data = TRcBuf::UninitializedPageAligned(sizeof(TIntegrityBlock));
+    auto* block = reinterpret_cast<TIntegrityBlock*>(data.GetDataMut());
+    memset(block, 0, sizeof(*block));
+
+    TIntegrityBlockHeader& header = block->Header;
+    header.Magic = MagicIntegrityBlock;
+    header.FormatVersion = static_cast<ui16>(EIntegrityFormatVersion::BaseAwupf4KiB);
+    header.ChecksumBlockIdx = pairIdx;
+    header.OwnerId = key.TabletId;
+    header.VChunkId = key.VChunkIndex;
+    header.VChunkGeneration = extent.Ref.VChunkGeneration;
+    header.IntegrityChunkId = extent.Ref.IntegrityChunkIdx;
+    header.IntegrityExtentId = extent.Ref.ExtentSlot;
+    header.IntegrityChunkGeneration = IntegrityChunks.at(extent.Ref.IntegrityChunkIdx).Generation;
+    header.IntegrityBlockDigest = pair.Digest;
+    header.PairSequenceNumber = state.PairSequenceNumber + 1;
+
+    const ui32 firstBlock = pairIdx * ChecksumsPerIntegrityBlock;
+    const ui32 endBlock = Min(DataBlocksPerChunkCount, firstBlock + ChecksumsPerIntegrityBlock);
+    for (ui32 blockIdx = firstBlock; blockIdx < endBlock; ++blockIdx) {
+        const ui32 slot = blockIdx - firstBlock;
+        if (!extent.UsedBlocks.Get(blockIdx)) {
+            continue;
+        }
+        header.UsedBlocksBitmap[slot / 8] |= ui8(1u << (slot % 8));
+        Y_ABORT_UNLESS(state.Known.Get(slot));
+        block->Checksums[slot] = SealBlockChecksum(state.Checksums[slot], DDiskId,
+            PDiskGuid, key.TabletId, key.VChunkIndex, blockIdx);
+    }
+    header.BlockChecksum = CalculateRawChecksum(block, sizeof(*block));
+
+    const EPairSlot targetSlot = pair.CurrentSlot == EPairSlot::A ? EPairSlot::B : EPairSlot::A;
+    const ui32 targetSlotIdx = targetSlot == EPairSlot::A ? 0 : 1;
+    const ui64 ioId = NextIoId++;
+    runtime.WriteIoId = ioId;
+    runtime.WriteVersion = runtime.MutationVersion;
+    runtime.Dirty = false;
+    IosInFlight.emplace(ioId, TPairWriteRef{key, pairIdx, runtime.WriteVersion, targetSlot});
+    Actions.emplace_back(TWriteIo{
+        .IoId = ioId,
+        .ChunkIdx = extent.Ref.IntegrityChunkIdx,
+        .OffsetInBytes = ExtentOffset(extent.Ref.ExtentSlot)
+            + (pairIdx * IntegrityPairSlots + targetSlotIdx) * static_cast<ui32>(IntegrityUnitSize),
+        .Data = std::move(data),
+        .Kind = EWriteIoKind::Pair,
+    });
+}
+
+ui64 TIntegrityManager::BeginBlocksWrite(TDataChunkKey key, ui32 offsetInBytes, ui32 size,
         const std::vector<ui64>& checksums) {
     const auto it = Extents.find(key);
     Y_ABORT_UNLESS(it != Extents.end(), "write to unknown data chunk, TabletId# %" PRIu64 " VChunkIndex# %" PRIu64,
@@ -426,64 +882,169 @@ void TIntegrityManager::OnBlocksWritten(TDataChunkKey key, ui32 offsetInBytes, u
 
     Y_ABORT_UNLESS(size > 0 && ui64(offsetInBytes) + size <= DataChunkSize);
 
-    // Blocks partially covered by an unaligned write are still marked used: the read path must
-    // return their (partially updated) disk contents, not zeros.
     const ui32 firstBlock = offsetInBytes / IntegrityUnitSize;
-    const ui32 endBlock = (offsetInBytes + size + IntegrityUnitSize - 1) / IntegrityUnitSize;
+    const ui32 endBlock = (offsetInBytes + size) / IntegrityUnitSize;
+    Y_ABORT_UNLESS(offsetInBytes % IntegrityUnitSize == 0 && size % IntegrityUnitSize == 0
+            && checksums.size() == endBlock - firstBlock,
+        "checksums must be per-4KiB-block of an aligned range: offset# %" PRIu32 " size# %" PRIu32
+        " checksums# %zu", offsetInBytes, size, checksums.size());
 
-    const bool aligned = offsetInBytes % IntegrityUnitSize == 0 && size % IntegrityUnitSize == 0;
-    const bool withChecksums = !checksums.empty();
-    if (withChecksums) {
-        Y_ABORT_UNLESS(aligned && checksums.size() == endBlock - firstBlock,
-            "checksums must be per-4KiB-block of an aligned range: offset# %" PRIu32 " size# %" PRIu32
-            " checksums# %zu", offsetInBytes, size, checksums.size());
+    const ui64 operationId = NextOperationId++;
+    auto [operationIt, inserted] = PendingOperations.emplace(operationId, TPendingOperation{
+        .Kind = EOperationKind::Write,
+        .Key = key,
+        .OffsetInBytes = offsetInBytes,
+        .Size = size,
+        .Checksums = checksums,
+    });
+    Y_ABORT_UNLESS(inserted);
+    TPendingOperation& operation = operationIt->second;
+
+    for (ui32 pairIdx = FirstPair(offsetInBytes); pairIdx < EndPair(offsetInBytes, size); ++pairIdx) {
+        const TPairMeta& pair = extent.Pairs.at(pairIdx);
+        if (pair.Corrupted) {
+            CompleteOperation(operationId, EOperationStatus::Corrupted,
+                extent.PairRuntime.at(pairIdx).CorruptionReason,
+                extent.PairRuntime.at(pairIdx).LostWriteCorruption);
+            return operationId;
+        }
     }
 
+    operation.PairsPinned = true;
+    for (ui32 pairIdx = FirstPair(offsetInBytes); pairIdx < EndPair(offsetInBytes, size); ++pairIdx) {
+        TPairMeta& pair = extent.Pairs.at(pairIdx);
+        ++pair.OperationPins;
+        if (!pair.Resident) {
+            GetPairRuntime(extent, pairIdx).LoadWaiters.push_back(operationId);
+            ++operation.PendingLoads;
+            QueuePairRead(key, extent, pairIdx);
+        }
+    }
+    if (!operation.PendingLoads) {
+        ApplyWriteOperation(operationId, operation);
+    }
+    return operationId;
+}
+
+void TIntegrityManager::ApplyWriteOperation(ui64 operationId, TPendingOperation& operation) {
+    Y_ABORT_UNLESS(operation.Kind == EOperationKind::Write && !operation.Applied
+        && operation.PendingLoads == 0);
+    TExtentInfo& extent = Extents.at(operation.Key);
+    const ui32 firstBlock = operation.OffsetInBytes / IntegrityUnitSize;
+    const ui32 endBlock = (operation.OffsetInBytes + operation.Size) / IntegrityUnitSize;
+
+    operation.Applied = true;
     for (ui32 block = firstBlock; block < endBlock; ++block) {
         extent.UsedBlocks.Set(block);
 
         const ui32 blockStateIdx = block / ChecksumsPerIntegrityBlock;
         const ui32 slot = block % ChecksumsPerIntegrityBlock;
         const ui64 generation = extent.Ref.VChunkGeneration;
+        TPairMeta& pair = extent.Pairs.at(blockStateIdx);
 
-        if (withChecksums) {
-            TIntegrityBlockState& state = GetOrCreateBlockState(key, extent, blockStateIdx);
-            const ui64 newCsum = checksums[block - firstBlock];
-            if (state.Known.Get(slot)) {
-                UpdateRoot(state.Digest, generation, block, state.Checksums[slot], newCsum);
-            } else {
-                state.Digest ^= Contribution(generation, block, newCsum);
-                state.Known.Set(slot);
-            }
-            state.Checksums[slot] = newCsum;
-        } else if (TIntegrityBlockState* state = FindBlockState(extent, blockStateIdx)) {
-            // The block was overwritten without a checksum: the recorded one is now stale.
-            if (state->Known.Get(slot)) {
-                state->Digest ^= Contribution(generation, block, state->Checksums[slot]);
-                state->Known.Reset(slot);
-                state->Checksums[slot] = 0;
-            }
+        TIntegrityBlockState& state = GetOrCreateBlockState(operation.Key, extent, blockStateIdx);
+        const ui64 newCsum = operation.Checksums[block - firstBlock];
+        if (state.Known.Get(slot)) {
+            UpdateRoot(pair.Digest, generation, block, state.Checksums[slot], newCsum);
+        } else {
+            pair.Digest ^= Contribution(generation, block, newCsum);
+            state.Known.Set(slot);
         }
+        state.Checksums[slot] = newCsum;
+        pair.DigestKnown = true;
     }
+
+    for (ui32 pairIdx = FirstPair(operation.OffsetInBytes);
+            pairIdx < EndPair(operation.OffsetInBytes, operation.Size); ++pairIdx) {
+        TPairRuntime& runtime = GetPairRuntime(extent, pairIdx);
+        ++runtime.MutationVersion;
+        runtime.Dirty = true;
+        runtime.DurabilityWaiters.emplace_back(operationId, runtime.MutationVersion);
+        ++operation.PendingDurability;
+        QueuePairWrite(operation.Key, extent, pairIdx);
+    }
+    if (!operation.PendingDurability) {
+        CompleteOperation(operationId);
+    }
+    EvictBlockStatesOverBudget();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Read path
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+ui64 TIntegrityManager::BeginChecksumRead(TDataChunkKey key, ui32 offsetInBytes, ui32 size) {
+    Y_ABORT_UNLESS(size > 0 && offsetInBytes % IntegrityUnitSize == 0
+        && size % IntegrityUnitSize == 0 && ui64(offsetInBytes) + size <= DataChunkSize);
+
+    const ui64 operationId = NextOperationId++;
+    auto [operationIt, inserted] = PendingOperations.emplace(operationId, TPendingOperation{
+        .Kind = EOperationKind::Read,
+        .Key = key,
+        .OffsetInBytes = offsetInBytes,
+        .Size = size,
+    });
+    Y_ABORT_UNLESS(inserted);
+    TPendingOperation& operation = operationIt->second;
+
+    const auto extentIt = Extents.find(key);
+    if (extentIt == Extents.end()) {
+        CompleteOperation(operationId, EOperationStatus::Corrupted,
+            "integrity extent is missing for an allocated data chunk");
+        return operationId;
+    }
+    TExtentInfo& extent = extentIt->second;
+
+    for (ui32 pairIdx = FirstPair(offsetInBytes); pairIdx < EndPair(offsetInBytes, size); ++pairIdx) {
+        const TPairMeta& pair = extent.Pairs.at(pairIdx);
+        if (pair.Corrupted) {
+            CompleteOperation(operationId, EOperationStatus::Corrupted,
+                extent.PairRuntime.at(pairIdx).CorruptionReason,
+                extent.PairRuntime.at(pairIdx).LostWriteCorruption);
+            return operationId;
+        }
+    }
+
+    operation.PairsPinned = true;
+    for (ui32 pairIdx = FirstPair(offsetInBytes); pairIdx < EndPair(offsetInBytes, size); ++pairIdx) {
+        TPairMeta& pair = extent.Pairs.at(pairIdx);
+        ++pair.OperationPins;
+        if (!pair.Resident) {
+            GetPairRuntime(extent, pairIdx).LoadWaiters.push_back(operationId);
+            ++operation.PendingLoads;
+            QueuePairRead(key, extent, pairIdx);
+        }
+    }
+    if (!operation.PendingLoads) {
+        CompleteReadOperation(operationId, operation);
+    }
+    return operationId;
+}
+
+std::vector<TIntegrityManager::TOperationResult> TIntegrityManager::TakeCompletedOperations() {
+    return std::exchange(CompletedOperations, {});
+}
+
 TIntegrityManager::TReadPlan TIntegrityManager::MakeReadPlan(TDataChunkKey key, ui32 offsetInBytes, ui32 size) const {
     TReadPlan plan;
 
     const auto it = Extents.find(key);
     if (it == Extents.end()) {
-        // Unknown chunk: pass through unchanged (safe fallback).
+        // BeginChecksumRead rejects allocated chunks without an integrity extent, so this fallback
+        // is unreachable through the actor read path.
         return plan;
     }
     const TExtentInfo& extent = it->second;
 
-    if (extent.BitmapUnknown) {
-        // Restored extent: the previous incarnation's bitmap is lost, so any block may hold data.
-        return plan;
+    if (offsetInBytes % IntegrityUnitSize == 0 && size % IntegrityUnitSize == 0 && size > 0
+            && ui64(offsetInBytes) + size <= DataChunkSize) {
+        for (ui32 pairIdx = FirstPair(offsetInBytes); pairIdx < EndPair(offsetInBytes, size); ++pairIdx) {
+            if (!extent.Pairs.at(pairIdx).BitmapKnown) {
+                // A restored pair has not been read yet; pass through until BeginChecksumRead
+                // restores its exact bitmap.
+                return plan;
+            }
+        }
     }
 
     if (extent.UsedBlocks.Empty()) {
@@ -574,9 +1135,8 @@ void TIntegrityManager::ApplyMappingSnapshot(const TMappingSnapshot& snapshot) {
         extent.Ref = entry.Ref;
         extent.State = EExtentState::Ready;
         extent.DataChunkIdx = entry.DataChunkIdx;
-        // The previous incarnation's used-block bitmap is not recoverable yet: reads must pass
-        // through unchanged until a later phase restores bitmaps from the extents on disk.
-        extent.BitmapUnknown = true;
+        // Pinned pair state is reconstructed lazily by adjacent 8 KiB A/B reads.
+        extent.Pairs.resize(BlocksPerExtentCount);
 
         GenerationCounter = Max(GenerationCounter, entry.Ref.VChunkGeneration);
 
@@ -621,8 +1181,8 @@ bool TIntegrityManager::IsIntegrityChunkFormatted(TChunkIdx chunkIdx) const {
 ui64 TIntegrityManager::GetIntegrityBlockDigest(TDataChunkKey key, ui32 integrityBlockIdx) const {
     const auto it = Extents.find(key);
     Y_ABORT_UNLESS(it != Extents.end() && integrityBlockIdx < BlocksPerExtentCount);
-    const auto stateIt = it->second.BlockStates.find(integrityBlockIdx);
-    return stateIt != it->second.BlockStates.end() ? stateIt->second->Digest : 0;
+    const TPairMeta& pair = it->second.Pairs.at(integrityBlockIdx);
+    return pair.DigestKnown ? pair.Digest : 0;
 }
 
 bool TIntegrityManager::GetBlockChecksum(TDataChunkKey key, ui32 blockIdx, ui64* checksum) const {
@@ -639,6 +1199,27 @@ bool TIntegrityManager::GetBlockChecksum(TDataChunkKey key, ui32 blockIdx, ui64*
     }
     *checksum = state.Checksums[slot];
     return true;
+}
+
+bool TIntegrityManager::HasInFlightOperationsForTablet(ui64 tabletId) const {
+    for (const auto& [operationId, operation] : PendingOperations) {
+        Y_UNUSED(operationId);
+        if (operation.Key.TabletId == tabletId) {
+            return true;
+        }
+    }
+    for (const auto& [ioId, ref] : IosInFlight) {
+        Y_UNUSED(ioId);
+        if (const auto* read = std::get_if<TPairReadRef>(&ref);
+                read && read->Key.TabletId == tabletId) {
+            return true;
+        }
+        if (const auto* write = std::get_if<TPairWriteRef>(&ref);
+                write && write->Key.TabletId == tabletId) {
+            return true;
+        }
+    }
+    return false;
 }
 
 } // namespace NKikimr::NDDisk

--- a/ydb/core/blobstorage/ddisk/integrity_manager.cpp
+++ b/ydb/core/blobstorage/ddisk/integrity_manager.cpp
@@ -1,0 +1,644 @@
+#include "integrity_manager.h"
+
+#include <util/generic/overloaded.h>
+
+#include <algorithm>
+#include <cstring>
+
+namespace NKikimr::NDDisk {
+
+TIntegrityManager::TIntegrityManager(ui64 dataChunkSizeBytes, ui64 ddiskId, ui64 pdiskGuid,
+        ui64 checksumCacheBytes)
+    : DataChunkSize(dataChunkSizeBytes)
+    , DataBlocksPerChunkCount(dataChunkSizeBytes / IntegrityUnitSize)
+    , BlocksPerExtentCount((DataBlocksPerChunkCount + ChecksumsPerIntegrityBlock - 1) / ChecksumsPerIntegrityBlock)
+    , ExtentOnDiskSizeBytes(size_t(BlocksPerExtentCount) * IntegrityUnitSize * IntegrityPairSlots)
+    , ExtentsPerChunkCount((dataChunkSizeBytes - IntegrityChunkHeaderRegionSize) / ExtentOnDiskSizeBytes)
+    , DDiskId(ddiskId)
+    , PDiskGuid(pdiskGuid)
+    , MaxBlockStates(Max<size_t>(1, checksumCacheBytes / BlockStateApproxBytes))
+{
+    Y_ABORT_UNLESS(dataChunkSizeBytes % IntegrityUnitSize == 0);
+    Y_ABORT_UNLESS(dataChunkSizeBytes > IntegrityChunkHeaderRegionSize);
+    Y_ABORT_UNLESS(ExtentsPerChunkCount >= 1);
+}
+
+std::vector<TIntegrityManager::TAction> TIntegrityManager::TakeActions() {
+    return std::exchange(Actions, {});
+}
+
+std::vector<TIntegrityManager::TDataChunkKey> TIntegrityManager::TakePlacedKeys() {
+    return std::exchange(PlacedKeys, {});
+}
+
+ui32 TIntegrityManager::ChunkHeaderReplicaOffset(ui32 replica) const {
+    Y_ABORT_UNLESS(replica < ChunkHeaderReplicaCount);
+    // Replicas are spread evenly across the header region so that a single localized corruption
+    // cannot take out all of them.
+    const ui32 headerRegionBlocks = IntegrityChunkHeaderRegionSize / IntegrityUnitSize;
+    return replica * (headerRegionBlocks / ChunkHeaderReplicaCount) * IntegrityUnitSize;
+}
+
+ui32 TIntegrityManager::ExtentOffset(ui32 extentSlot) const {
+    Y_ABORT_UNLESS(extentSlot < ExtentsPerChunkCount);
+    return IntegrityChunkHeaderRegionSize + extentSlot * ExtentOnDiskSizeBytes;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Data chunk lifecycle
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void TIntegrityManager::OnDataChunkAllocated(TDataChunkKey key, TChunkIdx dataChunkIdx) {
+    const auto [it, inserted] = Extents.try_emplace(key);
+    Y_ABORT_UNLESS(inserted, "data chunk already tracked, TabletId# %" PRIu64 " VChunkIndex# %" PRIu64,
+        key.TabletId, key.VChunkIndex);
+
+    TExtentInfo& extent = it->second;
+    extent.DataChunkIdx = dataChunkIdx;
+    extent.Ref.VChunkGeneration = AllocateGeneration();
+
+    PendingExtents.push_back(key);
+    EnsureChunkCapacity();
+    TryAssignExtents();
+}
+
+void TIntegrityManager::PrepareTabletChunksDeletion(ui64 tabletId) {
+    bool found = false;
+    for (auto& [key, extent] : Extents) {
+        if (key.TabletId != tabletId) {
+            continue;
+        }
+        Y_ABORT_UNLESS(!extent.DeletionPending);
+        extent.DeletionPending = true;
+        found = true;
+
+        // A pending extent has no durable mapping and no physical slot yet. Stop it from being
+        // assigned while the deletion record is in flight; CommitTabletChunksDeletion will erase
+        // the extent itself.
+        if (extent.State == EExtentState::Pending) {
+            std::erase(PendingExtents, key);
+        }
+    }
+    Y_ABORT_UNLESS(found, "tablet deletion has no integrity extents, TabletId# %" PRIu64, tabletId);
+}
+
+void TIntegrityManager::CommitTabletChunksDeletion(ui64 tabletId) {
+    bool found = false;
+    for (auto it = Extents.begin(); it != Extents.end(); ) {
+        if (it->first.TabletId == tabletId) {
+            Y_ABORT_UNLESS(it->second.DeletionPending);
+            found = true;
+            FreeExtent(it->first, it->second);
+            Extents.erase(it++);
+        } else {
+            ++it;
+        }
+    }
+    Y_ABORT_UNLESS(found, "tablet deletion was not prepared, TabletId# %" PRIu64, tabletId);
+}
+
+void TIntegrityManager::FreeExtent(TDataChunkKey key, TExtentInfo& extent) {
+    DropBlockStates(extent);
+    switch (extent.State) {
+        case EExtentState::Pending:
+            // Still queued for assignment: drop it from the queue.
+            std::erase(PendingExtents, key);
+            break;
+
+        case EExtentState::Formatting: {
+            if (extent.FormatIoId) {
+                // The format write is still in flight: the slot must not be reused until it
+                // settles, otherwise the old write could land after the new extent's format write
+                // and leave a stale-generation image on disk. Orphan the I/O; its completion
+                // releases the slot.
+                const auto ioIt = IosInFlight.find(extent.FormatIoId);
+                Y_ABORT_UNLESS(ioIt != IosInFlight.end());
+                ioIt->second = TOrphanedExtentFormatRef{extent.Ref.IntegrityChunkIdx, extent.Ref.ExtentSlot};
+            } else {
+                // Format write already landed; the extent was waiting for chunk headers.
+                TIntegrityChunkInfo& chunk = IntegrityChunks.at(extent.Ref.IntegrityChunkIdx);
+                std::erase(chunk.WaitingForChunkReady, key);
+                ReleaseSlot(extent.Ref.IntegrityChunkIdx, extent.Ref.ExtentSlot);
+            }
+            break;
+        }
+
+        case EExtentState::Ready:
+            // No I/O in flight: the slot is immediately reusable.
+            ReleaseSlot(extent.Ref.IntegrityChunkIdx, extent.Ref.ExtentSlot);
+            break;
+    }
+}
+
+void TIntegrityManager::ReleaseSlot(TChunkIdx chunkIdx, ui32 extentSlot) {
+    const auto chunkIt = IntegrityChunks.find(chunkIdx);
+    Y_ABORT_UNLESS(chunkIt != IntegrityChunks.end());
+    chunkIt->second.FreeSlots.push_back(extentSlot);
+    std::sort(chunkIt->second.FreeSlots.begin(), chunkIt->second.FreeSlots.end(), std::greater<ui32>());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Integrity chunk allocation and formatting
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void TIntegrityManager::EnsureChunkCapacity() {
+    size_t supply = size_t(PendingChunkAllocations) * ExtentsPerChunkCount;
+    for (const auto& [chunkIdx, chunk] : IntegrityChunks) {
+        supply += chunk.FreeSlots.size();
+    }
+    while (supply < PendingExtents.size()) {
+        Actions.emplace_back(TAllocateIntegrityChunk{});
+        ++PendingChunkAllocations;
+        supply += ExtentsPerChunkCount;
+    }
+}
+
+void TIntegrityManager::OnIntegrityChunkAllocated(TChunkIdx chunkIdx) {
+    Y_ABORT_UNLESS(PendingChunkAllocations > 0);
+    --PendingChunkAllocations;
+
+    const auto [it, inserted] = IntegrityChunks.try_emplace(chunkIdx);
+    Y_ABORT_UNLESS(inserted, "integrity chunk already in use, ChunkIdx# %" PRIu32, chunkIdx);
+
+    TIntegrityChunkInfo& chunk = it->second;
+    chunk.Generation = AllocateGeneration();
+    chunk.FreeSlots.reserve(ExtentsPerChunkCount);
+    for (ui32 slot = ExtentsPerChunkCount; slot > 0; --slot) {
+        chunk.FreeSlots.push_back(slot - 1);
+    }
+
+    chunk.HeaderWritesRemaining = ChunkHeaderReplicaCount;
+    for (ui32 replica = 0; replica < ChunkHeaderReplicaCount; ++replica) {
+        QueueChunkHeaderWrite(chunkIdx, replica);
+    }
+    TryAssignExtents();
+}
+
+bool TIntegrityManager::CancelChunkAllocationIfExcess() {
+    Y_ABORT_UNLESS(PendingChunkAllocations > 0);
+    size_t supply = size_t(PendingChunkAllocations - 1) * ExtentsPerChunkCount;
+    for (const auto& [chunkIdx, chunk] : IntegrityChunks) {
+        supply += chunk.FreeSlots.size();
+    }
+    if (supply < PendingExtents.size()) {
+        return false;
+    }
+    --PendingChunkAllocations;
+    return true;
+}
+
+void TIntegrityManager::QueueChunkHeaderWrite(TChunkIdx chunkIdx, ui32 replica) {
+    const TIntegrityChunkInfo& chunk = IntegrityChunks.at(chunkIdx);
+    Y_ABORT_UNLESS(chunk.State == EChunkState::Formatting && replica < ChunkHeaderReplicaCount);
+
+    auto data = TRcBuf::UninitializedPageAligned(sizeof(TIntegrityChunkHeader));
+    auto* header = reinterpret_cast<TIntegrityChunkHeader*>(data.GetDataMut());
+    memset(header, 0, sizeof(*header));
+    header->Magic = MagicIntegrityChunkHeader;
+    header->FormatVersion = static_cast<ui32>(EIntegrityFormatVersion::BaseAwupf4KiB);
+    header->HeaderSize = sizeof(TIntegrityChunkHeader);
+    header->DDiskId = DDiskId;
+    header->PDiskGuid = PDiskGuid;
+    header->IntegrityChunkId = chunkIdx;
+    header->IntegrityChunkGeneration = chunk.Generation;
+    header->HeaderChecksum = CalculateRawChecksum(header, sizeof(*header));
+
+    const ui64 ioId = NextIoId++;
+    IosInFlight.emplace(ioId, THeaderWriteRef{chunkIdx, replica});
+    Actions.emplace_back(TWriteIo{ioId, chunkIdx, ChunkHeaderReplicaOffset(replica), std::move(data)});
+}
+
+std::vector<TChunkIdx> TIntegrityManager::TakeReleasableIntegrityChunks() {
+    // Freed slots first satisfy pending extents (queueing their format writes); a chunk that is
+    // still fully free afterwards has no demand left for its slots.
+    TryAssignExtents();
+
+    std::vector<TChunkIdx> released;
+    for (auto it = IntegrityChunks.begin(); it != IntegrityChunks.end(); ) {
+        const TIntegrityChunkInfo& chunk = it->second;
+        // Formatting chunks have a header write in flight: skip them, they become releasable
+        // once headers settle. A slot withheld by an orphaned format write keeps FreeSlots
+        // below capacity, so a fully free chunk has no extent I/O in flight either.
+        if (chunk.State == EChunkState::Ready && chunk.FreeSlots.size() == ExtentsPerChunkCount) {
+            released.push_back(it->first);
+            IntegrityChunks.erase(it++);
+        } else {
+            ++it;
+        }
+    }
+    return released;
+}
+
+void TIntegrityManager::TryAssignExtents() {
+    while (!PendingExtents.empty()) {
+        // Find a chunk with a free slot (Formatting or Ready; smallest chunk index first for
+        // determinism). Extents may be formatted in parallel with the chunk's own headers.
+        TChunkIdx chunkIdx = 0;
+        TIntegrityChunkInfo* chunk = nullptr;
+        for (auto& [idx, info] : IntegrityChunks) {
+            if (!info.FreeSlots.empty() && (!chunk || idx < chunkIdx)) {
+                chunkIdx = idx;
+                chunk = &info;
+            }
+        }
+        if (!chunk) {
+            return; // waiting for a chunk allocation
+        }
+
+        const TDataChunkKey key = PendingExtents.front();
+        PendingExtents.pop_front();
+
+        const auto it = Extents.find(key);
+        Y_ABORT_UNLESS(it != Extents.end() && it->second.State == EExtentState::Pending);
+        TExtentInfo& extent = it->second;
+
+        extent.Ref.IntegrityChunkIdx = chunkIdx;
+        extent.Ref.ExtentSlot = chunk->FreeSlots.back();
+        chunk->FreeSlots.pop_back();
+        extent.State = EExtentState::Formatting;
+
+        PlacedKeys.push_back(key);
+        QueueExtentFormatWrite(key, extent);
+    }
+}
+
+void TIntegrityManager::QueueExtentFormatWrite(TDataChunkKey key, TExtentInfo& extent) {
+    const TIntegrityChunkInfo& chunk = IntegrityChunks.at(extent.Ref.IntegrityChunkIdx);
+
+    auto data = TRcBuf::UninitializedPageAligned(ExtentOnDiskSizeBytes);
+    auto* blocks = reinterpret_cast<TIntegrityBlock*>(data.GetDataMut());
+    memset(blocks, 0, ExtentOnDiskSizeBytes);
+
+    for (ui32 pair = 0; pair < BlocksPerExtentCount; ++pair) {
+        for (ui32 slot = 0; slot < IntegrityPairSlots; ++slot) {
+            TIntegrityBlock& block = blocks[pair * IntegrityPairSlots + slot];
+            TIntegrityBlockHeader& header = block.Header;
+            header.Magic = MagicIntegrityBlock;
+            header.FormatVersion = static_cast<ui16>(EIntegrityFormatVersion::BaseAwupf4KiB);
+            header.ChecksumBlockIdx = pair;
+            header.OwnerId = key.TabletId;
+            header.VChunkId = key.VChunkIndex;
+            header.VChunkGeneration = extent.Ref.VChunkGeneration;
+            header.IntegrityChunkId = extent.Ref.IntegrityChunkIdx;
+            header.IntegrityExtentId = extent.Ref.ExtentSlot;
+            header.IntegrityChunkGeneration = chunk.Generation;
+            // Slot A gets sequence 0, slot B gets 1, so B starts as the current slot of each pair.
+            header.PairSequenceNumber = slot;
+            header.BlockChecksum = CalculateRawChecksum(&block, sizeof(block));
+        }
+    }
+
+    const ui64 ioId = NextIoId++;
+    extent.FormatIoId = ioId;
+    IosInFlight.emplace(ioId, TExtentFormatRef{key});
+    Actions.emplace_back(TWriteIo{ioId, extent.Ref.IntegrityChunkIdx, ExtentOffset(extent.Ref.ExtentSlot),
+        std::move(data)});
+}
+
+void TIntegrityManager::MaybeCompleteExtent(TDataChunkKey key, TExtentInfo& extent,
+        std::vector<TDataChunkKey>& readyKeys) {
+    Y_ABORT_UNLESS(extent.State == EExtentState::Formatting);
+    TIntegrityChunkInfo& chunk = IntegrityChunks.at(extent.Ref.IntegrityChunkIdx);
+    if (!extent.FormatComplete || chunk.State != EChunkState::Ready) {
+        if (extent.FormatComplete && chunk.State != EChunkState::Ready) {
+            chunk.WaitingForChunkReady.push_back(key);
+        }
+        return;
+    }
+    extent.State = EExtentState::Ready;
+    if (!extent.DeletionPending) {
+        readyKeys.push_back(key);
+    }
+}
+
+std::vector<TIntegrityManager::TDataChunkKey> TIntegrityManager::OnIoCompleted(ui64 ioId) {
+    const auto ioIt = IosInFlight.find(ioId);
+    Y_ABORT_UNLESS(ioIt != IosInFlight.end(), "unknown IoId# %" PRIu64, ioId);
+    const TIoRef ref = ioIt->second;
+    IosInFlight.erase(ioIt);
+
+    std::vector<TDataChunkKey> readyKeys;
+
+    std::visit(TOverloaded{
+        [&](const THeaderWriteRef& headerRef) {
+            TIntegrityChunkInfo& chunk = IntegrityChunks.at(headerRef.ChunkIdx);
+            Y_ABORT_UNLESS(chunk.State == EChunkState::Formatting && chunk.HeaderWritesRemaining > 0);
+            --chunk.HeaderWritesRemaining;
+            if (chunk.HeaderWritesRemaining > 0) {
+                return;
+            }
+            chunk.State = EChunkState::Ready;
+            auto waiting = std::exchange(chunk.WaitingForChunkReady, {});
+            for (const TDataChunkKey& key : waiting) {
+                const auto it = Extents.find(key);
+                if (it == Extents.end() || it->second.State != EExtentState::Formatting) {
+                    continue;
+                }
+                MaybeCompleteExtent(key, it->second, readyKeys);
+            }
+            TryAssignExtents();
+        },
+        [&](const TExtentFormatRef& formatRef) {
+            // FreeExtent rewrites the ref of a freed extent to TOrphanedExtentFormatRef, so this
+            // completion always belongs to the live extent that issued exactly this write.
+            const auto it = Extents.find(formatRef.Key);
+            Y_ABORT_UNLESS(it != Extents.end() && it->second.State == EExtentState::Formatting
+                && it->second.FormatIoId == ioId);
+            it->second.FormatIoId = 0;
+            it->second.FormatComplete = true;
+            MaybeCompleteExtent(formatRef.Key, it->second, readyKeys);
+        },
+        [&](const TOrphanedExtentFormatRef& orphanRef) {
+            // The format write of a freed extent settled: the slot is now safe to reuse; a pending
+            // extent may have been waiting for it.
+            ReleaseSlot(orphanRef.ChunkIdx, orphanRef.ExtentSlot);
+            TryAssignExtents();
+        },
+    }, ref);
+
+    return readyKeys;
+}
+
+bool TIntegrityManager::IsExtentReady(TDataChunkKey key) const {
+    const auto it = Extents.find(key);
+    return it != Extents.end() && !it->second.DeletionPending
+        && it->second.State == EExtentState::Ready;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Write path
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+TIntegrityManager::TIntegrityBlockState& TIntegrityManager::GetOrCreateBlockState(TDataChunkKey key,
+        TExtentInfo& extent, ui32 blockIdx) {
+    const auto [it, inserted] = extent.BlockStates.try_emplace(blockIdx);
+    if (inserted) {
+        it->second = std::make_unique<TIntegrityBlockState>();
+        TIntegrityBlockState& state = *it->second;
+        state.Key = key;
+        state.BlockIdx = blockIdx;
+        state.Known.Reserve(ChecksumsPerIntegrityBlock);
+        state.Checksums.resize(ChecksumsPerIntegrityBlock, 0);
+        BlockStateLru.PushBack(&state);
+        ++BlockStateCount;
+        EvictBlockStatesOverBudget();
+        return state;
+    }
+    TIntegrityBlockState& state = *it->second;
+    state.Unlink();
+    BlockStateLru.PushBack(&state); // touch
+    return state;
+}
+
+TIntegrityManager::TIntegrityBlockState* TIntegrityManager::FindBlockState(TExtentInfo& extent, ui32 blockIdx) {
+    const auto it = extent.BlockStates.find(blockIdx);
+    if (it == extent.BlockStates.end()) {
+        return nullptr;
+    }
+    TIntegrityBlockState& state = *it->second;
+    state.Unlink();
+    BlockStateLru.PushBack(&state); // touch
+    return &state;
+}
+
+void TIntegrityManager::EvictBlockStatesOverBudget() {
+    while (BlockStateCount > MaxBlockStates) {
+        TIntegrityBlockState* victim = BlockStateLru.Front();
+        const auto extentIt = Extents.find(victim->Key);
+        Y_ABORT_UNLESS(extentIt != Extents.end());
+        const size_t numErased = extentIt->second.BlockStates.erase(victim->BlockIdx);
+        Y_ABORT_UNLESS(numErased == 1); // unlinks from the LRU via ~TIntrusiveListItem
+        --BlockStateCount;
+    }
+}
+
+void TIntegrityManager::DropBlockStates(TExtentInfo& extent) {
+    BlockStateCount -= extent.BlockStates.size();
+    extent.BlockStates.clear(); // each state unlinks from the LRU via ~TIntrusiveListItem
+}
+
+void TIntegrityManager::OnBlocksWritten(TDataChunkKey key, ui32 offsetInBytes, ui32 size,
+        const std::vector<ui64>& checksums) {
+    const auto it = Extents.find(key);
+    Y_ABORT_UNLESS(it != Extents.end(), "write to unknown data chunk, TabletId# %" PRIu64 " VChunkIndex# %" PRIu64,
+        key.TabletId, key.VChunkIndex);
+    TExtentInfo& extent = it->second;
+
+    Y_ABORT_UNLESS(size > 0 && ui64(offsetInBytes) + size <= DataChunkSize);
+
+    // Blocks partially covered by an unaligned write are still marked used: the read path must
+    // return their (partially updated) disk contents, not zeros.
+    const ui32 firstBlock = offsetInBytes / IntegrityUnitSize;
+    const ui32 endBlock = (offsetInBytes + size + IntegrityUnitSize - 1) / IntegrityUnitSize;
+
+    const bool aligned = offsetInBytes % IntegrityUnitSize == 0 && size % IntegrityUnitSize == 0;
+    const bool withChecksums = !checksums.empty();
+    if (withChecksums) {
+        Y_ABORT_UNLESS(aligned && checksums.size() == endBlock - firstBlock,
+            "checksums must be per-4KiB-block of an aligned range: offset# %" PRIu32 " size# %" PRIu32
+            " checksums# %zu", offsetInBytes, size, checksums.size());
+    }
+
+    for (ui32 block = firstBlock; block < endBlock; ++block) {
+        extent.UsedBlocks.Set(block);
+
+        const ui32 blockStateIdx = block / ChecksumsPerIntegrityBlock;
+        const ui32 slot = block % ChecksumsPerIntegrityBlock;
+        const ui64 generation = extent.Ref.VChunkGeneration;
+
+        if (withChecksums) {
+            TIntegrityBlockState& state = GetOrCreateBlockState(key, extent, blockStateIdx);
+            const ui64 newCsum = checksums[block - firstBlock];
+            if (state.Known.Get(slot)) {
+                UpdateRoot(state.Digest, generation, block, state.Checksums[slot], newCsum);
+            } else {
+                state.Digest ^= Contribution(generation, block, newCsum);
+                state.Known.Set(slot);
+            }
+            state.Checksums[slot] = newCsum;
+        } else if (TIntegrityBlockState* state = FindBlockState(extent, blockStateIdx)) {
+            // The block was overwritten without a checksum: the recorded one is now stale.
+            if (state->Known.Get(slot)) {
+                state->Digest ^= Contribution(generation, block, state->Checksums[slot]);
+                state->Known.Reset(slot);
+                state->Checksums[slot] = 0;
+            }
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Read path
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+TIntegrityManager::TReadPlan TIntegrityManager::MakeReadPlan(TDataChunkKey key, ui32 offsetInBytes, ui32 size) const {
+    TReadPlan plan;
+
+    const auto it = Extents.find(key);
+    if (it == Extents.end()) {
+        // Unknown chunk: pass through unchanged (safe fallback).
+        return plan;
+    }
+    const TExtentInfo& extent = it->second;
+
+    if (extent.BitmapUnknown) {
+        // Restored extent: the previous incarnation's bitmap is lost, so any block may hold data.
+        return plan;
+    }
+
+    if (extent.UsedBlocks.Empty()) {
+        // Nothing was ever written to this chunk.
+        plan.Kind = TReadPlan::AllZero;
+        return plan;
+    }
+
+    if (offsetInBytes % IntegrityUnitSize != 0 || size % IntegrityUnitSize != 0) {
+        // Unaligned ranges cannot be safely zero-masked per block; fall back to passthrough.
+        // (DDisk validates requests against a 4 KiB sector size, so this should not happen.)
+        return plan;
+    }
+
+    Y_ABORT_UNLESS(size > 0 && ui64(offsetInBytes) + size <= DataChunkSize);
+
+    const ui32 firstBlock = offsetInBytes / IntegrityUnitSize;
+    const ui32 numBlocks = size / IntegrityUnitSize;
+
+    ui32 usedCount = 0;
+    plan.UsedBlocks.Reserve(numBlocks);
+    for (ui32 i = 0; i < numBlocks; ++i) {
+        if (extent.UsedBlocks.Get(firstBlock + i)) {
+            plan.UsedBlocks.Set(i);
+            ++usedCount;
+        }
+    }
+
+    if (usedCount == 0) {
+        plan.Kind = TReadPlan::AllZero;
+        plan.UsedBlocks.Clear();
+    } else if (usedCount == numBlocks) {
+        plan.Kind = TReadPlan::Passthrough;
+        plan.UsedBlocks.Clear();
+    } else {
+        plan.Kind = TReadPlan::Mixed;
+    }
+    return plan;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Mapping snapshot
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+TIntegrityManager::TMappingSnapshot TIntegrityManager::SnapshotMapping() const {
+    TMappingSnapshot snapshot;
+    snapshot.GenerationCounter = GenerationCounter;
+    for (const auto& [chunkIdx, chunk] : IntegrityChunks) {
+        if (chunk.State == EChunkState::Ready) {
+            snapshot.IntegrityChunks.push_back({chunkIdx, chunk.Generation});
+        }
+    }
+    for (const auto& [key, extent] : Extents) {
+        if (extent.State == EExtentState::Ready && !extent.DeletionPending) {
+            snapshot.Extents.push_back({key, extent.DataChunkIdx, extent.Ref});
+        }
+    }
+    return snapshot;
+}
+
+void TIntegrityManager::ApplyMappingSnapshot(const TMappingSnapshot& snapshot) {
+    Y_ABORT_UNLESS(IntegrityChunks.empty() && Extents.empty() && PendingExtents.empty() && IosInFlight.empty(),
+        "mapping snapshot must be applied to a fresh manager");
+
+    // Resume the generation counter past everything ever persisted. Generations handed out after
+    // the snapshot watermark was taken can only appear in records logged after it, so the max
+    // over the watermark and the restored records covers all durable state. A generation reused
+    // from an uncommitted (crash-lost) record is benign: the identity fields plus the
+    // format-before-use ordering already disambiguate such extents.
+    GenerationCounter = Max(GenerationCounter, snapshot.GenerationCounter);
+
+    for (const auto& entry : snapshot.IntegrityChunks) {
+        const auto [it, inserted] = IntegrityChunks.try_emplace(entry.ChunkIdx);
+        Y_ABORT_UNLESS(inserted);
+        it->second.Generation = entry.Generation;
+        it->second.State = EChunkState::Ready;
+        GenerationCounter = Max(GenerationCounter, entry.Generation);
+    }
+
+    absl::flat_hash_map<TChunkIdx, TDynBitMap> usedSlots;
+    for (const auto& entry : snapshot.Extents) {
+        const auto chunkIt = IntegrityChunks.find(entry.Ref.IntegrityChunkIdx);
+        Y_ABORT_UNLESS(chunkIt != IntegrityChunks.end() && entry.Ref.ExtentSlot < ExtentsPerChunkCount);
+
+        const auto [it, inserted] = Extents.try_emplace(entry.Key);
+        Y_ABORT_UNLESS(inserted);
+        TExtentInfo& extent = it->second;
+        extent.Ref = entry.Ref;
+        extent.State = EExtentState::Ready;
+        extent.DataChunkIdx = entry.DataChunkIdx;
+        // The previous incarnation's used-block bitmap is not recoverable yet: reads must pass
+        // through unchanged until a later phase restores bitmaps from the extents on disk.
+        extent.BitmapUnknown = true;
+
+        GenerationCounter = Max(GenerationCounter, entry.Ref.VChunkGeneration);
+
+        usedSlots[entry.Ref.IntegrityChunkIdx].Set(entry.Ref.ExtentSlot);
+    }
+
+    for (auto& [chunkIdx, chunk] : IntegrityChunks) {
+        const auto usedIt = usedSlots.find(chunkIdx);
+        chunk.FreeSlots.reserve(ExtentsPerChunkCount);
+        for (ui32 slot = ExtentsPerChunkCount; slot > 0; --slot) {
+            if (usedIt == usedSlots.end() || !usedIt->second.Get(slot - 1)) {
+                chunk.FreeSlots.push_back(slot - 1);
+            }
+        }
+    }
+
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Introspection
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+const TIntegrityManager::TExtentRef* TIntegrityManager::FindExtentRef(TDataChunkKey key) const {
+    const auto it = Extents.find(key);
+    if (it == Extents.end() || it->second.DeletionPending
+            || it->second.State == EExtentState::Pending) {
+        return nullptr;
+    }
+    return &it->second.Ref;
+}
+
+ui64 TIntegrityManager::GetIntegrityChunkGeneration(TChunkIdx chunkIdx) const {
+    const auto it = IntegrityChunks.find(chunkIdx);
+    return it != IntegrityChunks.end() ? it->second.Generation : 0;
+}
+
+bool TIntegrityManager::IsIntegrityChunkFormatted(TChunkIdx chunkIdx) const {
+    const auto it = IntegrityChunks.find(chunkIdx);
+    return it != IntegrityChunks.end() && it->second.State == EChunkState::Ready;
+}
+
+ui64 TIntegrityManager::GetIntegrityBlockDigest(TDataChunkKey key, ui32 integrityBlockIdx) const {
+    const auto it = Extents.find(key);
+    Y_ABORT_UNLESS(it != Extents.end() && integrityBlockIdx < BlocksPerExtentCount);
+    const auto stateIt = it->second.BlockStates.find(integrityBlockIdx);
+    return stateIt != it->second.BlockStates.end() ? stateIt->second->Digest : 0;
+}
+
+bool TIntegrityManager::GetBlockChecksum(TDataChunkKey key, ui32 blockIdx, ui64* checksum) const {
+    const auto it = Extents.find(key);
+    Y_ABORT_UNLESS(it != Extents.end() && blockIdx < DataBlocksPerChunkCount);
+    const auto stateIt = it->second.BlockStates.find(blockIdx / ChecksumsPerIntegrityBlock);
+    if (stateIt == it->second.BlockStates.end()) {
+        return false;
+    }
+    const TIntegrityBlockState& state = *stateIt->second;
+    const ui32 slot = blockIdx % ChecksumsPerIntegrityBlock;
+    if (!state.Known.Get(slot)) {
+        return false;
+    }
+    *checksum = state.Checksums[slot];
+    return true;
+}
+
+} // namespace NKikimr::NDDisk

--- a/ydb/core/blobstorage/ddisk/integrity_manager.h
+++ b/ydb/core/blobstorage/ddisk/integrity_manager.h
@@ -24,8 +24,9 @@ namespace NKikimr::NDDisk {
 // Pure-logic (no I/O) owner of IntegrityChunk / IntegrityExtent allocation and of the in-memory
 // per-data-chunk integrity state: used-block bitmaps, data block checksums and per-TIntegrityBlock
 // digests. It performs no I/O itself: every disk operation it needs is queued as a TAction
-// (allocate an integrity chunk / write a buffer); TDDiskActor drains the queue with TakeActions(),
-// executes the async I/O and feeds completions back via OnIntegrityChunkAllocated / OnIoCompleted.
+// (allocate an integrity chunk / read or write a buffer); TDDiskActor drains the queue with
+// TakeActions(), executes the async I/O and feeds completions back via
+// OnIntegrityChunkAllocated / OnIoCompleted / OnReadIoCompleted.
 // This makes the whole state machine unit-testable without a DDisk.
 //
 // PDisk never restarts separately from DDisk, so a reserved chunk may be formatted immediately
@@ -83,20 +84,57 @@ public:
     struct TAllocateIntegrityChunk {};
 
     // Actor must write Data at the given chunk offset and call OnIoCompleted(IoId) on success.
+    enum class EWriteIoKind {
+        Pair,
+        ChunkHeader,
+        ExtentFormat,
+    };
+
     struct TWriteIo {
         ui64 IoId = 0;
         TChunkIdx ChunkIdx = 0;
         ui32 OffsetInBytes = 0;
         TRcBuf Data; // page-aligned, ready for direct I/O
+        EWriteIoKind Kind = EWriteIoKind::Pair;
     };
 
-    using TAction = std::variant<TAllocateIntegrityChunk, TWriteIo>;
+    // Actor must read Size bytes and call OnReadIoCompleted(IoId, Data) on success. Integrity pair
+    // reads are always one adjacent A/B pair (8 KiB).
+    struct TReadIo {
+        ui64 IoId = 0;
+        TChunkIdx ChunkIdx = 0;
+        ui32 OffsetInBytes = 0;
+        ui32 Size = 0;
+    };
+
+    using TAction = std::variant<TAllocateIntegrityChunk, TWriteIo, TReadIo>;
+
+    enum class EOperationKind {
+        Write,
+        Read,
+    };
+
+    enum class EOperationStatus {
+        Ok,
+        Corrupted,
+    };
+
+    struct TOperationResult {
+        ui64 OperationId = 0;
+        EOperationKind Kind = EOperationKind::Write;
+        EOperationStatus Status = EOperationStatus::Ok;
+        TString ErrorReason;
+        bool LostWriteDetected = false;
+
+        // Read only. One pure checksum per requested 4 KiB block.
+        std::vector<ui64> Checksums;
+    };
 
     // ---- read plans ----
 
     struct TReadPlan {
         enum EKind {
-            Passthrough, // read from disk as-is (untracked chunk, or every block of the range is used)
+            Passthrough, // read from disk as-is because every block of the range is used
             AllZero,     // no block of the range was ever written: reply zeros without disk I/O
             Mixed,       // read from disk, then zero the unused blocks according to UsedBlocks
         };
@@ -192,6 +230,7 @@ public:
     // Reports successful completion of a TWriteIo. Returns the data chunk keys whose extents
     // became Ready as a result (empty for chunk header writes that do not finish an extent).
     std::vector<TDataChunkKey> OnIoCompleted(ui64 ioId);
+    void OnReadIoCompleted(ui64 ioId, TRope data);
 
     // True when the key needs no further integrity work before its mapping may be logged: its
     // extent is formatted and the owning chunk's headers are written.
@@ -199,15 +238,20 @@ public:
 
     // ---- write path (called at data-write submission) ----
 
-    // Marks the 4 KiB blocks covered by [offsetInBytes, offsetInBytes + size) as used. checksums
-    // may be empty (write carried no checksums): the blocks are then marked used with unknown
-    // checksums. When non-empty, the range must be IntegrityUnitSize-aligned and checksums must
-    // hold one entry per block; per-TIntegrityBlock digests are updated incrementally.
-    void OnBlocksWritten(TDataChunkKey key, ui32 offsetInBytes, ui32 size, const std::vector<ui64>& checksums);
+    // Starts persistence of the supplied pure data checksums. The range must be 4 KiB aligned and
+    // carry exactly one checksum per block. Completion is reported by TakeCompletedOperations only
+    // after every affected pair image is durable.
+    ui64 BeginBlocksWrite(TDataChunkKey key, ui32 offsetInBytes, ui32 size,
+        const std::vector<ui64>& checksums);
 
     // ---- read path ----
 
     TReadPlan MakeReadPlan(TDataChunkKey key, ui32 offsetInBytes, ui32 size) const;
+
+    // Starts a metadata read and returns an operation id. The result is always delivered through
+    // TakeCompletedOperations (possibly immediately, without queued I/O).
+    ui64 BeginChecksumRead(TDataChunkKey key, ui32 offsetInBytes, ui32 size);
+    [[nodiscard]] std::vector<TOperationResult> TakeCompletedOperations();
 
     // ---- persistence hooks ----
 
@@ -247,6 +291,7 @@ public:
     // Currently cached TIntegrityBlockState count and the cache capacity (for unit tests).
     size_t CachedBlockStates() const { return BlockStateCount; }
     size_t MaxCachedBlockStates() const { return MaxBlockStates; }
+    bool HasInFlightOperationsForTablet(ui64 tabletId) const;
 
 private:
     enum class EChunkState {
@@ -274,10 +319,45 @@ private:
     // manager-wide LRU (checksums, Known and Digest live and die together).
     struct TIntegrityBlockState : TIntrusiveListItem<TIntegrityBlockState> {
         TDataChunkKey Key;   // owning extent, for eviction
-        ui32 BlockIdx = 0;   // TIntegrityBlock index within the extent
-        ui64 Digest = 0;
+        ui32 PairIdx = 0;    // TIntegrityBlock pair index within the extent
+        ui64 PairSequenceNumber = 0;
         TDynBitMap Known;              // per checksum slot: Checksums[slot] is recorded
         std::vector<ui64> Checksums;   // ChecksumsPerIntegrityBlock entries
+    };
+
+    enum class EPairSlot : ui8 {
+        Unknown,
+        A,
+        B,
+    };
+
+    // Small, pinned state used for lost-write detection. Checksum arrays remain evictable, but the
+    // expected digest must survive their eviction.
+    struct TPairMeta {
+        ui64 Digest = 0;
+        ui32 OperationPins = 0;
+        EPairSlot CurrentSlot = EPairSlot::Unknown;
+        bool DigestKnown : 1 = false;
+        bool BitmapKnown : 1 = false;
+        bool Resident : 1 = false;
+        bool Corrupted : 1 = false;
+    };
+
+    static_assert(sizeof(TPairMeta) <= 16);
+
+    // Sparse state only for pairs with queued/in-flight work (or a remembered corruption). It is
+    // removed when a pair becomes idle, keeping the per-disk pinned footprint at TPairMeta size.
+    struct TPairRuntime {
+        ui64 MutationVersion = 0;
+        ui64 DurableVersion = 0;
+        ui64 ReadIoId = 0;
+        ui64 WriteIoId = 0;
+        ui64 WriteVersion = 0;
+        bool Dirty = false;
+        bool LostWriteCorruption = false;
+        TString CorruptionReason;
+        std::vector<ui64> LoadWaiters;
+        std::vector<std::pair<ui64, ui64>> DurabilityWaiters; // operation id, required version
     };
 
     struct TExtentInfo {
@@ -290,13 +370,11 @@ private:
         // logical snapshots, but its physical slot is quarantined until that record is durable.
         bool DeletionPending = false;
 
-        // Restored via ApplyMappingSnapshot: the on-disk bitmap of the previous incarnation is not
-        // recoverable yet, so reads must pass through unchanged regardless of UsedBlocks (which
-        // only reflects writes made after the restore).
-        bool BitmapUnknown = false;
-
         // Empty until the first write to the chunk; never evicted (reads depend on it).
         TDynBitMap UsedBlocks; // per data block of the chunk
+        // One pinned entry per on-disk A/B pair.
+        std::vector<TPairMeta> Pairs;
+        absl::flat_hash_map<ui32, TPairRuntime> PairRuntime;
         // Sparse per-TIntegrityBlock checksum/digest states, keyed by TIntegrityBlock index.
         absl::flat_hash_map<ui32, std::unique_ptr<TIntegrityBlockState>> BlockStates;
     };
@@ -321,7 +399,32 @@ private:
         ui32 ExtentSlot = 0;
     };
 
-    using TIoRef = std::variant<THeaderWriteRef, TExtentFormatRef, TOrphanedExtentFormatRef>;
+    struct TPairReadRef {
+        TDataChunkKey Key;
+        ui32 PairIdx = 0;
+    };
+
+    struct TPairWriteRef {
+        TDataChunkKey Key;
+        ui32 PairIdx = 0;
+        ui64 Version = 0;
+        EPairSlot Slot = EPairSlot::Unknown;
+    };
+
+    using TIoRef = std::variant<THeaderWriteRef, TExtentFormatRef, TOrphanedExtentFormatRef,
+        TPairReadRef, TPairWriteRef>;
+
+    struct TPendingOperation {
+        EOperationKind Kind = EOperationKind::Write;
+        TDataChunkKey Key;
+        ui32 OffsetInBytes = 0;
+        ui32 Size = 0;
+        std::vector<ui64> Checksums;
+        ui32 PendingLoads = 0;
+        ui32 PendingDurability = 0;
+        bool Applied = false;
+        bool PairsPinned = false;
+    };
 
 private:
     ui64 AllocateGeneration() { return ++GenerationCounter; }
@@ -332,12 +435,30 @@ private:
     void FreeExtent(TDataChunkKey key, TExtentInfo& extent);
     void ReleaseSlot(TChunkIdx chunkIdx, ui32 extentSlot);
     void MaybeCompleteExtent(TDataChunkKey key, TExtentInfo& extent, std::vector<TDataChunkKey>& readyKeys);
+    ui32 FirstPair(ui32 offsetInBytes) const;
+    ui32 EndPair(ui32 offsetInBytes, ui32 size) const;
+    void QueuePairRead(TDataChunkKey key, TExtentInfo& extent, ui32 pairIdx);
+    void QueuePairWrite(TDataChunkKey key, TExtentInfo& extent, ui32 pairIdx);
+    void ApplyWriteOperation(ui64 operationId, TPendingOperation& operation);
+    void CompleteReadOperation(ui64 operationId, TPendingOperation& operation);
+    void CompleteOperation(ui64 operationId, EOperationStatus status = EOperationStatus::Ok,
+        TString errorReason = {}, bool lostWriteDetected = false);
+    void NotifyPairLoaded(TDataChunkKey key, TExtentInfo& extent, ui32 pairIdx);
+    void NotifyPairDurable(TDataChunkKey key, TExtentInfo& extent, ui32 pairIdx);
+    bool LoadPairImage(TDataChunkKey key, TExtentInfo& extent, ui32 pairIdx, const TRope& data,
+        TString* errorReason, bool* lostWriteDetected);
+    TIntegrityBlockIdentity MakeBlockIdentity(TDataChunkKey key, const TExtentInfo& extent,
+        ui32 pairIdx) const;
+    bool PairHasAllUsedChecksums(const TExtentInfo& extent, ui32 pairIdx,
+        const TIntegrityBlockState& state) const;
+    TPairRuntime& GetPairRuntime(TExtentInfo& extent, ui32 pairIdx);
+    void MaybeDropPairRuntime(TExtentInfo& extent, ui32 pairIdx);
 
     // Get-or-create the state of the given TIntegrityBlock, touching the LRU; creation may evict
     // the least recently used state (of any extent) when over budget.
-    TIntegrityBlockState& GetOrCreateBlockState(TDataChunkKey key, TExtentInfo& extent, ui32 blockIdx);
+    TIntegrityBlockState& GetOrCreateBlockState(TDataChunkKey key, TExtentInfo& extent, ui32 pairIdx);
     // Lookup without creation (still touches the LRU); nullptr when absent (never written/evicted).
-    TIntegrityBlockState* FindBlockState(TExtentInfo& extent, ui32 blockIdx);
+    TIntegrityBlockState* FindBlockState(TExtentInfo& extent, ui32 pairIdx);
     void EvictBlockStatesOverBudget();
     void DropBlockStates(TExtentInfo& extent);
 
@@ -372,6 +493,9 @@ private:
     std::vector<TAction> Actions;
     absl::flat_hash_map<ui64, TIoRef> IosInFlight;
     ui64 NextIoId = 1;
+    absl::flat_hash_map<ui64, TPendingOperation> PendingOperations;
+    std::vector<TOperationResult> CompletedOperations;
+    ui64 NextOperationId = 1;
 };
 
 } // namespace NKikimr::NDDisk

--- a/ydb/core/blobstorage/ddisk/integrity_manager.h
+++ b/ydb/core/blobstorage/ddisk/integrity_manager.h
@@ -1,0 +1,377 @@
+#pragma once
+
+#include "defs.h"
+
+#include "ddisk_checksums.h"
+
+#include <ydb/library/actors/util/rc_buf.h>
+
+#include <library/cpp/containers/absl/flat_hash_map.h>
+
+#include <util/generic/bitmap.h>
+#include <util/generic/intrlist.h>
+
+#include <deque>
+#include <memory>
+#include <variant>
+#include <vector>
+
+namespace NKikimr::NDDisk {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// TIntegrityManager
+//
+// Pure-logic (no I/O) owner of IntegrityChunk / IntegrityExtent allocation and of the in-memory
+// per-data-chunk integrity state: used-block bitmaps, data block checksums and per-TIntegrityBlock
+// digests. It performs no I/O itself: every disk operation it needs is queued as a TAction
+// (allocate an integrity chunk / write a buffer); TDDiskActor drains the queue with TakeActions(),
+// executes the async I/O and feeds completions back via OnIntegrityChunkAllocated / OnIoCompleted.
+// This makes the whole state machine unit-testable without a DDisk.
+//
+// PDisk never restarts separately from DDisk, so a reserved chunk may be formatted immediately
+// (as if committed). Formatting writes (chunk headers, extent image) run in parallel; the actor
+// logs a single combined increment only after the extent is Ready, and does not reply to the
+// originating write until that record is durable. A crash before the increment just loses the
+// reserved chunks.
+//
+// Persistence scope: the DataChunk -> IntegrityExtent mapping (plus generations and the monotonic
+// generation counter) is persisted in the DDisk chunk-map log by the actor and restored on boot
+// via ApplyMappingSnapshot(). A durable increment always references a fully formatted extent (and,
+// when it carries an IntegrityChunk, a fully formatted chunk), so every restored chunk is Ready.
+// The used-block bitmaps and checksums still live in memory only; extent formatting writes valid
+// TIntegrityBlock images with empty bitmaps, and TIntegrityBlocks are not rewritten on data
+// writes. Restored extents therefore have unknown bitmaps: reads of them pass through unchanged
+// until a later phase restores bitmaps from the extents on disk; new writes are tracked again.
+//
+// Memory: used-block bitmaps are small (1 bit per 4 KiB data block) and are kept per extent,
+// never evicted - reads depend on them. Checksums and digests are kept sparsely, one
+// TIntegrityBlockState (~4 KiB) per TIntegrityBlock actually written with checksums, bounded by a
+// manager-wide LRU budget. Evicting a state loses its checksums and its digest together, which
+// preserves the invariant "digest = XOR of contributions of the currently known checksums" - the
+// same information loss a checksum-less overwrite already produces.
+//
+// On-disk layout of an integrity chunk (same size as a data chunk):
+//   [0, IntegrityChunkHeaderRegionSize)  - TIntegrityChunkHeader replicas
+//   then ExtentsPerChunk() extents, each occupying ExtentOnDiskSize() bytes: BlocksPerExtent()
+//   ping-pong pairs of two adjacent 4 KiB TIntegrityBlock slots (A then B). Formatting writes both
+//   slots with PairSequenceNumber 0 (A) and 1 (B), so slot B starts as the current one.
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+class TIntegrityManager {
+public:
+    struct TDataChunkKey {
+        ui64 TabletId = 0;
+        ui64 VChunkIndex = 0;
+
+        friend constexpr auto operator<=>(const TDataChunkKey&, const TDataChunkKey&) = default;
+
+        template <typename H>
+        friend H AbslHashValue(H h, const TDataChunkKey& key) {
+            return H::combine(std::move(h), key.TabletId, key.VChunkIndex);
+        }
+    };
+
+    struct TExtentRef {
+        TChunkIdx IntegrityChunkIdx = 0;
+        ui32 ExtentSlot = 0;
+        ui64 VChunkGeneration = 0;
+    };
+
+    // ---- actions (outputs): drained by the actor after any mutating call ----
+
+    // Actor must obtain a chunk (e.g. from its reserve) and call OnIntegrityChunkAllocated().
+    struct TAllocateIntegrityChunk {};
+
+    // Actor must write Data at the given chunk offset and call OnIoCompleted(IoId) on success.
+    struct TWriteIo {
+        ui64 IoId = 0;
+        TChunkIdx ChunkIdx = 0;
+        ui32 OffsetInBytes = 0;
+        TRcBuf Data; // page-aligned, ready for direct I/O
+    };
+
+    using TAction = std::variant<TAllocateIntegrityChunk, TWriteIo>;
+
+    // ---- read plans ----
+
+    struct TReadPlan {
+        enum EKind {
+            Passthrough, // read from disk as-is (untracked chunk, or every block of the range is used)
+            AllZero,     // no block of the range was ever written: reply zeros without disk I/O
+            Mixed,       // read from disk, then zero the unused blocks according to UsedBlocks
+        };
+
+        EKind Kind = Passthrough;
+        // Mixed only: bit i corresponds to the i-th IntegrityUnitSize block of the requested range;
+        // set = keep disk data, unset = zero-fill.
+        TDynBitMap UsedBlocks;
+    };
+
+    // ---- persistence hooks ----
+
+    struct TMappingSnapshot {
+        struct TIntegrityChunkEntry {
+            TChunkIdx ChunkIdx = 0;
+            ui64 Generation = 0;
+        };
+
+        struct TExtentEntry {
+            TDataChunkKey Key;
+            TChunkIdx DataChunkIdx = 0;
+            TExtentRef Ref;
+        };
+
+        std::vector<TIntegrityChunkEntry> IntegrityChunks;
+        std::vector<TExtentEntry> Extents;
+        // Last generation value ever assigned (see AllocateGeneration); restore resumes past the
+        // maximum of this watermark and every generation in the restored records.
+        ui64 GenerationCounter = 0;
+    };
+
+public:
+    // Approximate memory cost of one cached TIntegrityBlockState; the ctor's checksumCacheBytes
+    // budget is converted to a state count with it (tests pass N * BlockStateApproxBytes).
+    static constexpr size_t BlockStateApproxBytes =
+        128 /* struct + hash map overhead */ + ChecksumsPerIntegrityBlock * sizeof(ui64)
+        + ChecksumsPerIntegrityBlock / 8;
+
+    static constexpr ui64 DefaultChecksumCacheBytes = 64ull << 20;
+
+public:
+    // Geometry is derived from the data chunk size so that unit tests can use small chunks.
+    // ddiskId / pdiskGuid are stamped into TIntegrityChunkHeader. checksumCacheBytes bounds the
+    // total memory spent on cached checksums/digests (see the memory note above).
+    TIntegrityManager(ui64 dataChunkSizeBytes, ui64 ddiskId, ui64 pdiskGuid,
+        ui64 checksumCacheBytes = DefaultChecksumCacheBytes);
+
+    [[nodiscard]] std::vector<TAction> TakeActions();
+    bool HasActions() const { return !Actions.empty(); }
+
+    // Keys whose extents were assigned a slot (IntegrityChunk found) since the last take.
+    // The actor uses this to open the data-write path in parallel with formatting.
+    [[nodiscard]] std::vector<TDataChunkKey> TakePlacedKeys();
+
+    // ---- data chunk lifecycle ----
+
+    // A new data chunk was allocated: starts extent assignment (may queue TAllocateIntegrityChunk
+    // and/or extent-format TWriteIo actions). The chunk is *placed* once it has an IntegrityChunk
+    // (slot assigned) and *Ready* once its extent format I/O and the owning chunk's header writes
+    // have both completed.
+    void OnDataChunkAllocated(TDataChunkKey key, TChunkIdx dataChunkIdx);
+
+    // Starts a durable tablet deletion. Matching extents stop participating in snapshots and
+    // pending assignment, but their slots remain withheld until CommitTabletChunksDeletion():
+    // reusing a slot before the deletion snapshot commits could overwrite an extent that recovery
+    // would still map to the old data chunk.
+    void PrepareTabletChunksDeletion(ui64 tabletId);
+
+    // Completes a prepared deletion after its removal snapshot commits. The extents are erased and
+    // their slots become available for pending allocations / integrity-chunk reclamation.
+    void CommitTabletChunksDeletion(ui64 tabletId);
+
+    // ---- integrity chunk / I/O completions ----
+
+    ui64 GetGenerationCounter() const { return GenerationCounter; }
+
+    // Fulfills one previously queued TAllocateIntegrityChunk. Draws the next IntegrityChunkGeneration
+    // and queues all header replica writes in parallel. Extents may be assigned immediately
+    // (placed) into this still-formatting chunk.
+    void OnIntegrityChunkAllocated(TChunkIdx chunkIdx);
+
+    // Cancels one queued-but-unfulfilled TAllocateIntegrityChunk when the remaining supply still
+    // covers all pending extents (demand may vanish when a tablet deletion frees slots). Returns
+    // false when the allocation is still needed and must proceed.
+    bool CancelChunkAllocationIfExcess();
+
+    // Removes and returns the integrity chunks that can be released back to PDisk: header writes
+    // settled (Ready), every slot free (slots withheld by in-flight orphaned format writes do not
+    // count as free, so no extent I/O targets these chunks) and no pending extent demand - pending
+    // extents are assigned into free slots first, which may queue their format writes.
+    std::vector<TChunkIdx> TakeReleasableIntegrityChunks();
+
+    // Reports successful completion of a TWriteIo. Returns the data chunk keys whose extents
+    // became Ready as a result (empty for chunk header writes that do not finish an extent).
+    std::vector<TDataChunkKey> OnIoCompleted(ui64 ioId);
+
+    // True when the key needs no further integrity work before its mapping may be logged: its
+    // extent is formatted and the owning chunk's headers are written.
+    bool IsExtentReady(TDataChunkKey key) const;
+
+    // ---- write path (called at data-write submission) ----
+
+    // Marks the 4 KiB blocks covered by [offsetInBytes, offsetInBytes + size) as used. checksums
+    // may be empty (write carried no checksums): the blocks are then marked used with unknown
+    // checksums. When non-empty, the range must be IntegrityUnitSize-aligned and checksums must
+    // hold one entry per block; per-TIntegrityBlock digests are updated incrementally.
+    void OnBlocksWritten(TDataChunkKey key, ui32 offsetInBytes, ui32 size, const std::vector<ui64>& checksums);
+
+    // ---- read path ----
+
+    TReadPlan MakeReadPlan(TDataChunkKey key, ui32 offsetInBytes, ui32 size) const;
+
+    // ---- persistence hooks ----
+
+    // Captures the Ready part of the mapping (integrity chunks + key -> extent). In-flight
+    // allocations are deliberately excluded: they will be redone after recovery.
+    TMappingSnapshot SnapshotMapping() const;
+
+    // Rebuilds the mapping from a snapshot; the manager must be freshly constructed. Bitmaps and
+    // checksums are not part of the snapshot, so restored extents are marked BitmapUnknown: reads
+    // of them pass through unchanged (a later phase restores bitmaps from the extents on disk).
+    // Every restored chunk is Ready: a durable increment is only logged after formatting.
+    void ApplyMappingSnapshot(const TMappingSnapshot& snapshot);
+
+    // ---- geometry / introspection (for the actor and unit tests) ----
+
+    ui32 DataBlocksInChunk() const { return DataBlocksPerChunkCount; }
+    ui32 BlocksPerExtent() const { return BlocksPerExtentCount; }
+    ui32 ExtentsPerChunk() const { return ExtentsPerChunkCount; }
+    size_t ExtentOnDiskSize() const { return ExtentOnDiskSizeBytes; }
+
+    static constexpr ui32 ChunkHeaderReplicaCount = 3;
+    // Offset of the i-th TIntegrityChunkHeader replica within the chunk.
+    ui32 ChunkHeaderReplicaOffset(ui32 replica) const;
+    // Offset of the extent slot within the chunk.
+    ui32 ExtentOffset(ui32 extentSlot) const;
+
+    const TExtentRef* FindExtentRef(TDataChunkKey key) const;
+    ui64 GetIntegrityChunkGeneration(TChunkIdx chunkIdx) const;
+    // True once all header replicas of the chunk were written (State == Ready). False for chunks
+    // the manager does not know yet.
+    bool IsIntegrityChunkFormatted(TChunkIdx chunkIdx) const;
+    // Digest of the given TIntegrityBlock (pair) of the key's extent; 0 when nothing was recorded
+    // (or the state was evicted).
+    ui64 GetIntegrityBlockDigest(TDataChunkKey key, ui32 integrityBlockIdx) const;
+    // Recorded checksum of the given data block; returns false when the block has no known checksum.
+    bool GetBlockChecksum(TDataChunkKey key, ui32 blockIdx, ui64* checksum) const;
+    // Currently cached TIntegrityBlockState count and the cache capacity (for unit tests).
+    size_t CachedBlockStates() const { return BlockStateCount; }
+    size_t MaxCachedBlockStates() const { return MaxBlockStates; }
+
+private:
+    enum class EChunkState {
+        Formatting, // TIntegrityChunkHeader replica writes are in flight
+        Ready,
+    };
+
+    struct TIntegrityChunkInfo {
+        EChunkState State = EChunkState::Formatting;
+        ui64 Generation = 0;
+        std::vector<ui32> FreeSlots; // kept descending, so the smallest slot is assigned first
+        ui32 HeaderWritesRemaining = 0;
+        // Extents whose format write has completed while this chunk is still Formatting.
+        std::vector<TDataChunkKey> WaitingForChunkReady;
+    };
+
+    enum class EExtentState {
+        Pending,    // waiting for an integrity chunk with a free slot
+        Formatting, // extent-format write is in flight, or done and waiting for chunk headers
+        Ready,
+    };
+
+    // Checksums and digest of one TIntegrityBlock (ChecksumsPerIntegrityBlock data blocks),
+    // allocated lazily on the first checksummed write to its range and evictable via the
+    // manager-wide LRU (checksums, Known and Digest live and die together).
+    struct TIntegrityBlockState : TIntrusiveListItem<TIntegrityBlockState> {
+        TDataChunkKey Key;   // owning extent, for eviction
+        ui32 BlockIdx = 0;   // TIntegrityBlock index within the extent
+        ui64 Digest = 0;
+        TDynBitMap Known;              // per checksum slot: Checksums[slot] is recorded
+        std::vector<ui64> Checksums;   // ChecksumsPerIntegrityBlock entries
+    };
+
+    struct TExtentInfo {
+        TExtentRef Ref; // valid once State >= Formatting
+        EExtentState State = EExtentState::Pending;
+        TChunkIdx DataChunkIdx = 0;
+        ui64 FormatIoId = 0; // the in-flight extent-format write; valid while the write is in flight
+        bool FormatComplete = false;
+        // Set while the actor's tablet-removal snapshot is in flight. The extent is absent from
+        // logical snapshots, but its physical slot is quarantined until that record is durable.
+        bool DeletionPending = false;
+
+        // Restored via ApplyMappingSnapshot: the on-disk bitmap of the previous incarnation is not
+        // recoverable yet, so reads must pass through unchanged regardless of UsedBlocks (which
+        // only reflects writes made after the restore).
+        bool BitmapUnknown = false;
+
+        // Empty until the first write to the chunk; never evicted (reads depend on it).
+        TDynBitMap UsedBlocks; // per data block of the chunk
+        // Sparse per-TIntegrityBlock checksum/digest states, keyed by TIntegrityBlock index.
+        absl::flat_hash_map<ui32, std::unique_ptr<TIntegrityBlockState>> BlockStates;
+    };
+
+    struct THeaderWriteRef {
+        TChunkIdx ChunkIdx = 0;
+        ui32 Replica = 0;
+    };
+
+    // Format write of a live extent. FreeExtent rewrites the ref of a freed extent to
+    // TOrphanedExtentFormatRef, so on completion this ref always identifies the extent whose
+    // FormatIoId issued it - a stale completion can never complete a reused key.
+    struct TExtentFormatRef {
+        TDataChunkKey Key;
+    };
+
+    // Format write whose extent was freed while the write was in flight. The slot is withheld
+    // from the free list until this completion: reusing it earlier could let the old write land
+    // after the new one, leaving a stale-generation image on disk.
+    struct TOrphanedExtentFormatRef {
+        TChunkIdx ChunkIdx = 0;
+        ui32 ExtentSlot = 0;
+    };
+
+    using TIoRef = std::variant<THeaderWriteRef, TExtentFormatRef, TOrphanedExtentFormatRef>;
+
+private:
+    ui64 AllocateGeneration() { return ++GenerationCounter; }
+    void EnsureChunkCapacity();
+    void TryAssignExtents();
+    void QueueChunkHeaderWrite(TChunkIdx chunkIdx, ui32 replica);
+    void QueueExtentFormatWrite(TDataChunkKey key, TExtentInfo& extent);
+    void FreeExtent(TDataChunkKey key, TExtentInfo& extent);
+    void ReleaseSlot(TChunkIdx chunkIdx, ui32 extentSlot);
+    void MaybeCompleteExtent(TDataChunkKey key, TExtentInfo& extent, std::vector<TDataChunkKey>& readyKeys);
+
+    // Get-or-create the state of the given TIntegrityBlock, touching the LRU; creation may evict
+    // the least recently used state (of any extent) when over budget.
+    TIntegrityBlockState& GetOrCreateBlockState(TDataChunkKey key, TExtentInfo& extent, ui32 blockIdx);
+    // Lookup without creation (still touches the LRU); nullptr when absent (never written/evicted).
+    TIntegrityBlockState* FindBlockState(TExtentInfo& extent, ui32 blockIdx);
+    void EvictBlockStatesOverBudget();
+    void DropBlockStates(TExtentInfo& extent);
+
+private:
+    // Geometry, computed once in the ctor.
+    const ui64 DataChunkSize;
+    const ui32 DataBlocksPerChunkCount;
+    const ui32 BlocksPerExtentCount;
+    const size_t ExtentOnDiskSizeBytes;
+    const ui32 ExtentsPerChunkCount;
+
+    const ui64 DDiskId;
+    const ui64 PDiskGuid;
+
+    absl::flat_hash_map<TChunkIdx, TIntegrityChunkInfo> IntegrityChunks;
+    absl::flat_hash_map<TDataChunkKey, TExtentInfo> Extents;
+
+    // Monotonic source of every VChunkGeneration / IntegrityChunkGeneration; persisted as a
+    // snapshot watermark, so reuse after free keeps bumping generations even across restarts
+    // (lost-write protection).
+    ui64 GenerationCounter = 0;
+
+    std::deque<TDataChunkKey> PendingExtents;
+    ui32 PendingChunkAllocations = 0; // TAllocateIntegrityChunk actions not yet fulfilled
+    std::vector<TDataChunkKey> PlacedKeys;
+
+    // LRU over all cached TIntegrityBlockStates: front is the eviction victim.
+    TIntrusiveList<TIntegrityBlockState> BlockStateLru;
+    size_t BlockStateCount = 0;
+    const size_t MaxBlockStates;
+
+    std::vector<TAction> Actions;
+    absl::flat_hash_map<ui64, TIoRef> IosInFlight;
+    ui64 NextIoId = 1;
+};
+
+} // namespace NKikimr::NDDisk

--- a/ydb/core/blobstorage/ddisk/persistent_buffer.h
+++ b/ydb/core/blobstorage/ddisk/persistent_buffer.h
@@ -19,9 +19,17 @@ namespace NKikimr::NDDisk {
         ui64 Checksum : 64;
     };
 
+    // DirectBlockGroupIndex extends the persistent buffer key from plain TabletId to
+    // (TabletId, DirectBlockGroupIndex): a direct block group number that fits in a single byte
+    // (0-255). It is appended as the LAST field (with a default of 0) so that every existing
+    // 2-/3-argument positional aggregate initialization (e.g. {tabletId, generation}) keeps working
+    // unchanged and defaults to group 0 - preserving today's "one persistent buffer namespace per
+    // tablet" behavior. Callers that want independent per-direct-block-group persistent buffer
+    // namespaces can opt in by supplying the extra value explicitly.
     struct TPersistentBufferId {
         ui64 TabletId;
         ui32 Generation;
+        ui8 DirectBlockGroupIndex = 0;
 
         friend constexpr std::strong_ordering operator <=>(const TPersistentBufferId& x, const TPersistentBufferId& y) = default;
     };
@@ -30,6 +38,7 @@ namespace NKikimr::NDDisk {
         ui64 TabletId;
         ui32 Generation;
         ui64 Lsn;
+        ui8 DirectBlockGroupIndex = 0;
 
         friend constexpr std::strong_ordering operator <=>(const TPersistentBufferRecordId& x, const TPersistentBufferRecordId& y) = default;
     };
@@ -58,7 +67,7 @@ namespace NKikimr::NDDisk {
     template <>
     struct hash<NKikimr::NDDisk::TPersistentBufferRecordId> {
         inline size_t operator()(const NKikimr::NDDisk::TPersistentBufferRecordId& r) const {
-            return MultiHash(r.TabletId, r.Generation, r.Lsn);
+            return MultiHash(r.TabletId, r.Generation, r.Lsn, r.DirectBlockGroupIndex);
         }
     };
 

--- a/ydb/core/blobstorage/ddisk/persistent_buffer_barriers_manager.cpp
+++ b/ydb/core/blobstorage/ddisk/persistent_buffer_barriers_manager.cpp
@@ -176,14 +176,12 @@ namespace NKikimr::NDDisk {
                 // across the map (ordering is TabletId, then Generation, then
                 // DirectBlockGroupIndex), so we scan every entry with a matching TabletId and
                 // filter by DirectBlockGroupIndex rather than relying on a contiguous range.
-                bool found = false;
                 for (auto it = persistentBuffers.lower_bound({barrier.TabletId, 0});
                         it != persistentBuffers.end() && it->first.TabletId == barrier.TabletId; ) {
                     if (it->first.DirectBlockGroupIndex != barrier.DirectBlockGroupIndex) {
                         ++it;
                         continue;
                     }
-                    found = true;
                     if (it->first.Generation < barrier.Generation) {
                         it = persistentBuffers.erase(it);
                         continue;
@@ -200,35 +198,27 @@ namespace NKikimr::NDDisk {
                         ++it;
                     }
                 }
-                if (!found) {
-                    YDB_LOG_DEBUG("TPersistentBufferBarriersManager::RestoreBarriers tablet records not found, erase barrier marked as free",
-                        {"marker", "BSDD30"},
+                // Barriers are durable state even when this namespace has no live records.
+                auto locationIt = PersistentBufferBarriersLocation.find(key);
+                if (locationIt == PersistentBufferBarriersLocation.end()) {
+                    PersistentBufferBarriersLocation[key] = {pos, FreeBarrierPosition};
+                } else {
+                    auto oldBarrierLocation = PersistentBufferBarriersLocation[key];
+                    auto oldBarrier = PersistentBufferBarriers[oldBarrierLocation.BarrierIdx].Header.Barriers[oldBarrierLocation.Position];
+                    YDB_LOG_DEBUG("TPersistentBufferBarriersManager::RestoreBarriers duplicated barrier erase record found, bigger lsn used",
+                        {"marker", "BSDD38"},
                         {"tabletId", barrier.TabletId},
                         {"directBlockGroupIndex", barrier.DirectBlockGroupIndex},
-                        {"lsn", barrier.Lsn});
-                    PersistentBufferBarrierHoles.push_back({pos, FreeBarrierPosition});
-                } else {
-                    auto locationIt = PersistentBufferBarriersLocation.find(key);
-                    if (locationIt == PersistentBufferBarriersLocation.end()) {
-                        PersistentBufferBarriersLocation[key] = {pos, FreeBarrierPosition};
+                        {"barrierGeneration", barrier.Generation},
+                        {"oldBarrierGeneration", oldBarrier.Generation},
+                        {"barrierLsn", barrier.Lsn},
+                        {"oldBarrier.Lsn", oldBarrier.Lsn});
+                    if (barrier.Generation > oldBarrier.Generation
+                        || (barrier.Generation == oldBarrier.Generation && barrier.Lsn > oldBarrier.Lsn)) {
+                        PersistentBufferBarrierHoles.push_back(locationIt->second);
+                        locationIt->second = {pos, FreeBarrierPosition};
                     } else {
-                        auto oldBarrierLocation = PersistentBufferBarriersLocation[key];
-                        auto oldBarrier = PersistentBufferBarriers[oldBarrierLocation.BarrierIdx].Header.Barriers[oldBarrierLocation.Position];
-                        YDB_LOG_DEBUG("TPersistentBufferBarriersManager::RestoreBarriers duplicated barrier erase record found, bigger lsn used",
-                            {"marker", "BSDD38"},
-                            {"tabletId", barrier.TabletId},
-                            {"directBlockGroupIndex", barrier.DirectBlockGroupIndex},
-                            {"barrierGeneration", barrier.Generation},
-                            {"oldBarrierGeneration", oldBarrier.Generation},
-                            {"barrierLsn", barrier.Lsn},
-                            {"oldBarrier.Lsn", oldBarrier.Lsn});
-                        if (barrier.Generation > oldBarrier.Generation
-                            || (barrier.Generation == oldBarrier.Generation && barrier.Lsn > oldBarrier.Lsn)) {
-                            PersistentBufferBarrierHoles.push_back(locationIt->second);
-                            locationIt->second = {pos, FreeBarrierPosition};
-                        } else {
-                            PersistentBufferBarrierHoles.push_back({pos, FreeBarrierPosition});
-                        }
+                        PersistentBufferBarrierHoles.push_back({pos, FreeBarrierPosition});
                     }
                 }
             }

--- a/ydb/core/blobstorage/ddisk/persistent_buffer_barriers_manager.cpp
+++ b/ydb/core/blobstorage/ddisk/persistent_buffer_barriers_manager.cpp
@@ -60,10 +60,11 @@ namespace NKikimr::NDDisk {
         SlotId = slotId;
     }
 
-    TPersistentBufferBarrierRecord TPersistentBufferBarriersManager::GetBarrier(ui64 tabletId) const {
-        auto it = PersistentBufferBarriersLocation.find(tabletId);
+    TPersistentBufferBarrierRecord TPersistentBufferBarriersManager::GetBarrier(ui64 tabletId, ui8 directBlockGroupIndex) const {
+        const TTabletKey key{tabletId, directBlockGroupIndex};
+        auto it = PersistentBufferBarriersLocation.find(key);
         if (it == PersistentBufferBarriersLocation.end()) {
-            return {tabletId, 0, 0};
+            return {tabletId, 0, 0, directBlockGroupIndex};
         }
         const auto barrierIdx = it->second.BarrierIdx;
         const auto hpos = it->second.Position;
@@ -72,27 +73,30 @@ namespace NKikimr::NDDisk {
         return PersistentBufferBarriers[barrierIdx].Header.Barriers[hpos];
     }
 
-    bool TPersistentBufferBarriersManager::CanMoveBarrier(ui64 tabletId, ui32 barriersLimit) {
+    bool TPersistentBufferBarriersManager::CanMoveBarrier(ui64 tabletId, ui32 barriersLimit, ui8 directBlockGroupIndex) {
+        const TTabletKey key{tabletId, directBlockGroupIndex};
         return !PersistentBufferBarrierHoles.empty()
-            || PersistentBufferBarriersLocation.find(tabletId) != PersistentBufferBarriersLocation.end()
+            || PersistentBufferBarriersLocation.find(key) != PersistentBufferBarriersLocation.end()
             || FreeBarrierPosition < TPersistentBufferBarriers::MaxBarriersPerHeader
             || PersistentBufferBarriers.size() < barriersLimit;
     }
 
-    std::unordered_map<ui64, ui64> TPersistentBufferBarriersManager::GetBarriers() const {
-        std::unordered_map<ui64, ui64> res;
+    std::map<std::pair<ui64, ui8>, ui64> TPersistentBufferBarriersManager::GetBarriers() const {
+        std::map<std::pair<ui64, ui8>, ui64> res;
         for (auto& b : PersistentBufferBarriers) {
             for (auto& h : b.Header.Barriers) {
                 if (h.TabletId != 0) {
-                    res[h.TabletId] = Max(res[h.TabletId], h.Lsn);
+                    const std::pair<ui64, ui8> key{h.TabletId, h.DirectBlockGroupIndex};
+                    res[key] = Max(res[key], h.Lsn);
                 }
             }
         }
         return res;
     }
 
-    std::tuple<ui32, ui32, TEraseBarrier&> TPersistentBufferBarriersManager::MoveBarrier(ui64 tabletId, ui32 generation, ui64 lsn, const TPersistentBufferSectorInfo& newSector) {
-        auto it = PersistentBufferBarriersLocation.find(tabletId);
+    std::tuple<ui32, ui32, TEraseBarrier&> TPersistentBufferBarriersManager::MoveBarrier(ui64 tabletId, ui32 generation, ui64 lsn, const TPersistentBufferSectorInfo& newSector, ui8 directBlockGroupIndex) {
+        const TTabletKey key{tabletId, directBlockGroupIndex};
+        auto it = PersistentBufferBarriersLocation.find(key);
         ui32 barrierIdx = 0;
         ui32 pos = 0;
         if (it == PersistentBufferBarriersLocation.end()) {
@@ -100,7 +104,7 @@ namespace NKikimr::NDDisk {
                 barrierIdx = PersistentBufferBarrierHoles.back().BarrierIdx;
                 pos = PersistentBufferBarrierHoles.back().Position;
                 PersistentBufferBarrierHoles.pop_back();
-                PersistentBufferBarriersLocation[tabletId] = {barrierIdx, pos};
+                PersistentBufferBarriersLocation[key] = {barrierIdx, pos};
             } else {
                 if (FreeBarrierPosition >= TPersistentBufferBarriers::MaxBarriersPerHeader || PersistentBufferBarriers.empty()) {
                     FreeBarrierPosition = 0;
@@ -120,7 +124,7 @@ namespace NKikimr::NDDisk {
                 }
                 barrierIdx = PersistentBufferBarriers.size() - 1;
                 pos = FreeBarrierPosition;
-                PersistentBufferBarriersLocation[tabletId] = {barrierIdx, pos};
+                PersistentBufferBarriersLocation[key] = {barrierIdx, pos};
                 FreeBarrierPosition++;
             }
         } else {
@@ -140,13 +144,14 @@ namespace NKikimr::NDDisk {
             YDB_LOG_ERROR("TPersistentBufferBarriersManager::MoveBarrier tablet new barrier lsn is not bigger than previous",
                 {"marker", "BSDD29"},
                 {"tabletId", tabletId},
+                {"directBlockGroupIndex", directBlockGroupIndex},
                 {"lsn", lsn},
                 {"prevLsn", barrier.Header.Barriers[pos].Lsn});
         }
-        barrier.Header.Barriers[pos] = {tabletId, generation, lsn};
+        barrier.Header.Barriers[pos] = {tabletId, generation, lsn, directBlockGroupIndex};
         barrier.Header.Header.RecordLsn++;
 
-        auto erasesIt = Erases.find(tabletId);
+        auto erasesIt = Erases.find(key);
         if (erasesIt != Erases.end()) {
             if (erasesIt->second.Generation < generation) {
                 erasesIt->second.Lsns.clear();
@@ -166,37 +171,19 @@ namespace NKikimr::NDDisk {
             allocator.MarkOccupied(std::span<const TPersistentBufferSectorInfo>(&barrierSector, 1));
             for (FreeBarrierPosition = 0; FreeBarrierPosition < TPersistentBufferBarriers::MaxBarriersPerHeader && b.Header.Barriers[FreeBarrierPosition].TabletId > 0; FreeBarrierPosition++) {
                 auto& barrier = b.Header.Barriers[FreeBarrierPosition];
-                auto it = persistentBuffers.lower_bound({barrier.TabletId, 0});
-                if (it == persistentBuffers.end() || it->first.TabletId != barrier.TabletId) {
-                    YDB_LOG_DEBUG("TPersistentBufferBarriersManager::RestoreBarriers tablet records not found, erase barrier marked as free",
-                        {"marker", "BSDD30"},
-                        {"tabletId", barrier.TabletId},
-                        {"lsn", barrier.Lsn});
-                    PersistentBufferBarrierHoles.push_back({pos, FreeBarrierPosition});
-                } else {
-                    auto locationIt = PersistentBufferBarriersLocation.find(barrier.TabletId);
-                    if (locationIt == PersistentBufferBarriersLocation.end()) {
-                        PersistentBufferBarriersLocation[barrier.TabletId] = {pos, FreeBarrierPosition};
-                    } else {
-                        auto oldBarrierLocation = PersistentBufferBarriersLocation[barrier.TabletId];
-                        auto oldBarrier = PersistentBufferBarriers[oldBarrierLocation.BarrierIdx].Header.Barriers[oldBarrierLocation.Position];
-                        YDB_LOG_DEBUG("TPersistentBufferBarriersManager::RestoreBarriers duplicated barrier erase record found, bigger lsn used",
-                            {"marker", "BSDD38"},
-                            {"tabletId", barrier.TabletId},
-                            {"barrierGeneration", barrier.Generation},
-                            {"oldBarrierGeneration", oldBarrier.Generation},
-                            {"barrierLsn", barrier.Lsn},
-                            {"oldBarrier.Lsn", oldBarrier.Lsn});
-                        if (barrier.Generation > oldBarrier.Generation
-                            || (barrier.Generation == oldBarrier.Generation && barrier.Lsn > oldBarrier.Lsn)) {
-                            PersistentBufferBarrierHoles.push_back(locationIt->second);
-                            locationIt->second = {pos, FreeBarrierPosition};
-                        } else {
-                            PersistentBufferBarrierHoles.push_back({pos, FreeBarrierPosition});
-                        }
+                const TTabletKey key{barrier.TabletId, barrier.DirectBlockGroupIndex};
+                // Persistent buffers for this (tabletId, directBlockGroupIndex) can be scattered
+                // across the map (ordering is TabletId, then Generation, then
+                // DirectBlockGroupIndex), so we scan every entry with a matching TabletId and
+                // filter by DirectBlockGroupIndex rather than relying on a contiguous range.
+                bool found = false;
+                for (auto it = persistentBuffers.lower_bound({barrier.TabletId, 0});
+                        it != persistentBuffers.end() && it->first.TabletId == barrier.TabletId; ) {
+                    if (it->first.DirectBlockGroupIndex != barrier.DirectBlockGroupIndex) {
+                        ++it;
+                        continue;
                     }
-                }
-                while (it != persistentBuffers.end() && it->first.TabletId == barrier.TabletId) {
+                    found = true;
                     if (it->first.Generation < barrier.Generation) {
                         it = persistentBuffers.erase(it);
                         continue;
@@ -211,6 +198,37 @@ namespace NKikimr::NDDisk {
                         it = persistentBuffers.erase(it);
                     } else {
                         ++it;
+                    }
+                }
+                if (!found) {
+                    YDB_LOG_DEBUG("TPersistentBufferBarriersManager::RestoreBarriers tablet records not found, erase barrier marked as free",
+                        {"marker", "BSDD30"},
+                        {"tabletId", barrier.TabletId},
+                        {"directBlockGroupIndex", barrier.DirectBlockGroupIndex},
+                        {"lsn", barrier.Lsn});
+                    PersistentBufferBarrierHoles.push_back({pos, FreeBarrierPosition});
+                } else {
+                    auto locationIt = PersistentBufferBarriersLocation.find(key);
+                    if (locationIt == PersistentBufferBarriersLocation.end()) {
+                        PersistentBufferBarriersLocation[key] = {pos, FreeBarrierPosition};
+                    } else {
+                        auto oldBarrierLocation = PersistentBufferBarriersLocation[key];
+                        auto oldBarrier = PersistentBufferBarriers[oldBarrierLocation.BarrierIdx].Header.Barriers[oldBarrierLocation.Position];
+                        YDB_LOG_DEBUG("TPersistentBufferBarriersManager::RestoreBarriers duplicated barrier erase record found, bigger lsn used",
+                            {"marker", "BSDD38"},
+                            {"tabletId", barrier.TabletId},
+                            {"directBlockGroupIndex", barrier.DirectBlockGroupIndex},
+                            {"barrierGeneration", barrier.Generation},
+                            {"oldBarrierGeneration", oldBarrier.Generation},
+                            {"barrierLsn", barrier.Lsn},
+                            {"oldBarrier.Lsn", oldBarrier.Lsn});
+                        if (barrier.Generation > oldBarrier.Generation
+                            || (barrier.Generation == oldBarrier.Generation && barrier.Lsn > oldBarrier.Lsn)) {
+                            PersistentBufferBarrierHoles.push_back(locationIt->second);
+                            locationIt->second = {pos, FreeBarrierPosition};
+                        } else {
+                            PersistentBufferBarrierHoles.push_back({pos, FreeBarrierPosition});
+                        }
                     }
                 }
             }
@@ -331,11 +349,12 @@ namespace NKikimr::NDDisk {
     }
 
     std::optional<TFastErase> TPersistentBufferBarriersManager::Erase(ui64 tabletId, ui32 generation, std::vector<ui64>& lsns,
-        TPersistentBufferSpaceAllocator& allocator) {
+        TPersistentBufferSpaceAllocator& allocator, ui8 directBlockGroupIndex) {
         if (allocator.GetFreeSpace() < 2 || lsns.size() < 2) {
             return std::nullopt;
         }
-        auto& erase = Erases[tabletId];
+        const TTabletKey key{tabletId, directBlockGroupIndex};
+        auto& erase = Erases[key];
 
         if (erase.Generation < generation) {
             erase.Lsns.clear();
@@ -362,6 +381,7 @@ namespace NKikimr::NDDisk {
         header.Header.PDiskId = PDiskId;
         header.Header.SlotId = SlotId;
         header.TabletId = tabletId;
+        header.DirectBlockGroupIndex = directBlockGroupIndex;
         header.Header.RecordIdx = 0;
         header.Header.Version = 0;
 
@@ -374,11 +394,13 @@ namespace NKikimr::NDDisk {
         }
         TPersistentBufferFastErases* erasesHeader = (TPersistentBufferFastErases*)header;
         auto tabletId = erasesHeader->TabletId;
-        auto& erase = Erases[tabletId];
+        const TTabletKey key{tabletId, erasesHeader->DirectBlockGroupIndex};
+        auto& erase = Erases[key];
         if (erase.HeaderLsn > header->RecordLsn) {
             YDB_LOG_DEBUG("TPersistentBufferBarriersManager::AddErase deprecated HeaderLsn found",
                 {"marker", "BSDD30"},
                 {"tabletId", tabletId},
+                {"directBlockGroupIndex", erasesHeader->DirectBlockGroupIndex},
                 {"headerLsn", erase.HeaderLsn},
                 {"recordLsn", header->RecordLsn});
             return false;
@@ -391,19 +413,22 @@ namespace NKikimr::NDDisk {
         YDB_LOG_DEBUG("TPersistentBufferBarriersManager::AddErase",
             {"marker", "BSDD30"},
             {"tabletId", tabletId},
+            {"directBlockGroupIndex", erasesHeader->DirectBlockGroupIndex},
             {"headerLsn", header->RecordLsn});
         return true;
     }
 
     void TPersistentBufferBarriersManager::RestoreErases(std::map<TPersistentBufferId, TPersistentBuffer> &persistentBuffers, TPersistentBufferSpaceAllocator& allocator) {
         for (auto it = Erases.begin(); it != Erases.end();) {
-            auto& [tid, erase] = *it;
+            auto& [key, erase] = *it;
+            const auto tid = key.TabletId;
+            const auto dbg = key.DirectBlockGroupIndex;
 
-            const auto barrier = GetBarrier(tid);
+            const auto barrier = GetBarrier(tid, dbg);
             auto itErase = std::upper_bound(erase.Lsns.begin(), erase.Lsns.end(), barrier.Lsn);
             erase.Lsns = std::vector<ui64>(itErase, erase.Lsns.end());
 
-            auto pbIt = persistentBuffers.find({tid, erase.Generation});
+            auto pbIt = persistentBuffers.find({tid, erase.Generation, dbg});
             if (pbIt == persistentBuffers.end()) {
                 it = Erases.erase(it);
                 continue;
@@ -417,6 +442,7 @@ namespace NKikimr::NDDisk {
                 YDB_LOG_DEBUG("TPersistentBufferBarriersManager::RestoreErases tablet erase record found",
                     {"marker", "BSDD30"},
                     {"tabletId", tid},
+                    {"directBlockGroupIndex", dbg},
                     {"lsn", lsn});
                 buffer.Records.erase(lsn);
             }
@@ -430,16 +456,17 @@ namespace NKikimr::NDDisk {
         }
     }
 
-    ui32 TPersistentBufferBarriersManager::GetErasesCount(ui64 tabletId) {
-        const auto& it = Erases.find(tabletId);
+    ui32 TPersistentBufferBarriersManager::GetErasesCount(ui64 tabletId, ui8 directBlockGroupIndex) {
+        const TTabletKey key{tabletId, directBlockGroupIndex};
+        const auto& it = Erases.find(key);
         if (it == Erases.end()) {
             return 0;
         }
         return it->second.Lsns.size();
     }
 
-    bool TPersistentBufferBarriersManager::CanFastErase(ui64 tabletId, ui32 generation) {
-        const auto barrier = GetBarrier(tabletId);
+    bool TPersistentBufferBarriersManager::CanFastErase(ui64 tabletId, ui32 generation, ui8 directBlockGroupIndex) {
+        const auto barrier = GetBarrier(tabletId, directBlockGroupIndex);
         return barrier.Generation == generation;
     }
 

--- a/ydb/core/blobstorage/ddisk/persistent_buffer_barriers_manager.h
+++ b/ydb/core/blobstorage/ddisk/persistent_buffer_barriers_manager.h
@@ -21,7 +21,36 @@ namespace NKikimr::NDDisk {
         TPersistentBufferFastErases Header;
     };
 
+    // The persistent buffer key is (TabletId, DirectBlockGroupIndex): a direct block group number
+    // that fits in a single byte (0-255). TPersistentBufferTabletKey packs that pair as the lookup
+    // key for the barriers manager's Erases / PersistentBufferBarriersLocation maps.
+    // DirectBlockGroupIndex defaults to 0 everywhere so existing single-argument (tabletId-only)
+    // call sites keep addressing the same namespace as before this change. Declared at namespace
+    // scope (rather than nested inside TPersistentBufferBarriersManager) so the std::hash
+    // specialization below is visible before any unordered_map<TPersistentBufferTabletKey, ...>
+    // member is instantiated.
+    struct TPersistentBufferTabletKey {
+        ui64 TabletId;
+        ui8 DirectBlockGroupIndex = 0;
+
+        friend constexpr std::strong_ordering operator <=>(const TPersistentBufferTabletKey& x, const TPersistentBufferTabletKey& y) = default;
+    };
+}
+
+namespace std {
+    template <>
+    struct hash<NKikimr::NDDisk::TPersistentBufferTabletKey> {
+        inline size_t operator()(const NKikimr::NDDisk::TPersistentBufferTabletKey& k) const {
+            return MultiHash(k.TabletId, k.DirectBlockGroupIndex);
+        }
+    };
+}
+
+namespace NKikimr::NDDisk {
+
     struct TPersistentBufferBarriersManager {
+        using TTabletKey = TPersistentBufferTabletKey;
+
         struct TErase {
             std::vector<ui64> Lsns;
             ui32 ChunkIdx = Max<ui32>();
@@ -40,27 +69,29 @@ namespace NKikimr::NDDisk {
         ui32 PDiskId;
         ui32 SlotId;
 
-        std::unordered_map<ui64, TErase> Erases;
+        std::unordered_map<TTabletKey, TErase> Erases;
 
         std::vector<TEraseBarrier> PersistentBufferBarriers;
-        std::unordered_map<ui64, TBarrierLocation> PersistentBufferBarriersLocation;
+        std::unordered_map<TTabletKey, TBarrierLocation> PersistentBufferBarriersLocation;
 
         std::vector<TBarrierLocation> PersistentBufferBarrierHoles;
         ui32 FreeBarrierPosition = 0;
 
         void Initialize(ui64 uniqueId, ui32 nodeId, ui32 pdiskId, ui32 slotId);
-        bool CanMoveBarrier(ui64 tabletId, ui32 barriersLimit);
-        TPersistentBufferBarrierRecord GetBarrier(ui64 tabletId) const;
-        std::unordered_map<ui64, ui64> GetBarriers() const;
-        std::tuple<ui32, ui32, TEraseBarrier&> MoveBarrier(ui64 tabletId, ui32 generation, ui64 lsn, const TPersistentBufferSectorInfo& newSector);
+        bool CanMoveBarrier(ui64 tabletId, ui32 barriersLimit, ui8 directBlockGroupIndex = 0);
+        TPersistentBufferBarrierRecord GetBarrier(ui64 tabletId, ui8 directBlockGroupIndex = 0) const;
+        // Keyed by (TabletId, DirectBlockGroupIndex): a plain TabletId key would collapse barriers
+        // belonging to different direct block groups of the same tablet into a single entry.
+        std::map<std::pair<ui64, ui8>, ui64> GetBarriers() const;
+        std::tuple<ui32, ui32, TEraseBarrier&> MoveBarrier(ui64 tabletId, ui32 generation, ui64 lsn, const TPersistentBufferSectorInfo& newSector, ui8 directBlockGroupIndex = 0);
         void RestoreBarriers(std::map<TPersistentBufferId, TPersistentBuffer> &persistentBuffers, TPersistentBufferSpaceAllocator& allocator);
         bool AddBarrier(const TPersistentBufferHeader* header, ui32 chunkIdx, ui32 sectorIdx);
 
         bool Compact(std::vector<ui64>& oldLsns, std::vector<ui64>& newLsns, TPersistentBufferFastErases& header);
         std::vector<ui64> Uncompact(const ui8* data, bool isCompact);
-        bool CanFastErase(ui64 tabletId, ui32 generation);
-        ui32 GetErasesCount(ui64 tabletId);
-        std::optional<TFastErase> Erase(ui64 tabletId, ui32 generation, std::vector<ui64>& lsns, TPersistentBufferSpaceAllocator& allocator);
+        bool CanFastErase(ui64 tabletId, ui32 generation, ui8 directBlockGroupIndex = 0);
+        ui32 GetErasesCount(ui64 tabletId, ui8 directBlockGroupIndex = 0);
+        std::optional<TFastErase> Erase(ui64 tabletId, ui32 generation, std::vector<ui64>& lsns, TPersistentBufferSpaceAllocator& allocator, ui8 directBlockGroupIndex = 0);
         bool AddErase(const TPersistentBufferHeader* header, ui32 chunkIdx, ui32 sectorIdx);
         void RestoreErases(std::map<TPersistentBufferId, TPersistentBuffer> &persistentBuffers, TPersistentBufferSpaceAllocator& allocator);
     };

--- a/ydb/core/blobstorage/ddisk/persistent_buffer_header.h
+++ b/ydb/core/blobstorage/ddisk/persistent_buffer_header.h
@@ -41,6 +41,11 @@ namespace NKikimr::NDDisk {
         ui64 TabletId;
         ui32 Generation;
         ui64 Lsn;
+        // Direct block group number this barrier applies to. Fits in a single byte (0-255);
+        // defaults to 0 so on-disk records written before this field existed (and callers that
+        // never pass a direct block group) keep using persistent buffer namespace 0, matching the
+        // pre-existing "one namespace per tablet" behavior.
+        ui8 DirectBlockGroupIndex = 0;
     };
 
     struct TPersistentBufferBarriers {
@@ -53,7 +58,10 @@ namespace NKikimr::NDDisk {
     static_assert(sizeof(TPersistentBufferBarriers) <= DataAlignment);
 
     struct TPersistentBufferFastErases {
-        static constexpr ui32 ErasesBufferSize = DataAlignment - sizeof(TPersistentBufferHeader) - sizeof(ui64) - sizeof(ui32);
+        // Direct block group number this fast-erase record applies to (accounted for in
+        // ErasesBufferSize below). See TPersistentBufferId for rationale; defaults to 0 to preserve
+        // the pre-existing single-namespace-per-tablet behavior.
+        static constexpr ui32 ErasesBufferSize = DataAlignment - sizeof(TPersistentBufferHeader) - sizeof(ui64) - sizeof(ui32) - sizeof(ui8);
         // Heuristic based on ErasesBufferSize, means that it's better to fallback on zeroing erases
         // If lsns count exeed this number - barrier was not moved for a long time and fast erases is not efficient in this case.
         // It is better to fall back to zeroing erases a little bit earlier,
@@ -63,6 +71,7 @@ namespace NKikimr::NDDisk {
         TPersistentBufferHeader Header;
         ui64 TabletId;
         ui32 Generation;
+        ui8 DirectBlockGroupIndex = 0;
         ui8 CompactLsns[ErasesBufferSize];
     };
 
@@ -92,6 +101,9 @@ namespace NKikimr::NDDisk {
         ui32 OffsetInBytes;
         ui32 Size;
         ui64 Lsn;
+        // Direct block group number this record applies to. See TPersistentBufferId for rationale;
+        // defaults to 0 to preserve the pre-existing single-namespace-per-tablet behavior.
+        ui8 DirectBlockGroupIndex = 0;
     };
 
     static_assert(sizeof(TPersistentBufferLsnRecordHeader) <= DataAlignment);

--- a/ydb/core/blobstorage/ddisk/persistent_buffer_mon.cpp
+++ b/ydb/core/blobstorage/ddisk/persistent_buffer_mon.cpp
@@ -379,7 +379,7 @@ namespace NKikimr {
                                         TABLER() {
                                             TABLED() {str << ti.TabletId;}
                                             TABLED() {str << ti.Generation;}
-                                            if (auto it = b->EraseBarriers.find(ti.TabletId); it != b->EraseBarriers.end()) {
+                                            if (auto it = b->EraseBarriers.find({ti.TabletId, ti.DirectBlockGroupIndex}); it != b->EraseBarriers.end()) {
                                                 TABLED() {str << it->second;}
                                             } else {
                                                 TABLED() {str << "No barrier";}

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_batch_write_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_batch_write_ut.cpp
@@ -58,7 +58,7 @@ using NKikimrBlobStorage::NDDisk::TReplyStatus;
 
 constexpr ui32 NodeId = 1;
 constexpr ui32 BlockSize = 4096;
-constexpr ui32 MinChunksReserved = 2;
+constexpr ui32 MinChunksReserved = 4;
 constexpr ui32 PersistentBufferInitChunks = 4;
 
 struct TDiskHandle {

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_checksum_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_checksum_ut.cpp
@@ -1,5 +1,5 @@
-// Tests for the sender-supplied per-block payload checksum piggybacked on the PB write path
-// (TEvWritePersistentBuffer / TEvWritePersistentBuffers Checksums field, see RFC 006).
+// Contract tests for sender-supplied 4 KiB checksums on direct DDisk and persistent-buffer writes,
+// and for pure-checksum propagation on direct DDisk reads (see RFC 006).
 //
 // The PB validates the checksum before writing anything to disk and rejects a mismatch with
 // TReplyStatus::CORRUPTED, without ever touching PDisk. For TEvWritePersistentBuffers, the
@@ -11,6 +11,7 @@
 
 #include <ydb/core/blobstorage/ddisk/ddisk.h>
 #include <ydb/core/blobstorage/ddisk/ddisk_actor.h>
+#include <ydb/core/blobstorage/ddisk/ddisk_checksums.h>
 #include <ydb/core/blobstorage/ddisk/persistent_buffer_header.h>
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk.h>
@@ -24,6 +25,8 @@
 #include <util/string/printf.h>
 
 #include <cstring>
+#include <functional>
+#include <map>
 
 namespace NKikimr {
 namespace {
@@ -42,6 +45,47 @@ struct TDiskHandle {
     ui32 PDiskId;
     ui32 SlotId;
     ui32 FirstChunkId;
+};
+
+class TFakeDiskStorage {
+public:
+    void Write(const NPDisk::TEvChunkWriteRaw& request) {
+        const TString data = request.Data.ConvertToString();
+        UNIT_ASSERT_VALUES_EQUAL(request.Offset % BlockSize, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(data.size() % BlockSize, 0u);
+        for (ui32 offset = 0; offset < data.size(); offset += BlockSize) {
+            Blocks[{request.ChunkIdx, request.Offset + offset}] = data.substr(offset, BlockSize);
+        }
+    }
+
+    TRope Read(const NPDisk::TEvChunkReadRaw& request) const {
+        UNIT_ASSERT_VALUES_EQUAL(request.Offset % BlockSize, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(request.Size % BlockSize, 0u);
+        auto data = TRcBuf::UninitializedPageAligned(request.Size);
+        memset(data.GetDataMut(), 0, data.size());
+        for (ui32 offset = 0; offset < request.Size; offset += BlockSize) {
+            const auto it = Blocks.find({request.ChunkIdx, request.Offset + offset});
+            if (it != Blocks.end()) {
+                memcpy(data.GetDataMut() + offset, it->second.data(), BlockSize);
+            }
+        }
+        return TRope(std::move(data));
+    }
+
+    TString GetBlock(ui32 chunkIdx, ui32 offset) const {
+        const auto it = Blocks.find({chunkIdx, offset});
+        UNIT_ASSERT_C(it != Blocks.end(),
+            "missing fake-PDisk block at " << chunkIdx << ':' << offset);
+        return it->second;
+    }
+
+    void SetBlock(ui32 chunkIdx, ui32 offset, TString data) {
+        UNIT_ASSERT_VALUES_EQUAL(data.size(), BlockSize);
+        Blocks[{chunkIdx, offset}] = std::move(data);
+    }
+
+private:
+    std::map<std::pair<ui32, ui32>, TString> Blocks;
 };
 
 class TTestContext {
@@ -74,7 +118,7 @@ public:
         Runtime.Stop();
     }
 
-    TDiskHandle CreateDDisk(ui32 pdiskId, ui32 slotId) {
+    TDiskHandle CreateDDisk(ui32 pdiskId, ui32 slotId, NDDisk::TDDiskConfig ddiskConfig = {}) {
         const TActorId pdiskEdge = Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
         const TActorId pdiskServiceId = MakeBlobStoragePDiskID(NodeId, pdiskId);
         Runtime.RegisterService(pdiskServiceId, pdiskEdge);
@@ -97,7 +141,7 @@ public:
             "ddisk_pool");
         NDDisk::TPersistentBufferFormat pbFormat{256, 4, BlockSize * 128, 8, 5000, 512 * 1024};
         const TActorId ddiskActor = Runtime.Register(NDDisk::CreateDDiskActor(std::move(baseInfo), groupInfo,
-            std::move(pbFormat), NDDisk::TDDiskConfig{}, Counters),
+            std::move(pbFormat), std::move(ddiskConfig), Counters),
             NodeId);
         const TActorId ddiskServiceId = MakeBlobStorageDDiskId(NodeId, pdiskId, slotId);
         const TActorId pbServiceId = MakeBlobStoragePersistentBufferId(NodeId, pdiskId, slotId);
@@ -107,6 +151,82 @@ public:
         BootstrapDDisk(disk);
 
         return disk;
+    }
+
+    std::unique_ptr<TEventHandle<NDDisk::TEvWriteResult>> CompleteDirectWrite(
+            const TDiskHandle& disk, TFakeDiskStorage& storage) {
+        for (ui32 guard = 0; ; ++guard) {
+            UNIT_ASSERT_C(guard < 500, "timed out completing fake-PDisk direct write");
+            std::unique_ptr<IEventHandle> raw =
+                Runtime.WaitForEdgeActorEvent({disk.PDiskEdge, Edge});
+            const ui32 type = raw->GetTypeRewrite();
+            if (raw->Recipient == Edge) {
+                UNIT_ASSERT_VALUES_EQUAL(type, NDDisk::TEvWriteResult::EventType);
+                return RecastEvent<NDDisk::TEvWriteResult>(std::move(raw));
+            }
+            if (type == NPDisk::TEvChunkWriteRaw::EventType) {
+                auto write = RecastEvent<NPDisk::TEvChunkWriteRaw>(std::move(raw));
+                storage.Write(*write->Get());
+                SendPDiskResponse(disk, *write,
+                    new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+            } else if (type == NPDisk::TEvLog::EventType) {
+                auto log = RecastEvent<NPDisk::TEvLog>(std::move(raw));
+                auto result = std::make_unique<NPDisk::TEvLogResult>(
+                    NKikimrProto::OK, 0, "", 0);
+                result->Results.emplace_back(log->Get()->Lsn, log->Get()->Cookie);
+                SendPDiskResponse(disk, *log, result.release());
+            } else if (type == NPDisk::TEvChunkReserve::EventType) {
+                auto reserve = RecastEvent<NPDisk::TEvChunkReserve>(std::move(raw));
+                auto result =
+                    std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
+                for (ui32 i = 0; i < reserve->Get()->SizeChunks; ++i) {
+                    result->ChunkIds.push_back(NextChunkId++);
+                }
+                SendPDiskResponse(disk, *reserve, result.release());
+            } else if (type == NPDisk::TEvCheckSpace::EventType) {
+                auto checkSpace = RecastEvent<NPDisk::TEvCheckSpace>(std::move(raw));
+                SendPDiskResponse(disk, *checkSpace,
+                    new NPDisk::TEvCheckSpaceResult(
+                        NKikimrProto::OK, 0, 0, 0, 0, 0, 0, 0, "", 0));
+            } else {
+                UNIT_FAIL("unexpected fake-PDisk event while completing write: " << type);
+            }
+        }
+    }
+
+    using TReadOverride =
+        std::function<std::optional<TRope>(const NPDisk::TEvChunkReadRaw&)>;
+
+    std::unique_ptr<TEventHandle<NDDisk::TEvReadResult>> CompleteDirectRead(
+            const TDiskHandle& disk, const TFakeDiskStorage& storage,
+            TReadOverride readOverride = {}) {
+        for (ui32 guard = 0; ; ++guard) {
+            UNIT_ASSERT_C(guard < 100, "timed out completing fake-PDisk direct read");
+            std::unique_ptr<IEventHandle> raw =
+                Runtime.WaitForEdgeActorEvent({disk.PDiskEdge, Edge});
+            const ui32 type = raw->GetTypeRewrite();
+            if (raw->Recipient == Edge) {
+                UNIT_ASSERT_VALUES_EQUAL(type, NDDisk::TEvReadResult::EventType);
+                return RecastEvent<NDDisk::TEvReadResult>(std::move(raw));
+            }
+            if (type == NPDisk::TEvChunkReadRaw::EventType) {
+                auto read = RecastEvent<NPDisk::TEvChunkReadRaw>(std::move(raw));
+                std::optional<TRope> data;
+                if (readOverride) {
+                    data = readOverride(*read->Get());
+                }
+                SendPDiskResponse(disk, *read,
+                    new NPDisk::TEvChunkReadRawResult(
+                        data ? std::move(*data) : storage.Read(*read->Get())));
+            } else if (type == NPDisk::TEvCheckSpace::EventType) {
+                auto checkSpace = RecastEvent<NPDisk::TEvCheckSpace>(std::move(raw));
+                SendPDiskResponse(disk, *checkSpace,
+                    new NPDisk::TEvCheckSpaceResult(
+                        NKikimrProto::OK, 0, 0, 0, 0, 0, 0, 0, "", 0));
+            } else {
+                UNIT_FAIL("unexpected fake-PDisk event while completing read: " << type);
+            }
+        }
     }
 
     template<typename TEvent>
@@ -294,6 +414,9 @@ public:
 
         return disk;
     }
+
+private:
+    ui32 NextChunkId = 900000;
 };
 
 void SendToDDisk(TTestContext& ctx, const TActorId& serviceId, IEventBase* event, ui64 cookie = 0) {
@@ -356,7 +479,7 @@ void AssertNoDiskWrite(TTestContext& ctx, const std::set<TActorId>& pdiskEdges) 
     waitFor.insert(sentinelEdge);
     auto ev = ctx.Runtime.WaitForEdgeActorEvent(waitFor);
     UNIT_ASSERT_VALUES_EQUAL_C(ev->Recipient, sentinelEdge,
-        "checksum-mismatched write must not issue any disk write");
+        "malformed-checksum write must not issue any disk write");
 }
 
 // Walks the same counters subgroup chain TDDiskActor builds (see TDDiskActor::TDDiskActor and
@@ -377,6 +500,44 @@ NMonitoring::TDynamicCounters::TCounterPtr GetChecksumCounter(TTestContext& ctx,
         ->GetSubgroup("media", "nvme")
         ->GetSubgroup("subsystem", "checksums")
         ->GetCounter(name, true);
+}
+
+std::unique_ptr<TEventHandle<NDDisk::TEvWriteResult>> WriteDirect(
+        TTestContext& ctx, const TDiskHandle& disk, TFakeDiskStorage& storage,
+        const NDDisk::TQueryCredentials& creds, ui64 vChunkIndex, ui32 offset,
+        const TString& payload) {
+    auto write = std::make_unique<NDDisk::TEvWrite>(
+        creds, NDDisk::TBlockSelector{vChunkIndex, offset, static_cast<ui32>(payload.size())},
+        NDDisk::TWriteInstruction(0));
+    write->AddPayloadThenChecksum(MakeAlignedRope(payload));
+    SendToDDisk(ctx, disk.ServiceId, write.release());
+    return ctx.CompleteDirectWrite(disk, storage);
+}
+
+std::unique_ptr<TEventHandle<NDDisk::TEvReadResult>> ReadDirect(
+        TTestContext& ctx, const TDiskHandle& disk, const TFakeDiskStorage& storage,
+        const NDDisk::TQueryCredentials& creds, ui64 vChunkIndex, ui32 offset, ui32 size,
+        TTestContext::TReadOverride readOverride = {}) {
+    SendToDDisk(ctx, disk.ServiceId,
+        new NDDisk::TEvRead(
+            creds, NDDisk::TBlockSelector{vChunkIndex, offset, size}, {true}));
+    return ctx.CompleteDirectRead(disk, storage, std::move(readOverride));
+}
+
+std::vector<ui64> CalculateChecksums(const TString& payload) {
+    return NDDisk::CalculatePayloadChecksums(MakeAlignedRope(payload));
+}
+
+void AssertDirectRead(const std::unique_ptr<TEventHandle<NDDisk::TEvReadResult>>& result,
+        const TString& expectedPayload, const std::vector<ui64>& expectedChecksums) {
+    AssertStatus(result, TReplyStatus::OK);
+    UNIT_ASSERT_VALUES_EQUAL(result->Get()->GetPayload(0).ConvertToString(), expectedPayload);
+    UNIT_ASSERT_VALUES_EQUAL(
+        static_cast<ui32>(result->Get()->Record.ChecksumsSize()), expectedChecksums.size());
+    for (ui32 i = 0; i < expectedChecksums.size(); ++i) {
+        UNIT_ASSERT_VALUES_EQUAL_C(result->Get()->Record.GetChecksums(i), expectedChecksums[i],
+            "checksum " << i << " must be the pure XXH3 value for its 4 KiB block");
+    }
 }
 
 Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
@@ -403,6 +564,7 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
 
         AssertNoDiskWrite(ctx, {disk.PDiskEdge});
         UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "ChecksumMismatch")->Val(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "WritesWithoutChecksums")->Val(), 0);
     }
 
     // 2. Single PB write with 4 4 KiB blocks: for each subcase exactly one block's checksum is
@@ -427,6 +589,8 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
             AssertStatus(writeResult, TReplyStatus::CORRUPTED);
 
             AssertNoDiskWrite(ctx, {disk.PDiskEdge});
+            UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "ChecksumMismatch")->Val(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "WritesWithoutChecksums")->Val(), 0);
         }
     }
 
@@ -466,6 +630,10 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
         }
 
         AssertNoDiskWrite(ctx, {disk1.PDiskEdge, disk2.PDiskEdge, disk3.PDiskEdge});
+        for (const TDiskHandle& disk : {disk1, disk2, disk3}) {
+            UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "ChecksumMismatch")->Val(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "WritesWithoutChecksums")->Val(), 0);
+        }
     }
 
     // 3b/2 combined for multi-PB: 4 blocks, one bad block per subcase; every peer must reject.
@@ -503,6 +671,53 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
             }
 
             AssertNoDiskWrite(ctx, {disk1.PDiskEdge, disk2.PDiskEdge, disk3.PDiskEdge});
+            for (const TDiskHandle& disk : {disk1, disk2, disk3}) {
+                UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "ChecksumMismatch")->Val(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "WritesWithoutChecksums")->Val(), 0);
+            }
+        }
+    }
+
+    Y_UNIT_TEST(MultiPBWriteChecksumCountMismatchTooFewAndTooMany) {
+        for (const bool tooMany : {false, true}) {
+            TTestContext ctx;
+            const TDiskHandle disk1 = ctx.CreateDDisk(70, 1);
+            const TDiskHandle disk2 = ctx.CreateDDisk(71, 1);
+            const TDiskHandle disk3 = ctx.CreateDDisk(72, 1);
+            NDDisk::TQueryCredentials creds = Connect(ctx, disk1.PBServiceId, 140, 1);
+            const TString payload = MakeData('C', 2 * BlockSize);
+            const NDDisk::TBlockSelector selector{3, 0, 2 * BlockSize};
+            const std::vector<std::tuple<ui32, ui32, ui32>> pbs{
+                {NodeId, disk1.PDiskId, disk1.SlotId},
+                {NodeId, disk2.PDiskId, disk2.SlotId},
+                {NodeId, disk3.PDiskId, disk3.SlotId},
+            };
+
+            auto write = std::make_unique<NDDisk::TEvWritePersistentBuffers>(
+                creds, selector, 1, NDDisk::TWriteInstruction(0), pbs, 1000);
+            write->AddPayloadThenChecksum(MakeAlignedRope(payload));
+            if (tooMany) {
+                write->Record.AddChecksums(0);
+            } else {
+                write->Record.MutableChecksums()->RemoveLast();
+            }
+
+            auto result = SendToDDiskAndWait<NDDisk::TEvWritePersistentBuffersResult>(
+                ctx, disk1.PBServiceId, write.release());
+            UNIT_ASSERT_VALUES_EQUAL(result->Get()->Record.ResultSize(), 3);
+            for (const auto& item : result->Get()->Record.GetResult()) {
+                UNIT_ASSERT_EQUAL(
+                    static_cast<TReplyStatus::E>(item.GetResult().GetStatus()),
+                    TReplyStatus::INCORRECT_REQUEST);
+            }
+            AssertNoDiskWrite(
+                ctx, {disk1.PDiskEdge, disk2.PDiskEdge, disk3.PDiskEdge});
+            for (const TDiskHandle& disk : {disk1, disk2, disk3}) {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    GetChecksumCounter(ctx, disk, "ChecksumMismatch")->Val(), 0);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    GetChecksumCounter(ctx, disk, "WritesWithoutChecksums")->Val(), 0);
+            }
         }
     }
 
@@ -597,6 +812,28 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
         AssertStatus(writeResult, TReplyStatus::INCORRECT_REQUEST);
 
         AssertNoDiskWrite(ctx, {disk.PDiskEdge});
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "ChecksumMismatch")->Val(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "WritesWithoutChecksums")->Val(), 0);
+    }
+
+    Y_UNIT_TEST(SinglePBWriteTooManyChecksums) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(73, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.PBServiceId, 141, 1);
+        const TString payload = MakeData('P', BlockSize);
+        const NDDisk::TBlockSelector selector{3, 0, BlockSize};
+
+        auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(
+            creds, selector, 1, NDDisk::TWriteInstruction(0));
+        write->AddPayloadThenChecksum(MakeAlignedRope(payload));
+        write->Record.AddChecksums(0);
+        auto result = SendToDDiskAndWait<NDDisk::TEvWritePersistentBufferResult>(
+            ctx, disk.PBServiceId, write.release());
+
+        AssertStatus(result, TReplyStatus::INCORRECT_REQUEST);
+        AssertNoDiskWrite(ctx, {disk.PDiskEdge});
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "ChecksumMismatch")->Val(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "WritesWithoutChecksums")->Val(), 0);
     }
 
     // 6. Plain TEvWrite with a mismatched checksum: rejected with CORRUPTED and never reaches PDisk,
@@ -620,6 +857,7 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
 
         AssertNoDiskWrite(ctx, {disk.PDiskEdge});
         UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "ChecksumMismatch")->Val(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "WritesWithoutChecksums")->Val(), 0);
     }
 
     // 7. Plain TEvWrite where the sender's Checksums count does not match the payload size: rejected
@@ -643,12 +881,32 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
         AssertStatus(writeResult, TReplyStatus::INCORRECT_REQUEST);
 
         AssertNoDiskWrite(ctx, {disk.PDiskEdge});
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "ChecksumMismatch")->Val(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "WritesWithoutChecksums")->Val(), 0);
     }
 
-    // 8. External (non-internal) PB write with no Checksums attached at all: validation is opt-in, so
-    // this is skipped entirely, the write proceeds and succeeds normally, and WritesWithoutChecksums is
-    // incremented to track how common this still is for non-internal senders.
-    Y_UNIT_TEST(SinglePBWriteWithoutChecksums) {
+    Y_UNIT_TEST(PlainWriteTooManyChecksums) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(74, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 142, 1);
+        const TString payload = MakeData('X', BlockSize);
+        const NDDisk::TBlockSelector selector{3, 0, BlockSize};
+
+        auto write = std::make_unique<NDDisk::TEvWrite>(
+            creds, selector, NDDisk::TWriteInstruction(0));
+        write->AddPayloadThenChecksum(MakeAlignedRope(payload));
+        write->Record.AddChecksums(0);
+        auto result = SendToDDiskAndWait<NDDisk::TEvWriteResult>(
+            ctx, disk.ServiceId, write.release());
+
+        AssertStatus(result, TReplyStatus::INCORRECT_REQUEST);
+        AssertNoDiskWrite(ctx, {disk.PDiskEdge});
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "ChecksumMismatch")->Val(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "WritesWithoutChecksums")->Val(), 0);
+    }
+
+    // 8. Missing checksums are rejected unconditionally by the default configuration.
+    Y_UNIT_TEST(DefaultConfigDeclinesPBWriteWithoutChecksums) {
         TTestContext ctx;
         const TDiskHandle disk = ctx.CreateDDisk(52, 1);
         NDDisk::TQueryCredentials creds = Connect(ctx, disk.PBServiceId, 93, 1);
@@ -659,18 +917,78 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
 
         auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(creds, selector, lsn, NDDisk::TWriteInstruction(0));
         write->AddPayload(TRope(payload));
-        // Deliberately not calling AddPayloadThenChecksum(): checksum validation is opt-in.
+        // Deliberately not calling AddPayloadThenChecksum().
         UNIT_ASSERT_VALUES_EQUAL(write->Record.ChecksumsSize(), 0u);
 
-        SendToDDisk(ctx, disk.PBServiceId, write.release());
-
-        auto pbWriteRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
-        ctx.SendPDiskResponse(disk, *pbWriteRaw, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
-
-        auto writeResult = WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx);
-        AssertStatus(writeResult, TReplyStatus::OK);
-
+        auto result = SendToDDiskAndWait<NDDisk::TEvWritePersistentBufferResult>(
+            ctx, disk.PBServiceId, write.release());
+        AssertStatus(result, TReplyStatus::INCORRECT_REQUEST);
+        AssertNoDiskWrite(ctx, {disk.PDiskEdge});
         UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "WritesWithoutChecksums")->Val(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "ChecksumMismatch")->Val(), 0);
+    }
+
+    Y_UNIT_TEST(RequiredChecksumsDeclinePBWriteWithoutChecksums) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(52, 2);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.PBServiceId, 94, 1);
+        const NDDisk::TBlockSelector selector{3, 0, BlockSize};
+
+        auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(
+            creds, selector, 1, NDDisk::TWriteInstruction(0));
+        write->AddPayload(MakeAlignedRope(MakeData('R', BlockSize)));
+        auto result = SendToDDiskAndWait<NDDisk::TEvWritePersistentBufferResult>(
+            ctx, disk.PBServiceId, write.release());
+        AssertStatus(result, TReplyStatus::INCORRECT_REQUEST);
+        AssertNoDiskWrite(ctx, {disk.PDiskEdge});
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "WritesWithoutChecksums")->Val(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "ChecksumMismatch")->Val(), 0);
+    }
+
+    Y_UNIT_TEST(DefaultConfigDeclinesMultiPBWriteWithoutChecksums) {
+        TTestContext ctx;
+        const TDiskHandle disk1 = ctx.CreateDDisk(52, 3);
+        const TDiskHandle disk2 = ctx.CreateDDisk(54, 4);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk1.PBServiceId, 94, 1);
+        const NDDisk::TBlockSelector selector{3, 0, BlockSize};
+        const std::vector<std::tuple<ui32, ui32, ui32>> pbs{
+            {NodeId, disk1.PDiskId, disk1.SlotId},
+            {NodeId, disk2.PDiskId, disk2.SlotId},
+        };
+
+        auto write = std::make_unique<NDDisk::TEvWritePersistentBuffers>(
+            creds, selector, 1, NDDisk::TWriteInstruction(0), pbs, 1000);
+        write->AddPayload(MakeAlignedRope(MakeData('M', BlockSize)));
+        auto result = SendToDDiskAndWait<NDDisk::TEvWritePersistentBuffersResult>(
+            ctx, disk1.PBServiceId, write.release());
+        UNIT_ASSERT_VALUES_EQUAL(result->Get()->Record.ResultSize(), 2);
+        for (const auto& item : result->Get()->Record.GetResult()) {
+            UNIT_ASSERT_EQUAL(
+                static_cast<TReplyStatus::E>(item.GetResult().GetStatus()),
+                TReplyStatus::INCORRECT_REQUEST);
+        }
+        AssertNoDiskWrite(ctx, {disk1.PDiskEdge, disk2.PDiskEdge});
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk1, "WritesWithoutChecksums")->Val(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk1, "ChecksumMismatch")->Val(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk2, "WritesWithoutChecksums")->Val(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk2, "ChecksumMismatch")->Val(), 0);
+    }
+
+    Y_UNIT_TEST(RequiredChecksumsDeclinePlainWriteWithoutChecksums) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(53, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 95, 1);
+        const NDDisk::TBlockSelector selector{3, 0, BlockSize};
+
+        auto write = std::make_unique<NDDisk::TEvWrite>(
+            creds, selector, NDDisk::TWriteInstruction(0));
+        write->AddPayload(MakeAlignedRope(MakeData('S', BlockSize)));
+        auto result = SendToDDiskAndWait<NDDisk::TEvWriteResult>(
+            ctx, disk.ServiceId, write.release());
+        AssertStatus(result, TReplyStatus::INCORRECT_REQUEST);
+        AssertNoDiskWrite(ctx, {disk.PDiskEdge});
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "WritesWithoutChecksums")->Val(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(GetChecksumCounter(ctx, disk, "ChecksumMismatch")->Val(), 0);
     }
 
     // 9. Persistence: a PB write carrying sender checksums stores them, and an in-memory read
@@ -794,6 +1112,35 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
         }();
         UNIT_ASSERT_C(actualUniqueId != 0, "PersistentBufferUniqueId must not be zero");
 
+        // Rewrite the independently stored record A as a valid version-0 legacy record. Its
+        // payload remains readable after restore, but it intentionally has no payload checksums.
+        {
+            TString& chunk = chunkBufs[rawA->Get()->ChunkIdx];
+            char* sector = chunk.Detach() + rawA->Get()->Offset;
+            auto* header =
+                reinterpret_cast<NDDisk::TPersistentBufferHeader*>(sector);
+            auto* record = reinterpret_cast<
+                NDDisk::TPersistentBufferLsnRecordHeader*>(
+                    sector + sizeof(NDDisk::TPersistentBufferHeader));
+            UNIT_ASSERT(
+                record->Flags
+                & NDDisk::TPersistentBufferLsnRecordHeader::
+                    HAS_PAYLOAD_CHECKSUMS);
+            record->Flags =
+                NDDisk::TPersistentBufferLsnRecordHeader::NONE;
+            header->Version = 0;
+            header->Checksum = 0;
+
+            TString checksumInput(sector, BlockSize);
+            checksumInput.append(
+                reinterpret_cast<const char*>(
+                    &header->PersistentBufferUniqueId),
+                sizeof(header->PersistentBufferUniqueId));
+            header->Checksum = NDDisk::CalculateRawChecksum(
+                checksumInput.data(), checksumInput.size());
+        }
+        checksumsA.clear();
+
         // Step 6: complete the combined write -> B and C both reply.
         ctx.SendPDiskResponse(disk1, *rawBC, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
         auto wrB = WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx);
@@ -808,6 +1155,8 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
 
         // Phase 2: restart with instance 2 (same PDiskId, same UniqueId).
         std::optional<TActorId> disk2PdiskEdge;
+        std::optional<TActorId> destinationPdiskEdge;
+        bool sawDestinationPersistence = false;
         ctx.Runtime.FilterFunction = [&](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev) -> bool {
             if (ev->Sender == disk1ActorId) {
                 if (ev->GetTypeRewrite() == NPDisk::TEvCheckSpace::EventType) {
@@ -816,6 +1165,14 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
                         0, ev->Cookie), NodeId);
                 }
                 return false;
+            }
+            if (destinationPdiskEdge
+                    && ev->GetRecipientRewrite() == *destinationPdiskEdge
+                    && (ev->GetTypeRewrite()
+                            == NPDisk::TEvChunkWriteRaw::EventType
+                        || ev->GetTypeRewrite()
+                            == NPDisk::TEvLog::EventType)) {
+                sawDestinationPersistence = true;
             }
             if (disk2PdiskEdge &&
                     ev->GetTypeRewrite() == NPDisk::TEvChunkReadRaw::EventType &&
@@ -872,6 +1229,30 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
         checkRead(selectorA, lsnA, payloadA, checksumsA, "record A (non-batch)");
         checkRead(selectorB, lsnB, payloadB, checksumsB, "record B (batched)");
         checkRead(selectorC, lsnC, payloadC, checksumsC, "record C (batched)");
+
+        // Legacy data may still be read, but it cannot be used as a source for a new
+        // checksum-mandatory DDisk write.
+        const TDiskHandle destination = ctx.CreateDDisk(75, 1);
+        destinationPdiskEdge = destination.PDiskEdge;
+        const NDDisk::TQueryCredentials destinationCreds =
+            Connect(ctx, destination.ServiceId, 111, 1);
+        auto sync = std::make_unique<NDDisk::TEvSync>(destinationCreds);
+        sync->AddSegmentFromPB(
+            {NodeId, disk2.PDiskId, disk2.SlotId},
+            *creds2.DDiskInstanceGuid,
+            selectorA,
+            lsnA,
+            creds2.Generation);
+        auto syncResult = SendToDDiskAndWait<NDDisk::TEvSyncResult>(
+            ctx, destination.ServiceId, sync.release());
+        AssertStatus(syncResult, TReplyStatus::ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(
+            syncResult->Get()->Record.SegmentResultsSize(), 1);
+        UNIT_ASSERT(
+            static_cast<TReplyStatus::E>(
+                syncResult->Get()->Record.GetSegmentResults(0).GetStatus())
+            == TReplyStatus::INCORRECT_REQUEST);
+        UNIT_ASSERT(!sawDestinationPersistence);
     }
 
     // 11. Signature-correction sector: the sender's checksum is validated over, and must be
@@ -919,104 +1300,21 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
         }
     }
 
-    // 12. Legacy / no-checksum compatibility across restart: a write without sender checksums
-    // (opt-in, same as SinglePBWriteWithoutChecksums) must restore successfully and its read must
-    // return an empty Checksums list, both immediately and after a restart.
-    Y_UNIT_TEST(LegacyWriteWithoutChecksumsSurvivesRestartWithEmptyChecksums) {
+    // 12. A checksum-less PB record cannot be created, so it cannot become acknowledged legacy
+    // state that later restores without checksums.
+    Y_UNIT_TEST(ChecksumlessPBWriteIsNotPersisted) {
         TTestContext ctx;
-        const TDiskHandle disk1 = ctx.CreateDDisk(63, 1);
-        NDDisk::TQueryCredentials creds1 = Connect(ctx, disk1.PBServiceId, 113, 1);
-
-        const ui64 lsn = 1;
-        const TString payload = MakeData('L', BlockSize);
+        const TDiskHandle disk = ctx.CreateDDisk(63, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.PBServiceId, 113, 1);
         const NDDisk::TBlockSelector selector{4, 0, BlockSize};
+        auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(
+            creds, selector, 1, NDDisk::TWriteInstruction(0));
+        write->AddPayload(MakeAlignedRope(MakeData('L', BlockSize)));
 
-        std::unordered_map<ui32, TString> chunkBufs;
-        auto captureWrite = [&](const std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>>& raw) {
-            const ui32 chunkIdx = raw->Get()->ChunkIdx;
-            const ui32 offset   = raw->Get()->Offset;
-            TString written = raw->Get()->Data.ConvertToString();
-            if (chunkBufs.find(chunkIdx) == chunkBufs.end()) {
-                chunkBufs[chunkIdx] = TString(TTestContext::ChunkSize, '\0');
-            }
-            UNIT_ASSERT_C(offset + written.size() <= TTestContext::ChunkSize, "Write exceeds chunk size");
-            memcpy(chunkBufs[chunkIdx].Detach() + offset, written.data(), written.size());
-        };
-
-        auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(creds1, selector, lsn, NDDisk::TWriteInstruction(0));
-        write->AddPayload(TRope(payload));
-        // Deliberately not calling AddPayloadThenChecksum(): checksum persistence is opt-in.
-        UNIT_ASSERT_VALUES_EQUAL(write->Record.ChecksumsSize(), 0u);
-
-        SendToDDisk(ctx, disk1.PBServiceId, write.release());
-
-        auto rawWrite = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk1);
-        const TActorId disk1SenderActorId = rawWrite->Sender;
-        captureWrite(rawWrite);
-        const ui64 actualUniqueId = [&]() -> ui64 {
-            const TString& buf = chunkBufs[rawWrite->Get()->ChunkIdx];
-            const auto* hdr = reinterpret_cast<const NDDisk::TPersistentBufferHeader*>(buf.data() + rawWrite->Get()->Offset);
-            UNIT_ASSERT_VALUES_EQUAL_C(hdr->Version, 0u, "Header Version must stay 0 for a checksum-less write");
-            return hdr->PersistentBufferUniqueId;
-        }();
-        ctx.SendPDiskResponse(disk1, *rawWrite, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
-
-        auto writeResult = WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx);
-        AssertStatus(writeResult, TReplyStatus::OK);
-
-        std::vector<ui32> pbChunkIds;
-        for (ui32 i = 0; i < PersistentBufferInitChunks; ++i) {
-            pbChunkIds.push_back(disk1.FirstChunkId + i);
-        }
-
-        std::optional<TActorId> disk2PdiskEdge;
-        ctx.Runtime.FilterFunction = [&](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev) -> bool {
-            if (ev->Sender == disk1SenderActorId) {
-                if (ev->GetTypeRewrite() == NPDisk::TEvCheckSpace::EventType) {
-                    ctx.Runtime.Send(new IEventHandle(ev->Sender, disk1.PDiskEdge,
-                        new NPDisk::TEvCheckSpaceResult(NKikimrProto::OK, 0, 0, 0, 0, 0, 0, 0, "", 0),
-                        0, ev->Cookie), NodeId);
-                }
-                return false;
-            }
-            if (disk2PdiskEdge &&
-                    ev->GetTypeRewrite() == NPDisk::TEvChunkReadRaw::EventType &&
-                    ev->GetRecipientRewrite() == *disk2PdiskEdge) {
-                auto* req = ev->Get<NPDisk::TEvChunkReadRaw>();
-                const ui32 chunkIdx = req->ChunkIdx;
-                const ui32 offset   = req->Offset;
-                const ui32 size     = req->Size;
-                auto it = chunkBufs.find(chunkIdx);
-                TString slice(size, '\0');
-                if (it != chunkBufs.end()) {
-                    const TString& buf = it->second;
-                    UNIT_ASSERT_C(offset + size <= buf.size(), "Read request out of chunk bounds");
-                    memcpy(slice.Detach(), buf.data() + offset, size);
-                }
-                ctx.Runtime.Send(new IEventHandle(ev->Sender, *disk2PdiskEdge,
-                    new NPDisk::TEvChunkReadRawResult(TRope(slice)),
-                    0, ev->Cookie), NodeId);
-                return false;
-            }
-            return true;
-        };
-
-        const TDiskHandle disk2 = ctx.CreateDDiskWithRestoredChunkData(
-            63, 1,
-            pbChunkIds,
-            /*oldUniqueId=*/actualUniqueId - 1,
-            chunkBufs);
-        disk2PdiskEdge = disk2.PDiskEdge;
-
-        NDDisk::TQueryCredentials creds2 = Connect(ctx, disk2.PBServiceId, 113, 1);
-
-        auto readResult = SendToDDiskAndWait<NDDisk::TEvReadPersistentBufferResult>(
-            ctx, disk2.PBServiceId, new NDDisk::TEvReadPersistentBuffer(creds2, selector, lsn, 1, {true}));
-        AssertStatus(readResult, TReplyStatus::OK);
-        UNIT_ASSERT_VALUES_EQUAL_C(readResult->Get()->GetPayload(0).ConvertToString(), payload,
-            "Legacy record's payload must survive restart");
-        UNIT_ASSERT_VALUES_EQUAL_C(static_cast<ui32>(readResult->Get()->Record.ChecksumsSize()), 0u,
-            "A checksum-less record must return an empty Checksums list after restore");
+        auto result = SendToDDiskAndWait<NDDisk::TEvWritePersistentBufferResult>(
+            ctx, disk.PBServiceId, write.release());
+        AssertStatus(result, TReplyStatus::INCORRECT_REQUEST);
+        AssertNoDiskWrite(ctx, {disk.PDiskEdge});
     }
 
     // 13. Re-replication (TEvReadThenWritePersistentBuffers) must forward the checksums that were
@@ -1115,7 +1413,7 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
         const NDDisk::TBlockSelector selectorA{1, 0, BlockSize};
         {
             auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(creds1, selectorA, 1, NDDisk::TWriteInstruction(0));
-            write->AddPayload(TRope(payloadA));
+            write->AddPayloadThenChecksum(TRope(payloadA));
             SendToDDisk(ctx, disk1.PBServiceId, write.release());
         }
         auto rawA = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk1);
@@ -1294,11 +1592,8 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
             "Second returned checksum must be the record's block 2");
     }
 
-    // 16. Mixed batch: a checksummed record and a checksum-less record share the same batch header.
-    // After a restart, the checksummed record must restore with its checksums and the checksum-less
-    // one must restore with an empty Checksums list -- exercising the per-record HAS_PAYLOAD_CHECKSUMS
-    // flag check during batch restore parsing, as opposed to a single Version-wide switch.
-    Y_UNIT_TEST(MixedChecksummedAndLegacyBatchRestoresCorrectly) {
+    // 16. Every record in a batch carries and restores its own checksum list.
+    Y_UNIT_TEST(ChecksummedBatchRestoresCorrectly) {
         TTestContext ctx;
         const TDiskHandle disk1 = ctx.CreateDDisk(69, 1);
         NDDisk::TQueryCredentials creds1 = Connect(ctx, disk1.PBServiceId, 123, 1);
@@ -1321,18 +1616,20 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
         const NDDisk::TBlockSelector selectorA{1, 0, BlockSize};
         {
             auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(creds1, selectorA, 1, NDDisk::TWriteInstruction(0));
-            write->AddPayload(TRope(payloadA));
+            write->AddPayloadThenChecksum(TRope(payloadA));
             SendToDDisk(ctx, disk1.PBServiceId, write.release());
         }
         auto rawA = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk1);
         captureWrite(rawA);
 
-        // Write B: batched, WITHOUT checksums (legacy/opt-out).
+        // Write B: checksummed and batched.
         const TString payloadB = MakeData('B', BlockSize);
         const NDDisk::TBlockSelector selectorB{2, 0, BlockSize};
+        std::vector<ui64> checksumsB;
         {
             auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(creds1, selectorB, 2, NDDisk::TWriteInstruction(0));
-            write->AddPayload(TRope(payloadB));
+            write->AddPayloadThenChecksum(TRope(payloadB));
+            checksumsB.assign(write->Record.GetChecksums().begin(), write->Record.GetChecksums().end());
             SendToDDisk(ctx, disk1.PBServiceId, write.release());
         }
 
@@ -1415,9 +1712,11 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
             ctx, disk2.PBServiceId, new NDDisk::TEvReadPersistentBuffer(creds2, selectorB, 2, 1, {true}));
         AssertStatus(readB, TReplyStatus::OK);
         UNIT_ASSERT_VALUES_EQUAL_C(readB->Get()->GetPayload(0).ConvertToString(), payloadB,
-            "Checksum-less batched record's payload must survive restart");
-        UNIT_ASSERT_VALUES_EQUAL_C(static_cast<ui32>(readB->Get()->Record.ChecksumsSize()), 0u,
-            "Checksum-less batched record must restore with an empty Checksums list");
+            "Checksummed batched record's payload must survive restart");
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            static_cast<ui32>(readB->Get()->Record.ChecksumsSize()), checksumsB.size(),
+            "Checksummed batched record must restore with its checksums");
+        UNIT_ASSERT_VALUES_EQUAL(readB->Get()->Record.GetChecksums(0), checksumsB[0]);
 
         auto readC = SendToDDiskAndWait<NDDisk::TEvReadPersistentBufferResult>(
             ctx, disk2.PBServiceId, new NDDisk::TEvReadPersistentBuffer(creds2, selectorC, 3, 1, {true}));
@@ -1430,6 +1729,284 @@ Y_UNIT_TEST_SUITE(TDDiskChecksumTests) {
             UNIT_ASSERT_VALUES_EQUAL_C(readC->Get()->Record.GetChecksums(i), checksumsC[i],
                 "Checksum " << i << " must survive restart for the checksummed batched record");
         }
+    }
+
+    Y_UNIT_TEST(DirectReadUnallocatedReturnsZeroChecksums) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(80, 1);
+        const NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 200, 1);
+        TFakeDiskStorage storage;
+
+        auto result = ReadDirect(
+            ctx, disk, storage, creds, 7, 0, 3 * BlockSize);
+        AssertDirectRead(result, TString(3 * BlockSize, '\0'),
+            std::vector<ui64>(3, NDDisk::GetZeroBlockChecksum()));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetChecksumCounter(ctx, disk, "IntegrityPairReads")->Val(), 0);
+    }
+
+    Y_UNIT_TEST(DirectReadAllocatedUnwrittenReturnsZeroChecksums) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(81, 1);
+        const NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 201, 1);
+        TFakeDiskStorage storage;
+
+        AssertStatus(WriteDirect(
+            ctx, disk, storage, creds, 7, 0, MakeData('A', BlockSize)),
+            TReplyStatus::OK);
+        storage.SetBlock(
+            disk.FirstChunkId + PersistentBufferInitChunks, BlockSize,
+            MakeData('G', BlockSize));
+        storage.SetBlock(
+            disk.FirstChunkId + PersistentBufferInitChunks, 2 * BlockSize,
+            MakeData('G', BlockSize));
+        ui32 diskReads = 0;
+        auto result = ReadDirect(
+            ctx, disk, storage, creds, 7, BlockSize, 2 * BlockSize,
+            [&](const NPDisk::TEvChunkReadRaw&) -> std::optional<TRope> {
+                ++diskReads;
+                return std::nullopt;
+            });
+        AssertDirectRead(result, TString(2 * BlockSize, '\0'),
+            std::vector<ui64>(2, NDDisk::GetZeroBlockChecksum()));
+        UNIT_ASSERT_VALUES_EQUAL(diskReads, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetChecksumCounter(ctx, disk, "IntegrityPairReads")->Val(), 0);
+    }
+
+    Y_UNIT_TEST(DirectReadFullRangeReturnsPureChecksums) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(82, 1);
+        const NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 202, 1);
+        TFakeDiskStorage storage;
+        const TString payload =
+            MakeData('A', BlockSize) + MakeData('B', BlockSize) + MakeData('C', BlockSize);
+
+        AssertStatus(
+            WriteDirect(ctx, disk, storage, creds, 8, 0, payload), TReplyStatus::OK);
+        AssertDirectRead(
+            ReadDirect(ctx, disk, storage, creds, 8, 0, payload.size()),
+            payload, CalculateChecksums(payload));
+    }
+
+    Y_UNIT_TEST(DirectReadMixedHolesReturnsZeroDataAndChecksums) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(83, 1);
+        const NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 203, 1);
+        TFakeDiskStorage storage;
+        const ui32 firstOffset =
+            (NDDisk::ChecksumsPerIntegrityBlock - 1) * BlockSize;
+        const TString first = MakeData('L', BlockSize);
+        const TString last = MakeData('R', BlockSize);
+
+        AssertStatus(
+            WriteDirect(ctx, disk, storage, creds, 9, firstOffset, first),
+            TReplyStatus::OK);
+        AssertStatus(WriteDirect(
+            ctx, disk, storage, creds, 9, firstOffset + 2 * BlockSize, last),
+            TReplyStatus::OK);
+
+        // Stale physical bytes in the logical hole must be masked by the used-block bitmap.
+        storage.SetBlock(
+            disk.FirstChunkId + PersistentBufferInitChunks,
+            firstOffset + BlockSize,
+            MakeData('G', BlockSize));
+        const TString expected = first + TString(BlockSize, '\0') + last;
+        const std::vector<ui64> expectedChecksums{
+            CalculateChecksums(first)[0],
+            NDDisk::GetZeroBlockChecksum(),
+            CalculateChecksums(last)[0],
+        };
+        AssertDirectRead(
+            ReadDirect(
+                ctx, disk, storage, creds, 9, firstOffset, 3 * BlockSize),
+            expected, expectedChecksums);
+    }
+
+    Y_UNIT_TEST(DirectReadOverwritePreservesNeighborChecksums) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(84, 1);
+        const NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 204, 1);
+        TFakeDiskStorage storage;
+        const TString first = MakeData('A', BlockSize);
+        const TString middle = MakeData('B', BlockSize);
+        const TString last = MakeData('C', BlockSize);
+        const TString replacement = MakeData('D', BlockSize);
+
+        AssertStatus(WriteDirect(
+            ctx, disk, storage, creds, 10, 0, first + middle + last), TReplyStatus::OK);
+        AssertStatus(WriteDirect(
+            ctx, disk, storage, creds, 10, BlockSize, replacement), TReplyStatus::OK);
+
+        const TString expected = first + replacement + last;
+        AssertDirectRead(
+            ReadDirect(ctx, disk, storage, creds, 10, 0, 3 * BlockSize),
+            expected, CalculateChecksums(expected));
+    }
+
+    Y_UNIT_TEST(DirectReadDoesNotValidatePayloadAgainstStoredChecksum) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(85, 1);
+        const NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 205, 1);
+        TFakeDiskStorage storage;
+        const TString original = MakeData('O', BlockSize);
+        TString mutated = original;
+        mutated.Detach()[17] ^= 1;
+
+        AssertStatus(
+            WriteDirect(ctx, disk, storage, creds, 11, 0, original), TReplyStatus::OK);
+        const ui32 dataChunk = disk.FirstChunkId + PersistentBufferInitChunks;
+        storage.SetBlock(dataChunk, 0, mutated);
+
+        const std::vector<ui64> storedChecksum = CalculateChecksums(original);
+        UNIT_ASSERT_VALUES_UNEQUAL(storedChecksum[0], CalculateChecksums(mutated)[0]);
+        AssertDirectRead(
+            ReadDirect(ctx, disk, storage, creds, 11, 0, BlockSize),
+            mutated, storedChecksum);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetChecksumCounter(ctx, disk, "IntegrityCorruption")->Val(), 0);
+    }
+
+    Y_UNIT_TEST(DirectReadFallsBackToOlderValidIntegritySlot) {
+        TTestContext ctx;
+        NDDisk::TDDiskConfig config;
+        config.IntegrityChecksumCacheBytes = 1;
+        const TDiskHandle disk = ctx.CreateDDisk(86, 1, config);
+        const NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 206, 1);
+        TFakeDiskStorage storage;
+        const TString payload = MakeData('F', BlockSize);
+
+        // Two identical writes leave both ping-pong slots valid with the same digest. A write to
+        // the next pair evicts pair 0's checksum array while its pinned digest remains.
+        AssertStatus(
+            WriteDirect(ctx, disk, storage, creds, 12, 0, payload), TReplyStatus::OK);
+        AssertStatus(
+            WriteDirect(ctx, disk, storage, creds, 12, 0, payload), TReplyStatus::OK);
+        AssertStatus(WriteDirect(ctx, disk, storage, creds, 12,
+            NDDisk::ChecksumsPerIntegrityBlock * BlockSize, MakeData('E', BlockSize)),
+            TReplyStatus::OK);
+
+        const ui32 integrityChunk =
+            disk.FirstChunkId + PersistentBufferInitChunks + 1;
+        const ui32 pairOffset = NDDisk::IntegrityChunkHeaderRegionSize;
+        TString badCurrent = storage.GetBlock(integrityChunk, pairOffset + BlockSize);
+        badCurrent.Detach()[0] ^= 1;
+        storage.SetBlock(integrityChunk, pairOffset + BlockSize, std::move(badCurrent));
+
+        ui32 integrityReads = 0;
+        ui32 dataReads = 0;
+        auto result = ReadDirect(ctx, disk, storage, creds, 12, 0, BlockSize,
+            [&](const NPDisk::TEvChunkReadRaw& read) -> std::optional<TRope> {
+                if (read.ChunkIdx == integrityChunk) {
+                    ++integrityReads;
+                } else {
+                    ++dataReads;
+                }
+                return std::nullopt;
+            });
+        AssertDirectRead(result, payload, CalculateChecksums(payload));
+        UNIT_ASSERT_VALUES_EQUAL(integrityReads, 1);
+        UNIT_ASSERT_VALUES_EQUAL(dataReads, 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetChecksumCounter(ctx, disk, "IntegrityPairReads")->Val(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetChecksumCounter(ctx, disk, "IntegrityCorruption")->Val(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetChecksumCounter(ctx, disk, "IntegrityLostWriteDetected")->Val(), 0);
+    }
+
+    Y_UNIT_TEST(DirectReadRejectsBothCorruptedIntegritySlots) {
+        TTestContext ctx;
+        NDDisk::TDDiskConfig config;
+        config.IntegrityChecksumCacheBytes = 1;
+        const TDiskHandle disk = ctx.CreateDDisk(87, 1, config);
+        const NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 207, 1);
+        TFakeDiskStorage storage;
+
+        AssertStatus(WriteDirect(
+            ctx, disk, storage, creds, 13, 0, MakeData('C', BlockSize)),
+            TReplyStatus::OK);
+        AssertStatus(WriteDirect(ctx, disk, storage, creds, 13,
+            NDDisk::ChecksumsPerIntegrityBlock * BlockSize, MakeData('E', BlockSize)),
+            TReplyStatus::OK);
+
+        const ui32 integrityChunk =
+            disk.FirstChunkId + PersistentBufferInitChunks + 1;
+        const ui32 pairOffset = NDDisk::IntegrityChunkHeaderRegionSize;
+        for (ui32 slot = 0; slot < NDDisk::IntegrityPairSlots; ++slot) {
+            TString corrupted =
+                storage.GetBlock(integrityChunk, pairOffset + slot * BlockSize);
+            corrupted.Detach()[0] ^= 1;
+            storage.SetBlock(
+                integrityChunk, pairOffset + slot * BlockSize, std::move(corrupted));
+        }
+
+        ui32 dataReads = 0;
+        auto result = ReadDirect(ctx, disk, storage, creds, 13, 0, BlockSize,
+            [&](const NPDisk::TEvChunkReadRaw& read) -> std::optional<TRope> {
+                if (read.ChunkIdx != integrityChunk) {
+                    ++dataReads;
+                }
+                return std::nullopt;
+            });
+        AssertStatus(result, TReplyStatus::CORRUPTED);
+        UNIT_ASSERT_VALUES_EQUAL(result->Get()->Record.ChecksumsSize(), 0);
+        UNIT_ASSERT_C(result->Get()->Record.GetErrorReason().Contains(
+            "both integrity slots are invalid"), result->Get()->Record.GetErrorReason());
+        UNIT_ASSERT_VALUES_EQUAL(dataReads, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetChecksumCounter(ctx, disk, "IntegrityPairReads")->Val(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetChecksumCounter(ctx, disk, "IntegrityCorruption")->Val(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetChecksumCounter(ctx, disk, "IntegrityLostWriteDetected")->Val(), 0);
+    }
+
+    Y_UNIT_TEST(DirectReadDetectsEvictedDigestLostWrite) {
+        TTestContext ctx;
+        NDDisk::TDDiskConfig config;
+        config.IntegrityChecksumCacheBytes = 1;
+        const TDiskHandle disk = ctx.CreateDDisk(88, 1, config);
+        const NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 208, 1);
+        TFakeDiskStorage storage;
+
+        AssertStatus(WriteDirect(
+            ctx, disk, storage, creds, 14, 0, MakeData('L', BlockSize)),
+            TReplyStatus::OK);
+
+        const ui32 integrityChunk =
+            disk.FirstChunkId + PersistentBufferInitChunks + 1;
+        const ui32 pairOffset = NDDisk::IntegrityChunkHeaderRegionSize;
+        // Slot B is the valid, formatted pre-write image. Replacing both slots with it simulates
+        // the acknowledged pair-0 write being lost while retaining valid metadata identities.
+        const TString stale =
+            storage.GetBlock(integrityChunk, pairOffset + BlockSize);
+
+        AssertStatus(WriteDirect(ctx, disk, storage, creds, 14,
+            NDDisk::ChecksumsPerIntegrityBlock * BlockSize, MakeData('E', BlockSize)),
+            TReplyStatus::OK);
+        storage.SetBlock(integrityChunk, pairOffset, stale);
+        storage.SetBlock(integrityChunk, pairOffset + BlockSize, stale);
+
+        ui32 dataReads = 0;
+        auto result = ReadDirect(ctx, disk, storage, creds, 14, 0, BlockSize,
+            [&](const NPDisk::TEvChunkReadRaw& read) -> std::optional<TRope> {
+                if (read.ChunkIdx != integrityChunk) {
+                    ++dataReads;
+                }
+                return std::nullopt;
+            });
+        AssertStatus(result, TReplyStatus::CORRUPTED);
+        UNIT_ASSERT_VALUES_EQUAL(result->Get()->Record.ChecksumsSize(), 0);
+        UNIT_ASSERT_C(result->Get()->Record.GetErrorReason().Contains(
+            "integrity digest mismatch"), result->Get()->Record.GetErrorReason());
+        UNIT_ASSERT_VALUES_EQUAL(dataReads, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetChecksumCounter(ctx, disk, "IntegrityPairReads")->Val(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetChecksumCounter(ctx, disk, "IntegrityCorruption")->Val(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetChecksumCounter(ctx, disk, "IntegrityLostWriteDetected")->Val(), 1);
     }
 }
 

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_checksum_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_checksum_ut.cpp
@@ -32,7 +32,7 @@ using NKikimrBlobStorage::NDDisk::TReplyStatus;
 
 constexpr ui32 NodeId = 1;
 constexpr ui32 BlockSize = 4096;
-constexpr ui32 MinChunksReserved = 2;
+constexpr ui32 MinChunksReserved = 4;
 constexpr ui32 PersistentBufferInitChunks = 4;
 
 struct TDiskHandle {

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_pdisk_common_ut.h
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_pdisk_common_ut.h
@@ -338,6 +338,27 @@ TString MakeDataWithTabletAndBlock(ui32 tabletId, ui32 blockIdx, ui32 size) {
     return data;
 }
 
+TString AssertReadResult(const NDDisk::TEvReadResult::TPtr& readResult, TStringBuf expected) {
+    AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
+
+    const TString actual = readResult->Get()->GetPayload(0).ConvertToString();
+    UNIT_ASSERT_VALUES_EQUAL(actual, expected);
+    UNIT_ASSERT_VALUES_EQUAL(expected.size() % NDDisk::IntegrityUnitSize, 0u);
+
+    const ui32 expectedChecksumCount = expected.size() / NDDisk::IntegrityUnitSize;
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        static_cast<ui32>(readResult->Get()->Record.ChecksumsSize()), expectedChecksumCount,
+        "checksum count mismatch");
+    for (ui32 i = 0; i < expectedChecksumCount; ++i) {
+        const ui64 expectedChecksum = NDDisk::CalculateRawChecksum(
+            expected.data() + i * NDDisk::IntegrityUnitSize, NDDisk::IntegrityUnitSize);
+        UNIT_ASSERT_VALUES_EQUAL_C(readResult->Get()->Record.GetChecksums(i), expectedChecksum,
+            "checksum mismatch at block# " << i);
+    }
+
+    return actual;
+}
+
 NDDisk::TQueryCredentials Connect(TTestContext& ctx, ui64 tabletId, ui32 generation) {
     NDDisk::TQueryCredentials creds;
     creds.TabletId = tabletId;
@@ -378,8 +399,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
 
     auto readResult = ctx.SendAndGrab<NDDisk::TEvReadResult>(
         new NDDisk::TEvRead(creds, {7, blockSize, static_cast<ui32>(payload.size())}, {true}));
-    AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-    UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), payload);
+    AssertReadResult(readResult, payload);
 
     const TString payload2 = MakeData('R', 2 * blockSize);
     const ui32 secondOffset = blockSize + static_cast<ui32>(payload.size());
@@ -392,8 +412,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
 
     auto readResult2 = ctx.SendAndGrab<NDDisk::TEvReadResult>(
         new NDDisk::TEvRead(creds, {7, secondOffset, static_cast<ui32>(payload2.size())}, {true}));
-    AssertStatus<NDDisk::TEvReadResult>(readResult2, TReplyStatus::OK);
-    UNIT_ASSERT_VALUES_EQUAL(readResult2->Get()->GetPayload(0).ConvertToString(), payload2);
+    AssertReadResult(readResult2, payload2);
 }
 
 [[maybe_unused]] void TestCheckVChunksArePerTablet(NDDisk::TDDiskConfig ddiskConfig) {
@@ -414,8 +433,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
     {
         auto readResult = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds1, {0, 0, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), payload1);
+        AssertReadResult(readResult, payload1);
     }
 
     NDDisk::TQueryCredentials creds2 = Connect(ctx, 102, 1);
@@ -423,10 +441,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
     {
         auto rr = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds2, {0, 0, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(rr, TReplyStatus::OK);
-        const TString data = rr->Get()->GetPayload(0).ConvertToString();
-        UNIT_ASSERT_VALUES_EQUAL(data.size(), MinBlockSize);
-        UNIT_ASSERT(std::all_of(data.begin(), data.end(), [](char c) { return c == '\0'; }));
+        AssertReadResult(rr, TString(MinBlockSize, '\0'));
     }
 
     {
@@ -440,15 +455,13 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
     {
         auto readResult = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds2, {0, 0, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), payload2);
+        AssertReadResult(readResult, payload2);
     }
 
     {
         auto readResult = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds1, {0, 0, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), payload1);
+        AssertReadResult(readResult, payload1);
     }
 }
 
@@ -497,8 +510,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
 
         auto readResult = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds, {vchunkIdx, offset, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), expected);
+        AssertReadResult(readResult, expected);
     }
 }
 
@@ -522,8 +534,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
 
     auto readResult = ctx.SendAndGrab<NDDisk::TEvReadResult>(
         new NDDisk::TEvRead(creds, {0, 0, MinBlockSize}, {true}));
-    AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-    UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), data2);
+    AssertReadResult(readResult, data2);
 }
 
 [[maybe_unused]] void TestReadUnallocatedChunk(NDDisk::TDDiskConfig ddiskConfig) {
@@ -532,11 +543,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
 
     auto readResult = ctx.SendAndGrab<NDDisk::TEvReadResult>(
         new NDDisk::TEvRead(creds, {42, 0, 2 * MinBlockSize}, {true}));
-    AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-
-    const TString data = readResult->Get()->GetPayload(0).ConvertToString();
-    UNIT_ASSERT_VALUES_EQUAL(data.size(), 2 * MinBlockSize);
-    UNIT_ASSERT(std::all_of(data.begin(), data.end(), [](char c) { return c == '\0'; }));
+    AssertReadResult(readResult, TString(2 * MinBlockSize, '\0'));
 }
 
 [[maybe_unused]] void TestManyVChunks(NDDisk::TDDiskConfig ddiskConfig) {
@@ -558,8 +565,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
         TString expected = MakeDataWithIndex(i, MinBlockSize);
         auto readResult = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds, {i, 0, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), expected);
+        AssertReadResult(readResult, expected);
     }
 }
 
@@ -590,14 +596,12 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
         TString expected1 = MakeDataWithIndex(i, MinBlockSize);
         auto rr1 = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds1, {0, i * MinBlockSize, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(rr1, TReplyStatus::OK);
-        UNIT_ASSERT_VALUES_EQUAL(rr1->Get()->GetPayload(0).ConvertToString(), expected1);
+        AssertReadResult(rr1, expected1);
 
         TString expected2 = MakeDataWithIndex(i + 1000, MinBlockSize);
         auto rr2 = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds2, {0, i * MinBlockSize, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(rr2, TReplyStatus::OK);
-        UNIT_ASSERT_VALUES_EQUAL(rr2->Get()->GetPayload(0).ConvertToString(), expected2);
+        AssertReadResult(rr2, expected2);
     }
 }
 
@@ -716,14 +720,11 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
 
                     auto readResult = ctx.SendAndGrab<NDDisk::TEvReadResult>(
                         new NDDisk::TEvRead(creds[t], {v, b * MinBlockSize, MinBlockSize}, {true}));
-                    AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-
-                    const TString actual = readResult->Get()->GetPayload(0).ConvertToString();
+                    const TString actual = AssertReadResult(readResult, expected);
                     ui32 readTabletId = 0;
                     std::memcpy(&readTabletId, actual.data(), sizeof(readTabletId));
                     UNIT_ASSERT_VALUES_EQUAL_C(readTabletId, tabletId,
                         "tablet id mismatch at tablet=" << tabletId << " vchunk=" << v << " block=" << b);
-                    UNIT_ASSERT_VALUES_EQUAL(actual, expected);
                 }
             }
         }
@@ -760,14 +761,11 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
 
         auto readResult = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds, {vchunkIdx, blockInChunk * MinBlockSize, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-
-        const TString actual = readResult->Get()->GetPayload(0).ConvertToString();
+        const TString actual = AssertReadResult(readResult, expected);
         ui32 readTabletId = 0;
         std::memcpy(&readTabletId, actual.data(), sizeof(readTabletId));
         UNIT_ASSERT_VALUES_EQUAL_C(readTabletId, tabletId,
             "tablet id mismatch at tablet=" << tabletId << " vchunk=" << vchunkIdx << " block=" << blockInChunk);
-        UNIT_ASSERT_VALUES_EQUAL(actual, expected);
     };
 
     NDDisk::TQueryCredentials creds[numTablets];
@@ -833,14 +831,11 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
 
         auto readResult = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds, {vchunkIdx, blockInChunk * MinBlockSize, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-
-        const TString actual = readResult->Get()->GetPayload(0).ConvertToString();
+        const TString actual = AssertReadResult(readResult, expected);
         ui32 readTabletId = 0;
         std::memcpy(&readTabletId, actual.data(), sizeof(readTabletId));
         UNIT_ASSERT_VALUES_EQUAL_C(readTabletId, tabletId,
             "tablet id mismatch at tablet=" << tabletId << " vchunk=" << vchunkIdx << " block=" << blockInChunk);
-        UNIT_ASSERT_VALUES_EQUAL(actual, expected);
     };
 
     NDDisk::TQueryCredentials creds[numTablets];
@@ -899,8 +894,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
     {
         auto rr = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds, {0, 0, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(rr, TReplyStatus::OK);
-        UNIT_ASSERT_VALUES_EQUAL(rr->Get()->GetPayload(0).ConvertToString(), dataB);
+        AssertReadResult(rr, dataB);
     }
 
     const TString dataC = MakeData('C', MinBlockSize);
@@ -914,8 +908,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
     {
         auto rr = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds, {0, MinBlockSize, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(rr, TReplyStatus::OK);
-        UNIT_ASSERT_VALUES_EQUAL(rr->Get()->GetPayload(0).ConvertToString(), dataC);
+        AssertReadResult(rr, dataC);
     }
 }
 
@@ -937,8 +930,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
     {
         auto rr = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds, {0, 0, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(rr, TReplyStatus::OK);
-        UNIT_ASSERT_VALUES_EQUAL(rr->Get()->GetPayload(0).ConvertToString(), data);
+        AssertReadResult(rr, data);
     }
 }
 
@@ -962,7 +954,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
     UNIT_ASSERT(*creds.ConnectionToken != oldToken);
 
     auto currentRead = ctx.SendAndGrab<NDDisk::TEvReadResult>(new NDDisk::TEvRead(creds, {0, 0, MinBlockSize}, {true}));
-    AssertStatus<NDDisk::TEvReadResult>(currentRead, TReplyStatus::OK);
+    AssertReadResult(currentRead, TString(MinBlockSize, '\0'));
 
     NDDisk::TQueryCredentials staleCreds = creds;
     staleCreds.ConnectionToken = oldToken;
@@ -994,14 +986,11 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
 
         auto readResult = ctx.SendAndGrab<NDDisk::TEvReadResult>(
             new NDDisk::TEvRead(creds, {vchunkIdx, blockInChunk * MinBlockSize, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-
-        const TString actual = readResult->Get()->GetPayload(0).ConvertToString();
+        const TString actual = AssertReadResult(readResult, expected);
         ui32 readTabletId = 0;
         std::memcpy(&readTabletId, actual.data(), sizeof(readTabletId));
         UNIT_ASSERT_VALUES_EQUAL_C(readTabletId, tabletId,
             "tablet id mismatch at tablet=" << tabletId << " vchunk=" << vchunkIdx << " block=" << blockInChunk);
-        UNIT_ASSERT_VALUES_EQUAL(actual, expected);
     };
 
     NDDisk::TQueryCredentials creds[numTablets];
@@ -1131,14 +1120,11 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
 
                 auto readResult = ctx.SendToAndGrab<NDDisk::TEvReadResult>(1,
                     new NDDisk::TEvRead(tablets[t].Dst, {v, b * MinBlockSize, MinBlockSize}, {true}));
-                AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-
-                const TString actual = readResult->Get()->GetPayload(0).ConvertToString();
+                const TString actual = AssertReadResult(readResult, expected);
                 ui32 readValue = 0;
                 std::memcpy(&readValue, actual.data(), sizeof(readValue));
                 UNIT_ASSERT_VALUES_EQUAL_C(readValue, tabletId,
                     "tablet id mismatch at tablet=" << tabletId << " vchunk=" << v << " block=" << b);
-                UNIT_ASSERT_VALUES_EQUAL(actual, expected);
             }
         }
     }
@@ -1205,15 +1191,12 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
 
         auto readResult = ctx.SendToAndGrab<NDDisk::TEvReadResult>(diskIdx,
             new NDDisk::TEvRead(creds, {vchunkIdx, blockInChunk * MinBlockSize, MinBlockSize}, {true}));
-        AssertStatus<NDDisk::TEvReadResult>(readResult, TReplyStatus::OK);
-
-        const TString actual = readResult->Get()->GetPayload(0).ConvertToString();
+        const TString actual = AssertReadResult(readResult, expected);
         ui32 readTabletId = 0;
         std::memcpy(&readTabletId, actual.data(), sizeof(readTabletId));
         UNIT_ASSERT_VALUES_EQUAL_C(readTabletId, tabletId,
             "tablet id mismatch at disk=" << diskIdx << " tablet=" << tabletId
             << " vchunk=" << vchunkIdx << " block=" << blockInChunk);
-        UNIT_ASSERT_VALUES_EQUAL(actual, expected);
     };
 
     NDDisk::TQueryCredentials creds1 = ConnectTo(ctx, 0, baseTabletId + 0, 1);
@@ -1343,15 +1326,13 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
         for (ui64 vchunk : {0u, 1u}) {
             auto rr = ctx.SendToAndGrab<NDDisk::TEvReadResult>(diskIdx,
                 new NDDisk::TEvRead(c1, {vchunk, 0, MinBlockSize}, {true}));
-            AssertStatus<NDDisk::TEvReadResult>(rr, TReplyStatus::OK);
-            UNIT_ASSERT_VALUES_EQUAL(rr->Get()->GetPayload(0).ConvertToString(), data1);
+            AssertReadResult(rr, data1);
         }
         // Tablet2 should read zeroes from both VChunks (chunks were freed)
         for (ui64 vchunk : {0u, 1u}) {
             auto rr = ctx.SendToAndGrab<NDDisk::TEvReadResult>(diskIdx,
                 new NDDisk::TEvRead(c2, {vchunk, 0, MinBlockSize}, {true}));
-            AssertStatus<NDDisk::TEvReadResult>(rr, TReplyStatus::OK);
-            UNIT_ASSERT_VALUES_EQUAL(rr->Get()->GetPayload(0).ConvertToString(), zeroes);
+            AssertReadResult(rr, zeroes);
         }
     };
 

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_pdisk_common_ut.h
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_pdisk_common_ut.h
@@ -1165,6 +1165,9 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
 //   fallback) does not enforce OwnerRound — both modes still get a reply. Then vchunk 1
 //   page 0 writes need a fresh chunk reservation that always goes through PDisk, so this
 //   is guaranteed to zombify and produce no reply in either mode. The test must NOT crash.
+//   Isolation of a fresh owner from zombie uring I/O is not asserted: reserved chunks
+//   may already have been formatted, so PDisk restart can reassign those physical
+//   offsets while the zombie still holds a live ring.
 //
 // Variant restartDDisk == true (warden-style recovery):
 //   After the PDisk restart we also restart DDisk slot 0; the new DDisk instance uses
@@ -1242,6 +1245,11 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
     const ui32 disk2Idx = ctx.AddDDiskOnPDisk(0);
     NDDisk::TQueryCredentials creds3 = ConnectTo(ctx, disk2Idx, baseTabletId + 2, 1);
     writeBlock(disk2Idx, creds3, baseTabletId + 2, 0, 0);
+    // Prove the restarted PDisk is usable through a fresh owner before any
+    // zombie-slot I/O. Reserved chunks may already have been formatted
+    // (invariant 3: PDisk is not restarted separately from DDisk), so later
+    // zombie uring writes can land on those same physical offsets.
+    readAndVerify(disk2Idx, creds3, baseTabletId + 2, 0, 0);
 
     if (restartDDisk) {
         // Reconnect tablets 1 and 2 to the new DDisk slot 0 actor (their old credentials
@@ -1286,9 +1294,10 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
     ctx.SendTo(0, makeWrite(creds2, baseTabletId + 1, 1, 0).release());
     ctx.ExpectNoReply<NDDisk::TEvWriteResult>();
 
-    // Tablet 3's writes on the new DDisk slot are still readable -- proves the
-    // restarted PDisk is functional and the zombie DDisk slot didn't corrupt it.
-    readAndVerify(disk2Idx, creds3, baseTabletId + 2, 0, 0);
+    // Isolation of the new owner from the zombie slot is not guaranteed: the
+    // zombie still holds a live io_uring on physical offsets that PDisk may
+    // have reassigned after restart. The fresh-owner check above already
+    // proved the restarted PDisk works.
 }
 
 // Write from 2 tablets to multiple VChunks, free all chunks of one tablet, verify the other

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
@@ -60,6 +60,7 @@ public:
     TActorId Edge;
     std::set<TActorId> PDiskEdges;
     std::set<TActorId> PDiskServiceIds;
+    std::unique_ptr<TEventHandle<NPDisk::TEvChunkReserve>> HeldBootstrapRefill;
 
     TTestContext()
         : Runtime(1)
@@ -313,7 +314,14 @@ public:
         SendFromPDisk(Runtime, disk.PDiskEdge, request.Sender, response, request.Cookie);
     }
 
-    void BootstrapDDisk(const TDiskHandle& disk) {
+    void BootstrapDDisk(const TDiskHandle& disk, ui32 chunkSize = ChunkSize,
+            ui32 ddiskReserveChunks = MinChunksReserved,
+            const NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord* chunkMapSnapshot = nullptr,
+            ui64 chunkMapSnapshotLsn = 0,
+            const std::vector<std::pair<
+                NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord, ui64>>& replay = {},
+            TVector<TChunkIdx>* bootReclaimedChunks = nullptr) {
+        HeldBootstrapRefill.reset();
         const NPDisk::TOwner Owner = 1;
         const NPDisk::TOwnerRound OwnerRound = 1;
 
@@ -323,7 +331,7 @@ public:
             NKikimrProto::OK,
             0, 0, 0, // seek/read/write speed
             BlockSize, BlockSize, BlockSize,
-            ChunkSize,
+            chunkSize,
             BlockSize,
             Owner,
             OwnerRound,
@@ -337,9 +345,16 @@ public:
 
         NPDisk::TDiskFormat format = {};
         format.Clear(false);
+        format.ChunkSize = chunkSize;
         initReply->DiskFormat = NPDisk::TDiskFormatPtr(new NPDisk::TDiskFormat(format), +[](NPDisk::TDiskFormat* ptr) {
             delete ptr;
         });
+        if (chunkMapSnapshot) {
+            TString data;
+            UNIT_ASSERT(chunkMapSnapshot->SerializeToString(&data));
+            initReply->StartingPoints[TLogSignature::SignatureDDiskChunkMap] =
+                NPDisk::TLogRecord(TLogSignature::SignatureDDiskChunkMap, TRcBuf(data), chunkMapSnapshotLsn);
+        }
         SendPDiskResponse(disk, *init, initReply.release());
         auto readLog = WaitPDiskRequest<NPDisk::TEvReadLog>(disk);
 
@@ -351,26 +366,66 @@ public:
             0,    // status flags
             "",
             Owner);
+        for (const auto& [record, lsn] : replay) {
+            TString data;
+            UNIT_ASSERT(record.SerializeToString(&data));
+            readLogReply->Results.emplace_back(
+                TLogSignature::SignatureDDiskChunkMap, TRcBuf(data), lsn);
+        }
         SendPDiskResponse(disk, *readLog, readLogReply.release());
+        if (bootReclaimedChunks) {
+            auto reclaim = WaitPDiskRequestNoAutoServe<NPDisk::TEvLog>(disk);
+            *bootReclaimedChunks = reclaim->Get()->CommitRecord.DeleteChunks;
+            ReplyLog(disk, *reclaim);
+        }
 
         // DDisk bootstrap starts persistent buffer initialization in background.
         // Burn these PDisk requests here, so later client-only phases don't see unsolicited PDisk traffic.
         auto reserve = WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
         UNIT_ASSERT_VALUES_EQUAL(reserve->Get()->SizeChunks, MinChunksReserved);
         auto reserveReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
-        const ui32 startupReserveChunks = PersistentBufferInitChunks + MinChunksReserved;
+        const ui32 startupReserveChunks = PersistentBufferInitChunks + ddiskReserveChunks;
         for (ui32 i = 0; i < startupReserveChunks; ++i) {
             reserveReply->ChunkIds.push_back(disk.FirstChunkId + i);
         }
         SendPDiskResponse(disk, *reserve, reserveReply.release());
 
         for (ui32 i = 0; i < PersistentBufferInitChunks; ++i) {
-            auto log = WaitPDiskRequest<NPDisk::TEvLog>(disk);
+            std::unique_ptr<TEventHandle<NPDisk::TEvLog>> log;
+            if (ddiskReserveChunks < MinChunksReserved) {
+                while (!log) {
+                    auto raw = Runtime.WaitForEdgeActorEvent({disk.PDiskEdge});
+                    if (raw->GetTypeRewrite() == NPDisk::TEvChunkReserve::EventType) {
+                        UNIT_ASSERT(!HeldBootstrapRefill);
+                        HeldBootstrapRefill = RecastEvent<NPDisk::TEvChunkReserve>(std::move(raw));
+                        continue;
+                    }
+                    UNIT_ASSERT_VALUES_EQUAL(raw->GetTypeRewrite(), NPDisk::TEvLog::EventType);
+                    log = RecastEvent<NPDisk::TEvLog>(std::move(raw));
+                }
+            } else {
+                log = WaitPDiskRequest<NPDisk::TEvLog>(disk);
+            }
             auto logReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
             logReply->Results.emplace_back(log->Get()->Lsn, log->Get()->Cookie);
             SendPDiskResponse(disk, *log, logReply.release());
         }
-        auto checkSpace = WaitPDiskRequest<NPDisk::TEvCheckSpace>(disk);
+        std::unique_ptr<TEventHandle<NPDisk::TEvCheckSpace>> checkSpace;
+        if (ddiskReserveChunks < MinChunksReserved) {
+            while (!checkSpace) {
+                auto raw = Runtime.WaitForEdgeActorEvent({disk.PDiskEdge});
+                if (raw->GetTypeRewrite() == NPDisk::TEvChunkReserve::EventType) {
+                    UNIT_ASSERT(!HeldBootstrapRefill);
+                    HeldBootstrapRefill = RecastEvent<NPDisk::TEvChunkReserve>(std::move(raw));
+                    continue;
+                }
+                UNIT_ASSERT_VALUES_EQUAL(raw->GetTypeRewrite(), NPDisk::TEvCheckSpace::EventType);
+                checkSpace = RecastEvent<NPDisk::TEvCheckSpace>(std::move(raw));
+            }
+            UNIT_ASSERT(HeldBootstrapRefill);
+        } else {
+            checkSpace = WaitPDiskRequest<NPDisk::TEvCheckSpace>(disk);
+        }
         auto res = new NPDisk::TEvCheckSpaceResult(NKikimrProto::OK, 0, 0, 0, 0, 0, 0, 0, "", 0);
         SendPDiskResponse(disk, *checkSpace, res);
     }
@@ -426,6 +481,14 @@ TRope MakeMisalignedRope(const TString& data) {
     return TRope(TRcBuf(TRcBuf::Piece, buf.data() + 1, data.size(), buf));
 }
 
+std::unique_ptr<NDDisk::TEvWrite> MakeWrite(const NDDisk::TQueryCredentials& creds,
+        ui64 vChunkIndex, ui32 offset, const TString& payload) {
+    auto write = std::make_unique<NDDisk::TEvWrite>(
+        creds, NDDisk::TBlockSelector(vChunkIndex, offset, payload.size()), NDDisk::TWriteInstruction(0));
+    write->AddPayloadThenChecksum(MakeAlignedRope(payload));
+    return write;
+}
+
 NDDisk::TEvSync::TDDiskId MakeSyncSourceId(ui32 pdiskId, ui32 slotId) {
     return std::make_tuple(NodeId, pdiskId, slotId);
 }
@@ -448,6 +511,19 @@ NDDisk::TQueryCredentials Connect(
     creds.ConnectionToken.emplace(connectResult->Get()->Record.GetConnectionToken());
 
     return creds;
+}
+
+void AssertNoClientReplyBeforeSentinel(TTestContext& ctx, TStringBuf message) {
+    const TActorId sentinelEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+    ctx.Runtime.Send(new IEventHandle(sentinelEdge, ctx.Edge, new TEvents::TEvWakeup()), NodeId);
+    for (;;) {
+        auto ev = ctx.Runtime.WaitForEdgeActorEvent(ctx.ClientWaitEdges({sentinelEdge}));
+        if (ctx.ConsumeUnsolicitedPDiskEvent(ev)) {
+            continue;
+        }
+        UNIT_ASSERT_VALUES_EQUAL_C(ev->Recipient, sentinelEdge, message);
+        break;
+    }
 }
 
 struct TInitialWriteOutcome {
@@ -3445,6 +3521,835 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         ctx.ReplyLog(disk, *logIncr);
         auto writeResult = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
         AssertStatus(writeResult, TReplyStatus::OK);
+    }
+
+    Y_UNIT_TEST(SecondExtentInSameIntegrityChunkOmitsIntegrityRecord) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(44, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 220, 1);
+        const ui32 firstDataChunk = disk.FirstChunkId + PersistentBufferInitChunks;
+        const ui32 integrityChunk = firstDataChunk + 1;
+
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 0, 0, MakeData('A', BlockSize)).release());
+        auto first = ctx.CollectAllocationTraffic(disk, true, 1);
+
+        // Issue the second allocation before the first increment is acknowledged. The first
+        // increment already establishes log ordering and owns the integrity-chunk commit.
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 1, 0, MakeData('B', BlockSize)).release());
+        auto second = ctx.CollectAllocationTraffic(disk, false, 1);
+
+        const auto firstRecord = TTestContext::ParseChunkMapLog(*first.Increment->Get());
+        const auto secondRecord = TTestContext::ParseChunkMapLog(*second.Increment->Get());
+        UNIT_ASSERT(firstRecord.GetIncrement().HasIntegrityChunk());
+        UNIT_ASSERT_VALUES_EQUAL(
+            firstRecord.GetIncrement().GetIntegrityChunk().GetChunkIdx(), integrityChunk);
+        UNIT_ASSERT(!secondRecord.GetIncrement().HasIntegrityChunk());
+        UNIT_ASSERT_VALUES_EQUAL(
+            secondRecord.GetIncrement().GetDataChunk().GetExtentRef().GetIntegrityChunkIdx(),
+            integrityChunk);
+        UNIT_ASSERT(first.Increment->Get()->Lsn < second.Increment->Get()->Lsn);
+
+        UNIT_ASSERT_VALUES_EQUAL(first.Increment->Get()->CommitRecord.CommitChunks.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(first.Increment->Get()->CommitRecord.CommitChunks[0], integrityChunk);
+        UNIT_ASSERT_VALUES_EQUAL(first.Increment->Get()->CommitRecord.CommitChunks[1], firstDataChunk);
+        UNIT_ASSERT_VALUES_EQUAL(second.Increment->Get()->CommitRecord.CommitChunks.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(
+            second.Increment->Get()->CommitRecord.CommitChunks[0],
+            second.DataWrites[0]->Get()->ChunkIdx);
+
+        ctx.SendPDiskResponse(disk, *first.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.SendPDiskResponse(disk, *second.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *first.Increment);
+        ctx.ReplyLog(disk, *second.Increment);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+    }
+
+    Y_UNIT_TEST(ConcurrentWritesToAllocatingChunkAllParkedUntilCommit) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(45, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 221, 1);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 7, 0, MakeData('A', BlockSize)).release(), 101);
+        auto first = ctx.CollectAllocationTraffic(disk, true, 1);
+
+        // The extent is ready and the write path is open, but allocation durability is pending.
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 7, BlockSize, MakeData('B', BlockSize)).release(), 102);
+        auto secondWrite = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+        UNIT_ASSERT(!TTestContext::IsIntegrityMetadataWrite(*secondWrite->Get()));
+        UNIT_ASSERT_VALUES_EQUAL(
+            secondWrite->Get()->ChunkIdx, first.DataWrites[0]->Get()->ChunkIdx);
+
+        ctx.SendPDiskResponse(disk, *first.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.SendPDiskResponse(disk, *secondWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "all write replies must remain parked until the allocation increment commits");
+
+        ctx.ReplyLog(disk, *first.Increment);
+        auto firstResult = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
+        auto secondResult = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
+        AssertStatus(firstResult, TReplyStatus::OK);
+        AssertStatus(secondResult, TReplyStatus::OK);
+        std::set<ui64> cookies{firstResult->Cookie, secondResult->Cookie};
+        const std::set<ui64> expectedCookies{101, 102};
+        UNIT_ASSERT(cookies == expectedCookies);
+    }
+
+    Y_UNIT_TEST(ReadParkedBehindAllocatingWriteSeesData) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(46, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 222, 1);
+        const TString payload = MakeData('R', BlockSize);
+
+        SendToDDisk(ctx, disk.ServiceId, MakeWrite(creds, 3, 0, payload).release());
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvRead(creds, {3, 0, BlockSize}, {true}));
+
+        std::unique_ptr<TEventHandle<NPDisk::TEvLog>> increment;
+        std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>> dataWrite;
+        std::unique_ptr<TEventHandle<NPDisk::TEvChunkReadRaw>> dataRead;
+        bool sawSnapshot = false;
+        for (ui32 guard = 0; !increment || !dataWrite || !dataRead; ++guard) {
+            UNIT_ASSERT_C(guard < 100, "allocation traffic did not drain the parked read");
+            auto raw = ctx.Runtime.WaitForEdgeActorEvent({disk.PDiskEdge});
+            const ui32 type = raw->GetTypeRewrite();
+            if (type == NPDisk::TEvChunkWriteRaw::EventType) {
+                auto write = std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>>(
+                    reinterpret_cast<TEventHandle<NPDisk::TEvChunkWriteRaw>*>(raw.release()));
+                if (TTestContext::IsIntegrityMetadataWrite(*write->Get())) {
+                    ctx.SendPDiskResponse(disk, *write,
+                        new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+                } else {
+                    UNIT_ASSERT(!dataWrite);
+                    dataWrite = std::move(write);
+                }
+            } else if (type == NPDisk::TEvChunkReadRaw::EventType) {
+                UNIT_ASSERT(!dataRead);
+                dataRead = std::unique_ptr<TEventHandle<NPDisk::TEvChunkReadRaw>>(
+                    reinterpret_cast<TEventHandle<NPDisk::TEvChunkReadRaw>*>(raw.release()));
+            } else if (type == NPDisk::TEvLog::EventType) {
+                auto log = std::unique_ptr<TEventHandle<NPDisk::TEvLog>>(
+                    reinterpret_cast<TEventHandle<NPDisk::TEvLog>*>(raw.release()));
+                const auto record = TTestContext::ParseChunkMapLog(*log->Get());
+                if (record.HasSnapshot()) {
+                    UNIT_ASSERT(!sawSnapshot);
+                    sawSnapshot = true;
+                    ctx.ReplyLog(disk, *log);
+                } else {
+                    UNIT_ASSERT(!increment);
+                    increment = std::move(log);
+                }
+            } else if (type == NPDisk::TEvChunkReserve::EventType) {
+                auto reserve = std::unique_ptr<TEventHandle<NPDisk::TEvChunkReserve>>(
+                    reinterpret_cast<TEventHandle<NPDisk::TEvChunkReserve>*>(raw.release()));
+                auto reply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
+                for (ui32 i = 0; i < reserve->Get()->SizeChunks; ++i) {
+                    reply->ChunkIds.push_back(910000 + i);
+                }
+                ctx.SendPDiskResponse(disk, *reserve, reply.release());
+            } else if (type == NPDisk::TEvCheckSpace::EventType) {
+                ctx.ConsumeUnsolicitedPDiskEvent(raw);
+            } else {
+                UNIT_ASSERT_C(false, "unexpected PDisk event type " << type);
+            }
+        }
+
+        UNIT_ASSERT(sawSnapshot);
+        UNIT_ASSERT_VALUES_EQUAL(dataRead->Get()->ChunkIdx, dataWrite->Get()->ChunkIdx);
+        ctx.SendPDiskResponse(disk, *dataWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.SendPDiskResponse(disk, *dataRead,
+            new NPDisk::TEvChunkReadRawResult(TRope(payload)));
+
+        auto readResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
+        AssertStatus(readResult, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), payload);
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "the allocating write must still wait for the increment");
+        ctx.ReplyLog(disk, *increment);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+    }
+
+    Y_UNIT_TEST(ExcessIntegrityAllocationReturnsChunkToReserve) {
+        // A 140 KiB chunk has exactly one integrity extent. This makes the cancellation path
+        // practical to exercise without allocating hundreds of 128 MiB data chunks.
+        constexpr ui32 SmallChunkSize = 140 * 1024;
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.RegisterDDisk(47, 1);
+        ctx.BootstrapDDisk(disk, SmallChunkSize, 3);
+        auto heldRefill = std::move(ctx.HeldBootstrapRefill);
+        UNIT_ASSERT(heldRefill);
+
+        NDDisk::TQueryCredentials firstCreds = Connect(ctx, disk.ServiceId, 223, 1);
+        NDDisk::TQueryCredentials secondCreds = Connect(ctx, disk.ServiceId, 224, 1);
+        const ui32 firstDataChunk = disk.FirstChunkId + PersistentBufferInitChunks;
+        const ui32 integrityChunk = firstDataChunk + 1;
+
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(firstCreds, 0, 0, MakeData('A', BlockSize)).release());
+        auto first = ctx.CollectAllocationTraffic(disk, true, 1);
+        ctx.SendPDiskResponse(disk, *first.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *first.Increment);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+
+        // The last reserve chunk becomes the second tablet's data chunk. Its extent cannot be
+        // assigned until the first tablet is deleted, so an integrity allocation stays queued.
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(secondCreds, 0, 0, MakeData('B', BlockSize)).release());
+
+        SendToDDisk(ctx, disk.ServiceId, new NDDisk::TEvDeleteTabletChunks(firstCreds));
+        auto deleteLog = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(deleteLog->Get()->CommitRecord.DeleteChunks.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(deleteLog->Get()->CommitRecord.DeleteChunks[0], firstDataChunk);
+        std::unique_ptr<IEventHandle> heldDeleteResult;
+        ctx.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (!heldDeleteResult
+                    && ev->GetTypeRewrite() == NDDisk::TEvDeleteTabletChunksResult::EventType) {
+                heldDeleteResult = std::move(ev);
+                return false;
+            }
+            return true;
+        };
+        ctx.ReplyLog(disk, *deleteLog);
+
+        // The freed slot is assigned to the waiting second extent; formatting and the parked data
+        // write then run, followed by the second allocation increment.
+        auto second = ctx.CollectAllocationTraffic(disk, false, 1);
+        ctx.Runtime.FilterFunction = {};
+        UNIT_ASSERT(heldDeleteResult);
+        UNIT_ASSERT_VALUES_EQUAL(second.DataWrites[0]->Get()->ChunkIdx, firstDataChunk + 2);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TTestContext::ParseChunkMapLog(*second.Increment->Get())
+                .GetIncrement().GetDataChunk().GetExtentRef().GetIntegrityChunkIdx(),
+            integrityChunk);
+
+        const ui32 excessChunk = 777001;
+        auto refillReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
+        refillReply->ChunkIds.push_back(excessChunk);
+        ctx.SendPDiskResponse(disk, *heldRefill, refillReply.release());
+        auto nextRefill = ctx.WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
+
+        ctx.SendPDiskResponse(disk, *second.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *second.Increment);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+        auto deleteResult = std::unique_ptr<TEventHandle<NDDisk::TEvDeleteTabletChunksResult>>(
+            reinterpret_cast<TEventHandle<NDDisk::TEvDeleteTabletChunksResult>*>(
+                heldDeleteResult.release()));
+        AssertStatus(deleteResult, TReplyStatus::OK);
+
+        // The excess chunk was returned unformatted and is reused as the next data chunk. A new
+        // integrity chunk is still needed because the one-slot chunk is occupied by tablet 224.
+        NDDisk::TQueryCredentials thirdCreds = Connect(ctx, disk.ServiceId, 225, 1);
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(thirdCreds, 0, 0, MakeData('C', BlockSize)).release());
+        auto nextRefillReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
+        nextRefillReply->ChunkIds.push_back(777002);
+        ctx.SendPDiskResponse(disk, *nextRefill, nextRefillReply.release());
+        auto third = ctx.CollectAllocationTraffic(disk, false, 1);
+        UNIT_ASSERT_VALUES_EQUAL(third.DataWrites[0]->Get()->ChunkIdx, excessChunk);
+    }
+
+    Y_UNIT_TEST(DataAndIntegrityDemandDrainReserveOneToOne) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.RegisterDDisk(48, 1);
+        ctx.BootstrapDDisk(disk, TTestContext::ChunkSize, 1);
+        auto heldRefill = std::move(ctx.HeldBootstrapRefill);
+        UNIT_ASSERT(heldRefill);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 226, 1);
+        const ui32 dataChunk = disk.FirstChunkId + PersistentBufferInitChunks;
+        const ui32 integrityChunk = 778001;
+
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 0, 0, MakeData('D', BlockSize)).release());
+        auto snapshot = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvLog>(disk);
+        UNIT_ASSERT(TTestContext::ParseChunkMapLog(*snapshot->Get()).HasSnapshot());
+        ctx.ReplyLog(disk, *snapshot);
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "one reserve chunk can satisfy data demand but not integrity demand");
+
+        auto refillReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
+        refillReply->ChunkIds.push_back(integrityChunk);
+        ctx.SendPDiskResponse(disk, *heldRefill, refillReply.release());
+        auto traffic = ctx.CollectAllocationTraffic(disk, false, 1);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->ChunkIdx, dataChunk);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.Increment->Get()->CommitRecord.CommitChunks.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.Increment->Get()->CommitRecord.CommitChunks[0], integrityChunk);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.Increment->Get()->CommitRecord.CommitChunks[1], dataChunk);
+
+        ctx.SendPDiskResponse(disk, *traffic.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *traffic.Increment);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+    }
+
+    Y_UNIT_TEST(ExtentSlotExhaustionAllocatesSecondIntegrityChunk) {
+        constexpr ui32 SmallChunkSize = 140 * 1024; // one extent per integrity chunk
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.RegisterDDisk(61, 1);
+        ctx.BootstrapDDisk(disk, SmallChunkSize);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 240, 1);
+        const ui32 firstDataChunk = disk.FirstChunkId + PersistentBufferInitChunks;
+
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 0, 0, MakeData('A', BlockSize)).release());
+        auto first = ctx.CollectAllocationTraffic(disk, true, 1);
+        const auto firstRecord = TTestContext::ParseChunkMapLog(*first.Increment->Get());
+        UNIT_ASSERT(firstRecord.GetIncrement().HasIntegrityChunk());
+        const ui32 firstIntegrityChunk =
+            firstRecord.GetIncrement().GetIntegrityChunk().GetChunkIdx();
+        ctx.SendPDiskResponse(disk, *first.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *first.Increment);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 1, 0, MakeData('B', BlockSize)).release());
+        auto second = ctx.CollectAllocationTraffic(disk, false, 1);
+        const auto secondRecord = TTestContext::ParseChunkMapLog(*second.Increment->Get());
+        UNIT_ASSERT(secondRecord.GetIncrement().HasIntegrityChunk());
+        const ui32 secondIntegrityChunk =
+            secondRecord.GetIncrement().GetIntegrityChunk().GetChunkIdx();
+        UNIT_ASSERT_VALUES_UNEQUAL(firstIntegrityChunk, secondIntegrityChunk);
+        UNIT_ASSERT_VALUES_EQUAL(second.Increment->Get()->CommitRecord.CommitChunks.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(
+            second.Increment->Get()->CommitRecord.CommitChunks[0], secondIntegrityChunk);
+        UNIT_ASSERT_VALUES_EQUAL(
+            second.Increment->Get()->CommitRecord.CommitChunks[1], firstDataChunk + 2);
+        ctx.SendPDiskResponse(disk, *second.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *second.Increment);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+    }
+
+    Y_UNIT_TEST(CutLogDuringAllocationIncludesInFlightKeyOnce) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(49, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 227, 1);
+        const TString payload = MakeData('K', BlockSize);
+
+        SendToDDisk(ctx, disk.ServiceId, MakeWrite(creds, 5, 0, payload).release());
+        auto allocation = ctx.CollectAllocationTraffic(disk, true, 1);
+        const auto incrementRecord = TTestContext::ParseChunkMapLog(*allocation.Increment->Get());
+        const auto& incrementData = incrementRecord.GetIncrement().GetDataChunk();
+
+        // The increment is issued but not yet acknowledged. A later starting point must include
+        // the key exactly once because PDisk replays starting points after all lower LSN records.
+        ctx.Runtime.Send(new IEventHandle(disk.ServiceId, disk.PDiskEdge,
+            new NPDisk::TEvCutLog(0, 0, Max<ui64>(), 0, 0, 0, 0)), NodeId);
+        auto cutSnapshot = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvLog>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(
+            cutSnapshot->Get()->Signature.GetUnmasked(),
+            static_cast<ui32>(TLogSignature::SignatureDDiskChunkMap));
+        auto pbSnapshot = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvLog>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(
+            pbSnapshot->Get()->Signature.GetUnmasked(),
+            static_cast<ui32>(TLogSignature::SignaturePersistentBufferChunkMap));
+        const auto snapshotRecord = TTestContext::ParseChunkMapLog(*cutSnapshot->Get());
+        UNIT_ASSERT(snapshotRecord.HasSnapshot());
+
+        ui32 keyCount = 0;
+        for (const auto& tablet : snapshotRecord.GetSnapshot().GetTabletRecords()) {
+            if (tablet.GetTabletId() != 227) {
+                continue;
+            }
+            for (const auto& chunk : tablet.GetChunkRefs()) {
+                if (chunk.GetVChunkIndex() == 5) {
+                    ++keyCount;
+                    UNIT_ASSERT_VALUES_EQUAL(chunk.GetChunkIdx(), incrementData.GetChunkIdx());
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        chunk.GetExtentRef().GetIntegrityChunkIdx(),
+                        incrementData.GetExtentRef().GetIntegrityChunkIdx());
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        chunk.GetExtentRef().GetExtentSlot(),
+                        incrementData.GetExtentRef().GetExtentSlot());
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        chunk.GetExtentRef().GetVChunkGeneration(),
+                        incrementData.GetExtentRef().GetVChunkGeneration());
+                }
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL(keyCount, 1u);
+
+        ctx.SendPDiskResponse(disk, *allocation.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *allocation.Increment);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+        ctx.ReplyLog(disk, *cutSnapshot);
+
+        // CutLog also rewrites the PB starting point; drain it before using another fake PDisk.
+        ctx.ReplyLog(disk, *pbSnapshot);
+
+        // Boot another actor from the captured starting point and verify that the recovered key
+        // routes a read to the original physical data chunk.
+        const TDiskHandle recovered = ctx.RegisterDDisk(50, 1);
+        ctx.BootstrapDDisk(
+            recovered, TTestContext::ChunkSize, MinChunksReserved,
+            &snapshotRecord, cutSnapshot->Get()->Lsn);
+        NDDisk::TQueryCredentials recoveredCreds =
+            Connect(ctx, recovered.ServiceId, 227, 1);
+        SendToDDisk(ctx, recovered.ServiceId,
+            new NDDisk::TEvRead(recoveredCreds, {5, 0, BlockSize}, {true}));
+        auto readRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(recovered);
+        UNIT_ASSERT_VALUES_EQUAL(readRaw->Get()->ChunkIdx, incrementData.GetChunkIdx());
+        ctx.SendPDiskResponse(recovered, *readRaw,
+            new NPDisk::TEvChunkReadRawResult(TRope(payload)));
+        auto readResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
+        AssertStatus(readResult, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), payload);
+    }
+
+    Y_UNIT_TEST(BootSkipsIncrementOlderThanSnapshot) {
+        using TChunkMapLogRecord =
+            NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord;
+        constexpr ui64 SnapshotLsn = 20;
+        TChunkMapLogRecord snapshotRecord;
+        {
+            auto* snapshot = snapshotRecord.MutableSnapshot();
+            auto* tablet = snapshot->AddTabletRecords();
+            tablet->SetTabletId(228);
+            auto* data = tablet->AddChunkRefs();
+            data->SetVChunkIndex(0);
+            data->SetChunkIdx(500);
+            data->MutableExtentRef()->SetIntegrityChunkIdx(600);
+            data->MutableExtentRef()->SetExtentSlot(0);
+            data->MutableExtentRef()->SetVChunkGeneration(1);
+            auto* integrity = snapshot->AddIntegrityChunks();
+            integrity->SetChunkIdx(600);
+            integrity->SetGeneration(1);
+            snapshot->SetGenerationCounter(2);
+        }
+
+        // This conflicting increment predates the starting point and must be ignored completely.
+        TChunkMapLogRecord olderIncrement;
+        {
+            auto* increment = olderIncrement.MutableIncrement();
+            auto* integrity = increment->MutableIntegrityChunk();
+            integrity->SetChunkIdx(601);
+            integrity->SetGeneration(99);
+            auto* data = increment->MutableDataChunk();
+            data->SetTabletId(228);
+            data->SetVChunkIndex(0);
+            data->SetChunkIdx(501);
+            data->MutableExtentRef()->SetIntegrityChunkIdx(601);
+            data->MutableExtentRef()->SetExtentSlot(0);
+            data->MutableExtentRef()->SetVChunkGeneration(99);
+        }
+
+        // This increment follows the snapshot and must be applied.
+        TChunkMapLogRecord newerIncrement;
+        {
+            auto* data = newerIncrement.MutableIncrement()->MutableDataChunk();
+            data->SetTabletId(228);
+            data->SetVChunkIndex(1);
+            data->SetChunkIdx(502);
+            data->MutableExtentRef()->SetIntegrityChunkIdx(600);
+            data->MutableExtentRef()->SetExtentSlot(1);
+            data->MutableExtentRef()->SetVChunkGeneration(2);
+        }
+
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.RegisterDDisk(51, 1);
+        ctx.BootstrapDDisk(
+            disk, TTestContext::ChunkSize, MinChunksReserved,
+            &snapshotRecord, SnapshotLsn,
+            {{olderIncrement, SnapshotLsn - 1}, {newerIncrement, SnapshotLsn + 1}});
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 228, 1);
+
+        for (const auto& [vChunkIndex, expectedChunk] :
+                std::vector<std::pair<ui64, ui32>>{{0, 500}, {1, 502}}) {
+            SendToDDisk(ctx, disk.ServiceId,
+                new NDDisk::TEvRead(creds, {vChunkIndex, 0, BlockSize}, {true}));
+            auto readRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
+            UNIT_ASSERT_VALUES_EQUAL(readRaw->Get()->ChunkIdx, expectedChunk);
+            ctx.SendPDiskResponse(disk, *readRaw,
+                new NPDisk::TEvChunkReadRawResult(TRope(MakeData('L', BlockSize))));
+            AssertStatus(WaitFromDDisk<NDDisk::TEvReadResult>(ctx), TReplyStatus::OK);
+        }
+    }
+
+    Y_UNIT_TEST(SyncAndReadRejectedWhileDeletionInFlight) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(52, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 229, 1);
+        const ui32 dataChunk = disk.FirstChunkId + PersistentBufferInitChunks;
+
+        auto initial = DoWriteWithChunkAllocation(
+            ctx, disk, MakeWrite(creds, 0, 0, MakeData('A', BlockSize)),
+            dataChunk, 0, MakeData('A', BlockSize), true, true);
+        AssertStatus(initial.WriteResult, TReplyStatus::OK);
+
+        SendToDDisk(ctx, disk.ServiceId, new NDDisk::TEvDeleteTabletChunks(creds));
+        auto phaseOne = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
+
+        auto readResult = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx, disk.ServiceId, new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}));
+        AssertStatus(readResult, TReplyStatus::BUSY);
+        // The deletion guard runs before normal sync validation, so even an otherwise-invalid
+        // empty sync is rejected specifically as BUSY.
+        auto syncResult = SendToDDiskAndWait<NDDisk::TEvSyncResult>(
+            ctx, disk.ServiceId, new NDDisk::TEvSync(creds));
+        AssertStatus(syncResult, TReplyStatus::BUSY);
+
+        ctx.ReplyLog(disk, *phaseOne);
+        auto phaseTwo = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
+        ctx.ReplyLog(disk, *phaseTwo);
+        AssertStatus(
+            WaitFromDDisk<NDDisk::TEvDeleteTabletChunksResult>(ctx), TReplyStatus::OK);
+
+        // A later sync can allocate the vchunk again and receives a fresh extent generation.
+        constexpr ui32 SourcePDiskId = 88;
+        const TActorId sourceEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(
+            MakeBlobStorageDDiskId(NodeId, SourcePDiskId, 1), sourceEdge);
+        auto sync = std::make_unique<NDDisk::TEvSync>(creds);
+        sync->AddSegmentFromDDisk(
+            MakeSyncSourceId(SourcePDiskId, 1), 1,
+            NDDisk::TBlockSelector(0, 0, BlockSize));
+        SendToDDisk(ctx, disk.ServiceId, sync.release());
+        auto sourceRead = ctx.Runtime.WaitForEdgeActorEvent({sourceEdge});
+        ctx.Runtime.Send(new IEventHandle(sourceRead->Sender, sourceEdge,
+            new NDDisk::TEvReadResult(
+                TReplyStatus::OK, std::nullopt, TRope(MakeData('S', BlockSize))),
+            0, sourceRead->Cookie), NodeId);
+        auto allocation = ctx.CollectAllocationTraffic(disk, false, 1);
+        const auto allocationRecord =
+            TTestContext::ParseChunkMapLog(*allocation.Increment->Get());
+        UNIT_ASSERT(
+            allocationRecord.GetIncrement().GetDataChunk()
+                .GetExtentRef().GetVChunkGeneration() > 1);
+        ctx.SendPDiskResponse(disk, *allocation.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *allocation.Increment);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvSyncResult>(ctx), TReplyStatus::OK);
+    }
+
+    Y_UNIT_TEST(RebootBetweenDeletionPhasesReleasesIntegrityChunk) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(53, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 230, 1);
+        const ui32 dataChunk = disk.FirstChunkId + PersistentBufferInitChunks;
+        const ui32 integrityChunk = dataChunk + 1;
+
+        auto initial = DoWriteWithChunkAllocation(
+            ctx, disk, MakeWrite(creds, 0, 0, MakeData('A', BlockSize)),
+            dataChunk, 0, MakeData('A', BlockSize), true, true);
+        AssertStatus(initial.WriteResult, TReplyStatus::OK);
+
+        SendToDDisk(ctx, disk.ServiceId, new NDDisk::TEvDeleteTabletChunks(creds));
+        auto phaseOne = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
+        const auto phaseOneRecord = TTestContext::ParseChunkMapLog(*phaseOne->Get());
+        const ui64 phaseOneLsn = phaseOne->Get()->Lsn;
+        UNIT_ASSERT_VALUES_EQUAL(
+            phaseOneRecord.GetSnapshot().IntegrityChunksSize(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            phaseOneRecord.GetSnapshot().TabletRecordsSize(), 0);
+        ctx.ReplyLog(disk, *phaseOne);
+
+        // Simulate a crash after phase 1 became durable but before phase 2 did.
+        auto abandonedPhaseTwo = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(
+            abandonedPhaseTwo->Get()->CommitRecord.DeleteChunks[0], integrityChunk);
+
+        const TDiskHandle recovered = ctx.RegisterDDisk(54, 1);
+        TVector<TChunkIdx> reclaimed;
+        ctx.BootstrapDDisk(
+            recovered, TTestContext::ChunkSize, MinChunksReserved,
+            &phaseOneRecord, phaseOneLsn, {}, &reclaimed);
+        UNIT_ASSERT_VALUES_EQUAL(reclaimed.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(reclaimed[0], integrityChunk);
+
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "a client reply from the abandoned pre-crash deletion must not be recreated");
+    }
+
+    Y_UNIT_TEST(SharedIntegrityChunkSurvivesTabletDeletion) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(55, 1);
+        NDDisk::TQueryCredentials firstCreds = Connect(ctx, disk.ServiceId, 231, 1);
+        NDDisk::TQueryCredentials secondCreds = Connect(ctx, disk.ServiceId, 232, 1);
+        const ui32 firstDataChunk = disk.FirstChunkId + PersistentBufferInitChunks;
+        const ui32 integrityChunk = firstDataChunk + 1;
+
+        AssertStatus(DoWriteWithChunkAllocation(
+            ctx, disk, MakeWrite(firstCreds, 0, 0, MakeData('A', BlockSize)),
+            firstDataChunk, 0, MakeData('A', BlockSize), true, true).WriteResult,
+            TReplyStatus::OK);
+        AssertStatus(DoWriteWithChunkAllocation(
+            ctx, disk, MakeWrite(secondCreds, 0, 0, MakeData('B', BlockSize)),
+            firstDataChunk + 2, 0, MakeData('B', BlockSize), true, false).WriteResult,
+            TReplyStatus::OK);
+
+        SendToDDisk(ctx, disk.ServiceId, new NDDisk::TEvDeleteTabletChunks(firstCreds));
+        auto deleteLog = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
+        ctx.ReplyLog(disk, *deleteLog);
+        AssertStatus(
+            WaitFromDDisk<NDDisk::TEvDeleteTabletChunksResult>(ctx), TReplyStatus::OK);
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "a shared integrity chunk must not produce a phase-2 release record");
+
+        NDDisk::TQueryCredentials thirdCreds = Connect(ctx, disk.ServiceId, 233, 1);
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(thirdCreds, 0, 0, MakeData('C', BlockSize)).release());
+        auto third = ctx.CollectAllocationTraffic(disk, false, 1);
+        const auto thirdRecord = TTestContext::ParseChunkMapLog(*third.Increment->Get());
+        UNIT_ASSERT(!thirdRecord.GetIncrement().HasIntegrityChunk());
+        UNIT_ASSERT_VALUES_EQUAL(
+            thirdRecord.GetIncrement().GetDataChunk().GetExtentRef().GetIntegrityChunkIdx(),
+            integrityChunk);
+        UNIT_ASSERT_VALUES_EQUAL(
+            thirdRecord.GetIncrement().GetDataChunk().GetExtentRef().GetExtentSlot(), 0u);
+        ctx.SendPDiskResponse(disk, *third.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *third.Increment);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+    }
+
+    Y_UNIT_TEST(ConcurrentDeletionsOfTabletsSharingChunk) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(56, 1);
+        NDDisk::TQueryCredentials firstCreds = Connect(ctx, disk.ServiceId, 234, 1);
+        NDDisk::TQueryCredentials secondCreds = Connect(ctx, disk.ServiceId, 235, 1);
+        const ui32 firstDataChunk = disk.FirstChunkId + PersistentBufferInitChunks;
+        const ui32 integrityChunk = firstDataChunk + 1;
+
+        AssertStatus(DoWriteWithChunkAllocation(
+            ctx, disk, MakeWrite(firstCreds, 0, 0, MakeData('A', BlockSize)),
+            firstDataChunk, 0, MakeData('A', BlockSize), true, true).WriteResult,
+            TReplyStatus::OK);
+        AssertStatus(DoWriteWithChunkAllocation(
+            ctx, disk, MakeWrite(secondCreds, 0, 0, MakeData('B', BlockSize)),
+            firstDataChunk + 2, 0, MakeData('B', BlockSize), true, false).WriteResult,
+            TReplyStatus::OK);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvDeleteTabletChunks(firstCreds), 301);
+        auto firstDelete = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvDeleteTabletChunks(secondCreds), 302);
+        auto secondDelete = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
+
+        ctx.ReplyLog(disk, *firstDelete);
+        auto firstResult = WaitFromDDisk<NDDisk::TEvDeleteTabletChunksResult>(ctx);
+        AssertStatus(firstResult, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(firstResult->Cookie, 301u);
+
+        ctx.ReplyLog(disk, *secondDelete);
+        auto release = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(release->Get()->CommitRecord.DeleteChunks.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(
+            release->Get()->CommitRecord.DeleteChunks[0], integrityChunk);
+        ctx.ReplyLog(disk, *release);
+
+        auto secondResult = WaitFromDDisk<NDDisk::TEvDeleteTabletChunksResult>(ctx);
+        AssertStatus(secondResult, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(secondResult->Cookie, 302u);
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "the shared integrity chunk must be released exactly once");
+    }
+
+    Y_UNIT_TEST(BrokenAfterIncrementIssuedSkipsCallbackAndFailsParkedRepliesOnce) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(57, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 236, 1);
+        constexpr ui32 SourcePDiskId = 87;
+        const TActorId sourceEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(
+            MakeBlobStorageDDiskId(NodeId, SourcePDiskId, 1), sourceEdge);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 0, 0, MakeData('A', BlockSize)).release(), 401);
+        auto allocation = ctx.CollectAllocationTraffic(disk, true, 1);
+
+        auto sync = std::make_unique<NDDisk::TEvSync>(creds);
+        sync->AddSegmentFromDDisk(
+            MakeSyncSourceId(SourcePDiskId, 1), 1,
+            NDDisk::TBlockSelector(0, BlockSize, BlockSize));
+        SendToDDisk(ctx, disk.ServiceId, sync.release(), 402);
+        auto sourceRead = ctx.Runtime.WaitForEdgeActorEvent({sourceEdge});
+        ctx.Runtime.Send(new IEventHandle(sourceRead->Sender, sourceEdge,
+            new NDDisk::TEvReadResult(
+                TReplyStatus::OK, std::nullopt, TRope(MakeData('B', BlockSize))),
+            0, sourceRead->Cookie), NodeId);
+        auto syncWrite = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+
+        ctx.SendPDiskResponse(disk, *allocation.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.SendPDiskResponse(disk, *syncWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "write and sync results must both be parked on the increment");
+
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TDDiskActor::TEvPrivate::TEvIntegrityIoResult(
+                999901, TReplyStatus::ERROR, "injected failure after increment issue"));
+
+        std::unique_ptr<TEventHandle<NDDisk::TEvWriteResult>> writeResult;
+        std::unique_ptr<TEventHandle<NDDisk::TEvSyncResult>> syncResult;
+        while (!writeResult || !syncResult) {
+            auto raw = ctx.Runtime.WaitForEdgeActorEvent({ctx.Edge});
+            if (raw->GetTypeRewrite() == NDDisk::TEvWriteResult::EventType) {
+                writeResult = std::unique_ptr<TEventHandle<NDDisk::TEvWriteResult>>(
+                    reinterpret_cast<TEventHandle<NDDisk::TEvWriteResult>*>(raw.release()));
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    raw->GetTypeRewrite(), NDDisk::TEvSyncResult::EventType);
+                syncResult = std::unique_ptr<TEventHandle<NDDisk::TEvSyncResult>>(
+                    reinterpret_cast<TEventHandle<NDDisk::TEvSyncResult>*>(raw.release()));
+            }
+        }
+        AssertStatus(writeResult, TReplyStatus::ERROR);
+        AssertStatus(syncResult, TReplyStatus::ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(writeResult->Cookie, 401u);
+        UNIT_ASSERT_VALUES_EQUAL(syncResult->Cookie, 402u);
+
+        // A late successful commit must not run CompleteDataChunkAllocation against state that
+        // EnterBroken already drained, and must not emit replacement OK replies.
+        ctx.ReplyLog(disk, *allocation.Increment);
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "the successful late log callback must be skipped while Broken");
+    }
+
+    Y_UNIT_TEST(BrokenFailsParkedPendingEventsExactlyOnce) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.RegisterDDisk(58, 1);
+        ctx.BootstrapDDisk(disk, TTestContext::ChunkSize, 1);
+        UNIT_ASSERT(ctx.HeldBootstrapRefill);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 237, 1);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 0, 0, MakeData('A', BlockSize)).release(), 501);
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}), 502);
+        // The sole reserve chunk was used for data; both requests remain in the per-chunk queue
+        // because no integrity chunk has been supplied.
+        auto snapshot = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvLog>(disk);
+        UNIT_ASSERT(TTestContext::ParseChunkMapLog(*snapshot->Get()).HasSnapshot());
+
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TDDiskActor::TEvPrivate::TEvIntegrityIoResult(
+                999902, TReplyStatus::ERROR, "injected failure with pending events"));
+
+        std::unique_ptr<TEventHandle<NDDisk::TEvWriteResult>> writeResult;
+        std::unique_ptr<TEventHandle<NDDisk::TEvReadResult>> readResult;
+        while (!writeResult || !readResult) {
+            auto raw = ctx.Runtime.WaitForEdgeActorEvent({ctx.Edge});
+            if (raw->GetTypeRewrite() == NDDisk::TEvWriteResult::EventType) {
+                writeResult = std::unique_ptr<TEventHandle<NDDisk::TEvWriteResult>>(
+                    reinterpret_cast<TEventHandle<NDDisk::TEvWriteResult>*>(raw.release()));
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    raw->GetTypeRewrite(), NDDisk::TEvReadResult::EventType);
+                readResult = std::unique_ptr<TEventHandle<NDDisk::TEvReadResult>>(
+                    reinterpret_cast<TEventHandle<NDDisk::TEvReadResult>*>(raw.release()));
+            }
+        }
+        AssertStatus(writeResult, TReplyStatus::ERROR);
+        AssertStatus(readResult, TReplyStatus::ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(writeResult->Cookie, 501u);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Cookie, 502u);
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "each pending request must be failed exactly once");
+
+        SendToDDisk(ctx, disk.PBServiceId,
+            new NDDisk::TEvGetPersistentBufferInfo(false, false));
+        UNIT_ASSERT(WaitFromDDisk<NDDisk::TEvPersistentBufferInfo>(ctx));
+    }
+
+    Y_UNIT_TEST(SyncErrorReplyStillGatedOnIncrementCommit) {
+        // Unlike SyncReplyWaitsForCombinedIncrement, inject a target-write completion error after
+        // a successful source read. The resulting ERROR reply obeys the same durability barrier.
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(59, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 238, 1);
+        constexpr ui32 SourcePDiskId = 86;
+        const TActorId sourceEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(
+            MakeBlobStorageDDiskId(NodeId, SourcePDiskId, 1), sourceEdge);
+
+        auto sync = std::make_unique<NDDisk::TEvSync>(creds);
+        sync->AddSegmentFromDDisk(
+            MakeSyncSourceId(SourcePDiskId, 1), 1,
+            NDDisk::TBlockSelector(0, 0, BlockSize));
+        SendToDDisk(ctx, disk.ServiceId, sync.release());
+        auto sourceRead = ctx.Runtime.WaitForEdgeActorEvent({sourceEdge});
+        ctx.Runtime.Send(new IEventHandle(sourceRead->Sender, sourceEdge,
+            new NDDisk::TEvReadResult(
+                TReplyStatus::OK, std::nullopt, TRope(MakeData('S', BlockSize))),
+            0, sourceRead->Cookie), NodeId);
+        auto allocation = ctx.CollectAllocationTraffic(disk, true, 1);
+
+        bool changedCompletion = false;
+        ctx.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite()
+                    == NDDisk::TDDiskActor::TEvPrivate::TEvInternalSyncWriteResult::EventType) {
+                auto* result = ev->CastAsLocal<
+                    NDDisk::TDDiskActor::TEvPrivate::TEvInternalSyncWriteResult>();
+                result->Status = TReplyStatus::ERROR;
+                result->ErrorMessage = "injected target write error";
+                changedCompletion = true;
+            }
+            return true;
+        };
+        ctx.SendPDiskResponse(disk, *allocation.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ui32 eventsProcessed = 0;
+        ctx.Runtime.Sim([&] {
+            return !changedCompletion && ++eventsProcessed <= 200;
+        });
+        ctx.Runtime.FilterFunction = {};
+        UNIT_ASSERT(changedCompletion);
+
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "an ERROR sync result must wait for the allocation increment");
+        ctx.ReplyLog(disk, *allocation.Increment);
+        auto syncResult = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
+        AssertStatus(syncResult, TReplyStatus::ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(syncResult->Get()->Record.SegmentResultsSize(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(syncResult->Get()->Record.GetSegmentResults(0).GetStatus()),
+            static_cast<int>(TReplyStatus::ERROR));
+    }
+
+    Y_UNIT_TEST(IncrementLogFailureTerminatesQuietly) {
+        TTestContext ctx;
+        const TActorId wardenEdge =
+            ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(MakeBlobStorageNodeWardenID(NodeId), wardenEdge);
+        const TDiskHandle disk = ctx.CreateDDisk(60, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 239, 1);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 0, 0, MakeData('A', BlockSize)).release());
+        auto allocation = ctx.CollectAllocationTraffic(disk, true, 1);
+        ctx.SendPDiskResponse(disk, *allocation.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "the client write must still be parked before the log failure");
+
+        auto error = std::make_unique<NPDisk::TEvLogResult>(
+            NKikimrProto::INVALID_ROUND, 0, "injected owner-round loss", 0);
+        error->Results.emplace_back(
+            allocation.Increment->Get()->Lsn, allocation.Increment->Get()->Cookie);
+        ctx.SendPDiskResponse(disk, *allocation.Increment, error.release());
+
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}));
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "Terminate must silently drop both the parked write and later requests");
+
+        SendToDDisk(ctx, disk.ServiceId, new TEvents::TEvPoison());
+        auto gone = ctx.Runtime.WaitForEdgeActorEvent({wardenEdge});
+        UNIT_ASSERT_VALUES_EQUAL(gone->GetTypeRewrite(), TEvents::TEvGone::EventType);
     }
 
     Y_UNIT_TEST(IntegrityFormattingFailureEntersLiveBrokenState) {

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
@@ -75,8 +75,9 @@ public:
     }
 
     TDiskHandle CreateDDisk(ui32 pdiskId, ui32 slotId,
-            std::optional<NDDisk::TPersistentBufferFormat> customFormat = std::nullopt) {
-        TDiskHandle disk = RegisterDDisk(pdiskId, slotId, customFormat);
+            std::optional<NDDisk::TPersistentBufferFormat> customFormat = std::nullopt,
+            NDDisk::TDDiskConfig ddiskConfig = {}) {
+        TDiskHandle disk = RegisterDDisk(pdiskId, slotId, customFormat, std::move(ddiskConfig));
         BootstrapDDisk(disk);
         return disk;
     }
@@ -84,7 +85,8 @@ public:
     // Registers the actors without running the bootstrap protocol: tests that need a custom boot
     // sequence (e.g. recovery from starting points) drive the PDisk side themselves.
     TDiskHandle RegisterDDisk(ui32 pdiskId, ui32 slotId,
-            std::optional<NDDisk::TPersistentBufferFormat> customFormat = std::nullopt) {
+            std::optional<NDDisk::TPersistentBufferFormat> customFormat = std::nullopt,
+            NDDisk::TDDiskConfig ddiskConfig = {}) {
         const TActorId pdiskEdge = Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
         const TActorId pdiskServiceId = MakeBlobStoragePDiskID(NodeId, pdiskId);
         Runtime.RegisterService(pdiskServiceId, pdiskEdge);
@@ -110,7 +112,7 @@ public:
         NDDisk::TPersistentBufferFormat pbFormat = customFormat.value_or(
             NDDisk::TPersistentBufferFormat{256, 4, BlockSize * 128, 8, 5000, 512 * 1024});
         const TActorId ddiskActor = Runtime.Register(NDDisk::CreateDDiskActor(std::move(baseInfo), groupInfo,
-            std::move(pbFormat), NDDisk::TDDiskConfig{}, Counters),
+            std::move(pbFormat), std::move(ddiskConfig), Counters),
             NodeId);
         const TActorId ddiskServiceId = MakeBlobStorageDDiskId(NodeId, pdiskId, slotId);
         const TActorId pbServiceId = MakeBlobStoragePersistentBufferId(NodeId, pdiskId, slotId);
@@ -475,10 +477,44 @@ TRope MakeAlignedRope(const TString& data) {
     return TRope(std::move(buf));
 }
 
+std::vector<ui64> MakeBlockChecksums(const TString& data) {
+    return NDDisk::CalculatePayloadChecksums(MakeAlignedRope(data));
+}
+
 TRope MakeMisalignedRope(const TString& data) {
     auto buf = TRcBuf::UninitializedPageAligned(data.size() + BlockSize);
     memcpy(buf.GetDataMut() + 1, data.data(), data.size());
     return TRope(TRcBuf(TRcBuf::Piece, buf.data() + 1, data.size(), buf));
+}
+
+TRope MakeRestoredIntegrityPair(ui64 ddiskId, ui64 pdiskGuid, ui64 tabletId, ui64 vChunkIndex,
+        ui64 vChunkGeneration, ui32 integrityChunkIdx, ui32 extentSlot,
+        ui64 integrityChunkGeneration, const TString& blockData) {
+    UNIT_ASSERT_VALUES_EQUAL(blockData.size(), BlockSize);
+    const ui64 pureChecksum = NDDisk::CalculateRawChecksum(blockData.data(), blockData.size());
+    NDDisk::TIntegrityBlock slots[NDDisk::IntegrityPairSlots]{};
+    for (ui32 slotIdx = 0; slotIdx < NDDisk::IntegrityPairSlots; ++slotIdx) {
+        auto& block = slots[slotIdx];
+        auto& header = block.Header;
+        header.Magic = NDDisk::MagicIntegrityBlock;
+        header.FormatVersion = static_cast<ui16>(NDDisk::EIntegrityFormatVersion::BaseAwupf4KiB);
+        header.ChecksumBlockIdx = 0;
+        header.OwnerId = tabletId;
+        header.VChunkId = vChunkIndex;
+        header.VChunkGeneration = vChunkGeneration;
+        header.IntegrityChunkId = integrityChunkIdx;
+        header.IntegrityExtentId = extentSlot;
+        header.IntegrityChunkGeneration = integrityChunkGeneration;
+        header.IntegrityBlockDigest = NDDisk::Contribution(vChunkGeneration, 0, pureChecksum);
+        header.PairSequenceNumber = slotIdx;
+        header.UsedBlocksBitmap[0] = 1;
+        block.Checksums[0] = NDDisk::SealBlockChecksum(
+            pureChecksum, ddiskId, pdiskGuid, tabletId, vChunkIndex, 0);
+        header.BlockChecksum = NDDisk::CalculateRawChecksum(&block, sizeof(block));
+    }
+    auto data = TRcBuf::UninitializedPageAligned(sizeof(slots));
+    memcpy(data.GetDataMut(), slots, sizeof(slots));
+    return TRope(std::move(data));
 }
 
 std::unique_ptr<NDDisk::TEvWrite> MakeWrite(const NDDisk::TQueryCredentials& creds,
@@ -1175,6 +1211,9 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         const TString data = readResult->Get()->GetPayload(0).ConvertToString();
         UNIT_ASSERT_VALUES_EQUAL(data.size(), 2 * BlockSize);
         UNIT_ASSERT(std::all_of(data.begin(), data.end(), [](char c) { return c == '\0'; }));
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->Record.ChecksumsSize(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->Record.GetChecksums(0), NDDisk::GetZeroBlockChecksum());
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->Record.GetChecksums(1), NDDisk::GetZeroBlockChecksum());
     }
 
     Y_UNIT_TEST(NoZeroRead) {
@@ -1302,6 +1341,11 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         auto readResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
         AssertStatus(readResult, TReplyStatus::OK);
         UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), payload);
+        const auto expectedChecksums = NDDisk::CalculatePayloadChecksums(MakeAlignedRope(payload));
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->Record.ChecksumsSize(), expectedChecksums.size());
+        for (ui32 i = 0; i < expectedChecksums.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->Record.GetChecksums(i), expectedChecksums[i]);
+        }
 
         // Second write to the same vchunk: only TEvChunkWriteRaw (DoWriteWithChunkAllocation's log/reserve path must not run)
 
@@ -1325,6 +1369,295 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         auto readResult2 = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
         AssertStatus(readResult2, TReplyStatus::OK);
         UNIT_ASSERT_VALUES_EQUAL(readResult2->Get()->GetPayload(0).ConvertToString(), payload2);
+        const auto expectedChecksums2 = NDDisk::CalculatePayloadChecksums(MakeAlignedRope(payload2));
+        UNIT_ASSERT_VALUES_EQUAL(readResult2->Get()->Record.ChecksumsSize(), expectedChecksums2.size());
+        for (ui32 i = 0; i < expectedChecksums2.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(readResult2->Get()->Record.GetChecksums(i), expectedChecksums2[i]);
+        }
+    }
+
+    Y_UNIT_TEST(WriteReplyWaitsForIntegrityPairDurability) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(5, 2);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 31, 1);
+
+        const TString firstPayload = MakeData('A', BlockSize);
+        auto first = DoWriteWithChunkAllocation(ctx, disk,
+            MakeWrite(creds, 0, 0, firstPayload),
+            disk.FirstChunkId + PersistentBufferInitChunks, 0, firstPayload, true, true);
+        AssertStatus(first.WriteResult, TReplyStatus::OK);
+
+        SendToDDisk(ctx, disk.ServiceId, MakeWrite(creds, 0, BlockSize, MakeData('B', BlockSize)).release());
+        auto write1 = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvChunkWriteRaw>(disk);
+        auto write2 = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvChunkWriteRaw>(disk);
+        auto* dataWrite = write1->Get()->ChunkIdx == first.ChunkIdx ? write1.get() : write2.get();
+        auto* integrityWrite = write1->Get()->ChunkIdx == first.ChunkIdx ? write2.get() : write1.get();
+        UNIT_ASSERT_VALUES_UNEQUAL(dataWrite->Get()->ChunkIdx, integrityWrite->Get()->ChunkIdx);
+
+        ctx.SendPDiskResponse(disk, *dataWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        AssertNoClientReplyBeforeSentinel(ctx,
+            "write reply must wait for the integrity pair image");
+
+        ctx.SendPDiskResponse(disk, *integrityWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+    }
+
+    Y_UNIT_TEST(WriteReplyWaitsForDataWhenIntegrityCompletesFirst) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(75, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 253, 1);
+
+        const TString firstPayload = MakeData('A', BlockSize);
+        auto first = DoWriteWithChunkAllocation(ctx, disk,
+            MakeWrite(creds, 0, 0, firstPayload),
+            disk.FirstChunkId + PersistentBufferInitChunks, 0, firstPayload, true, true);
+        AssertStatus(first.WriteResult, TReplyStatus::OK);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 0, BlockSize, MakeData('B', BlockSize)).release());
+        auto write1 =
+            ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvChunkWriteRaw>(disk);
+        auto write2 =
+            ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvChunkWriteRaw>(disk);
+        auto* dataWrite =
+            write1->Get()->ChunkIdx == first.ChunkIdx ? write1.get() : write2.get();
+        auto* integrityWrite =
+            write1->Get()->ChunkIdx == first.ChunkIdx ? write2.get() : write1.get();
+
+        bool sawWriteReply = false;
+        ctx.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == NDDisk::TEvWriteResult::EventType
+                    && ev->GetRecipientRewrite() == ctx.Edge) {
+                sawWriteReply = true;
+            }
+            return true;
+        };
+        ctx.SendPDiskResponse(disk, *integrityWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "write reply must also wait when integrity completes before data");
+        UNIT_ASSERT(!sawWriteReply);
+
+        ctx.SendPDiskResponse(disk, *dataWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto result = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
+        ctx.Runtime.FilterFunction = {};
+        UNIT_ASSERT(sawWriteReply);
+        AssertStatus(result, TReplyStatus::OK);
+    }
+
+    Y_UNIT_TEST(SameExtentWritesSerializeDataAndIntegrity) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(5, 4);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 33, 1);
+
+        const TString initialPayload = MakeData('A', BlockSize);
+        auto initial = DoWriteWithChunkAllocation(ctx, disk,
+            MakeWrite(creds, 0, 0, initialPayload),
+            disk.FirstChunkId + PersistentBufferInitChunks, 0, initialPayload, true, true);
+        AssertStatus(initial.WriteResult, TReplyStatus::OK);
+
+        std::vector<std::unique_ptr<IEventHandle>> heldWrites;
+        ctx.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetRecipientRewrite() == disk.PDiskEdge
+                    && ev->GetTypeRewrite() == NPDisk::TEvChunkWriteRaw::EventType) {
+                heldWrites.push_back(std::move(ev));
+                return false;
+            }
+            return true;
+        };
+
+        const TString firstPayload = MakeData('B', BlockSize);
+        const TString secondPayload = MakeData('C', BlockSize);
+        SendToDDisk(ctx, disk.ServiceId, MakeWrite(creds, 0, 0, firstPayload).release());
+        SendToDDisk(ctx, disk.ServiceId, MakeWrite(creds, 0, 0, secondPayload).release());
+        ui32 eventsProcessed = 0;
+        ctx.Runtime.Sim([&] {
+            return heldWrites.size() < 2 && ++eventsProcessed <= 200;
+        });
+        ctx.Runtime.FilterFunction = {};
+        UNIT_ASSERT_VALUES_EQUAL_C(heldWrites.size(), 2,
+            "only the first write's data and integrity I/O may be submitted");
+
+        auto firstRaw = std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>>(
+            reinterpret_cast<TEventHandle<NPDisk::TEvChunkWriteRaw>*>(heldWrites[0].release()));
+        auto secondRaw = std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>>(
+            reinterpret_cast<TEventHandle<NPDisk::TEvChunkWriteRaw>*>(heldWrites[1].release()));
+        auto* firstData = firstRaw->Get()->ChunkIdx == initial.ChunkIdx ? firstRaw.get() : secondRaw.get();
+        auto* firstIntegrity = firstRaw->Get()->ChunkIdx == initial.ChunkIdx ? secondRaw.get() : firstRaw.get();
+        UNIT_ASSERT_VALUES_EQUAL(firstData->Get()->Data.ConvertToString(), firstPayload);
+
+        heldWrites.clear();
+        ctx.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetRecipientRewrite() == disk.PDiskEdge
+                    && ev->GetTypeRewrite() == NPDisk::TEvChunkWriteRaw::EventType) {
+                heldWrites.push_back(std::move(ev));
+                return false;
+            }
+            return true;
+        };
+        ctx.SendPDiskResponse(disk, *firstData,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.SendPDiskResponse(disk, *firstIntegrity,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+        eventsProcessed = 0;
+        ctx.Runtime.Sim([&] {
+            return heldWrites.size() < 2 && ++eventsProcessed <= 200;
+        });
+        ctx.Runtime.FilterFunction = {};
+        UNIT_ASSERT_VALUES_EQUAL(heldWrites.size(), 2);
+
+        auto nextRaw1 = std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>>(
+            reinterpret_cast<TEventHandle<NPDisk::TEvChunkWriteRaw>*>(heldWrites[0].release()));
+        auto nextRaw2 = std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>>(
+            reinterpret_cast<TEventHandle<NPDisk::TEvChunkWriteRaw>*>(heldWrites[1].release()));
+        auto* secondData = nextRaw1->Get()->ChunkIdx == initial.ChunkIdx ? nextRaw1.get() : nextRaw2.get();
+        auto* secondIntegrity = nextRaw1->Get()->ChunkIdx == initial.ChunkIdx ? nextRaw2.get() : nextRaw1.get();
+        UNIT_ASSERT_VALUES_EQUAL(secondData->Get()->Data.ConvertToString(), secondPayload);
+
+        ctx.SendPDiskResponse(disk, *secondData,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.SendPDiskResponse(disk, *secondIntegrity,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}));
+        auto dataRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
+        ctx.SendPDiskResponse(
+            disk, *dataRead, new NPDisk::TEvChunkReadRawResult(TRope(secondPayload)));
+        auto readResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
+        AssertStatus(readResult, TReplyStatus::OK);
+        const auto expectedChecksums =
+            NDDisk::CalculatePayloadChecksums(MakeAlignedRope(secondPayload));
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->Record.ChecksumsSize(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->Record.GetChecksums(0), expectedChecksums[0]);
+    }
+
+    Y_UNIT_TEST(DifferentExtentWritesRemainConcurrent) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(5, 6);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 35, 1);
+        const ui32 firstChunk = disk.FirstChunkId + PersistentBufferInitChunks;
+
+        auto first = DoWriteWithChunkAllocation(ctx, disk,
+            MakeWrite(creds, 0, 0, MakeData('A', BlockSize)),
+            firstChunk, 0, MakeData('A', BlockSize), true, true);
+        AssertStatus(first.WriteResult, TReplyStatus::OK);
+        auto second = DoWriteWithChunkAllocation(ctx, disk,
+            MakeWrite(creds, 1, 0, MakeData('B', BlockSize)),
+            firstChunk + 2, 0, MakeData('B', BlockSize), true, false);
+        AssertStatus(second.WriteResult, TReplyStatus::OK);
+
+        std::vector<std::unique_ptr<IEventHandle>> heldWrites;
+        ctx.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetRecipientRewrite() == disk.PDiskEdge
+                    && ev->GetTypeRewrite() == NPDisk::TEvChunkWriteRaw::EventType) {
+                heldWrites.push_back(std::move(ev));
+                return false;
+            }
+            return true;
+        };
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 0, BlockSize, MakeData('C', BlockSize)).release());
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 1, BlockSize, MakeData('D', BlockSize)).release());
+        ui32 eventsProcessed = 0;
+        ctx.Runtime.Sim([&] {
+            return heldWrites.size() < 4 && ++eventsProcessed <= 300;
+        });
+        ctx.Runtime.FilterFunction = {};
+        UNIT_ASSERT_VALUES_EQUAL_C(heldWrites.size(), 4,
+            "two different extents must submit both data+integrity batches concurrently");
+
+        bool sawFirstData = false;
+        bool sawSecondData = false;
+        for (auto& raw : heldWrites) {
+            auto write = std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>>(
+                reinterpret_cast<TEventHandle<NPDisk::TEvChunkWriteRaw>*>(raw.release()));
+            if (write->Get()->ChunkIdx == first.ChunkIdx) {
+                sawFirstData = true;
+            } else if (write->Get()->ChunkIdx == second.ChunkIdx) {
+                sawSecondData = true;
+            }
+            ctx.SendPDiskResponse(disk, *write,
+                new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        }
+        UNIT_ASSERT(sawFirstData);
+        UNIT_ASSERT(sawSecondData);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+    }
+
+    Y_UNIT_TEST(IntegrityWriteFailureBreaksDDiskAndFailsPendingWrite) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(5, 3);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 32, 1);
+
+        const TString firstPayload = MakeData('A', BlockSize);
+        auto first = DoWriteWithChunkAllocation(ctx, disk,
+            MakeWrite(creds, 0, 0, firstPayload),
+            disk.FirstChunkId + PersistentBufferInitChunks, 0, firstPayload, true, true);
+        AssertStatus(first.WriteResult, TReplyStatus::OK);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 0, BlockSize, MakeData('B', BlockSize)).release());
+        auto write1 = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvChunkWriteRaw>(disk);
+        auto write2 = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvChunkWriteRaw>(disk);
+        auto* dataWrite = write1->Get()->ChunkIdx == first.ChunkIdx ? write1.get() : write2.get();
+        auto* integrityWrite = write1->Get()->ChunkIdx == first.ChunkIdx ? write2.get() : write1.get();
+        UNIT_ASSERT_VALUES_UNEQUAL(dataWrite->Get()->ChunkIdx, integrityWrite->Get()->ChunkIdx);
+
+        ctx.SendPDiskResponse(disk, *dataWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.SendPDiskResponse(disk, *integrityWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::ERROR, "injected integrity failure"));
+
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::ERROR);
+        auto read = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx, disk.ServiceId, new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}));
+        AssertStatus(read, TReplyStatus::ERROR);
+    }
+
+    Y_UNIT_TEST(FallbackIntegrityReadFailureBreaksDDiskAndReplies) {
+        TTestContext ctx;
+        NDDisk::TDDiskConfig config;
+        config.ForcePDiskFallback = true;
+        config.IntegrityChecksumCacheBytes = NDDisk::TIntegrityManager::BlockStateApproxBytes;
+        const TDiskHandle disk = ctx.CreateDDisk(5, 5, std::nullopt, std::move(config));
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 34, 1);
+
+        const TString firstPayload = MakeData('A', BlockSize);
+        auto initial = DoWriteWithChunkAllocation(ctx, disk,
+            MakeWrite(creds, 0, 0, firstPayload),
+            disk.FirstChunkId + PersistentBufferInitChunks, 0, firstPayload, true, true);
+        AssertStatus(initial.WriteResult, TReplyStatus::OK);
+
+        const ui32 secondPairOffset =
+            NDDisk::ChecksumsPerIntegrityBlock * NDDisk::IntegrityUnitSize;
+        AssertStatus(
+            DoWrite(ctx, disk, MakeWrite(
+                creds, 0, secondPairOffset, MakeData('B', BlockSize))),
+            TReplyStatus::OK);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}));
+        auto integrityRead = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvChunkReadRaw>(disk);
+        UNIT_ASSERT_VALUES_UNEQUAL(integrityRead->Get()->ChunkIdx, initial.ChunkIdx);
+        UNIT_ASSERT_VALUES_EQUAL(
+            integrityRead->Get()->Size,
+            NDDisk::IntegrityPairSlots * NDDisk::IntegrityUnitSize);
+        ctx.SendPDiskResponse(disk, *integrityRead,
+            new NPDisk::TEvChunkReadRawResult(
+                NKikimrProto::ERROR, "injected integrity read failure"));
+
+        AssertStatus(WaitFromDDisk<NDDisk::TEvReadResult>(ctx), TReplyStatus::ERROR);
+        auto laterRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx, disk.ServiceId, new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}));
+        AssertStatus(laterRead, TReplyStatus::ERROR);
     }
 
     Y_UNIT_TEST(CheckVChunksArePerTablet) {
@@ -2071,6 +2404,99 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         AssertStatus(syncResult, TReplyStatus::ERROR);
     }
 
+    Y_UNIT_TEST(SyncRejectsCorruptedSourcePayloadBeforeWrite) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(10, 2);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 51, 1);
+        const ui32 srcPDiskId = 97;
+        const ui32 srcSlotId = 1;
+        const TActorId fakeSourceEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(
+            MakeBlobStorageDDiskId(NodeId, srcPDiskId, srcSlotId), fakeSourceEdge);
+
+        auto sync = std::make_unique<NDDisk::TEvSync>(creds);
+        sync->AddSegmentFromDDisk(
+            MakeSyncSourceId(srcPDiskId, srcSlotId), 42,
+            NDDisk::TBlockSelector(0, 0, BlockSize));
+        SendToDDisk(ctx, disk.ServiceId, sync.release());
+
+        auto readReq = ctx.Runtime.WaitForEdgeActorEvent({fakeSourceEdge});
+        const TString payload = MakeData('C', BlockSize);
+        const std::vector<ui64> badChecksums{
+            NDDisk::CalculateRawChecksum(payload.data(), payload.size()) + 1};
+        bool sawTargetPersistence = false;
+        ctx.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetRecipientRewrite() == disk.PDiskEdge
+                    && (ev->GetTypeRewrite() == NPDisk::TEvChunkWriteRaw::EventType
+                        || ev->GetTypeRewrite() == NPDisk::TEvLog::EventType)) {
+                sawTargetPersistence = true;
+            }
+            return true;
+        };
+        ctx.Runtime.Send(new IEventHandle(readReq->Sender, fakeSourceEdge,
+            new NDDisk::TEvReadResult(
+                TReplyStatus::OK, std::nullopt, TRope(payload), badChecksums),
+            0, readReq->Cookie), NodeId);
+
+        auto result = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
+        ctx.Runtime.FilterFunction = {};
+        AssertStatus(result, TReplyStatus::ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(result->Get()->Record.SegmentResultsSize(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(result->Get()->Record.GetSegmentResults(0).GetStatus()),
+            static_cast<int>(TReplyStatus::CORRUPTED));
+        UNIT_ASSERT_C(!sawTargetPersistence,
+            "checksum-mismatched source data must not persist target data or integrity metadata");
+    }
+
+    Y_UNIT_TEST(SyncRejectsSourceChecksumCountMismatchBeforeWrite) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(10, 3);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 52, 1);
+        const ui32 srcPDiskId = 96;
+        const ui32 srcSlotId = 1;
+        const TActorId fakeSourceEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(
+            MakeBlobStorageDDiskId(NodeId, srcPDiskId, srcSlotId), fakeSourceEdge);
+
+        bool sawTargetPersistence = false;
+        ctx.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetRecipientRewrite() == disk.PDiskEdge
+                    && (ev->GetTypeRewrite() == NPDisk::TEvChunkWriteRaw::EventType
+                        || ev->GetTypeRewrite() == NPDisk::TEvLog::EventType)) {
+                sawTargetPersistence = true;
+            }
+            return true;
+        };
+        const TString payload = MakeData('M', 2 * BlockSize);
+        const auto validChecksums = MakeBlockChecksums(payload);
+        for (const ui32 checksumCount : {1u, 3u}) {
+            auto sync = std::make_unique<NDDisk::TEvSync>(creds);
+            sync->AddSegmentFromDDisk(
+                MakeSyncSourceId(srcPDiskId, srcSlotId), 42,
+                NDDisk::TBlockSelector(0, 0, 2 * BlockSize));
+            SendToDDisk(ctx, disk.ServiceId, sync.release());
+            auto readReq = ctx.Runtime.WaitForEdgeActorEvent({fakeSourceEdge});
+
+            std::vector<ui64> checksums = validChecksums;
+            checksums.resize(checksumCount, 0);
+            ctx.Runtime.Send(new IEventHandle(readReq->Sender, fakeSourceEdge,
+                new NDDisk::TEvReadResult(
+                    TReplyStatus::OK, std::nullopt, TRope(payload), checksums),
+                0, readReq->Cookie), NodeId);
+
+            auto result = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
+            AssertStatus(result, TReplyStatus::ERROR);
+            UNIT_ASSERT_VALUES_EQUAL(result->Get()->Record.SegmentResultsSize(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<int>(result->Get()->Record.GetSegmentResults(0).GetStatus()),
+                static_cast<int>(TReplyStatus::INCORRECT_REQUEST));
+        }
+        ctx.Runtime.FilterFunction = {};
+        UNIT_ASSERT_C(!sawTargetPersistence,
+            "source checksum count mismatch must not persist target data or integrity metadata");
+    }
+
     Y_UNIT_TEST(LateOutdatedSyncReadResultDoesNotLogUnknownSync) {
         TStringStream log;
         TTestContext ctx;
@@ -2124,13 +2550,27 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             static_cast<int>(TReplyStatus::OUTDATED));
 
         const TString stalePayload = MakeData('O', BlockSize);
+        bool sawTargetPersistence = false;
+        ctx.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetRecipientRewrite() == disk.PDiskEdge
+                    && (ev->GetTypeRewrite() == NPDisk::TEvChunkWriteRaw::EventType
+                        || ev->GetTypeRewrite() == NPDisk::TEvLog::EventType)) {
+                sawTargetPersistence = true;
+            }
+            return true;
+        };
         ctx.Runtime.Send(new IEventHandle(staleReadReq->Sender, fakeSourceEdge,
-            new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(stalePayload)),
+            new NDDisk::TEvReadResult(
+                TReplyStatus::OK, std::nullopt, TRope(stalePayload),
+                MakeBlockChecksums(stalePayload)),
             0, staleReadReq->Cookie), NodeId);
 
         auto connectResult = SendToDDiskAndWait<NDDisk::TEvConnectResult>(ctx, disk.ServiceId, new NDDisk::TEvConnect(creds));
+        ctx.Runtime.FilterFunction = {};
         AssertStatus(connectResult, TReplyStatus::OK);
 
+        UNIT_ASSERT_C(!sawTargetPersistence,
+            "a late source result made stale by an overlapping sync must not persist metadata");
         UNIT_ASSERT_C(!log.Str().Contains("unknown sync for cookie"), log.Str());
     }
 
@@ -2189,7 +2629,8 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         }
 
         ctx.Runtime.Send(new IEventHandle(readReq->Sender, fakeSourceEdge,
-            new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(payload)),
+            new NDDisk::TEvReadResult(
+                TReplyStatus::OK, std::nullopt, TRope(payload), MakeBlockChecksums(payload)),
             0, readReq->Cookie), NodeId);
 
         auto traffic = ctx.CollectAllocationTraffic(disk, true, 1);
@@ -2205,6 +2646,251 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         UNIT_ASSERT_VALUES_EQUAL(
             static_cast<int>(syncResult->Get()->Record.GetSegmentResults(0).GetStatus()),
             static_cast<int>(TReplyStatus::OK));
+    }
+
+    Y_UNIT_TEST(DDiskToDDiskSyncPreservesPureChecksums) {
+        TTestContext ctx;
+        const TDiskHandle source = ctx.CreateDDisk(70, 1);
+        const TDiskHandle destination = ctx.CreateDDisk(71, 1);
+        NDDisk::TQueryCredentials sourceCreds =
+            Connect(ctx, source.ServiceId, 250, 1);
+        NDDisk::TQueryCredentials destinationCreds =
+            Connect(ctx, destination.ServiceId, 250, 1);
+        const TString payload =
+            MakeData('A', BlockSize) + MakeData('B', BlockSize);
+        const auto expectedChecksums = MakeBlockChecksums(payload);
+
+        auto sourceWrite = DoWriteWithChunkAllocation(
+            ctx, source, MakeWrite(sourceCreds, 3, 0, payload),
+            source.FirstChunkId + PersistentBufferInitChunks, 0, payload, true, true);
+        AssertStatus(sourceWrite.WriteResult, TReplyStatus::OK);
+
+        auto sync = std::make_unique<NDDisk::TEvSync>(destinationCreds);
+        sync->AddSegmentFromDDisk(
+            MakeSyncSourceId(source.PDiskId, source.SlotId),
+            *sourceCreds.DDiskInstanceGuid,
+            NDDisk::TBlockSelector(3, 0, payload.size()));
+        SendToDDisk(ctx, destination.ServiceId, sync.release());
+
+        auto sourceRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(source);
+        UNIT_ASSERT_VALUES_EQUAL(sourceRead->Get()->ChunkIdx, sourceWrite.ChunkIdx);
+        ctx.SendPDiskResponse(source, *sourceRead,
+            new NPDisk::TEvChunkReadRawResult(TRope(payload)));
+
+        auto allocation = ctx.CollectAllocationTraffic(destination, true, 1);
+        ctx.SendPDiskResponse(destination, *allocation.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(destination, *allocation.Increment);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvSyncResult>(ctx), TReplyStatus::OK);
+
+        SendToDDisk(ctx, destination.ServiceId,
+            new NDDisk::TEvRead(destinationCreds, {3, 0, static_cast<ui32>(payload.size())}, {true}));
+        auto destinationRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(destination);
+        ctx.SendPDiskResponse(destination, *destinationRead,
+            new NPDisk::TEvChunkReadRawResult(TRope(payload)));
+        auto readResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
+        AssertStatus(readResult, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), payload);
+        UNIT_ASSERT_VALUES_EQUAL(
+            readResult->Get()->Record.ChecksumsSize(), expectedChecksums.size());
+        for (ui32 i = 0; i < expectedChecksums.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                readResult->Get()->Record.GetChecksums(i), expectedChecksums[i]);
+        }
+    }
+
+    Y_UNIT_TEST(PersistentBufferToDDiskSyncPreservesPureChecksums) {
+        TTestContext ctx;
+        const TDiskHandle source = ctx.CreateDDisk(72, 1);
+        const TDiskHandle destination = ctx.CreateDDisk(73, 1);
+        NDDisk::TQueryCredentials sourceCreds =
+            Connect(ctx, source.PBServiceId, 251, 1);
+        NDDisk::TQueryCredentials destinationCreds =
+            Connect(ctx, destination.ServiceId, 251, 1);
+        constexpr ui64 Lsn = 10;
+        const TString payload =
+            MakeData('P', BlockSize) + MakeData('Q', BlockSize);
+        const NDDisk::TBlockSelector selector{
+            4, 2 * BlockSize, static_cast<ui32>(payload.size())};
+        const auto expectedChecksums = MakeBlockChecksums(payload);
+
+        auto sourceWrite = std::make_unique<NDDisk::TEvWritePersistentBuffer>(
+            sourceCreds, selector, Lsn, NDDisk::TWriteInstruction(0));
+        sourceWrite->AddPayloadThenChecksum(TRope(payload));
+        SendToDDisk(ctx, source.PBServiceId, sourceWrite.release());
+        auto sourceWriteRaw =
+            ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(source);
+        ctx.SendPDiskResponse(source, *sourceWriteRaw,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        AssertStatus(
+            WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx),
+            TReplyStatus::OK);
+
+        auto sync = std::make_unique<NDDisk::TEvSync>(destinationCreds);
+        sync->AddSegmentFromPB(
+            MakeSyncSourceId(source.PDiskId, source.SlotId),
+            *sourceCreds.DDiskInstanceGuid, selector, Lsn, sourceCreds.Generation);
+        SendToDDisk(ctx, destination.ServiceId, sync.release());
+
+        auto allocation = ctx.CollectAllocationTraffic(destination, true, 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            allocation.DataWrites[0]->Get()->Data.ConvertToString(), payload);
+        ctx.SendPDiskResponse(destination, *allocation.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(destination, *allocation.Increment);
+        AssertStatus(WaitFromDDisk<NDDisk::TEvSyncResult>(ctx), TReplyStatus::OK);
+
+        SendToDDisk(ctx, destination.ServiceId,
+            new NDDisk::TEvRead(destinationCreds, selector, {true}));
+        auto destinationRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(destination);
+        ctx.SendPDiskResponse(destination, *destinationRead,
+            new NPDisk::TEvChunkReadRawResult(TRope(payload)));
+        auto readResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
+        AssertStatus(readResult, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), payload);
+        UNIT_ASSERT_VALUES_EQUAL(
+            readResult->Get()->Record.ChecksumsSize(), expectedChecksums.size());
+        for (ui32 i = 0; i < expectedChecksums.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                readResult->Get()->Record.GetChecksums(i), expectedChecksums[i]);
+        }
+    }
+
+    Y_UNIT_TEST(SyncSlicesChecksumsAcrossSegmentsAndIntegrityPair) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(74, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 252, 1);
+        constexpr ui32 SourcePDiskId = 93;
+        const TActorId sourceEdge =
+            ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(
+            MakeBlobStorageDDiskId(NodeId, SourcePDiskId, 1), sourceEdge);
+
+        const ui32 firstOffset =
+            (NDDisk::ChecksumsPerIntegrityBlock - 1) * BlockSize;
+        const TString firstPayload =
+            MakeData('A', BlockSize) + MakeData('B', BlockSize);
+        const TString secondPayload =
+            MakeData('C', BlockSize) + MakeData('D', BlockSize);
+        const TString allPayload = firstPayload + secondPayload;
+        const auto expectedChecksums = MakeBlockChecksums(allPayload);
+
+        auto sync = std::make_unique<NDDisk::TEvSync>(creds);
+        sync->AddSegmentFromDDisk(
+            MakeSyncSourceId(SourcePDiskId, 1), 42,
+            NDDisk::TBlockSelector(
+                6, firstOffset, static_cast<ui32>(firstPayload.size())));
+        sync->AddSegmentFromDDisk(
+            MakeSyncSourceId(SourcePDiskId, 1), 42,
+            NDDisk::TBlockSelector(
+                6, firstOffset + firstPayload.size(),
+                static_cast<ui32>(secondPayload.size())));
+        SendToDDisk(ctx, disk.ServiceId, sync.release());
+
+        for (const TString* payload : {&firstPayload, &secondPayload}) {
+            auto sourceRead = ctx.Runtime.WaitForEdgeActorEvent({sourceEdge});
+            ctx.Runtime.Send(new IEventHandle(sourceRead->Sender, sourceEdge,
+                new NDDisk::TEvReadResult(
+                    TReplyStatus::OK, std::nullopt, TRope(*payload),
+                    MakeBlockChecksums(*payload)),
+                0, sourceRead->Cookie), NodeId);
+        }
+
+        auto allocation = ctx.CollectAllocationTraffic(disk, true, 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            allocation.DataWrites[0]->Get()->Offset, firstOffset);
+        UNIT_ASSERT_VALUES_EQUAL(
+            allocation.DataWrites[0]->Get()->Data.ConvertToString(), firstPayload);
+        ctx.SendPDiskResponse(disk, *allocation.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *allocation.Increment);
+
+        auto secondWrite = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(
+            secondWrite->Get()->Offset, firstOffset + firstPayload.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            secondWrite->Get()->Data.ConvertToString(), secondPayload);
+        ctx.SendPDiskResponse(disk, *secondWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        AssertStatus(WaitFromDDisk<NDDisk::TEvSyncResult>(ctx), TReplyStatus::OK);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvRead(
+                creds,
+                {6, firstOffset, static_cast<ui32>(allPayload.size())},
+                {true}));
+        auto dataRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
+        ctx.SendPDiskResponse(disk, *dataRead,
+            new NPDisk::TEvChunkReadRawResult(TRope(allPayload)));
+        auto readResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
+        AssertStatus(readResult, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(
+            readResult->Get()->Record.ChecksumsSize(), expectedChecksums.size());
+        for (ui32 i = 0; i < expectedChecksums.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                readResult->Get()->Record.GetChecksums(i), expectedChecksums[i]);
+        }
+    }
+
+    Y_UNIT_TEST(SyncReplyWaitsForDestinationDataAndIntegrity) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(76, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 254, 1);
+        const TString initialPayload = MakeData('A', BlockSize);
+        auto initial = DoWriteWithChunkAllocation(
+            ctx, disk, MakeWrite(creds, 0, 0, initialPayload),
+            disk.FirstChunkId + PersistentBufferInitChunks,
+            0, initialPayload, true, true);
+        AssertStatus(initial.WriteResult, TReplyStatus::OK);
+
+        constexpr ui32 SourcePDiskId = 92;
+        const TActorId sourceEdge =
+            ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(
+            MakeBlobStorageDDiskId(NodeId, SourcePDiskId, 1), sourceEdge);
+        auto sync = std::make_unique<NDDisk::TEvSync>(creds);
+        sync->AddSegmentFromDDisk(
+            MakeSyncSourceId(SourcePDiskId, 1), 42,
+            NDDisk::TBlockSelector(0, BlockSize, BlockSize));
+        SendToDDisk(ctx, disk.ServiceId, sync.release());
+
+        auto sourceRead = ctx.Runtime.WaitForEdgeActorEvent({sourceEdge});
+        const TString sourcePayload = MakeData('S', BlockSize);
+        ctx.Runtime.Send(new IEventHandle(sourceRead->Sender, sourceEdge,
+            new NDDisk::TEvReadResult(
+                TReplyStatus::OK, std::nullopt, TRope(sourcePayload),
+                MakeBlockChecksums(sourcePayload)),
+            0, sourceRead->Cookie), NodeId);
+
+        auto write1 =
+            ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvChunkWriteRaw>(disk);
+        auto write2 =
+            ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvChunkWriteRaw>(disk);
+        auto* dataWrite =
+            write1->Get()->ChunkIdx == initial.ChunkIdx ? write1.get() : write2.get();
+        auto* integrityWrite =
+            write1->Get()->ChunkIdx == initial.ChunkIdx ? write2.get() : write1.get();
+
+        bool sawSyncReply = false;
+        ctx.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == NDDisk::TEvSyncResult::EventType
+                    && ev->GetRecipientRewrite() == ctx.Edge) {
+                sawSyncReply = true;
+            }
+            return true;
+        };
+        ctx.SendPDiskResponse(disk, *integrityWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        AssertNoClientReplyBeforeSentinel(
+            ctx, "sync reply must wait for destination data after integrity is durable");
+        UNIT_ASSERT(!sawSyncReply);
+
+        ctx.SendPDiskResponse(disk, *dataWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto result = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
+        ctx.Runtime.FilterFunction = {};
+        UNIT_ASSERT(sawSyncReply);
+        AssertStatus(result, TReplyStatus::OK);
     }
 
     Y_UNIT_TEST(SyncReplyWaitsForCombinedIncrement) {
@@ -2233,7 +2919,8 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
 
         const TString payload = MakeData('G', BlockSize);
         ctx.Runtime.Send(new IEventHandle(firstRead->Sender, fakeSourceEdge,
-            new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(payload)),
+            new NDDisk::TEvReadResult(
+                TReplyStatus::OK, std::nullopt, TRope(payload), MakeBlockChecksums(payload)),
             0, firstRead->Cookie), NodeId);
 
         auto traffic = ctx.CollectAllocationTraffic(disk, true, 1);
@@ -2292,7 +2979,8 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
 
         const TString payload = MakeData('O', BlockSize);
         ctx.Runtime.Send(new IEventHandle(completedRead->Sender, fakeSourceEdge,
-            new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(payload)),
+            new NDDisk::TEvReadResult(
+                TReplyStatus::OK, std::nullopt, TRope(payload), MakeBlockChecksums(payload)),
             0, completedRead->Cookie), NodeId);
 
         auto traffic = ctx.CollectAllocationTraffic(disk, true, 1);
@@ -2376,7 +3064,8 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             UNIT_ASSERT_VALUES_EQUAL(readRecord.GetSelector().GetSize(), BlockSize);
         }
         ctx.Runtime.Send(new IEventHandle(readReq1->Sender, fakeSourceEdge1,
-            new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(payload1)),
+            new NDDisk::TEvReadResult(
+                TReplyStatus::OK, std::nullopt, TRope(payload1), MakeBlockChecksums(payload1)),
             0, readReq1->Cookie), NodeId);
 
         auto readReq2 = ctx.Runtime.WaitForEdgeActorEvent({fakeSourceEdge2});
@@ -2389,17 +3078,19 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             UNIT_ASSERT_VALUES_EQUAL(readRecord.GetSelector().GetSize(), BlockSize);
         }
         ctx.Runtime.Send(new IEventHandle(readReq2->Sender, fakeSourceEdge2,
-            new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(payload2)),
+            new NDDisk::TEvReadResult(
+                TReplyStatus::OK, std::nullopt, TRope(payload2), MakeBlockChecksums(payload2)),
             0, readReq2->Cookie), NodeId);
 
-        auto traffic = ctx.CollectAllocationTraffic(disk, true, 2);
-        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 2u);
+        auto traffic = ctx.CollectAllocationTraffic(disk, true, 1);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 1u);
         UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Offset, 0u);
         UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Data.ConvertToString(), payload1);
         ctx.SendPDiskResponse(disk, *traffic.DataWrites[0], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
-        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[1]->Get()->Offset, BlockSize);
-        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[1]->Get()->Data.ConvertToString(), payload2);
-        ctx.SendPDiskResponse(disk, *traffic.DataWrites[1], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto secondWrite = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(secondWrite->Get()->Offset, BlockSize);
+        UNIT_ASSERT_VALUES_EQUAL(secondWrite->Get()->Data.ConvertToString(), payload2);
+        ctx.SendPDiskResponse(disk, *secondWrite, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
         ctx.ReplyLog(disk, *traffic.Increment);
 
         auto syncResult = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
@@ -2471,7 +3162,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         }
         ctx.Runtime.Send(new IEventHandle(pbufferReadReq->Sender, fakePBufferSourceEdge,
             new NDDisk::TEvReadPersistentBufferResult(TReplyStatus::OK, std::nullopt,
-                7, 0, BlockSize, TRope(pbufferPayload)),
+                7, 0, BlockSize, TRope(pbufferPayload), MakeBlockChecksums(pbufferPayload)),
             0, pbufferReadReq->Cookie), NodeId);
 
         auto ddiskReadReq = ctx.Runtime.WaitForEdgeActorEvent({fakeDDiskSourceEdge});
@@ -2487,17 +3178,19 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             UNIT_ASSERT_VALUES_EQUAL(readRecord.GetSelector().GetSize(), BlockSize);
         }
         ctx.Runtime.Send(new IEventHandle(ddiskReadReq->Sender, fakeDDiskSourceEdge,
-            new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(ddiskPayload)),
+            new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt,
+                TRope(ddiskPayload), MakeBlockChecksums(ddiskPayload)),
             0, ddiskReadReq->Cookie), NodeId);
 
-        auto traffic = ctx.CollectAllocationTraffic(disk, true, 2);
-        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 2u);
+        auto traffic = ctx.CollectAllocationTraffic(disk, true, 1);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 1u);
         UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Offset, 0u);
         UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Data.ConvertToString(), pbufferPayload);
         ctx.SendPDiskResponse(disk, *traffic.DataWrites[0], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
-        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[1]->Get()->Offset, BlockSize);
-        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[1]->Get()->Data.ConvertToString(), ddiskPayload);
-        ctx.SendPDiskResponse(disk, *traffic.DataWrites[1], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto secondWrite = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(secondWrite->Get()->Offset, BlockSize);
+        UNIT_ASSERT_VALUES_EQUAL(secondWrite->Get()->Data.ConvertToString(), ddiskPayload);
+        ctx.SendPDiskResponse(disk, *secondWrite, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
         ctx.ReplyLog(disk, *traffic.Increment);
 
         auto syncResult = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
@@ -2567,7 +3260,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         }
         ctx.Runtime.Send(new IEventHandle(pbufferReadReq->Sender, fakePBufferSourceEdge,
             new NDDisk::TEvReadPersistentBufferResult(TReplyStatus::OK, std::nullopt,
-                7, 0, BlockSize, TRope(pbufferPayload)),
+                7, 0, BlockSize, TRope(pbufferPayload), MakeBlockChecksums(pbufferPayload)),
             0, pbufferReadReq->Cookie), NodeId);
 
         auto ddiskReadReq = ctx.Runtime.WaitForEdgeActorEvent({fakeDDiskSourceEdge});
@@ -2583,17 +3276,19 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             UNIT_ASSERT_VALUES_EQUAL(readRecord.GetSelector().GetSize(), BlockSize);
         }
         ctx.Runtime.Send(new IEventHandle(ddiskReadReq->Sender, fakeDDiskSourceEdge,
-            new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(ddiskPayload)),
+            new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt,
+                TRope(ddiskPayload), MakeBlockChecksums(ddiskPayload)),
             0, ddiskReadReq->Cookie), NodeId);
 
-        auto traffic = ctx.CollectAllocationTraffic(disk, true, 2);
-        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 2u);
+        auto traffic = ctx.CollectAllocationTraffic(disk, true, 1);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 1u);
         UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Offset, 0u);
         UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Data.ConvertToString(), pbufferPayload);
         ctx.SendPDiskResponse(disk, *traffic.DataWrites[0], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
-        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[1]->Get()->Offset, BlockSize);
-        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[1]->Get()->Data.ConvertToString(), ddiskPayload);
-        ctx.SendPDiskResponse(disk, *traffic.DataWrites[1], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto secondWrite = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(secondWrite->Get()->Offset, BlockSize);
+        UNIT_ASSERT_VALUES_EQUAL(secondWrite->Get()->Data.ConvertToString(), ddiskPayload);
+        ctx.SendPDiskResponse(disk, *secondWrite, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
         ctx.ReplyLog(disk, *traffic.Increment);
 
         auto syncResult = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
@@ -2635,7 +3330,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             static_cast<ui32>(NDDisk::TEv::EvReadPersistentBuffer));
         ctx.Runtime.Send(new IEventHandle(readReq->Sender, fakeSourceEdge,
             new NDDisk::TEvReadPersistentBufferResult(TReplyStatus::OK, std::nullopt,
-                5, 0, BlockSize, TRope(payload)),
+                5, 0, BlockSize, TRope(payload), MakeBlockChecksums(payload)),
             0, readReq->Cookie), NodeId);
 
         auto traffic = ctx.CollectAllocationTraffic(disk, true, 1);
@@ -3623,6 +4318,16 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
                     reinterpret_cast<TEventHandle<NPDisk::TEvChunkReserve>*>(raw.release()));
                 continue;
             }
+            if (type == NPDisk::TEvChunkWriteRaw::EventType) {
+                auto integrityWrite = std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>>(
+                    reinterpret_cast<TEventHandle<NPDisk::TEvChunkWriteRaw>*>(raw.release()));
+                UNIT_ASSERT(TTestContext::IsIntegrityMetadataWrite(*integrityWrite->Get()));
+                UNIT_ASSERT_VALUES_EQUAL(integrityWrite->Get()->ChunkIdx, integrityChunk);
+                UNIT_ASSERT_VALUES_EQUAL(integrityWrite->Get()->Data.size(), NDDisk::IntegrityUnitSize);
+                ctx.SendPDiskResponse(disk, *integrityWrite,
+                    new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+                continue;
+            }
             UNIT_ASSERT_VALUES_EQUAL(type, NPDisk::TEvLog::EventType);
             logIncr = std::unique_ptr<TEventHandle<NPDisk::TEvLog>>(
                 reinterpret_cast<TEventHandle<NPDisk::TEvLog>*>(raw.release()));
@@ -3725,26 +4430,63 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         // The extent is ready and the write path is open, but allocation durability is pending.
         SendToDDisk(ctx, disk.ServiceId,
             MakeWrite(creds, 7, BlockSize, MakeData('B', BlockSize)).release(), 102);
+
+        ctx.SendPDiskResponse(disk, *first.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        // The second write is released only after the first data+integrity pair is complete.
         auto secondWrite = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
         UNIT_ASSERT(!TTestContext::IsIntegrityMetadataWrite(*secondWrite->Get()));
         UNIT_ASSERT_VALUES_EQUAL(
             secondWrite->Get()->ChunkIdx, first.DataWrites[0]->Get()->ChunkIdx);
-
-        ctx.SendPDiskResponse(disk, *first.DataWrites[0],
-            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
         ctx.SendPDiskResponse(disk, *secondWrite,
             new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
-        AssertNoClientReplyBeforeSentinel(
-            ctx, "all write replies must remain parked until the allocation increment commits");
+        const TActorId sentinelEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.Send(new IEventHandle(sentinelEdge, ctx.Edge, new TEvents::TEvWakeup()), NodeId);
+        for (;;) {
+            auto raw = ctx.Runtime.WaitForEdgeActorEvent(ctx.ClientWaitEdges({sentinelEdge}));
+            if (raw->Recipient == sentinelEdge) {
+                break;
+            }
+            if (ctx.TryAutoServeIntegrityTraffic<TEvents::TEvWakeup>(*raw)) {
+                continue;
+            }
+            UNIT_FAIL("all write replies must remain parked until the allocation increment commits");
+        }
 
         ctx.ReplyLog(disk, *first.Increment);
-        auto firstResult = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
-        auto secondResult = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
-        AssertStatus(firstResult, TReplyStatus::OK);
-        AssertStatus(secondResult, TReplyStatus::OK);
-        std::set<ui64> cookies{firstResult->Cookie, secondResult->Cookie};
+        std::set<ui64> cookies;
+        while (cookies.size() < 2) {
+            auto raw = ctx.Runtime.WaitForEdgeActorEvent(ctx.ClientWaitEdges());
+            if (ctx.TryAutoServeIntegrityTraffic<NDDisk::TEvWriteResult>(*raw)) {
+                continue;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(raw->GetTypeRewrite(), NDDisk::TEvWriteResult::EventType);
+            const auto result = std::unique_ptr<TEventHandle<NDDisk::TEvWriteResult>>(
+                reinterpret_cast<TEventHandle<NDDisk::TEvWriteResult>*>(raw.release()));
+            AssertStatus(result, TReplyStatus::OK);
+            cookies.insert(result->Cookie);
+        }
         const std::set<ui64> expectedCookies{101, 102};
         UNIT_ASSERT(cookies == expectedCookies);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvRead(creds, {7, 0, 2 * BlockSize}, {true}));
+        auto dataRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(dataRead->Get()->ChunkIdx, first.DataWrites[0]->Get()->ChunkIdx);
+        UNIT_ASSERT_VALUES_EQUAL(dataRead->Get()->Offset, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(dataRead->Get()->Size, 2 * BlockSize);
+        const TString expectedData = MakeData('A', BlockSize) + MakeData('B', BlockSize);
+        ctx.SendPDiskResponse(disk, *dataRead,
+            new NPDisk::TEvChunkReadRawResult(TRope(expectedData)));
+
+        auto readResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
+        AssertStatus(readResult, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), expectedData);
+        const auto expectedChecksums = NDDisk::CalculatePayloadChecksums(MakeAlignedRope(expectedData));
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->Record.ChecksumsSize(), expectedChecksums.size());
+        for (ui32 i = 0; i < expectedChecksums.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->Record.GetChecksums(i), expectedChecksums[i]);
+        }
     }
 
     Y_UNIT_TEST(ReadParkedBehindAllocatingWriteSeesData) {
@@ -4043,9 +4785,18 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             Connect(ctx, recovered.ServiceId, 227, 1);
         SendToDDisk(ctx, recovered.ServiceId,
             new NDDisk::TEvRead(recoveredCreds, {5, 0, BlockSize}, {true}));
-        auto readRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(recovered);
-        UNIT_ASSERT_VALUES_EQUAL(readRaw->Get()->ChunkIdx, incrementData.GetChunkIdx());
-        ctx.SendPDiskResponse(recovered, *readRaw,
+        auto integrityRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(recovered);
+        UNIT_ASSERT_VALUES_EQUAL(
+            integrityRead->Get()->ChunkIdx, incrementData.GetExtentRef().GetIntegrityChunkIdx());
+        ctx.SendPDiskResponse(recovered, *integrityRead, new NPDisk::TEvChunkReadRawResult(
+            MakeRestoredIntegrityPair(recovered.SlotId, 0x100000 + recovered.PDiskId, 227, 5,
+                incrementData.GetExtentRef().GetVChunkGeneration(),
+                incrementData.GetExtentRef().GetIntegrityChunkIdx(),
+                incrementData.GetExtentRef().GetExtentSlot(),
+                incrementRecord.GetIncrement().GetIntegrityChunk().GetGeneration(), payload)));
+        auto dataRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(recovered);
+        UNIT_ASSERT_VALUES_EQUAL(dataRead->Get()->ChunkIdx, incrementData.GetChunkIdx());
+        ctx.SendPDiskResponse(recovered, *dataRead,
             new NPDisk::TEvChunkReadRawResult(TRope(payload)));
         auto readResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
         AssertStatus(readResult, TReplyStatus::OK);
@@ -4109,14 +4860,21 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             {{olderIncrement, SnapshotLsn - 1}, {newerIncrement, SnapshotLsn + 1}});
         NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 228, 1);
 
-        for (const auto& [vChunkIndex, expectedChunk] :
-                std::vector<std::pair<ui64, ui32>>{{0, 500}, {1, 502}}) {
+        for (const auto& [vChunkIndex, expectedChunk, extentSlot, vChunkGeneration] :
+                std::vector<std::tuple<ui64, ui32, ui32, ui64>>{{0, 500, 0, 1}, {1, 502, 1, 2}}) {
+            const TString payload = MakeData('L', BlockSize);
             SendToDDisk(ctx, disk.ServiceId,
                 new NDDisk::TEvRead(creds, {vChunkIndex, 0, BlockSize}, {true}));
-            auto readRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
-            UNIT_ASSERT_VALUES_EQUAL(readRaw->Get()->ChunkIdx, expectedChunk);
-            ctx.SendPDiskResponse(disk, *readRaw,
-                new NPDisk::TEvChunkReadRawResult(TRope(MakeData('L', BlockSize))));
+            auto integrityRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
+            UNIT_ASSERT_VALUES_EQUAL(integrityRead->Get()->ChunkIdx, 600);
+            ctx.SendPDiskResponse(disk, *integrityRead, new NPDisk::TEvChunkReadRawResult(
+                MakeRestoredIntegrityPair(disk.SlotId, 0x100000 + disk.PDiskId,
+                    228, vChunkIndex, vChunkGeneration,
+                    600, extentSlot, 1, payload)));
+            auto dataRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
+            UNIT_ASSERT_VALUES_EQUAL(dataRead->Get()->ChunkIdx, expectedChunk);
+            ctx.SendPDiskResponse(disk, *dataRead,
+                new NPDisk::TEvChunkReadRawResult(TRope(payload)));
             AssertStatus(WaitFromDDisk<NDDisk::TEvReadResult>(ctx), TReplyStatus::OK);
         }
     }
@@ -4161,9 +4919,11 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             NDDisk::TBlockSelector(0, 0, BlockSize));
         SendToDDisk(ctx, disk.ServiceId, sync.release());
         auto sourceRead = ctx.Runtime.WaitForEdgeActorEvent({sourceEdge});
+        const TString sourcePayload = MakeData('S', BlockSize);
         ctx.Runtime.Send(new IEventHandle(sourceRead->Sender, sourceEdge,
             new NDDisk::TEvReadResult(
-                TReplyStatus::OK, std::nullopt, TRope(MakeData('S', BlockSize))),
+                TReplyStatus::OK, std::nullopt, TRope(sourcePayload),
+                MakeBlockChecksums(sourcePayload)),
             0, sourceRead->Cookie), NodeId);
         auto allocation = ctx.CollectAllocationTraffic(disk, false, 1);
         const auto allocationRecord =
@@ -4320,14 +5080,16 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             NDDisk::TBlockSelector(0, BlockSize, BlockSize));
         SendToDDisk(ctx, disk.ServiceId, sync.release(), 402);
         auto sourceRead = ctx.Runtime.WaitForEdgeActorEvent({sourceEdge});
+        const TString sourcePayload = MakeData('B', BlockSize);
         ctx.Runtime.Send(new IEventHandle(sourceRead->Sender, sourceEdge,
             new NDDisk::TEvReadResult(
-                TReplyStatus::OK, std::nullopt, TRope(MakeData('B', BlockSize))),
+                TReplyStatus::OK, std::nullopt, TRope(sourcePayload),
+                MakeBlockChecksums(sourcePayload)),
             0, sourceRead->Cookie), NodeId);
-        auto syncWrite = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
 
         ctx.SendPDiskResponse(disk, *allocation.DataWrites[0],
             new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto syncWrite = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
         ctx.SendPDiskResponse(disk, *syncWrite,
             new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
         AssertNoClientReplyBeforeSentinel(
@@ -4409,6 +5171,26 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         UNIT_ASSERT(WaitFromDDisk<NDDisk::TEvPersistentBufferInfo>(ctx));
     }
 
+    Y_UNIT_TEST(BrokenIgnoresLateSerializedWriteResume) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.RegisterDDisk(59, 1);
+        ctx.BootstrapDDisk(disk, TTestContext::ChunkSize, 1);
+        Connect(ctx, disk.ServiceId, 238, 1);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TDDiskActor::TEvPrivate::TEvIntegrityIoResult(
+                999903, TReplyStatus::ERROR, "injected failure before serialized resume"));
+
+        // EnterBroken clears SerializedWriteResumeScheduled but cannot recall a self-message
+        // already in the mailbox. The resume handler must not abort on the cleared flag.
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TDDiskActor::TEvPrivate::TEvHandleSerializedWriteForChunk(238, 0));
+
+        SendToDDisk(ctx, disk.PBServiceId,
+            new NDDisk::TEvGetPersistentBufferInfo(false, false));
+        UNIT_ASSERT(WaitFromDDisk<NDDisk::TEvPersistentBufferInfo>(ctx));
+    }
+
     Y_UNIT_TEST(SyncErrorReplyStillGatedOnIncrementCommit) {
         // Unlike SyncReplyWaitsForCombinedIncrement, inject a target-write completion error after
         // a successful source read. The resulting ERROR reply obeys the same durability barrier.
@@ -4426,9 +5208,11 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             NDDisk::TBlockSelector(0, 0, BlockSize));
         SendToDDisk(ctx, disk.ServiceId, sync.release());
         auto sourceRead = ctx.Runtime.WaitForEdgeActorEvent({sourceEdge});
+        const TString sourcePayload = MakeData('S', BlockSize);
         ctx.Runtime.Send(new IEventHandle(sourceRead->Sender, sourceEdge,
             new NDDisk::TEvReadResult(
-                TReplyStatus::OK, std::nullopt, TRope(MakeData('S', BlockSize))),
+                TReplyStatus::OK, std::nullopt, TRope(sourcePayload),
+                MakeBlockChecksums(sourcePayload)),
             0, sourceRead->Cookie), NodeId);
         auto allocation = ctx.CollectAllocationTraffic(disk, true, 1);
 
@@ -4533,9 +5317,11 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
 
         auto sourceRead = ctx.Runtime.WaitForEdgeActorEvent({fakeSourceEdge});
         UNIT_ASSERT_VALUES_EQUAL(sourceRead->GetTypeRewrite(), static_cast<ui32>(NDDisk::TEv::EvRead));
+        const TString sourcePayload = MakeData('S', BlockSize);
         ctx.Runtime.Send(new IEventHandle(sourceRead->Sender, fakeSourceEdge,
             new NDDisk::TEvReadResult(
-                TReplyStatus::OK, std::nullopt, TRope(MakeData('S', BlockSize))),
+                TReplyStatus::OK, std::nullopt, TRope(sourcePayload),
+                MakeBlockChecksums(sourcePayload)),
             0, sourceRead->Cookie), NodeId);
 
         auto snapshotLog = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvLog>(disk);
@@ -4651,13 +5437,198 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         AssertStatus(writeResult, TReplyStatus::ERROR);
     }
 
+    Y_UNIT_TEST(RestoredColdReadsSharePairLoadAndWritePreservesMetadata) {
+        using TChunkMapLogRecord =
+            NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord;
+        constexpr ui64 TabletId = 255;
+        constexpr ui32 DataChunk = 500;
+        constexpr ui32 IntegrityChunk = 600;
+
+        TChunkMapLogRecord snapshotRecord;
+        auto* snapshot = snapshotRecord.MutableSnapshot();
+        auto* tablet = snapshot->AddTabletRecords();
+        tablet->SetTabletId(TabletId);
+        auto* data = tablet->AddChunkRefs();
+        data->SetVChunkIndex(0);
+        data->SetChunkIdx(DataChunk);
+        data->MutableExtentRef()->SetIntegrityChunkIdx(IntegrityChunk);
+        data->MutableExtentRef()->SetExtentSlot(0);
+        data->MutableExtentRef()->SetVChunkGeneration(1);
+        auto* integrity = snapshot->AddIntegrityChunks();
+        integrity->SetChunkIdx(IntegrityChunk);
+        integrity->SetGeneration(1);
+        snapshot->SetGenerationCounter(1);
+
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.RegisterDDisk(77, 1);
+        ctx.BootstrapDDisk(
+            disk, TTestContext::ChunkSize, MinChunksReserved,
+            &snapshotRecord, 10);
+        NDDisk::TQueryCredentials creds =
+            Connect(ctx, disk.ServiceId, TabletId, 1);
+        const TString oldPayload = MakeData('R', BlockSize);
+        const ui64 oldChecksum =
+            NDDisk::CalculateRawChecksum(oldPayload.data(), oldPayload.size());
+
+        std::vector<std::unique_ptr<IEventHandle>> heldReads;
+        ctx.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetRecipientRewrite() == disk.PDiskEdge
+                    && ev->GetTypeRewrite()
+                        == NPDisk::TEvCheckSpace::EventType) {
+                ctx.Runtime.Send(new IEventHandle(
+                    ev->Sender,
+                    disk.PDiskEdge,
+                    new NPDisk::TEvCheckSpaceResult(
+                        NKikimrProto::OK, 0, 0, 0, 0, 0, 0, 0, "", 0),
+                    0,
+                    ev->Cookie), NodeId);
+                return false;
+            }
+            if (ev->GetRecipientRewrite() == disk.PDiskEdge
+                    && ev->GetTypeRewrite() == NPDisk::TEvChunkReadRaw::EventType) {
+                heldReads.push_back(std::move(ev));
+                return false;
+            }
+            return true;
+        };
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}), 701);
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}), 702);
+        ui32 eventsProcessed = 0;
+        ctx.Runtime.Sim([&] {
+            return heldReads.size() < 2 && ++eventsProcessed <= 300;
+        });
+        ctx.Runtime.FilterFunction = {};
+        UNIT_ASSERT_VALUES_EQUAL_C(heldReads.size(), 1,
+            "concurrent cold reads of one checksum pair must share one metadata load");
+
+        auto integrityRead =
+            std::unique_ptr<TEventHandle<NPDisk::TEvChunkReadRaw>>(
+                reinterpret_cast<TEventHandle<NPDisk::TEvChunkReadRaw>*>(
+                    heldReads[0].release()));
+        UNIT_ASSERT_VALUES_EQUAL(integrityRead->Get()->ChunkIdx, IntegrityChunk);
+        ctx.SendPDiskResponse(disk, *integrityRead,
+            new NPDisk::TEvChunkReadRawResult(
+                MakeRestoredIntegrityPair(
+                    disk.SlotId, 0x100000 + disk.PDiskId,
+                    TabletId, 0, 1, IntegrityChunk, 0, 1, oldPayload)));
+
+        for (ui32 i = 0; i < 2; ++i) {
+            auto dataRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
+            UNIT_ASSERT_VALUES_EQUAL(dataRead->Get()->ChunkIdx, DataChunk);
+            ctx.SendPDiskResponse(disk, *dataRead,
+                new NPDisk::TEvChunkReadRawResult(TRope(oldPayload)));
+        }
+        std::set<ui64> readCookies;
+        for (ui32 i = 0; i < 2; ++i) {
+            auto readResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
+            AssertStatus(readResult, TReplyStatus::OK);
+            UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->Record.ChecksumsSize(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(
+                readResult->Get()->Record.GetChecksums(0), oldChecksum);
+            readCookies.insert(readResult->Cookie);
+        }
+        UNIT_ASSERT(readCookies == std::set<ui64>({701, 702}));
+
+        // The pair is now cached: another read must go straight to the data chunk.
+        heldReads.clear();
+        ctx.Runtime.FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetRecipientRewrite() == disk.PDiskEdge
+                    && ev->GetTypeRewrite()
+                        == NPDisk::TEvCheckSpace::EventType) {
+                ctx.Runtime.Send(new IEventHandle(
+                    ev->Sender,
+                    disk.PDiskEdge,
+                    new NPDisk::TEvCheckSpaceResult(
+                        NKikimrProto::OK, 0, 0, 0, 0, 0, 0, 0, "", 0),
+                    0,
+                    ev->Cookie), NodeId);
+                return false;
+            }
+            if (ev->GetRecipientRewrite() == disk.PDiskEdge
+                    && ev->GetTypeRewrite() == NPDisk::TEvChunkReadRaw::EventType) {
+                heldReads.push_back(std::move(ev));
+                return false;
+            }
+            return true;
+        };
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}));
+        eventsProcessed = 0;
+        ctx.Runtime.Sim([&] {
+            return heldReads.empty() && ++eventsProcessed <= 200;
+        });
+        ctx.Runtime.FilterFunction = {};
+        UNIT_ASSERT_VALUES_EQUAL(heldReads.size(), 1);
+        auto cachedDataRead =
+            std::unique_ptr<TEventHandle<NPDisk::TEvChunkReadRaw>>(
+                reinterpret_cast<TEventHandle<NPDisk::TEvChunkReadRaw>*>(
+                    heldReads[0].release()));
+        UNIT_ASSERT_VALUES_EQUAL(cachedDataRead->Get()->ChunkIdx, DataChunk);
+        ctx.SendPDiskResponse(disk, *cachedDataRead,
+            new NPDisk::TEvChunkReadRawResult(TRope(oldPayload)));
+        AssertStatus(WaitFromDDisk<NDDisk::TEvReadResult>(ctx), TReplyStatus::OK);
+
+        // The first post-restart write updates block 1 but must carry block 0's restored
+        // checksum into the new ping-pong image.
+        const TString newPayload = MakeData('W', BlockSize);
+        const ui64 newChecksum =
+            NDDisk::CalculateRawChecksum(newPayload.data(), newPayload.size());
+        SendToDDisk(ctx, disk.ServiceId,
+            MakeWrite(creds, 0, BlockSize, newPayload).release());
+        auto write1 =
+            ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvChunkWriteRaw>(disk);
+        auto write2 =
+            ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvChunkWriteRaw>(disk);
+        auto* dataWrite =
+            write1->Get()->ChunkIdx == DataChunk ? write1.get() : write2.get();
+        auto* integrityWrite =
+            write1->Get()->ChunkIdx == DataChunk ? write2.get() : write1.get();
+        UNIT_ASSERT_VALUES_EQUAL(integrityWrite->Get()->ChunkIdx, IntegrityChunk);
+        const TString imageData = integrityWrite->Get()->Data.ConvertToString();
+        UNIT_ASSERT_VALUES_EQUAL(imageData.size(), sizeof(NDDisk::TIntegrityBlock));
+        NDDisk::TIntegrityBlock image;
+        memcpy(&image, imageData.data(), sizeof(image));
+        UNIT_ASSERT_VALUES_EQUAL(image.Header.Magic, NDDisk::MagicIntegrityBlock);
+        UNIT_ASSERT(image.Header.UsedBlocksBitmap[0] & 0x1);
+        UNIT_ASSERT(image.Header.UsedBlocksBitmap[0] & 0x2);
+        UNIT_ASSERT_VALUES_EQUAL(
+            NDDisk::UnsealBlockChecksum(
+                image.Checksums[0], disk.SlotId, 0x100000 + disk.PDiskId,
+                TabletId, 0, 0),
+            oldChecksum);
+        UNIT_ASSERT_VALUES_EQUAL(
+            NDDisk::UnsealBlockChecksum(
+                image.Checksums[1], disk.SlotId, 0x100000 + disk.PDiskId,
+                TabletId, 0, 1),
+            newChecksum);
+
+        ctx.SendPDiskResponse(disk, *integrityWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.SendPDiskResponse(disk, *dataWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        AssertStatus(WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), TReplyStatus::OK);
+
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}));
+        auto untouchedRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(untouchedRead->Get()->ChunkIdx, DataChunk);
+        ctx.SendPDiskResponse(disk, *untouchedRead,
+            new NPDisk::TEvChunkReadRawResult(TRope(oldPayload)));
+        auto untouchedResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
+        AssertStatus(untouchedResult, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(
+            untouchedResult->Get()->Record.GetChecksums(0), oldChecksum);
+    }
+
     Y_UNIT_TEST(IntegrityMappingRestoredOnBootAndCutLogDeferred) {
         // The DataChunk -> IntegrityExtent mapping is persisted in the chunk-map snapshot and log
         // increments. On boot the DDisk must keep recovered integrity chunks that still have
         // extents, reclaim empty ones immediately (every restored chunk is Ready — a durable
         // increment is only logged after formatting), defer CutLog until replay has populated the
-        // manager, pass reads of restored data chunks through unchanged (bitmaps unknown), and keep
-        // the generation watermark monotonic.
+        // manager, lazily restore checksum pairs/bitmaps for reads, and keep the generation
+        // watermark monotonic.
         TTestContext ctx;
         const TDiskHandle disk = ctx.RegisterDDisk(25, 1);
 
@@ -4816,18 +5787,32 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         UNIT_ASSERT(ctx.AutoServedIntegrityWriteChunks.empty());
 
         NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 204, 1);
-        for (const auto& [vChunkIndex, chunkIdx] : std::vector<std::pair<ui64, ui32>>{{0, 500}, {1, 501}}) {
+        for (const auto& [vChunkIndex, chunkIdx, integrityChunkIdx] :
+                std::vector<std::tuple<ui64, ui32, ui32>>{{0, 500, 600}, {1, 501, 602}}) {
+            const TString payload = MakeData('R', BlockSize);
             SendToDDisk(ctx, disk.ServiceId, new NDDisk::TEvRead(creds, {vChunkIndex, 0, BlockSize}, {true}));
-            auto readRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
-            UNIT_ASSERT_VALUES_EQUAL(readRaw->Get()->ChunkIdx, chunkIdx);
-            ctx.SendPDiskResponse(disk, *readRaw,
-                new NPDisk::TEvChunkReadRawResult(TRope(MakeData('R', BlockSize))));
+            auto integrityRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
+            UNIT_ASSERT_VALUES_EQUAL(integrityRead->Get()->ChunkIdx, integrityChunkIdx);
+            UNIT_ASSERT_VALUES_EQUAL(integrityRead->Get()->Size,
+                NDDisk::IntegrityPairSlots * NDDisk::IntegrityUnitSize);
+            ctx.SendPDiskResponse(disk, *integrityRead, new NPDisk::TEvChunkReadRawResult(
+                MakeRestoredIntegrityPair(disk.SlotId, 0x100000 + disk.PDiskId,
+                    204, vChunkIndex, 1,
+                    integrityChunkIdx, 0, 1, payload)));
+
+            auto dataRead = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
+            UNIT_ASSERT_VALUES_EQUAL(dataRead->Get()->ChunkIdx, chunkIdx);
+            ctx.SendPDiskResponse(disk, *dataRead,
+                new NPDisk::TEvChunkReadRawResult(TRope(payload)));
             auto readResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
             AssertStatus(readResult, TReplyStatus::OK);
+            UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->Record.ChecksumsSize(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->Record.GetChecksums(0),
+                NDDisk::CalculateRawChecksum(payload.data(), payload.size()));
         }
 
-        // A write to a restored chunk needs no allocation, log record or integrity formatting:
-        // it goes straight to the data chunk.
+        // A write to a restored chunk needs no allocation, log record or integrity formatting,
+        // but it does persist a new ping-pong slot alongside the data write.
         auto write = std::make_unique<NDDisk::TEvWrite>(creds,
             NDDisk::TBlockSelector(0, 0, BlockSize), NDDisk::TWriteInstruction(0));
         write->AddPayloadThenChecksum(MakeAlignedRope(MakeData('W', BlockSize)));
@@ -4838,7 +5823,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         auto writeResult = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
         AssertStatus(writeResult, TReplyStatus::OK);
 
-        UNIT_ASSERT(ctx.AutoServedIntegrityWriteChunks.empty());
+        UNIT_ASSERT(!ctx.AutoServedIntegrityWriteChunks.empty());
 
         // A brand-new allocation (VChunk 2) draws its generation past the persisted watermark
         // (3) and reuses a free slot of the lowest restored chunk. The extent format write and

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/blobstorage/ddisk/ddisk.h>
 #include <ydb/core/blobstorage/ddisk/ddisk_actor.h>
+#include <ydb/core/blobstorage/ddisk/ddisk_checksums.h>
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_data.h>
@@ -12,7 +13,12 @@
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cstring>
+#include <initializer_list>
+#include <map>
+#include <set>
+#include <tuple>
 
 namespace NKikimr {
 namespace {
@@ -21,7 +27,7 @@ using NKikimrBlobStorage::NDDisk::TReplyStatus;
 
 constexpr ui32 NodeId = 1;
 constexpr ui32 BlockSize = 4096;
-constexpr ui32 MinChunksReserved = 2;
+constexpr ui32 MinChunksReserved = 4;
 constexpr ui32 PersistentBufferInitChunks = 4;
 
 static_assert(NDDisk::NPrivate::THasSelectorField<NKikimrBlobStorage::NDDisk::TEvWrite>::value);
@@ -52,6 +58,8 @@ public:
     TTestActorSystem Runtime;
     TIntrusivePtr<::NMonitoring::TDynamicCounters> Counters;
     TActorId Edge;
+    std::set<TActorId> PDiskEdges;
+    std::set<TActorId> PDiskServiceIds;
 
     TTestContext()
         : Runtime(1)
@@ -67,9 +75,20 @@ public:
 
     TDiskHandle CreateDDisk(ui32 pdiskId, ui32 slotId,
             std::optional<NDDisk::TPersistentBufferFormat> customFormat = std::nullopt) {
+        TDiskHandle disk = RegisterDDisk(pdiskId, slotId, customFormat);
+        BootstrapDDisk(disk);
+        return disk;
+    }
+
+    // Registers the actors without running the bootstrap protocol: tests that need a custom boot
+    // sequence (e.g. recovery from starting points) drive the PDisk side themselves.
+    TDiskHandle RegisterDDisk(ui32 pdiskId, ui32 slotId,
+            std::optional<NDDisk::TPersistentBufferFormat> customFormat = std::nullopt) {
         const TActorId pdiskEdge = Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
         const TActorId pdiskServiceId = MakeBlobStoragePDiskID(NodeId, pdiskId);
         Runtime.RegisterService(pdiskServiceId, pdiskEdge);
+        PDiskEdges.insert(pdiskEdge);
+        PDiskServiceIds.insert(pdiskServiceId);
 
         TVector<TActorId> actorIds = {
             MakeBlobStorageDDiskId(NodeId, pdiskId, slotId),
@@ -96,25 +115,198 @@ public:
         const TActorId pbServiceId = MakeBlobStoragePersistentBufferId(NodeId, pdiskId, slotId);
         Runtime.RegisterService(ddiskServiceId, ddiskActor);
 
-        TDiskHandle disk{ddiskServiceId, pbServiceId, pdiskEdge, pdiskId, slotId, 100000 + pdiskId * 1000};
-        BootstrapDDisk(disk);
+        return TDiskHandle{ddiskServiceId, pbServiceId, pdiskEdge, pdiskId, slotId, 100000 + pdiskId * 1000};
+    }
 
-        return disk;
+    std::set<TActorId> ClientWaitEdges(std::initializer_list<TActorId> extra = {}) const {
+        std::set<TActorId> edges = PDiskEdges;
+        edges.insert(Edge);
+        for (const TActorId& id : extra) {
+            edges.insert(id);
+        }
+        return edges;
+    }
+
+    // Consume a PDisk-bound event that arrived while the test was waiting for a client
+    // reply. CheckSpace is acked so PB occupancy polling cannot stall; everything else
+    // is dropped unreplied (in-flight formatting / data I/O after Terminate or Broken).
+    bool ConsumeUnsolicitedPDiskEvent(std::unique_ptr<IEventHandle>& raw) {
+        if (!PDiskEdges.contains(raw->Recipient) && !PDiskServiceIds.contains(raw->Recipient)) {
+            return false;
+        }
+        if (raw->GetTypeRewrite() == NPDisk::TEvCheckSpace::EventType) {
+            SendFromPDisk(Runtime, raw->Recipient, raw->Sender,
+                new NPDisk::TEvCheckSpaceResult(NKikimrProto::OK, 0, 0, 0, 0, 0, 0, 0, "", 0), raw->Cookie);
+        }
+        return true;
     }
 
     template<typename TEvent>
     std::unique_ptr<TEventHandle<TEvent>> WaitPDiskRequest(const TDiskHandle& disk) {
-        std::unique_ptr<IEventHandle> raw = Runtime.WaitForEdgeActorEvent({disk.PDiskEdge});
-        UNIT_ASSERT_VALUES_EQUAL(raw->GetTypeRewrite(), TEvent::EventType);
-        return RecastEvent<TEvent>(std::move(raw));
+        return WaitPDiskRequests<TEvent>({disk.PDiskEdge});
     }
 
     template<typename TEvent>
     std::unique_ptr<TEventHandle<TEvent>> WaitPDiskRequests(const std::set<TActorId>& disks) {
-        std::unique_ptr<IEventHandle> raw = Runtime.WaitForEdgeActorEvent(disks);
-        UNIT_ASSERT_VALUES_EQUAL(raw->GetTypeRewrite(), TEvent::EventType);
-        return RecastEvent<TEvent>(std::move(raw));
+        for (;;) {
+            std::unique_ptr<IEventHandle> raw = Runtime.WaitForEdgeActorEvent(disks);
+            if (TryAutoServeIntegrityTraffic<TEvent>(*raw)) {
+                continue;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(raw->GetTypeRewrite(), TEvent::EventType);
+            return RecastEvent<TEvent>(std::move(raw));
+        }
     }
+
+    // For tests that inspect the integrity traffic itself and must see every PDisk event
+    // except periodic TEvCheckSpace (PB occupancy polling), which is auto-acked.
+    template<typename TEvent>
+    std::unique_ptr<TEventHandle<TEvent>> WaitPDiskRequestNoAutoServe(const TDiskHandle& disk) {
+        for (;;) {
+            std::unique_ptr<IEventHandle> raw = Runtime.WaitForEdgeActorEvent({disk.PDiskEdge});
+            if (raw->GetTypeRewrite() == NPDisk::TEvCheckSpace::EventType) {
+                SendFromPDisk(Runtime, raw->Recipient, raw->Sender,
+                    new NPDisk::TEvCheckSpaceResult(NKikimrProto::OK, 0, 0, 0, 0, 0, 0, 0, "", 0), raw->Cookie);
+                continue;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(raw->GetTypeRewrite(), TEvent::EventType);
+            return RecastEvent<TEvent>(std::move(raw));
+        }
+    }
+
+    // Integrity metadata I/O (chunk header replicas and extent-format writes, recognized by their
+    // magics) and reserve refills that a test script is not explicitly waiting for are
+    // transparently acknowledged, so scripts keep seeing only the data traffic they were written
+    // for. Combined allocation increments are *not* auto-served: they commit the data chunk and
+    // gate the client reply.
+    template<typename TExpectedEvent>
+    bool TryAutoServeIntegrityTraffic(IEventHandle& raw) {
+        if (raw.GetTypeRewrite() == NPDisk::TEvChunkWriteRaw::EventType) {
+            const auto* write = raw.CastAsLocal<NPDisk::TEvChunkWriteRaw>();
+            if (IsIntegrityMetadataWrite(*write)) {
+                AutoServedIntegrityWriteChunks.push_back(write->ChunkIdx);
+                SendFromPDisk(Runtime, raw.Recipient, raw.Sender,
+                    new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""), raw.Cookie);
+                return true;
+            }
+        } else if (raw.GetTypeRewrite() == NPDisk::TEvChunkReserve::EventType
+                && TExpectedEvent::EventType != NPDisk::TEvChunkReserve::EventType) {
+            const auto* reserve = raw.CastAsLocal<NPDisk::TEvChunkReserve>();
+            auto reply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
+            for (ui32 i = 0; i < reserve->SizeChunks; ++i) {
+                reply->ChunkIds.push_back(NextAutoReserveChunkId++);
+            }
+            SendFromPDisk(Runtime, raw.Recipient, raw.Sender, reply.release(), raw.Cookie);
+            return true;
+        } else if (raw.GetTypeRewrite() == NPDisk::TEvCheckSpace::EventType
+                && TExpectedEvent::EventType != NPDisk::TEvCheckSpace::EventType) {
+            SendFromPDisk(Runtime, raw.Recipient, raw.Sender,
+                new NPDisk::TEvCheckSpaceResult(NKikimrProto::OK, 0, 0, 0, 0, 0, 0, 0, "", 0), raw.Cookie);
+            return true;
+        }
+        return false;
+    }
+
+    static bool IsIntegrityMetadataWrite(const NPDisk::TEvChunkWriteRaw& write) {
+        auto it = write.Data.Begin();
+        if (!it.Valid() || it.ContiguousSize() < sizeof(ui64)) {
+            return false;
+        }
+        ui64 magic;
+        memcpy(&magic, it.ContiguousData(), sizeof(magic));
+        return magic == NDDisk::MagicIntegrityChunkHeader || magic == NDDisk::MagicIntegrityBlock;
+    }
+
+    static NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord ParseChunkMapLog(
+            const NPDisk::TEvLog& log) {
+        UNIT_ASSERT(log.Signature.GetUnmasked() == TLogSignature::SignatureDDiskChunkMap);
+        NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord record;
+        UNIT_ASSERT(record.ParseFromArray(log.Data.data(), log.Data.size()));
+        return record;
+    }
+
+    void ReplyLog(const TDiskHandle& disk, TEventHandle<NPDisk::TEvLog>& req) {
+        auto r = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
+        r->Results.emplace_back(req.Get()->Lsn, req.Get()->Cookie);
+        SendPDiskResponse(disk, req, r.release());
+    }
+
+    struct TAllocationTraffic {
+        std::unique_ptr<TEventHandle<NPDisk::TEvLog>> Snapshot;
+        std::unique_ptr<TEventHandle<NPDisk::TEvLog>> Increment;
+        std::vector<std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>>> DataWrites;
+        std::unique_ptr<TEventHandle<NPDisk::TEvChunkReserve>> Reserve;
+    };
+
+    // Formatting I/O, the data write and the combined increment may appear in any order.
+    // Integrity metadata writes are auto-served (so the increment can be issued). Reserves are
+    // auto-served unless holdReserve, in which case the first refill is captured unreplied.
+    TAllocationTraffic CollectAllocationTraffic(const TDiskHandle& disk,
+            bool expectSnapshot, ui32 expectedDataWrites, bool holdReserve = false) {
+        TAllocationTraffic traffic;
+        ui32 guard = 0;
+        while ((expectSnapshot && !traffic.Snapshot) || !traffic.Increment
+                || traffic.DataWrites.size() < expectedDataWrites) {
+            UNIT_ASSERT_C(++guard < 200, "timed out collecting allocation PDisk traffic");
+            std::unique_ptr<IEventHandle> raw = Runtime.WaitForEdgeActorEvent({disk.PDiskEdge});
+            const ui32 type = raw->GetTypeRewrite();
+            if (type == NPDisk::TEvChunkWriteRaw::EventType) {
+                auto write = RecastEvent<NPDisk::TEvChunkWriteRaw>(std::move(raw));
+                if (IsIntegrityMetadataWrite(*write->Get())) {
+                    AutoServedIntegrityWriteChunks.push_back(write->Get()->ChunkIdx);
+                    SendPDiskResponse(disk, *write, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+                    continue;
+                }
+                traffic.DataWrites.push_back(std::move(write));
+                continue;
+            }
+            if (type == NPDisk::TEvLog::EventType) {
+                auto log = RecastEvent<NPDisk::TEvLog>(std::move(raw));
+                const auto record = ParseChunkMapLog(*log->Get());
+                if (record.HasSnapshot()) {
+                    UNIT_ASSERT(expectSnapshot);
+                    UNIT_ASSERT(!traffic.Snapshot);
+                    ReplyLog(disk, *log);
+                    traffic.Snapshot = std::move(log);
+                    continue;
+                }
+                UNIT_ASSERT(record.HasIncrement());
+                UNIT_ASSERT(!traffic.Increment);
+                traffic.Increment = std::move(log);
+                continue;
+            }
+            if (type == NPDisk::TEvChunkReserve::EventType) {
+                auto reserve = RecastEvent<NPDisk::TEvChunkReserve>(std::move(raw));
+                if (holdReserve) {
+                    UNIT_ASSERT(!traffic.Reserve);
+                    traffic.Reserve = std::move(reserve);
+                    continue;
+                }
+                auto reply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
+                for (ui32 i = 0; i < reserve->Get()->SizeChunks; ++i) {
+                    reply->ChunkIds.push_back(NextAutoReserveChunkId++);
+                }
+                SendPDiskResponse(disk, *reserve, reply.release());
+                continue;
+            }
+            if (type == NPDisk::TEvCheckSpace::EventType) {
+                auto checkSpace = RecastEvent<NPDisk::TEvCheckSpace>(std::move(raw));
+                SendPDiskResponse(disk, *checkSpace,
+                    new NPDisk::TEvCheckSpaceResult(NKikimrProto::OK, 0, 0, 0, 0, 0, 0, 0, "", 0));
+                --guard; // occupancy polling is not allocation traffic
+                continue;
+            }
+            UNIT_ASSERT_C(false, "unexpected PDisk event type " << type);
+        }
+        return traffic;
+    }
+
+    // Fresh ids for auto-served reserve refills; far away from ids the tests assert on.
+    ui32 NextAutoReserveChunkId = 900000;
+
+    // Chunk ids of every auto-served integrity metadata write, so tests can check which chunks
+    // were (re-)formatted behind their back.
+    std::vector<ui32> AutoServedIntegrityWriteChunks;
 
     template<typename TRequestEvent>
     void SendPDiskResponse(const TDiskHandle& disk, const TEventHandle<TRequestEvent>& request, IEventBase* response) {
@@ -190,7 +382,15 @@ void SendToDDisk(TTestContext& ctx, const TActorId& serviceId, IEventBase* event
 
 template<typename TResponseEvent>
 std::unique_ptr<TEventHandle<TResponseEvent>> WaitFromDDisk(TTestContext& ctx) {
-    return ctx.Runtime.WaitForEdgeActorEvent<TResponseEvent>(ctx.Edge, false);
+    for (;;) {
+        std::unique_ptr<IEventHandle> raw = ctx.Runtime.WaitForEdgeActorEvent(ctx.ClientWaitEdges());
+        if (ctx.ConsumeUnsolicitedPDiskEvent(raw)) {
+            continue;
+        }
+        UNIT_ASSERT_VALUES_EQUAL(raw->GetTypeRewrite(), TResponseEvent::EventType);
+        return std::unique_ptr<TEventHandle<TResponseEvent>>(
+            reinterpret_cast<TEventHandle<TResponseEvent>*>(raw.release()));
+    }
 }
 
 template<typename TResponseEvent>
@@ -255,49 +455,38 @@ struct TInitialWriteOutcome {
     ui32 ChunkIdx = 0;
 };
 
-/** First write to a vchunk: PDisk sees log records, chunk reserve, then TEvChunkWriteRaw. */
+/** First write to a vchunk: formatting I/O, the data write and the combined increment run in
+ * parallel. Integrity metadata writes and reserve refills are auto-served. The client reply is
+ * gated on the increment becoming durable. */
 TInitialWriteOutcome DoWriteWithChunkAllocation(TTestContext& ctx, const TDiskHandle& disk, std::unique_ptr<NDDisk::TEvWrite> write,
         ui32 chunkId, ui32 expectedOffsetInBytes, const TString& expectedPayload,
         bool reserveExpected, bool checkSnapshot) {
     SendToDDisk(ctx, disk.ServiceId, write.release());
 
     if (!reserveExpected) {
-        // no existing reserve: have to request chunk
+        // no existing reserve: have to request chunks (the reserve is refilled up to MinChunksReserved)
         auto refill = ctx.WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
-        UNIT_ASSERT_VALUES_EQUAL(refill->Get()->SizeChunks, 2u);
+        UNIT_ASSERT_VALUES_EQUAL(refill->Get()->SizeChunks, MinChunksReserved);
 
         auto refillReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
-        refillReply->ChunkIds.push_back(chunkId);
-        refillReply->ChunkIds.push_back(chunkId + 1);
+        for (ui32 i = 0; i < MinChunksReserved; ++i) {
+            refillReply->ChunkIds.push_back(chunkId + i);
+        }
         ctx.SendPDiskResponse(disk, *refill, refillReply.release());
     }
 
-    auto logIncrement = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-    auto logIncrementReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
-    logIncrementReply->Results.emplace_back(logIncrement->Get()->Lsn, logIncrement->Get()->Cookie);
-    ctx.SendPDiskResponse(disk, *logIncrement, logIncrementReply.release());
-
-    if (checkSnapshot) {
-        auto logSnapshot = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        auto logSnapshotReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
-        logSnapshotReply->Results.emplace_back(logSnapshot->Get()->Lsn, logSnapshot->Get()->Cookie);
-        ctx.SendPDiskResponse(disk, *logSnapshot, logSnapshotReply.release());
-    }
-
-    // DDisk took 1 chunk from reserve, it will request one to have reserve
-    auto refill = ctx.WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
-    UNIT_ASSERT_VALUES_EQUAL(refill->Get()->SizeChunks, 1u);
-    auto refillReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
-    refillReply->ChunkIds.push_back(chunkId + 2);
-    ctx.SendPDiskResponse(disk, *refill, refillReply.release());
-
-    auto writeRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
-    const ui32 chunkIdx = writeRaw->Get()->ChunkIdx;
+    auto traffic = ctx.CollectAllocationTraffic(disk, checkSnapshot, 1);
+    UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 1u);
+    UNIT_ASSERT(traffic.Increment);
+    const ui32 chunkIdx = traffic.DataWrites[0]->Get()->ChunkIdx;
     UNIT_ASSERT(chunkIdx != 0u);
     UNIT_ASSERT_VALUES_EQUAL(chunkIdx, chunkId);
-    UNIT_ASSERT_VALUES_EQUAL(writeRaw->Get()->Offset, expectedOffsetInBytes);
-    UNIT_ASSERT_VALUES_EQUAL(writeRaw->Get()->Data.ConvertToString(), expectedPayload);
-    ctx.SendPDiskResponse(disk, *writeRaw, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+    UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Offset, expectedOffsetInBytes);
+    UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Data.ConvertToString(), expectedPayload);
+
+    // Data I/O first: the write result must stay parked until the increment commits.
+    ctx.SendPDiskResponse(disk, *traffic.DataWrites[0], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+    ctx.ReplyLog(disk, *traffic.Increment);
 
     return TInitialWriteOutcome{WaitFromDDisk<NDDisk::TEvWriteResult>(ctx), chunkIdx};
 }
@@ -1076,7 +1265,9 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         const TString payload2 = blockPayload("tablet2", 7);
 
         const ui32 chunkTablet1 = disk.FirstChunkId + PersistentBufferInitChunks;
-        const ui32 chunkTablet2 = disk.FirstChunkId + PersistentBufferInitChunks + 1;
+        // Tablet1's allocation consumed two reserve chunks (data + integrity); tablet2's data
+        // chunk is therefore the third one (its integrity extent reuses tablet1's integrity chunk).
+        const ui32 chunkTablet2 = disk.FirstChunkId + PersistentBufferInitChunks + 2;
 
         NDDisk::TQueryCredentials creds1 = Connect(ctx, disk.ServiceId, 101, 1);
         {
@@ -1781,25 +1972,12 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(payload)),
             0, readReq->Cookie), NodeId);
 
-        auto logIncrement = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        auto logIncrementReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
-        logIncrementReply->Results.emplace_back(logIncrement->Get()->Lsn, logIncrement->Get()->Cookie);
-        ctx.SendPDiskResponse(disk, *logIncrement, logIncrementReply.release());
-
-        auto logSnapshot = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        auto logSnapshotReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
-        logSnapshotReply->Results.emplace_back(logSnapshot->Get()->Lsn, logSnapshot->Get()->Cookie);
-        ctx.SendPDiskResponse(disk, *logSnapshot, logSnapshotReply.release());
-
-        auto refill = ctx.WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
-        auto refillReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
-        refillReply->ChunkIds.push_back(2001);
-        ctx.SendPDiskResponse(disk, *refill, refillReply.release());
-
-        auto writeRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw->Get()->Offset, 0u);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw->Get()->Data.ConvertToString(), payload);
-        ctx.SendPDiskResponse(disk, *writeRaw, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto traffic = ctx.CollectAllocationTraffic(disk, true, 1);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Offset, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Data.ConvertToString(), payload);
+        ctx.SendPDiskResponse(disk, *traffic.DataWrites[0], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *traffic.Increment);
 
         auto syncResult = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
         AssertStatus(syncResult, TReplyStatus::OK);
@@ -1807,6 +1985,133 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         UNIT_ASSERT_VALUES_EQUAL(
             static_cast<int>(syncResult->Get()->Record.GetSegmentResults(0).GetStatus()),
             static_cast<int>(TReplyStatus::OK));
+    }
+
+    Y_UNIT_TEST(SyncReplyWaitsForCombinedIncrement) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(28, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 208, 1);
+
+        const ui32 srcPDiskId = 91;
+        const ui32 srcSlotId = 1;
+        const TActorId fakeSourceEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(
+            MakeBlobStorageDDiskId(NodeId, srcPDiskId, srcSlotId), fakeSourceEdge);
+        const auto sourceId = MakeSyncSourceId(srcPDiskId, srcSlotId);
+
+        auto sync = std::make_unique<NDDisk::TEvSync>(creds);
+        sync->AddSegmentFromDDisk(sourceId, 42,
+            NDDisk::TBlockSelector(7, 0, BlockSize));
+        sync->AddSegmentFromDDisk(sourceId, 42,
+            NDDisk::TBlockSelector(7, BlockSize, BlockSize));
+        SendToDDisk(ctx, disk.ServiceId, sync.release());
+
+        auto firstRead = ctx.Runtime.WaitForEdgeActorEvent({fakeSourceEdge});
+        auto secondRead = ctx.Runtime.WaitForEdgeActorEvent({fakeSourceEdge});
+        UNIT_ASSERT_VALUES_EQUAL(firstRead->GetTypeRewrite(), static_cast<ui32>(NDDisk::TEv::EvRead));
+        UNIT_ASSERT_VALUES_EQUAL(secondRead->GetTypeRewrite(), static_cast<ui32>(NDDisk::TEv::EvRead));
+
+        const TString payload = MakeData('G', BlockSize);
+        ctx.Runtime.Send(new IEventHandle(firstRead->Sender, fakeSourceEdge,
+            new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(payload)),
+            0, firstRead->Cookie), NodeId);
+
+        auto traffic = ctx.CollectAllocationTraffic(disk, true, 1);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 1u);
+        ctx.SendPDiskResponse(disk, *traffic.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+
+        // The second source failure completes the sync, but its reply must remain parked until
+        // the combined data/integrity allocation increment is durable.
+        ctx.Runtime.Send(new IEventHandle(secondRead->Sender, fakeSourceEdge,
+            new TEvents::TEvUndelivered(
+                NDDisk::TEv::EvRead, TEvents::TEvUndelivered::ReasonActorUnknown),
+            0, secondRead->Cookie), NodeId);
+
+        const TActorId sentinelEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.Send(new IEventHandle(sentinelEdge, ctx.Edge, new TEvents::TEvWakeup()), NodeId);
+        auto sentinel = ctx.Runtime.WaitForEdgeActorEvent({ctx.Edge, sentinelEdge});
+        UNIT_ASSERT_VALUES_EQUAL_C(sentinel->Recipient, sentinelEdge,
+            "TEvSyncResult must wait for the combined increment to commit");
+
+        ctx.ReplyLog(disk, *traffic.Increment);
+        auto syncResult = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
+        AssertStatus(syncResult, TReplyStatus::ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(syncResult->Get()->Record.SegmentResultsSize(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(syncResult->Get()->Record.GetSegmentResults(0).GetStatus()),
+            static_cast<int>(TReplyStatus::OK));
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(syncResult->Get()->Record.GetSegmentResults(1).GetStatus()),
+            static_cast<int>(TReplyStatus::ERROR));
+    }
+
+    Y_UNIT_TEST(OutdatedSyncReplyWaitsForCommit) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(29, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 209, 1);
+
+        const ui32 srcPDiskId = 90;
+        const ui32 srcSlotId = 1;
+        const TActorId fakeSourceEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(
+            MakeBlobStorageDDiskId(NodeId, srcPDiskId, srcSlotId), fakeSourceEdge);
+        const auto sourceId = MakeSyncSourceId(srcPDiskId, srcSlotId);
+
+        auto firstSync = std::make_unique<NDDisk::TEvSync>(creds);
+        firstSync->AddSegmentFromDDisk(sourceId, 42,
+            NDDisk::TBlockSelector(7, 0, BlockSize));
+        firstSync->AddSegmentFromDDisk(sourceId, 42,
+            NDDisk::TBlockSelector(7, BlockSize, BlockSize));
+        SendToDDisk(ctx, disk.ServiceId, firstSync.release());
+
+        auto completedRead = ctx.Runtime.WaitForEdgeActorEvent({fakeSourceEdge});
+        auto staleRead = ctx.Runtime.WaitForEdgeActorEvent({fakeSourceEdge});
+        UNIT_ASSERT_VALUES_EQUAL(completedRead->GetTypeRewrite(), static_cast<ui32>(NDDisk::TEv::EvRead));
+        UNIT_ASSERT_VALUES_EQUAL(staleRead->GetTypeRewrite(), static_cast<ui32>(NDDisk::TEv::EvRead));
+
+        const TString payload = MakeData('O', BlockSize);
+        ctx.Runtime.Send(new IEventHandle(completedRead->Sender, fakeSourceEdge,
+            new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(payload)),
+            0, completedRead->Cookie), NodeId);
+
+        auto traffic = ctx.CollectAllocationTraffic(disk, true, 1);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 1u);
+        ctx.SendPDiskResponse(disk, *traffic.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+
+        // A newer overlapping sync outdates the only request still outstanding in firstSync.
+        // Its result must be parked because the first segment wrote into the allocating chunk.
+        auto newerSync = std::make_unique<NDDisk::TEvSync>(creds);
+        newerSync->AddSegmentFromDDisk(sourceId, 43,
+            NDDisk::TBlockSelector(7, BlockSize, BlockSize));
+        SendToDDisk(ctx, disk.ServiceId, newerSync.release());
+        auto newerRead = ctx.Runtime.WaitForEdgeActorEvent({fakeSourceEdge});
+        UNIT_ASSERT_VALUES_EQUAL(newerRead->GetTypeRewrite(), static_cast<ui32>(NDDisk::TEv::EvRead));
+
+        // A late undelivered notification for the already-OUTDATED request must be ignored:
+        // it must neither double-decrement RequestsInFlight nor replace OUTDATED with ERROR.
+        ctx.Runtime.Send(new IEventHandle(staleRead->Sender, fakeSourceEdge,
+            new TEvents::TEvUndelivered(
+                NDDisk::TEv::EvRead, TEvents::TEvUndelivered::ReasonActorUnknown),
+            0, staleRead->Cookie), NodeId);
+
+        const TActorId sentinelEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.Send(new IEventHandle(sentinelEdge, ctx.Edge, new TEvents::TEvWakeup()), NodeId);
+        auto sentinel = ctx.Runtime.WaitForEdgeActorEvent({ctx.Edge, sentinelEdge});
+        UNIT_ASSERT_VALUES_EQUAL_C(sentinel->Recipient, sentinelEdge,
+            "outdated TEvSyncResult must wait for the combined increment to commit");
+
+        ctx.ReplyLog(disk, *traffic.Increment);
+        auto syncResult = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
+        AssertStatus(syncResult, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(syncResult->Get()->Record.SegmentResultsSize(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(syncResult->Get()->Record.GetSegmentResults(0).GetStatus()),
+            static_cast<int>(TReplyStatus::OK));
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(syncResult->Get()->Record.GetSegmentResults(1).GetStatus()),
+            static_cast<int>(TReplyStatus::OUTDATED));
     }
 
     Y_UNIT_TEST(SyncReadsFromMultipleDDiskSources) {
@@ -1867,30 +2172,15 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(payload2)),
             0, readReq2->Cookie), NodeId);
 
-        auto logIncrement = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        auto logIncrementReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
-        logIncrementReply->Results.emplace_back(logIncrement->Get()->Lsn, logIncrement->Get()->Cookie);
-        ctx.SendPDiskResponse(disk, *logIncrement, logIncrementReply.release());
-
-        auto logSnapshot = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        auto logSnapshotReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
-        logSnapshotReply->Results.emplace_back(logSnapshot->Get()->Lsn, logSnapshot->Get()->Cookie);
-        ctx.SendPDiskResponse(disk, *logSnapshot, logSnapshotReply.release());
-
-        auto refill = ctx.WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
-        auto refillReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
-        refillReply->ChunkIds.push_back(4001);
-        ctx.SendPDiskResponse(disk, *refill, refillReply.release());
-
-        auto writeRaw1 = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw1->Get()->Offset, 0u);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw1->Get()->Data.ConvertToString(), payload1);
-        ctx.SendPDiskResponse(disk, *writeRaw1, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
-
-        auto writeRaw2 = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw2->Get()->Offset, BlockSize);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw2->Get()->Data.ConvertToString(), payload2);
-        ctx.SendPDiskResponse(disk, *writeRaw2, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto traffic = ctx.CollectAllocationTraffic(disk, true, 2);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Offset, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Data.ConvertToString(), payload1);
+        ctx.SendPDiskResponse(disk, *traffic.DataWrites[0], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[1]->Get()->Offset, BlockSize);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[1]->Get()->Data.ConvertToString(), payload2);
+        ctx.SendPDiskResponse(disk, *traffic.DataWrites[1], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *traffic.Increment);
 
         auto syncResult = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
         AssertStatus(syncResult, TReplyStatus::OK);
@@ -1980,30 +2270,15 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(ddiskPayload)),
             0, ddiskReadReq->Cookie), NodeId);
 
-        auto logIncrement = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        auto logIncrementReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
-        logIncrementReply->Results.emplace_back(logIncrement->Get()->Lsn, logIncrement->Get()->Cookie);
-        ctx.SendPDiskResponse(disk, *logIncrement, logIncrementReply.release());
-
-        auto logSnapshot = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        auto logSnapshotReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
-        logSnapshotReply->Results.emplace_back(logSnapshot->Get()->Lsn, logSnapshot->Get()->Cookie);
-        ctx.SendPDiskResponse(disk, *logSnapshot, logSnapshotReply.release());
-
-        auto refill = ctx.WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
-        auto refillReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
-        refillReply->ChunkIds.push_back(5001);
-        ctx.SendPDiskResponse(disk, *refill, refillReply.release());
-
-        auto writeRaw1 = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw1->Get()->Offset, 0u);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw1->Get()->Data.ConvertToString(), pbufferPayload);
-        ctx.SendPDiskResponse(disk, *writeRaw1, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
-
-        auto writeRaw2 = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw2->Get()->Offset, BlockSize);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw2->Get()->Data.ConvertToString(), ddiskPayload);
-        ctx.SendPDiskResponse(disk, *writeRaw2, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto traffic = ctx.CollectAllocationTraffic(disk, true, 2);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Offset, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Data.ConvertToString(), pbufferPayload);
+        ctx.SendPDiskResponse(disk, *traffic.DataWrites[0], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[1]->Get()->Offset, BlockSize);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[1]->Get()->Data.ConvertToString(), ddiskPayload);
+        ctx.SendPDiskResponse(disk, *traffic.DataWrites[1], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *traffic.Increment);
 
         auto syncResult = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
         AssertStatus(syncResult, TReplyStatus::OK);
@@ -2091,30 +2366,15 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             new NDDisk::TEvReadResult(TReplyStatus::OK, std::nullopt, TRope(ddiskPayload)),
             0, ddiskReadReq->Cookie), NodeId);
 
-        auto logIncrement = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        auto logIncrementReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
-        logIncrementReply->Results.emplace_back(logIncrement->Get()->Lsn, logIncrement->Get()->Cookie);
-        ctx.SendPDiskResponse(disk, *logIncrement, logIncrementReply.release());
-
-        auto logSnapshot = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        auto logSnapshotReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
-        logSnapshotReply->Results.emplace_back(logSnapshot->Get()->Lsn, logSnapshot->Get()->Cookie);
-        ctx.SendPDiskResponse(disk, *logSnapshot, logSnapshotReply.release());
-
-        auto refill = ctx.WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
-        auto refillReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
-        refillReply->ChunkIds.push_back(6001);
-        ctx.SendPDiskResponse(disk, *refill, refillReply.release());
-
-        auto writeRaw1 = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw1->Get()->Offset, 0u);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw1->Get()->Data.ConvertToString(), pbufferPayload);
-        ctx.SendPDiskResponse(disk, *writeRaw1, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
-
-        auto writeRaw2 = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw2->Get()->Offset, BlockSize);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw2->Get()->Data.ConvertToString(), ddiskPayload);
-        ctx.SendPDiskResponse(disk, *writeRaw2, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto traffic = ctx.CollectAllocationTraffic(disk, true, 2);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Offset, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Data.ConvertToString(), pbufferPayload);
+        ctx.SendPDiskResponse(disk, *traffic.DataWrites[0], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[1]->Get()->Offset, BlockSize);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[1]->Get()->Data.ConvertToString(), ddiskPayload);
+        ctx.SendPDiskResponse(disk, *traffic.DataWrites[1], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *traffic.Increment);
 
         auto syncResult = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
         AssertStatus(syncResult, TReplyStatus::OK);
@@ -2158,25 +2418,12 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
                 5, 0, BlockSize, TRope(payload)),
             0, readReq->Cookie), NodeId);
 
-        auto logIncrement = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        auto logIncrementReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
-        logIncrementReply->Results.emplace_back(logIncrement->Get()->Lsn, logIncrement->Get()->Cookie);
-        ctx.SendPDiskResponse(disk, *logIncrement, logIncrementReply.release());
-
-        auto logSnapshot = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        auto logSnapshotReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
-        logSnapshotReply->Results.emplace_back(logSnapshot->Get()->Lsn, logSnapshot->Get()->Cookie);
-        ctx.SendPDiskResponse(disk, *logSnapshot, logSnapshotReply.release());
-
-        auto refill = ctx.WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
-        auto refillReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
-        refillReply->ChunkIds.push_back(3001);
-        ctx.SendPDiskResponse(disk, *refill, refillReply.release());
-
-        auto writeRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw->Get()->Offset, 0u);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw->Get()->Data.ConvertToString(), payload);
-        ctx.SendPDiskResponse(disk, *writeRaw, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto traffic = ctx.CollectAllocationTraffic(disk, true, 1);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Offset, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->Data.ConvertToString(), payload);
+        ctx.SendPDiskResponse(disk, *traffic.DataWrites[0], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ctx.ReplyLog(disk, *traffic.Increment);
 
         auto syncResult = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
         AssertStatus(syncResult, TReplyStatus::OK);
@@ -2289,18 +2536,14 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         write->AddPayloadThenChecksum(MakeAlignedRope(payload));
         SendToDDisk(ctx, disk.ServiceId, write.release());
 
-        // A first-time write triggers three PDisk requests:
-        //   TEvLog (chunk map increment), TEvLog (chunk map snapshot), TEvChunkReserve (refill).
-        // Drain all of them so the PDisk edge is clean before the sentinel check.
-        auto logIncrement = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        auto logSnapshot = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        auto reserve = ctx.WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
-        Y_UNUSED(logSnapshot);
-        Y_UNUSED(reserve);
+        // A first-time write triggers a chunk-map snapshot (and, in parallel, formatting I/O,
+        // a reserve refill and the data write). Inject the error on the snapshot so DDisk
+        // enters the PDisk-session termination state before any increment is issued.
+        auto logSnapshot = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvLog>(disk);
 
         auto logReply = std::make_unique<NPDisk::TEvLogResult>(errorStatus, 0, "test injected error", 0);
-        logReply->Results.emplace_back(logIncrement->Get()->Lsn, logIncrement->Get()->Cookie);
-        ctx.SendPDiskResponse(disk, *logIncrement, logReply.release());
+        logReply->Results.emplace_back(logSnapshot->Get()->Lsn, logSnapshot->Get()->Cookie);
+        ctx.SendPDiskResponse(disk, *logSnapshot, logReply.release());
 
         // DDisk should be in StateFuncTerminate now (not crashed).
         // Verify it silently drops client requests.
@@ -2309,10 +2552,16 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         TActorId sentinelEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
         ctx.Runtime.Send(new IEventHandle(sentinelEdge, ctx.Edge, new TEvents::TEvWakeup()), NodeId);
 
-        auto ev = ctx.Runtime.WaitForEdgeActorEvent({ctx.Edge, sentinelEdge});
-        UNIT_ASSERT_VALUES_EQUAL_C(ev->Recipient, sentinelEdge,
-            "DDisk should not respond to client requests after PDisk "
-            << NKikimrProto::EReplyStatus_Name(errorStatus));
+        for (;;) {
+            auto ev = ctx.Runtime.WaitForEdgeActorEvent(ctx.ClientWaitEdges({sentinelEdge}));
+            if (ctx.ConsumeUnsolicitedPDiskEvent(ev)) {
+                continue;
+            }
+            UNIT_ASSERT_VALUES_EQUAL_C(ev->Recipient, sentinelEdge,
+                "DDisk should not respond to client requests after PDisk "
+                << NKikimrProto::EReplyStatus_Name(errorStatus));
+            break;
+        }
     }
 
     Y_UNIT_TEST(PDiskCorruptedStopsDDisk) {
@@ -2779,32 +3028,52 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         AssertStatus(readResult, TReplyStatus::MISSING_RECORD);
     }
 
+    Y_UNIT_TEST(DeleteTabletChunks_RejectedWhenSyncInFlight) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(30, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 210, 1);
+
+        const ui32 srcPDiskId = 89;
+        const ui32 srcSlotId = 1;
+        const TActorId fakeSourceEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(
+            MakeBlobStorageDDiskId(NodeId, srcPDiskId, srcSlotId), fakeSourceEdge);
+
+        auto sync = std::make_unique<NDDisk::TEvSync>(creds);
+        sync->AddSegmentFromDDisk(MakeSyncSourceId(srcPDiskId, srcSlotId), 42,
+            NDDisk::TBlockSelector(0, 0, BlockSize));
+        SendToDDisk(ctx, disk.ServiceId, sync.release());
+
+        // Hold the source read: no target chunk allocation or pending chunk event exists yet,
+        // but the sync may later allocate and write the target chunk.
+        auto sourceRead = ctx.Runtime.WaitForEdgeActorEvent({fakeSourceEdge});
+        UNIT_ASSERT_VALUES_EQUAL(sourceRead->GetTypeRewrite(), static_cast<ui32>(NDDisk::TEv::EvRead));
+
+        auto deleteResult = SendToDDiskAndWait<NDDisk::TEvDeleteTabletChunksResult>(
+            ctx, disk.ServiceId, new NDDisk::TEvDeleteTabletChunks(creds));
+        AssertStatus(deleteResult, TReplyStatus::BUSY);
+    }
+
     Y_UNIT_TEST(DeleteTabletChunks_RejectedWhenLogInFlight) {
-        // Verify that DeleteTabletChunks returns BUSY when a chunk-map increment log
-        // record for the tablet is in-flight (ChunkMapIncrementsInFlight is non-empty).
+        // Verify that DeleteTabletChunks returns BUSY while a data chunk allocation for the
+        // tablet is in flight (DataChunkAllocationsInFlight is non-empty).
         TTestContext ctx;
         const TDiskHandle disk = ctx.CreateDDisk(21, 1);
         NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 200, 1);
 
-        // First write to VChunk 0: DDisk will synchronously send TEvLog(increment),
-        // TEvLog(snapshot), TEvChunkReserve(refill) before waiting for any replies.
+        // First write to VChunk 0: DDisk sends TEvLog(snapshot) and starts formatting I/O
+        // immediately. Leave formatting unreplied so the combined increment is never issued
+        // and the allocation stays in flight.
         auto write = std::make_unique<NDDisk::TEvWrite>(creds,
             NDDisk::TBlockSelector(0, 0, BlockSize), NDDisk::TWriteInstruction(0));
         write->AddPayloadThenChecksum(MakeAlignedRope(MakeData('A', BlockSize)));
         SendToDDisk(ctx, disk.ServiceId, write.release());
 
-        // Wait for the increment log but do NOT reply — keeps ChunkMapIncrementsInFlight populated.
-        auto logIncrement = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        UNIT_ASSERT_VALUES_EQUAL(logIncrement->Get()->CommitRecord.CommitChunks.size(), 1u);
-        Y_UNUSED(logIncrement);
-
-        // Drain snapshot and refill so they don't interfere with the result wait.
-        auto logSnapshot = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
+        auto logSnapshot = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvLog>(disk);
+        UNIT_ASSERT(logSnapshot->Get()->CommitRecord.CommitChunks.empty());
         Y_UNUSED(logSnapshot);
-        auto refill = ctx.WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
-        Y_UNUSED(refill);
 
-        // DeleteTabletChunks must be rejected because the increment is still in-flight.
+        // DeleteTabletChunks must be rejected because the allocation is still in-flight.
         auto deleteResult = SendToDDiskAndWait<NDDisk::TEvDeleteTabletChunksResult>(
             ctx, disk.ServiceId, new NDDisk::TEvDeleteTabletChunks(creds));
         AssertStatus(deleteResult, TReplyStatus::BUSY);
@@ -2819,67 +3088,56 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
 
         const ui32 chunkBase = disk.FirstChunkId + PersistentBufferInitChunks;
 
-        auto replyLog = [&](const auto& req) {
-            auto r = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
-            r->Results.emplace_back(req->Get()->Lsn, req->Get()->Cookie);
-            ctx.SendPDiskResponse(disk, *req, r.release());
-        };
-
         // --- Write 1 (VChunk 0): handle all PDisk requests except the refill ---
+        // Consumes TWO reserve chunks: the data chunk (chunkBase) and the first integrity
+        // chunk (chunkBase + 1). The integrity metadata writes are auto-served.
         {
             auto w = std::make_unique<NDDisk::TEvWrite>(creds,
                 NDDisk::TBlockSelector(0, 0, BlockSize), NDDisk::TWriteInstruction(0));
             w->AddPayloadThenChecksum(MakeAlignedRope(MakeData('A', BlockSize)));
             SendToDDisk(ctx, disk.ServiceId, w.release());
 
-            auto logIncr1 = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-            UNIT_ASSERT_VALUES_EQUAL(logIncr1->Get()->CommitRecord.CommitChunks[0], chunkBase);
-            replyLog(logIncr1);
-
-            auto logSnap = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-            replyLog(logSnap);
-
-            // Hold the refill: ReserveInFlight stays true, ChunkReserve stays at 1 chunk.
-            auto refill1 = ctx.WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
-            Y_UNUSED(refill1);
-
-            auto writeRaw1 = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
-            ctx.SendPDiskResponse(disk, *writeRaw1, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+            auto traffic = ctx.CollectAllocationTraffic(disk, true, 1, /*holdReserve=*/ true);
+            UNIT_ASSERT(traffic.Reserve);
+            UNIT_ASSERT_VALUES_EQUAL(traffic.Increment->Get()->CommitRecord.CommitChunks.size(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(traffic.Increment->Get()->CommitRecord.CommitChunks[0], chunkBase + 1);
+            UNIT_ASSERT_VALUES_EQUAL(traffic.Increment->Get()->CommitRecord.CommitChunks[1], chunkBase);
+            ctx.SendPDiskResponse(disk, *traffic.DataWrites[0], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+            ctx.ReplyLog(disk, *traffic.Increment);
             auto wr1 = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
             AssertStatus(wr1, TReplyStatus::OK);
         }
-        // State: ChunkReserve=[chunkBase+1] (1 chunk), ReserveInFlight=true
+        // State: ChunkReserve=[chunkBase+2, chunkBase+3] (2 chunks), ReserveInFlight=true
 
-        // --- Write 2 (VChunk 1): consumes the last reserve chunk ---
-        {
+        // --- Writes 2 and 3 (VChunks 1 and 2): drain the remaining reserve chunks ---
+        // (their integrity extents reuse write 1's integrity chunk, so each takes one chunk)
+        for (ui32 i = 0; i < 2; ++i) {
             auto w = std::make_unique<NDDisk::TEvWrite>(creds,
-                NDDisk::TBlockSelector(1, 0, BlockSize), NDDisk::TWriteInstruction(0));
-            w->AddPayloadThenChecksum(MakeAlignedRope(MakeData('B', BlockSize)));
+                NDDisk::TBlockSelector(1 + i, 0, BlockSize), NDDisk::TWriteInstruction(0));
+            w->AddPayloadThenChecksum(MakeAlignedRope(MakeData('B' + i, BlockSize)));
             SendToDDisk(ctx, disk.ServiceId, w.release());
 
-            // No snapshot (ChunkMapSnapshotLsn already set).
-            // No refill (ReserveInFlight=true from write 1).
-            auto logIncr2 = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-            UNIT_ASSERT_VALUES_EQUAL(logIncr2->Get()->CommitRecord.CommitChunks[0], chunkBase + 1);
-            replyLog(logIncr2);
-
-            auto writeRaw2 = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
-            ctx.SendPDiskResponse(disk, *writeRaw2, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
-            auto wr2 = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
-            AssertStatus(wr2, TReplyStatus::OK);
+            auto traffic = ctx.CollectAllocationTraffic(disk, false, 1, /*holdReserve=*/ true);
+            UNIT_ASSERT(!traffic.Reserve);
+            UNIT_ASSERT_VALUES_EQUAL(traffic.Increment->Get()->CommitRecord.CommitChunks.size(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(traffic.Increment->Get()->CommitRecord.CommitChunks[0], chunkBase + 2 + i);
+            ctx.SendPDiskResponse(disk, *traffic.DataWrites[0], new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+            ctx.ReplyLog(disk, *traffic.Increment);
+            auto wr = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
+            AssertStatus(wr, TReplyStatus::OK);
         }
         // State: ChunkReserve=[] (empty), ReserveInFlight=true
 
-        // --- Write 3 (VChunk 2): ChunkReserve empty → allocation queued, no log in-flight ---
+        // --- Write 4 (VChunk 3): ChunkReserve empty → allocation queued, no log in-flight ---
         {
             auto w = std::make_unique<NDDisk::TEvWrite>(creds,
-                NDDisk::TBlockSelector(2, 0, BlockSize), NDDisk::TWriteInstruction(0));
-            w->AddPayloadThenChecksum(MakeAlignedRope(MakeData('C', BlockSize)));
+                NDDisk::TBlockSelector(3, 0, BlockSize), NDDisk::TWriteInstruction(0));
+            w->AddPayloadThenChecksum(MakeAlignedRope(MakeData('D', BlockSize)));
             SendToDDisk(ctx, disk.ServiceId, w.release());
-            // Write is now in PendingEventsForChunk[201][2]; ChunkMapIncrementsInFlight is empty.
+            // Write is now in PendingEventsForChunk[201][3]; ChunkMapIncrementsInFlight is empty.
         }
 
-        // DeleteTabletChunks must be rejected because write 3 is pending allocation.
+        // DeleteTabletChunks must be rejected because write 4 is pending allocation.
         auto deleteResult = SendToDDiskAndWait<NDDisk::TEvDeleteTabletChunksResult>(
             ctx, disk.ServiceId, new NDDisk::TEvDeleteTabletChunks(creds));
         AssertStatus(deleteResult, TReplyStatus::BUSY);
@@ -2907,41 +3165,565 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         write->AddPayloadThenChecksum(MakeAlignedRope(MakeData('Z', BlockSize)));
         SendToDDisk(ctx, disk.ServiceId, write.release());
 
-        // Increment log: after this reply ChunkRef[202][0].ChunkIdx = chunkA.
-        auto logIncr = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        UNIT_ASSERT_VALUES_EQUAL(logIncr->Get()->CommitRecord.CommitChunks.size(), 1u);
-        UNIT_ASSERT_VALUES_EQUAL(logIncr->Get()->CommitRecord.CommitChunks[0], chunkA);
-        replyLog(logIncr);
-
-        // Snapshot log (first allocation ever).
-        auto logSnap = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        replyLog(logSnap);
-
-        // Refill reserve.
-        auto refill = ctx.WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
-        auto refillReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
-        refillReply->ChunkIds.push_back(chunkA + 2);
-        ctx.SendPDiskResponse(disk, *refill, refillReply.release());
-
-        // Take the write-raw off the edge but do NOT reply — the chunk has no user data yet.
-        auto writeRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
-        UNIT_ASSERT_VALUES_EQUAL(writeRaw->Get()->ChunkIdx, chunkA);
-        Y_UNUSED(writeRaw);
+        auto traffic = ctx.CollectAllocationTraffic(disk, true, 1);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.Increment->Get()->CommitRecord.CommitChunks.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.Increment->Get()->CommitRecord.CommitChunks[0], chunkA + 1);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.Increment->Get()->CommitRecord.CommitChunks[1], chunkA);
+        UNIT_ASSERT_VALUES_EQUAL(traffic.DataWrites[0]->Get()->ChunkIdx, chunkA);
+        ctx.ReplyLog(disk, *traffic.Increment);
+        // Leave the data write unreplied — the chunk has no user data yet.
 
         // ChunkIdx is set, no in-flight increments, no pending events — delete must succeed.
         SendToDDisk(ctx, disk.ServiceId, new NDDisk::TEvDeleteTabletChunks(creds));
 
-        // The delete emits a snapshot log with the freed chunk in DeleteChunks.
-        auto deleteLog = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
-        const auto& cr = deleteLog->Get()->CommitRecord;
-        UNIT_ASSERT(cr.IsStartingPoint);
-        UNIT_ASSERT(cr.CommitChunks.empty());
-        UNIT_ASSERT_VALUES_EQUAL(cr.DeleteChunks.size(), 1u);
-        UNIT_ASSERT_VALUES_EQUAL(cr.DeleteChunks[0], chunkA);
+        // Phase 1 durably removes the tablet mapping and deallocates only the data chunk. The
+        // integrity chunk must remain owned while the deletion record is unacknowledged.
+        auto deleteDataLog = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
+        const auto& dataCr = deleteDataLog->Get()->CommitRecord;
+        UNIT_ASSERT(dataCr.IsStartingPoint);
+        UNIT_ASSERT(dataCr.CommitChunks.empty());
+        UNIT_ASSERT_VALUES_EQUAL(dataCr.DeleteChunks.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(dataCr.DeleteChunks[0], chunkA);
+        {
+            NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord record;
+            UNIT_ASSERT(record.ParseFromArray(
+                deleteDataLog->Get()->Data.data(), deleteDataLog->Get()->Data.size()));
+            UNIT_ASSERT(record.HasSnapshot());
+            UNIT_ASSERT_VALUES_EQUAL(record.GetSnapshot().TabletRecordsSize(), 0u);
+            UNIT_ASSERT_VALUES_EQUAL(record.GetSnapshot().IntegrityChunksSize(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(record.GetSnapshot().GetIntegrityChunks(0).GetChunkIdx(), chunkA + 1);
+        }
 
-        replyLog(deleteLog);
+        // The old extent is still quarantined: a new write from the same tablet is BUSY until the
+        // first snapshot is acknowledged.
+        auto blockedWrite = std::make_unique<NDDisk::TEvWrite>(creds,
+            NDDisk::TBlockSelector(1, 0, BlockSize), NDDisk::TWriteInstruction(0));
+        blockedWrite->AddPayloadThenChecksum(MakeAlignedRope(MakeData('Q', BlockSize)));
+        auto blockedResult = SendToDDiskAndWait<NDDisk::TEvWriteResult>(
+            ctx, disk.ServiceId, blockedWrite.release());
+        AssertStatus(blockedResult, TReplyStatus::BUSY);
+
+        replyLog(deleteDataLog);
+
+        // Phase 2 releases the now-empty integrity chunk only after phase 1 is durable.
+        auto deleteIntegrityLog = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
+        const auto& integrityCr = deleteIntegrityLog->Get()->CommitRecord;
+        UNIT_ASSERT(integrityCr.IsStartingPoint);
+        UNIT_ASSERT(integrityCr.CommitChunks.empty());
+        UNIT_ASSERT_VALUES_EQUAL(integrityCr.DeleteChunks.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(integrityCr.DeleteChunks[0], chunkA + 1);
+        {
+            NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord record;
+            UNIT_ASSERT(record.ParseFromArray(
+                deleteIntegrityLog->Get()->Data.data(), deleteIntegrityLog->Get()->Data.size()));
+            UNIT_ASSERT(record.HasSnapshot());
+            UNIT_ASSERT_VALUES_EQUAL(record.GetSnapshot().IntegrityChunksSize(), 0u);
+        }
+
+        replyLog(deleteIntegrityLog);
         auto deleteResult = WaitFromDDisk<NDDisk::TEvDeleteTabletChunksResult>(ctx);
         AssertStatus(deleteResult, TReplyStatus::OK);
+    }
+
+    Y_UNIT_TEST(IntegrityFormattingAndDataWriteRunBeforeCombinedIncrement) {
+        // Reserved chunks may be formatted immediately. Header replicas and the extent format
+        // run in parallel with the data write; a single combined increment is logged only after
+        // the extent is Ready, and the client reply waits for that record to commit.
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(24, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 203, 1);
+
+        const ui32 dataChunk = disk.FirstChunkId + PersistentBufferInitChunks;
+        const ui32 integrityChunk = dataChunk + 1;
+
+        auto write = std::make_unique<NDDisk::TEvWrite>(creds,
+            NDDisk::TBlockSelector(0, 0, BlockSize), NDDisk::TWriteInstruction(0));
+        write->AddPayloadThenChecksum(MakeAlignedRope(MakeData('A', BlockSize)));
+        SendToDDisk(ctx, disk.ServiceId, write.release());
+
+        auto logSnap = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvLog>(disk);
+        UNIT_ASSERT(TTestContext::ParseChunkMapLog(*logSnap->Get()).HasSnapshot());
+        ctx.ReplyLog(disk, *logSnap);
+
+        std::vector<std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>>> formatWrites;
+        std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>> dataWrite;
+        std::unique_ptr<TEventHandle<NPDisk::TEvChunkReserve>> refill;
+        for (ui32 guard = 0; formatWrites.size() < 4 || !dataWrite; ++guard) {
+            UNIT_ASSERT_C(guard < 32, "did not observe parallel formatting I/O and the data write");
+            std::unique_ptr<IEventHandle> raw = ctx.Runtime.WaitForEdgeActorEvent({disk.PDiskEdge});
+            const ui32 type = raw->GetTypeRewrite();
+            UNIT_ASSERT_C(type != NPDisk::TEvLog::EventType,
+                "combined increment must not be issued before formatting writes complete");
+            if (type == NPDisk::TEvCheckSpace::EventType) {
+                auto checkSpace = std::unique_ptr<TEventHandle<NPDisk::TEvCheckSpace>>(
+                    reinterpret_cast<TEventHandle<NPDisk::TEvCheckSpace>*>(raw.release()));
+                ctx.SendPDiskResponse(disk, *checkSpace,
+                    new NPDisk::TEvCheckSpaceResult(NKikimrProto::OK, 0, 0, 0, 0, 0, 0, 0, "", 0));
+                continue;
+            }
+            if (type == NPDisk::TEvChunkReserve::EventType) {
+                UNIT_ASSERT(!refill);
+                refill = std::unique_ptr<TEventHandle<NPDisk::TEvChunkReserve>>(
+                    reinterpret_cast<TEventHandle<NPDisk::TEvChunkReserve>*>(raw.release()));
+                continue;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(type, NPDisk::TEvChunkWriteRaw::EventType);
+            auto writeRaw = std::unique_ptr<TEventHandle<NPDisk::TEvChunkWriteRaw>>(
+                reinterpret_cast<TEventHandle<NPDisk::TEvChunkWriteRaw>*>(raw.release()));
+            if (TTestContext::IsIntegrityMetadataWrite(*writeRaw->Get())) {
+                UNIT_ASSERT_VALUES_EQUAL(writeRaw->Get()->ChunkIdx, integrityChunk);
+                formatWrites.push_back(std::move(writeRaw));
+            } else {
+                UNIT_ASSERT(!dataWrite);
+                UNIT_ASSERT_VALUES_EQUAL(writeRaw->Get()->ChunkIdx, dataChunk);
+                dataWrite = std::move(writeRaw);
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL(formatWrites.size(), 4u);
+        UNIT_ASSERT(dataWrite);
+
+        // Exercise the completion order most likely on a real disk: the single large extent write
+        // may settle independently of the three small headers. Complete it first; the manager UT
+        // asserts explicitly that the final header is what publishes readiness in this ordering.
+        const auto extentIt = std::find_if(formatWrites.begin(), formatWrites.end(), [](const auto& formatWrite) {
+            return formatWrite->Get()->Data.size() != sizeof(NDDisk::TIntegrityChunkHeader);
+        });
+        UNIT_ASSERT(extentIt != formatWrites.end());
+        ctx.SendPDiskResponse(disk, **extentIt, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        for (auto& formatWrite : formatWrites) {
+            if (formatWrite.get() != extentIt->get()) {
+                UNIT_ASSERT_VALUES_EQUAL(formatWrite->Get()->Data.size(), sizeof(NDDisk::TIntegrityChunkHeader));
+                ctx.SendPDiskResponse(disk, *formatWrite,
+                    new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+            }
+        }
+
+        std::unique_ptr<TEventHandle<NPDisk::TEvLog>> logIncr;
+        while (!logIncr) {
+            std::unique_ptr<IEventHandle> raw = ctx.Runtime.WaitForEdgeActorEvent({disk.PDiskEdge});
+            const ui32 type = raw->GetTypeRewrite();
+            if (type == NPDisk::TEvCheckSpace::EventType) {
+                auto checkSpace = std::unique_ptr<TEventHandle<NPDisk::TEvCheckSpace>>(
+                    reinterpret_cast<TEventHandle<NPDisk::TEvCheckSpace>*>(raw.release()));
+                ctx.SendPDiskResponse(disk, *checkSpace,
+                    new NPDisk::TEvCheckSpaceResult(NKikimrProto::OK, 0, 0, 0, 0, 0, 0, 0, "", 0));
+                continue;
+            }
+            if (type == NPDisk::TEvChunkReserve::EventType) {
+                UNIT_ASSERT(!refill);
+                refill = std::unique_ptr<TEventHandle<NPDisk::TEvChunkReserve>>(
+                    reinterpret_cast<TEventHandle<NPDisk::TEvChunkReserve>*>(raw.release()));
+                continue;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(type, NPDisk::TEvLog::EventType);
+            logIncr = std::unique_ptr<TEventHandle<NPDisk::TEvLog>>(
+                reinterpret_cast<TEventHandle<NPDisk::TEvLog>*>(raw.release()));
+        }
+
+        if (refill) {
+            auto refillReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
+            for (ui32 i = 0; i < refill->Get()->SizeChunks; ++i) {
+                refillReply->ChunkIds.push_back(dataChunk + 2 + i);
+            }
+            ctx.SendPDiskResponse(disk, *refill, refillReply.release());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(logIncr->Get()->CommitRecord.CommitChunks.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(logIncr->Get()->CommitRecord.CommitChunks[0], integrityChunk);
+        UNIT_ASSERT_VALUES_EQUAL(logIncr->Get()->CommitRecord.CommitChunks[1], dataChunk);
+        {
+            const auto record = TTestContext::ParseChunkMapLog(*logIncr->Get());
+            UNIT_ASSERT(record.HasIncrement());
+            const auto& increment = record.GetIncrement();
+            UNIT_ASSERT(increment.HasIntegrityChunk());
+            UNIT_ASSERT_VALUES_EQUAL(increment.GetIntegrityChunk().GetChunkIdx(), integrityChunk);
+            UNIT_ASSERT_VALUES_EQUAL(increment.GetIntegrityChunk().GetGeneration(), 2u);
+            const auto& data = increment.GetDataChunk();
+            UNIT_ASSERT_VALUES_EQUAL(data.GetTabletId(), 203u);
+            UNIT_ASSERT_VALUES_EQUAL(data.GetVChunkIndex(), 0u);
+            UNIT_ASSERT_VALUES_EQUAL(data.GetChunkIdx(), dataChunk);
+            UNIT_ASSERT_VALUES_EQUAL(data.GetExtentRef().GetIntegrityChunkIdx(), integrityChunk);
+            UNIT_ASSERT_VALUES_EQUAL(data.GetExtentRef().GetExtentSlot(), 0u);
+            UNIT_ASSERT_VALUES_EQUAL(data.GetExtentRef().GetVChunkGeneration(), 1u);
+        }
+
+        ctx.SendPDiskResponse(disk, *dataWrite, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+
+        TActorId sentinelEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.Send(new IEventHandle(sentinelEdge, ctx.Edge, new TEvents::TEvWakeup()), NodeId);
+        auto ev = ctx.Runtime.WaitForEdgeActorEvent({ctx.Edge, sentinelEdge});
+        UNIT_ASSERT_VALUES_EQUAL_C(ev->Recipient, sentinelEdge,
+            "TEvWriteResult must wait for the combined increment to commit");
+
+        ctx.ReplyLog(disk, *logIncr);
+        auto writeResult = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
+        AssertStatus(writeResult, TReplyStatus::OK);
+    }
+
+    Y_UNIT_TEST(IntegrityFormattingFailureEntersLiveBrokenState) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(26, 1);
+        const TActorId ddiskActorId =
+            ctx.Runtime.GetNode(NodeId)->ActorSystem->LookupLocalService(disk.ServiceId);
+        UNIT_ASSERT(ddiskActorId);
+
+        // A Broken transition caused by integrity formatting must not notify NodeWarden or kill
+        // either the DDisk actor or its separate PersistentBuffer actor.
+        const TActorId wardenEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(MakeBlobStorageNodeWardenID(NodeId), wardenEdge);
+        std::atomic_bool sawGone = false;
+        ctx.Runtime.FilterFunction = [&](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvents::TEvGone::EventType) {
+                sawGone.store(true);
+                return false;
+            }
+            return true;
+        };
+
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 205, 1);
+        const ui32 srcPDiskId = 98;
+        const ui32 srcSlotId = 1;
+        const TActorId fakeSourceEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+        ctx.Runtime.RegisterService(
+            MakeBlobStorageDDiskId(NodeId, srcPDiskId, srcSlotId), fakeSourceEdge);
+
+        // The triggering request is a Sync whose source read succeeds, then waits for the target
+        // data chunk and its first integrity extent to be formatted.
+        auto sync = std::make_unique<NDDisk::TEvSync>(creds);
+        sync->AddSegmentFromDDisk(
+            MakeSyncSourceId(srcPDiskId, srcSlotId), 42,
+            NDDisk::TBlockSelector(0, 0, BlockSize));
+        SendToDDisk(ctx, disk.ServiceId, sync.release());
+
+        auto sourceRead = ctx.Runtime.WaitForEdgeActorEvent({fakeSourceEdge});
+        UNIT_ASSERT_VALUES_EQUAL(sourceRead->GetTypeRewrite(), static_cast<ui32>(NDDisk::TEv::EvRead));
+        ctx.Runtime.Send(new IEventHandle(sourceRead->Sender, fakeSourceEdge,
+            new NDDisk::TEvReadResult(
+                TReplyStatus::OK, std::nullopt, TRope(MakeData('S', BlockSize))),
+            0, sourceRead->Cookie), NodeId);
+
+        auto snapshotLog = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvLog>(disk);
+        auto headerWrite = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvChunkWriteRaw>(disk);
+        UNIT_ASSERT(TTestContext::IsIntegrityMetadataWrite(*headerWrite->Get()));
+        ctx.SendPDiskResponse(disk, *headerWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::ERROR, "injected integrity failure"));
+
+        auto syncResult = WaitFromDDisk<NDDisk::TEvSyncResult>(ctx);
+        AssertStatus(syncResult, TReplyStatus::ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(syncResult->Get()->Record.SegmentResultsSize(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(syncResult->Get()->Record.GetSegmentResults(0).GetStatus()),
+            static_cast<int>(TReplyStatus::ERROR));
+
+        // Every future DDisk data operation fails immediately with the latched reason.
+        auto readResult = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx, disk.ServiceId, new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}));
+        AssertStatus(readResult, TReplyStatus::ERROR);
+
+        auto write = std::make_unique<NDDisk::TEvWrite>(
+            creds, NDDisk::TBlockSelector(0, 0, BlockSize), NDDisk::TWriteInstruction(0));
+        write->AddPayloadThenChecksum(MakeAlignedRope(MakeData('W', BlockSize)));
+        auto writeResult = SendToDDiskAndWait<NDDisk::TEvWriteResult>(
+            ctx, disk.ServiceId, write.release());
+        AssertStatus(writeResult, TReplyStatus::ERROR);
+
+        auto futureSync = SendToDDiskAndWait<NDDisk::TEvSyncResult>(
+            ctx, disk.ServiceId, new NDDisk::TEvSync(creds));
+        AssertStatus(futureSync, TReplyStatus::ERROR);
+        auto deleteResult = SendToDDiskAndWait<NDDisk::TEvDeleteTabletChunksResult>(
+            ctx, disk.ServiceId, new NDDisk::TEvDeleteTabletChunks(creds));
+        AssertStatus(deleteResult, TReplyStatus::ERROR);
+
+        // Duplicate raw-I/O completion, an outstanding log completion, and an arbitrary late
+        // integrity completion are consumed without resurrecting allocation or sending a second
+        // client reply.
+        ctx.SendPDiskResponse(disk, *headerWrite,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto snapshotReply = std::make_unique<NPDisk::TEvLogResult>(NKikimrProto::OK, 0, "", 0);
+        snapshotReply->Results.emplace_back(snapshotLog->Get()->Lsn, snapshotLog->Get()->Cookie);
+        ctx.SendPDiskResponse(disk, *snapshotLog, snapshotReply.release());
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TDDiskActor::TEvPrivate::TEvIntegrityIoResult(
+                999999, TReplyStatus::OK));
+
+        // Connection bookkeeping and PersistentBuffer remain operational.
+        NDDisk::TQueryCredentials anotherCreds = Connect(ctx, disk.ServiceId, 206, 1);
+        Y_UNUSED(anotherCreds);
+        SendToDDisk(ctx, disk.PBServiceId, new NDDisk::TEvGetPersistentBufferInfo(false, false));
+        auto pbInfo = WaitFromDDisk<NDDisk::TEvPersistentBufferInfo>(ctx);
+        UNIT_ASSERT(pbInfo);
+
+        UNIT_ASSERT(ctx.Runtime.WrapInActorContext(ddiskActorId, [](IActor*) {}));
+        UNIT_ASSERT(!sawGone.load());
+        ctx.Runtime.FilterFunction = {};
+    }
+
+    Y_UNIT_TEST(DDiskIoCompletionIsSerializedThroughBrokenState) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(27, 1);
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 207, 1);
+
+        // Establish a ready data chunk so the next write consists only of client data I/O.
+        const TString initialPayload = MakeData('A', BlockSize);
+        auto initialWrite = std::make_unique<NDDisk::TEvWrite>(
+            creds, NDDisk::TBlockSelector(7, 0, BlockSize), NDDisk::TWriteInstruction(0));
+        initialWrite->AddPayloadThenChecksum(MakeAlignedRope(initialPayload));
+        auto initial = DoWriteWithChunkAllocation(
+            ctx, disk, std::move(initialWrite),
+            disk.FirstChunkId + PersistentBufferInitChunks, 0, initialPayload,
+            true, true);
+        AssertStatus(initial.WriteResult, TReplyStatus::OK);
+
+        // Hold the completion-thread callback before it reaches the DDisk actor. No client reply
+        // is emitted directly from the completion thread.
+        std::unique_ptr<IEventHandle> heldCompletion;
+        ctx.Runtime.FilterFunction = [&](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev) {
+            if (!heldCompletion && ev->GetTypeRewrite()
+                    == NDDisk::TDDiskActor::TEvPrivate::TEvDDiskIoResult::EventType) {
+                heldCompletion = std::move(ev);
+                return false;
+            }
+            return true;
+        };
+
+        auto pendingWrite = std::make_unique<NDDisk::TEvWrite>(
+            creds, NDDisk::TBlockSelector(7, 0, BlockSize), NDDisk::TWriteInstruction(0));
+        pendingWrite->AddPayloadThenChecksum(MakeAlignedRope(MakeData('B', BlockSize)));
+        SendToDDisk(ctx, disk.ServiceId, pendingWrite.release());
+        auto writeRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+        ctx.SendPDiskResponse(disk, *writeRaw,
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+
+        ui32 eventsProcessed = 0;
+        ctx.Runtime.Sim([&] {
+            return !heldCompletion && ++eventsProcessed <= 200;
+        });
+        UNIT_ASSERT_C(heldCompletion, "DDisk I/O completion callback was not captured");
+        ctx.Runtime.FilterFunction = {};
+
+        // Actor-mailbox ordering is the health barrier: once this failure is handled, the delayed
+        // successful data callback must be converted into an ERROR response.
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TDDiskActor::TEvPrivate::TEvIntegrityIoResult(
+                999998, TReplyStatus::ERROR, "injected integrity failure"));
+        auto brokenRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx, disk.ServiceId, new NDDisk::TEvRead(creds, {7, 0, BlockSize}, {true}));
+        AssertStatus(brokenRead, TReplyStatus::ERROR);
+
+        ctx.Runtime.Send(std::move(heldCompletion), NodeId);
+        auto writeResult = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
+        AssertStatus(writeResult, TReplyStatus::ERROR);
+    }
+
+    Y_UNIT_TEST(IntegrityMappingRestoredOnBootAndCutLogDeferred) {
+        // The DataChunk -> IntegrityExtent mapping is persisted in the chunk-map snapshot and log
+        // increments. On boot the DDisk must keep recovered integrity chunks that still have
+        // extents, reclaim empty ones immediately (every restored chunk is Ready — a durable
+        // increment is only logged after formatting), defer CutLog until replay has populated the
+        // manager, pass reads of restored data chunks through unchanged (bitmaps unknown), and keep
+        // the generation watermark monotonic.
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.RegisterDDisk(25, 1);
+
+        const NPDisk::TOwner Owner = 1;
+        const NPDisk::TOwnerRound OwnerRound = 1;
+        const ui64 snapshotLsn = 10;
+
+        auto init = ctx.WaitPDiskRequest<NPDisk::TEvYardInit>(disk);
+        TVector<ui32> ownedChunks;
+        auto initReply = std::make_unique<NPDisk::TEvYardInitResult>(
+            NKikimrProto::OK,
+            0, 0, 0, // seek/read/write speed
+            BlockSize, BlockSize, BlockSize,
+            TTestContext::ChunkSize,
+            BlockSize,
+            Owner,
+            OwnerRound,
+            1, // slot size in units
+            0, // status flags
+            std::move(ownedChunks),
+            NPDisk::DEVICE_TYPE_NVME,
+            false,
+            BlockSize,
+            "");
+        NPDisk::TDiskFormat format = {};
+        format.Clear(false);
+        initReply->DiskFormat = NPDisk::TDiskFormatPtr(new NPDisk::TDiskFormat(format), +[](NPDisk::TDiskFormat* ptr) {
+            delete ptr;
+        });
+
+        // Starting point: one data chunk of tablet 204 mapped to an extent of integrity chunk 600,
+        // plus a second committed integrity chunk 601.
+        {
+            NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord chunkMap;
+            auto* snapshot = chunkMap.MutableSnapshot();
+            auto* tabletRecord = snapshot->AddTabletRecords();
+            tabletRecord->SetTabletId(204);
+            auto* chunkRef = tabletRecord->AddChunkRefs();
+            chunkRef->SetVChunkIndex(0);
+            chunkRef->SetChunkIdx(500);
+            auto* extentRef = chunkRef->MutableExtentRef();
+            extentRef->SetIntegrityChunkIdx(600);
+            extentRef->SetExtentSlot(0);
+            extentRef->SetVChunkGeneration(1);
+            for (const ui32 chunkIdx : {600, 601}) {
+                auto* integrityChunk = snapshot->AddIntegrityChunks();
+                integrityChunk->SetChunkIdx(chunkIdx);
+                integrityChunk->SetGeneration(1);
+            }
+            // Watermark above every restored generation: new allocations must draw past it.
+            snapshot->SetGenerationCounter(3);
+
+            TString data;
+            UNIT_ASSERT(chunkMap.SerializeToString(&data));
+            initReply->StartingPoints[TLogSignature::SignatureDDiskChunkMap] =
+                NPDisk::TLogRecord(TLogSignature::SignatureDDiskChunkMap, TRcBuf(data), snapshotLsn);
+        }
+        ctx.SendPDiskResponse(disk, *init, initReply.release());
+
+        // Log replay past the snapshot: one combined increment that first records integrity
+        // chunk 602, then the data chunk that uses it.
+        auto readLog = ctx.WaitPDiskRequest<NPDisk::TEvReadLog>(disk);
+        auto readLogReply = std::make_unique<NPDisk::TEvReadLogResult>(
+            NKikimrProto::OK,
+            readLog->Get()->Position,
+            readLog->Get()->Position,
+            true, // end of log
+            0,    // status flags
+            "",
+            Owner);
+        {
+            NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord chunkMap;
+            auto* increment = chunkMap.MutableIncrement();
+            auto* chunk = increment->MutableIntegrityChunk();
+            chunk->SetChunkIdx(602);
+            chunk->SetGeneration(1);
+            auto* dataInc = increment->MutableDataChunk();
+            dataInc->SetTabletId(204);
+            dataInc->SetVChunkIndex(1);
+            dataInc->SetChunkIdx(501);
+            auto* extentRef = dataInc->MutableExtentRef();
+            extentRef->SetIntegrityChunkIdx(602);
+            extentRef->SetExtentSlot(0);
+            extentRef->SetVChunkGeneration(1);
+            TString data;
+            UNIT_ASSERT(chunkMap.SerializeToString(&data));
+            readLogReply->Results.emplace_back(TLogSignature::SignatureDDiskChunkMap, TRcBuf(data),
+                snapshotLsn + 1);
+        }
+        // YardInit already registered this actor as the CutLog recipient, so PDisk may ask for a
+        // new starting point before this ReadLog result completes recovery. Send both messages
+        // from the PDisk edge to preserve their order at the DDisk mailbox.
+        ctx.Runtime.Send(new IEventHandle(disk.ServiceId, disk.PDiskEdge,
+            new NPDisk::TEvCutLog(0, 0, Max<ui64>(), 0, 0, 0, 0)), NodeId);
+        ctx.SendPDiskResponse(disk, *readLog, readLogReply.release());
+
+        // End-of-log: chunk 600 is kept for its restored extent; empty chunk 601 is reclaimed
+        // immediately; chunk 602 was restored from the increment and has an extent. No header
+        // rewrites — every restored chunk is already Ready.
+        auto reclaimLog = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvLog>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(reclaimLog->Get()->CommitRecord.DeleteChunks.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(reclaimLog->Get()->CommitRecord.DeleteChunks[0], 601u);
+        {
+            NKikimrBlobStorage::NDDisk::NInternal::TChunkMapLogRecord record;
+            UNIT_ASSERT(record.ParseFromArray(
+                reclaimLog->Get()->Data.data(), reclaimLog->Get()->Data.size()));
+            UNIT_ASSERT(record.HasSnapshot());
+            UNIT_ASSERT_VALUES_EQUAL(record.GetSnapshot().IntegrityChunksSize(), 2u);
+        }
+        ctx.ReplyLog(disk, *reclaimLog);
+
+        // The deferred CutLog is processed only after ApplyMappingSnapshot and the empty-chunk
+        // reclaim above. Its snapshot must contain the complete recovered mapping and watermark.
+        auto cutLogSnapshot = ctx.WaitPDiskRequestNoAutoServe<NPDisk::TEvLog>(disk);
+        UNIT_ASSERT(cutLogSnapshot->Get()->CommitRecord.IsStartingPoint);
+        UNIT_ASSERT(cutLogSnapshot->Get()->CommitRecord.CommitChunks.empty());
+        UNIT_ASSERT(cutLogSnapshot->Get()->CommitRecord.DeleteChunks.empty());
+        {
+            const auto record = TTestContext::ParseChunkMapLog(*cutLogSnapshot->Get());
+            UNIT_ASSERT(record.HasSnapshot());
+            const auto& snapshot = record.GetSnapshot();
+            UNIT_ASSERT_VALUES_EQUAL(snapshot.GetGenerationCounter(), 3u);
+            UNIT_ASSERT_VALUES_EQUAL(snapshot.IntegrityChunksSize(), 2u);
+
+            std::map<ui64, std::tuple<ui32, ui32, ui32, ui64>> refs;
+            for (const auto& tablet : snapshot.GetTabletRecords()) {
+                UNIT_ASSERT_VALUES_EQUAL(tablet.GetTabletId(), 204u);
+                for (const auto& chunk : tablet.GetChunkRefs()) {
+                    refs.emplace(chunk.GetVChunkIndex(), std::make_tuple(
+                        chunk.GetChunkIdx(),
+                        chunk.GetExtentRef().GetIntegrityChunkIdx(),
+                        chunk.GetExtentRef().GetExtentSlot(),
+                        chunk.GetExtentRef().GetVChunkGeneration()));
+                }
+            }
+            UNIT_ASSERT_VALUES_EQUAL(refs.size(), 2u);
+            UNIT_ASSERT(refs.at(0) == std::make_tuple(500u, 600u, 0u, 1u));
+            UNIT_ASSERT(refs.at(1) == std::make_tuple(501u, 602u, 0u, 1u));
+        }
+        ctx.ReplyLog(disk, *cutLogSnapshot);
+
+        auto reserve = ctx.WaitPDiskRequest<NPDisk::TEvChunkReserve>(disk);
+        auto reserveReply = std::make_unique<NPDisk::TEvChunkReserveResult>(NKikimrProto::OK, 0);
+        for (ui32 i = 0; i < PersistentBufferInitChunks + MinChunksReserved; ++i) {
+            reserveReply->ChunkIds.push_back(disk.FirstChunkId + i);
+        }
+        ctx.SendPDiskResponse(disk, *reserve, reserveReply.release());
+        for (ui32 i = 0; i < PersistentBufferInitChunks; ++i) {
+            auto log = ctx.WaitPDiskRequest<NPDisk::TEvLog>(disk);
+            ctx.ReplyLog(disk, *log);
+        }
+        auto checkSpace = ctx.WaitPDiskRequest<NPDisk::TEvCheckSpace>(disk);
+        ctx.SendPDiskResponse(disk, *checkSpace,
+            new NPDisk::TEvCheckSpaceResult(NKikimrProto::OK, 0, 0, 0, 0, 0, 0, 0, "", 0));
+
+        UNIT_ASSERT(ctx.AutoServedIntegrityWriteChunks.empty());
+
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 204, 1);
+        for (const auto& [vChunkIndex, chunkIdx] : std::vector<std::pair<ui64, ui32>>{{0, 500}, {1, 501}}) {
+            SendToDDisk(ctx, disk.ServiceId, new NDDisk::TEvRead(creds, {vChunkIndex, 0, BlockSize}, {true}));
+            auto readRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
+            UNIT_ASSERT_VALUES_EQUAL(readRaw->Get()->ChunkIdx, chunkIdx);
+            ctx.SendPDiskResponse(disk, *readRaw,
+                new NPDisk::TEvChunkReadRawResult(TRope(MakeData('R', BlockSize))));
+            auto readResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
+            AssertStatus(readResult, TReplyStatus::OK);
+        }
+
+        // A write to a restored chunk needs no allocation, log record or integrity formatting:
+        // it goes straight to the data chunk.
+        auto write = std::make_unique<NDDisk::TEvWrite>(creds,
+            NDDisk::TBlockSelector(0, 0, BlockSize), NDDisk::TWriteInstruction(0));
+        write->AddPayloadThenChecksum(MakeAlignedRope(MakeData('W', BlockSize)));
+        SendToDDisk(ctx, disk.ServiceId, write.release());
+        auto writeRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(writeRaw->Get()->ChunkIdx, 500u);
+        ctx.SendPDiskResponse(disk, *writeRaw, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        auto writeResult = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
+        AssertStatus(writeResult, TReplyStatus::OK);
+
+        UNIT_ASSERT(ctx.AutoServedIntegrityWriteChunks.empty());
+
+        // A brand-new allocation (VChunk 2) draws its generation past the persisted watermark
+        // (3) and reuses a free slot of the lowest restored chunk. The extent format write and
+        // the reserve refill are auto-served; the increment carries the extent ref and does not
+        // re-commit chunk 600.
+        auto write2 = std::make_unique<NDDisk::TEvWrite>(creds,
+            NDDisk::TBlockSelector(2, 0, BlockSize), NDDisk::TWriteInstruction(0));
+        write2->AddPayloadThenChecksum(MakeAlignedRope(MakeData('X', BlockSize)));
+        SendToDDisk(ctx, disk.ServiceId, write2.release());
+        auto traffic = ctx.CollectAllocationTraffic(disk, false, 1);
+        {
+            const auto record = TTestContext::ParseChunkMapLog(*traffic.Increment->Get());
+            UNIT_ASSERT(record.HasIncrement());
+            UNIT_ASSERT(!record.GetIncrement().HasIntegrityChunk());
+            const auto& ref = record.GetIncrement().GetDataChunk().GetExtentRef();
+            UNIT_ASSERT_VALUES_EQUAL(ref.GetVChunkGeneration(), 4u);
+            UNIT_ASSERT_VALUES_EQUAL(ref.GetIntegrityChunkIdx(), 600u);
+            UNIT_ASSERT_VALUES_EQUAL(ref.GetExtentSlot(), 1u);
+        }
+        for (const ui32 chunkIdx : ctx.AutoServedIntegrityWriteChunks) {
+            UNIT_ASSERT_VALUES_EQUAL(chunkIdx, 600u);
+        }
     }
 
     Y_UNIT_TEST(DeleteTabletChunks_NoChunks) {

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
@@ -3144,9 +3144,8 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
     }
 
     Y_UNIT_TEST(DeleteTabletChunks_CommittedChunkFreed) {
-        // Verify that a committed-but-not-yet-written chunk (ChunkIdx set, TEvChunkWriteRaw
-        // still pending) is correctly placed in TCommitRecord::DeleteChunks when
-        // DeleteTabletChunks is called.
+        // A committed chunk must not be deleted while its client data I/O is still in flight.
+        // Once the I/O drains, verify the existing two-phase data/integrity deletion.
         TTestContext ctx;
         const TDiskHandle disk = ctx.CreateDDisk(23, 1);
         NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 202, 1);
@@ -3173,7 +3172,96 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         ctx.ReplyLog(disk, *traffic.Increment);
         // Leave the data write unreplied — the chunk has no user data yet.
 
-        // ChunkIdx is set, no in-flight increments, no pending events — delete must succeed.
+        auto assertDeletionBusy = [&] {
+            // Capture either the expected immediate BUSY result or the buggy deletion log. A
+            // bounded simulation fails promptly instead of waiting for an unacknowledged log.
+            std::unique_ptr<IEventHandle> rawDeleteResult;
+            std::unique_ptr<IEventHandle> unexpectedDeleteLog;
+            ctx.Runtime.FilterFunction = [&](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev) {
+                if (!rawDeleteResult
+                        && ev->GetTypeRewrite() == NDDisk::TEvDeleteTabletChunksResult::EventType) {
+                    rawDeleteResult = std::move(ev);
+                    return false;
+                }
+                if (!unexpectedDeleteLog
+                        && ev->GetTypeRewrite() == NPDisk::TEvLog::EventType
+                        && ev->GetRecipientRewrite() == disk.PDiskEdge) {
+                    unexpectedDeleteLog = std::move(ev);
+                    return false;
+                }
+                return true;
+            };
+            SendToDDisk(ctx, disk.ServiceId, new NDDisk::TEvDeleteTabletChunks(creds));
+            ui32 eventsProcessed = 0;
+            ctx.Runtime.Sim([&] {
+                return !rawDeleteResult && !unexpectedDeleteLog && ++eventsProcessed <= 200;
+            });
+            ctx.Runtime.FilterFunction = {};
+            UNIT_ASSERT_C(!unexpectedDeleteLog,
+                "deletion emitted a chunk-map log while client data I/O was in flight");
+            UNIT_ASSERT_C(rawDeleteResult, "DeleteTabletChunks did not return BUSY");
+            auto busyResult = std::unique_ptr<TEventHandle<NDDisk::TEvDeleteTabletChunksResult>>(
+                reinterpret_cast<TEventHandle<NDDisk::TEvDeleteTabletChunksResult>*>(
+                    rawDeleteResult.release()));
+            AssertStatus(busyResult, TReplyStatus::BUSY);
+
+            // The BUSY path must not have queued a deletion log after sending its client result.
+            const TActorId sentinelEdge = ctx.Runtime.AllocateEdgeActor(NodeId, __FILE__, __LINE__);
+            ctx.Runtime.Send(new IEventHandle(sentinelEdge, ctx.Edge, new TEvents::TEvWakeup()), NodeId);
+            for (;;) {
+                auto ev = ctx.Runtime.WaitForEdgeActorEvent({disk.PDiskEdge, sentinelEdge});
+                if (ev->GetTypeRewrite() == NPDisk::TEvCheckSpace::EventType) {
+                    ctx.ConsumeUnsolicitedPDiskEvent(ev);
+                    continue;
+                }
+                UNIT_ASSERT_VALUES_EQUAL_C(ev->Recipient, sentinelEdge,
+                    "deletion queued PDisk traffic after returning BUSY");
+                break;
+            }
+        };
+
+        // The raw fallback write is still outstanding.
+        assertDeletionBusy();
+
+        // Completing the raw write is not enough: deletion must remain blocked until the DDisk
+        // actor processes the completion message in its own mailbox.
+        std::unique_ptr<IEventHandle> heldCompletion;
+        ctx.Runtime.FilterFunction = [&](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev) {
+            if (!heldCompletion && ev->GetTypeRewrite()
+                    == NDDisk::TDDiskActor::TEvPrivate::TEvDDiskIoResult::EventType) {
+                heldCompletion = std::move(ev);
+                return false;
+            }
+            return true;
+        };
+        ctx.SendPDiskResponse(disk, *traffic.DataWrites[0],
+            new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+        ui32 eventsProcessed = 0;
+        ctx.Runtime.Sim([&] {
+            return !heldCompletion && ++eventsProcessed <= 200;
+        });
+        ctx.Runtime.FilterFunction = {};
+        UNIT_ASSERT_C(heldCompletion, "DDisk I/O completion callback was not captured");
+        assertDeletionBusy();
+
+        ctx.Runtime.Send(std::move(heldCompletion), NodeId);
+        auto writeResult = WaitFromDDisk<NDDisk::TEvWriteResult>(ctx);
+        AssertStatus(writeResult, TReplyStatus::OK);
+
+        // Reads hold the same physical chunk alive until their completion reaches the actor.
+        SendToDDisk(ctx, disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}));
+        auto readRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkReadRaw>(disk);
+        UNIT_ASSERT_VALUES_EQUAL(readRaw->Get()->ChunkIdx, chunkA);
+        assertDeletionBusy();
+
+        const TString payload = MakeData('Z', BlockSize);
+        ctx.SendPDiskResponse(disk, *readRaw,
+            new NPDisk::TEvChunkReadRawResult(TRope(payload)));
+        auto readResult = WaitFromDDisk<NDDisk::TEvReadResult>(ctx);
+        AssertStatus(readResult, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), payload);
+
         SendToDDisk(ctx, disk.ServiceId, new NDDisk::TEvDeleteTabletChunks(creds));
 
         // Phase 1 durably removes the tablet mapping and deallocates only the data chunk. The

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
@@ -1800,6 +1800,150 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         UNIT_ASSERT_VALUES_EQUAL(readResult->Get()->GetPayload(0).ConvertToString(), payload);
     }
 
+    // Regression test for DirectBlockGroupIndex-aware persistent buffer keys: two direct block
+    // groups of the SAME tablet, on the SAME generation, writing to the SAME lsn must be stored,
+    // listed, read and erased as fully independent records (TPersistentBufferId /
+    // TPersistentBufferRecordId now include DirectBlockGroupIndex). Before that change all of these
+    // writes would have collided in a single "generation+lsn" slot.
+    Y_UNIT_TEST(PersistentBufferDirectBlockGroupIndexSeparation) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(6, 1);
+        const ui64 tabletId = 40;
+        const ui32 generation = 1;
+        const ui64 lsn = 10;
+        const NDDisk::TBlockSelector selector{3, 0, BlockSize};
+
+        NDDisk::TQueryCredentials credsDbg0 = Connect(ctx, disk.PBServiceId, tabletId, generation, /*directBlockGroupIndex=*/0);
+        NDDisk::TQueryCredentials credsDbg1 = Connect(ctx, disk.PBServiceId, tabletId, generation, /*directBlockGroupIndex=*/1);
+
+        const TString payload0 = MakeData('A', BlockSize);
+        auto write0 = std::make_unique<NDDisk::TEvWritePersistentBuffer>(credsDbg0, selector, lsn, NDDisk::TWriteInstruction(0));
+        write0->AddPayloadThenChecksum(TRope(payload0));
+        SendToDDisk(ctx, disk.PBServiceId, write0.release());
+
+        auto writeRaw0 = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+        UNIT_ASSERT(writeRaw0->Get()->Data.size() > 0);
+        ctx.SendPDiskResponse(disk, *writeRaw0, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+
+        auto writeResult0 = WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx);
+        AssertStatus(writeResult0, TReplyStatus::OK);
+
+        const TString payload1 = MakeData('B', BlockSize);
+        auto write1 = std::make_unique<NDDisk::TEvWritePersistentBuffer>(credsDbg1, selector, lsn, NDDisk::TWriteInstruction(0));
+        write1->AddPayloadThenChecksum(TRope(payload1));
+        SendToDDisk(ctx, disk.PBServiceId, write1.release());
+
+        auto writeRaw1 = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+        UNIT_ASSERT(writeRaw1->Get()->Data.size() > 0);
+        ctx.SendPDiskResponse(disk, *writeRaw1, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+
+        auto writeResult1 = WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx);
+        AssertStatus(writeResult1, TReplyStatus::OK);
+
+        // Each direct block group must only see its own record via ListPersistentBuffer.
+        auto listResultDbg0 = SendToDDiskAndWait<NDDisk::TEvListPersistentBufferResult>(
+            ctx, disk.PBServiceId, new NDDisk::TEvListPersistentBuffer(credsDbg0));
+        AssertStatus(listResultDbg0, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(listResultDbg0->Get()->Record.RecordsSize(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(listResultDbg0->Get()->Record.GetRecords(0).GetLsn(), lsn);
+
+        auto listResultDbg1 = SendToDDiskAndWait<NDDisk::TEvListPersistentBufferResult>(
+            ctx, disk.PBServiceId, new NDDisk::TEvListPersistentBuffer(credsDbg1));
+        AssertStatus(listResultDbg1, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(listResultDbg1->Get()->Record.RecordsSize(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(listResultDbg1->Get()->Record.GetRecords(0).GetLsn(), lsn);
+
+        // Reads must return the payload belonging to the requesting direct block group, not a
+        // mixed/overwritten value.
+        auto readResultDbg0 = SendToDDiskAndWait<NDDisk::TEvReadPersistentBufferResult>(
+            ctx, disk.PBServiceId, new NDDisk::TEvReadPersistentBuffer(credsDbg0, selector, lsn, 1, {true}));
+        AssertStatus(readResultDbg0, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(readResultDbg0->Get()->GetPayload(0).ConvertToString(), payload0);
+
+        auto readResultDbg1 = SendToDDiskAndWait<NDDisk::TEvReadPersistentBufferResult>(
+            ctx, disk.PBServiceId, new NDDisk::TEvReadPersistentBuffer(credsDbg1, selector, lsn, 1, {true}));
+        AssertStatus(readResultDbg1, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(readResultDbg1->Get()->GetPayload(0).ConvertToString(), payload1);
+
+        // Erasing DBG0's record must not affect DBG1's record for the same tablet/generation/lsn.
+        SendToDDisk(ctx, disk.PBServiceId, new NDDisk::TEvErasePersistentBuffer(credsDbg0, lsn));
+        auto eraseRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+        ctx.SendPDiskResponse(disk, *eraseRaw, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+
+        auto eraseResult = WaitFromDDisk<NDDisk::TEvErasePersistentBufferResult>(ctx);
+        AssertStatus(eraseResult, TReplyStatus::OK);
+
+        auto missingReadDbg0 = SendToDDiskAndWait<NDDisk::TEvReadPersistentBufferResult>(
+            ctx, disk.PBServiceId, new NDDisk::TEvReadPersistentBuffer(credsDbg0, selector, lsn, 1, {true}));
+        AssertStatus(missingReadDbg0, TReplyStatus::MISSING_RECORD);
+
+        auto readResultDbg1AfterErase = SendToDDiskAndWait<NDDisk::TEvReadPersistentBufferResult>(
+            ctx, disk.PBServiceId, new NDDisk::TEvReadPersistentBuffer(credsDbg1, selector, lsn, 1, {true}));
+        AssertStatus(readResultDbg1AfterErase, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(readResultDbg1AfterErase->Get()->GetPayload(0).ConvertToString(), payload1);
+
+        auto listResultDbg0AfterErase = SendToDDiskAndWait<NDDisk::TEvListPersistentBufferResult>(
+            ctx, disk.PBServiceId, new NDDisk::TEvListPersistentBuffer(credsDbg0));
+        AssertStatus(listResultDbg0AfterErase, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(listResultDbg0AfterErase->Get()->Record.RecordsSize(), 0);
+
+        auto listResultDbg1AfterErase = SendToDDiskAndWait<NDDisk::TEvListPersistentBufferResult>(
+            ctx, disk.PBServiceId, new NDDisk::TEvListPersistentBuffer(credsDbg1));
+        AssertStatus(listResultDbg1AfterErase, TReplyStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(listResultDbg1AfterErase->Get()->Record.RecordsSize(), 1);
+    }
+
+    // TEvGetPersistentBufferInfo(DescribeTablets=true) must report separate TTabletInfo entries
+    // per (TabletId, DirectBlockGroupIndex) pair, rather than merging every direct block group of a
+    // tablet into one entry.
+    Y_UNIT_TEST(PersistentBufferDirectBlockGroupIndexInfo) {
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(6, 1);
+        const ui64 tabletId = 41;
+        const ui32 generation = 1;
+        const NDDisk::TBlockSelector selector{3, 0, BlockSize};
+
+        NDDisk::TQueryCredentials credsDbg0 = Connect(ctx, disk.PBServiceId, tabletId, generation, /*directBlockGroupIndex=*/0);
+        NDDisk::TQueryCredentials credsDbg2 = Connect(ctx, disk.PBServiceId, tabletId, generation, /*directBlockGroupIndex=*/2);
+
+        auto doWrite = [&](const NDDisk::TQueryCredentials& creds, ui64 lsn, char fill) {
+            auto write = std::make_unique<NDDisk::TEvWritePersistentBuffer>(creds, selector, lsn, NDDisk::TWriteInstruction(0));
+            write->AddPayloadThenChecksum(TRope(MakeData(fill, BlockSize)));
+            SendToDDisk(ctx, disk.PBServiceId, write.release());
+
+            auto writeRaw = ctx.WaitPDiskRequest<NPDisk::TEvChunkWriteRaw>(disk);
+            UNIT_ASSERT(writeRaw->Get()->Data.size() > 0);
+            ctx.SendPDiskResponse(disk, *writeRaw, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::OK, ""));
+
+            auto writeResult = WaitFromDDisk<NDDisk::TEvWritePersistentBufferResult>(ctx);
+            AssertStatus(writeResult, TReplyStatus::OK);
+        };
+
+        doWrite(credsDbg0, /*lsn=*/10, 'X');
+        doWrite(credsDbg2, /*lsn=*/10, 'Y');
+
+        SendToDDisk(ctx, disk.PBServiceId, new NDDisk::TEvGetPersistentBufferInfo(false, true));
+        auto info = WaitFromDDisk<NDDisk::TEvPersistentBufferInfo>(ctx);
+
+        UNIT_ASSERT_VALUES_EQUAL(info->Get()->TabletInfos.size(), 2);
+        bool foundDbg0 = false;
+        bool foundDbg2 = false;
+        for (const auto& ti : info->Get()->TabletInfos) {
+            UNIT_ASSERT_VALUES_EQUAL(ti.TabletId, tabletId);
+            if (ti.DirectBlockGroupIndex == 0) {
+                foundDbg0 = true;
+                UNIT_ASSERT_VALUES_EQUAL(ti.LsnsCount, 1u);
+            } else if (ti.DirectBlockGroupIndex == 2) {
+                foundDbg2 = true;
+                UNIT_ASSERT_VALUES_EQUAL(ti.LsnsCount, 1u);
+            } else {
+                UNIT_FAIL("unexpected DirectBlockGroupIndex " << (ui32)ti.DirectBlockGroupIndex);
+            }
+        }
+        UNIT_ASSERT(foundDbg0);
+        UNIT_ASSERT(foundDbg2);
+    }
+
     Y_UNIT_TEST(PersistentBufferReadPart) {
         TTestContext ctx;
         const TDiskHandle disk = ctx.CreateDDisk(6, 1);

--- a/ydb/core/blobstorage/ddisk/ut/integrity_manager_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/integrity_manager_ut.cpp
@@ -5,6 +5,8 @@
 #include <util/generic/overloaded.h>
 
 #include <algorithm>
+#include <array>
+#include <cstddef>
 #include <cstring>
 #include <vector>
 
@@ -14,6 +16,7 @@ namespace {
 
 using TKey = TIntegrityManager::TDataChunkKey;
 using TWriteIo = TIntegrityManager::TWriteIo;
+using TReadIo = TIntegrityManager::TReadIo;
 using TReadPlan = TIntegrityManager::TReadPlan;
 
 constexpr ui64 TestDDiskId = 0xDD15C1D;
@@ -27,10 +30,12 @@ constexpr ui64 ProductionChunkSize = 128_MB;
 constexpr ui64 SmallChunkSize = 1_MB;
 constexpr ui64 TinyChunkSize = 160_KB;
 constexpr ui64 MultiBlockChunkSize = 4_MB;
+constexpr ui64 PairBoundaryChunkSize = (ChecksumsPerIntegrityBlock + 1) * IntegrityUnitSize;
 
 struct TActionLog {
     ui32 AllocateRequests = 0;
     std::vector<TWriteIo> Writes;
+    std::vector<TReadIo> Reads;
 };
 
 TActionLog Drain(TIntegrityManager& manager) {
@@ -42,6 +47,9 @@ TActionLog Drain(TIntegrityManager& manager) {
             },
             [&](TWriteIo& io) {
                 log.Writes.push_back(std::move(io));
+            },
+            [&](TReadIo& io) {
+                log.Reads.push_back(std::move(io));
             },
         }, action);
     }
@@ -141,6 +149,64 @@ void CheckExtentFormat(const TIntegrityManager& manager, const TWriteIo& io, TKe
     }
 }
 
+TIntegrityBlock MakeIntegrityBlock(TKey key, const TIntegrityManager::TExtentRef& ref,
+        ui64 integrityChunkGeneration, ui32 pairIdx, ui64 sequence,
+        const std::vector<std::pair<ui32, ui64>>& pureChecksums) {
+    TIntegrityBlock block{};
+    auto& header = block.Header;
+    header.Magic = MagicIntegrityBlock;
+    header.FormatVersion = static_cast<ui16>(EIntegrityFormatVersion::BaseAwupf4KiB);
+    header.ChecksumBlockIdx = pairIdx;
+    header.OwnerId = key.TabletId;
+    header.VChunkId = key.VChunkIndex;
+    header.VChunkGeneration = ref.VChunkGeneration;
+    header.IntegrityChunkId = ref.IntegrityChunkIdx;
+    header.IntegrityExtentId = ref.ExtentSlot;
+    header.IntegrityChunkGeneration = integrityChunkGeneration;
+    header.PairSequenceNumber = sequence;
+    for (const auto& [slot, pureChecksum] : pureChecksums) {
+        UNIT_ASSERT(slot < ChecksumsPerIntegrityBlock);
+        const ui32 blockIdx = pairIdx * ChecksumsPerIntegrityBlock + slot;
+        header.UsedBlocksBitmap[slot / 8] |= ui8(1u << (slot % 8));
+        block.Checksums[slot] = SealBlockChecksum(pureChecksum, TestDDiskId, TestPDiskGuid,
+            key.TabletId, key.VChunkIndex, blockIdx);
+        header.IntegrityBlockDigest ^= Contribution(ref.VChunkGeneration, blockIdx, pureChecksum);
+    }
+    header.BlockChecksum = CalculateRawChecksum(&block, sizeof(block));
+    return block;
+}
+
+TRope MakeIntegrityPair(TIntegrityBlock a, TIntegrityBlock b) {
+    auto data = TRcBuf::UninitializedPageAligned(IntegrityPairSlots * sizeof(TIntegrityBlock));
+    memcpy(data.GetDataMut(), &a, sizeof(a));
+    memcpy(data.GetDataMut() + sizeof(a), &b, sizeof(b));
+    return TRope(std::move(data));
+}
+
+void RecalculateBlockChecksum(TIntegrityBlock& block) {
+    block.Header.BlockChecksum = 0;
+    block.Header.BlockChecksum = CalculateRawChecksum(&block, sizeof(block));
+}
+
+TRope MakeFragmentedRope(const TString& data, const std::vector<size_t>& fragmentSizes) {
+    TRope rope;
+    size_t offset = 0;
+    for (const size_t size : fragmentSizes) {
+        UNIT_ASSERT(size > 0);
+        UNIT_ASSERT(offset + size <= data.size());
+        rope.Insert(rope.End(), TRope(TString(data.data() + offset, size)));
+        offset += size;
+    }
+    UNIT_ASSERT_VALUES_EQUAL(offset, data.size());
+    return rope;
+}
+
+TIntegrityManager::TOperationResult TakeOnlyCompletion(TIntegrityManager& manager) {
+    auto completed = manager.TakeCompletedOperations();
+    UNIT_ASSERT_VALUES_EQUAL(completed.size(), 1);
+    return std::move(completed.front());
+}
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
@@ -161,6 +227,206 @@ Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
             UNIT_ASSERT_VALUES_EQUAL(manager.BlocksPerExtent(), 67);
             UNIT_ASSERT_VALUES_EQUAL(manager.ExtentOnDiskSize(), 536_KB);
             UNIT_ASSERT_VALUES_EQUAL(manager.ExtentsPerChunk(), 244);
+        }
+    }
+
+    Y_UNIT_TEST(ContiguousAndFragmentedRopeChecksums) {
+        TString payload = TString::Uninitialized(3 * IntegrityUnitSize);
+        char* payloadData = payload.Detach();
+        for (size_t i = 0; i < payload.size(); ++i) {
+            payloadData[i] = static_cast<char>((i * 37 + i / IntegrityUnitSize * 53) & 0xff);
+        }
+
+        std::vector<ui64> expected;
+        for (ui32 block = 0; block < 3; ++block) {
+            expected.push_back(CalculateRawChecksum(
+                payload.data() + block * IntegrityUnitSize, IntegrityUnitSize));
+        }
+        UNIT_ASSERT_UNEQUAL(expected[0], expected[1]);
+        UNIT_ASSERT_UNEQUAL(expected[1], expected[2]);
+
+        const TRope contiguous(payload);
+        UNIT_ASSERT_VALUES_EQUAL(CalculatePayloadChecksums(contiguous), expected);
+        UNIT_ASSERT_VALUES_EQUAL(
+            CalculateBlockChecksum(contiguous.Begin(), payload.size()),
+            CalculateRawChecksum(payload.data(), payload.size()));
+
+        const std::array<std::vector<size_t>, 2> layouts{{
+            {17, IntegrityUnitSize - 17, 101, IntegrityUnitSize - 101,
+                IntegrityUnitSize - 1, 1},
+            {1024, 2048, 3072, 4096, 2048},
+        }};
+        for (const auto& layout : layouts) {
+            const TRope fragmented = MakeFragmentedRope(payload, layout);
+            UNIT_ASSERT(fragmented.Begin().ContiguousSize() < IntegrityUnitSize);
+            UNIT_ASSERT_VALUES_EQUAL(CalculatePayloadChecksums(fragmented), expected);
+            UNIT_ASSERT_VALUES_EQUAL(
+                CalculateBlockChecksum(fragmented.Begin(), payload.size()),
+                CalculateRawChecksum(payload.data(), payload.size()));
+        }
+    }
+
+    Y_UNIT_TEST(ZeroBlockChecksumProperties) {
+        const ui64 zeroChecksum = GetZeroBlockChecksum();
+        UNIT_ASSERT_UNEQUAL(zeroChecksum, 0);
+
+        for (const ui32 blocks : {1u, 3u}) {
+            TString zeros = TString::Uninitialized(blocks * IntegrityUnitSize);
+            memset(zeros.Detach(), 0, zeros.size());
+            const TRope rope(zeros);
+            const auto checksums = CalculatePayloadChecksums(rope);
+            UNIT_ASSERT_VALUES_EQUAL(checksums.size(), blocks);
+            for (const ui64 checksum : checksums) {
+                UNIT_ASSERT_VALUES_EQUAL(checksum, zeroChecksum);
+            }
+            UNIT_ASSERT_VALUES_EQUAL(
+                CalculateBlockChecksum(rope.Begin(), IntegrityUnitSize), zeroChecksum);
+        }
+
+        std::array<ui8, IntegrityUnitSize> zero{};
+        UNIT_ASSERT_VALUES_EQUAL(zeroChecksum, CalculateRawChecksum(zero.data(), zero.size()));
+        zero.back() = 1;
+        UNIT_ASSERT_UNEQUAL(zeroChecksum, CalculateRawChecksum(zero.data(), zero.size()));
+    }
+
+    Y_UNIT_TEST(ChecksumSealIdentitySeparation) {
+        struct TIdentity {
+            ui64 DDiskId;
+            ui64 PDiskGuid;
+            ui64 TabletId;
+            ui64 VChunkIndex;
+            ui64 BlockIdx;
+        };
+
+        const TIdentity baseline{TestDDiskId, TestPDiskGuid, 77, 9, 12};
+        const std::array<TIdentity, 5> changed{{
+            {TestDDiskId + 1, TestPDiskGuid, 77, 9, 12},
+            {TestDDiskId, TestPDiskGuid + 1, 77, 9, 12},
+            {TestDDiskId, TestPDiskGuid, 78, 9, 12},
+            {TestDDiskId, TestPDiskGuid, 77, 10, 12},
+            {TestDDiskId, TestPDiskGuid, 77, 9, 13},
+        }};
+
+        auto salt = [](const TIdentity& identity) {
+            return CalculateChecksumIdentitySalt(identity.DDiskId, identity.PDiskGuid,
+                identity.TabletId, identity.VChunkIndex, identity.BlockIdx);
+        };
+        auto seal = [](ui64 checksum, const TIdentity& identity) {
+            return SealBlockChecksum(checksum, identity.DDiskId, identity.PDiskGuid,
+                identity.TabletId, identity.VChunkIndex, identity.BlockIdx);
+        };
+        auto unseal = [](ui64 checksum, const TIdentity& identity) {
+            return UnsealBlockChecksum(checksum, identity.DDiskId, identity.PDiskGuid,
+                identity.TabletId, identity.VChunkIndex, identity.BlockIdx);
+        };
+
+        const ui64 pure = 0x123456789abcdef0ull;
+        const ui64 sealed = seal(pure, baseline);
+        UNIT_ASSERT_VALUES_EQUAL(unseal(sealed, baseline), pure);
+        for (const TIdentity& identity : changed) {
+            UNIT_ASSERT_UNEQUAL(salt(identity), salt(baseline));
+            UNIT_ASSERT_UNEQUAL(seal(pure, identity), sealed);
+            UNIT_ASSERT_UNEQUAL(unseal(sealed, identity), pure);
+        }
+    }
+
+    Y_UNIT_TEST(IntegrityBlockValidationRejectsCorruption) {
+        const TKey key{.TabletId = 77, .VChunkIndex = 9};
+        const TIntegrityManager::TExtentRef ref{
+            .IntegrityChunkIdx = 700,
+            .ExtentSlot = 3,
+            .VChunkGeneration = 5,
+        };
+        const ui64 chunkGeneration = 11;
+        const TIntegrityBlockIdentity expected{
+            .OwnerId = key.TabletId,
+            .VChunkId = key.VChunkIndex,
+            .VChunkGeneration = ref.VChunkGeneration,
+            .IntegrityChunkId = ref.IntegrityChunkIdx,
+            .IntegrityExtentId = ref.ExtentSlot,
+            .IntegrityChunkGeneration = chunkGeneration,
+            .ChecksumBlockIdx = 0,
+        };
+
+        const ui64 pure = 0x123456789abcdef0ull;
+        const TIntegrityBlock valid =
+            MakeIntegrityBlock(key, ref, chunkGeneration, 0, 2, {{0, pure}});
+        UNIT_ASSERT(ValidateIntegrityBlock(valid, expected));
+
+        struct TCorruption {
+            const char* Name;
+            size_t Offset;
+            bool RecalculateSelfChecksum;
+        };
+        const std::array<TCorruption, 11> corruptions{{
+            {"magic", offsetof(TIntegrityBlockHeader, Magic), true},
+            {"format version", offsetof(TIntegrityBlockHeader, FormatVersion), true},
+            {"checksum block index", offsetof(TIntegrityBlockHeader, ChecksumBlockIdx), true},
+            {"owner", offsetof(TIntegrityBlockHeader, OwnerId), true},
+            {"vchunk", offsetof(TIntegrityBlockHeader, VChunkId), true},
+            {"vchunk generation", offsetof(TIntegrityBlockHeader, VChunkGeneration), true},
+            {"integrity chunk", offsetof(TIntegrityBlockHeader, IntegrityChunkId), true},
+            {"integrity extent", offsetof(TIntegrityBlockHeader, IntegrityExtentId), true},
+            {"integrity chunk generation",
+                offsetof(TIntegrityBlockHeader, IntegrityChunkGeneration), true},
+            {"self checksum", offsetof(TIntegrityBlockHeader, BlockChecksum), false},
+            {"checksummed payload", offsetof(TIntegrityBlock, Checksums), false},
+        }};
+        for (const TCorruption& corruption : corruptions) {
+            TIntegrityBlock damaged = valid;
+            reinterpret_cast<ui8*>(&damaged)[corruption.Offset] ^= 1;
+            if (corruption.RecalculateSelfChecksum) {
+                RecalculateBlockChecksum(damaged);
+            }
+            UNIT_ASSERT_C(!ValidateIntegrityBlock(damaged, expected), corruption.Name);
+        }
+    }
+
+    Y_UNIT_TEST(IntegrityBlockWinnerSelection) {
+        const TKey key{.TabletId = 77, .VChunkIndex = 9};
+        const TIntegrityManager::TExtentRef ref{
+            .IntegrityChunkIdx = 700,
+            .ExtentSlot = 3,
+            .VChunkGeneration = 5,
+        };
+        const ui64 chunkGeneration = 11;
+        const TIntegrityBlockIdentity expected{
+            .OwnerId = key.TabletId,
+            .VChunkId = key.VChunkIndex,
+            .VChunkGeneration = ref.VChunkGeneration,
+            .IntegrityChunkId = ref.IntegrityChunkIdx,
+            .IntegrityExtentId = ref.ExtentSlot,
+            .IntegrityChunkGeneration = chunkGeneration,
+            .ChecksumBlockIdx = 0,
+        };
+
+        struct TCase {
+            bool ValidA;
+            ui64 SequenceA;
+            bool ValidB;
+            ui64 SequenceB;
+            i32 ExpectedWinner;
+        };
+        const std::array<TCase, 6> cases{{
+            {false, 2, false, 3, -1},
+            {true, 2, false, 3, 0},
+            {false, 2, true, 3, 1},
+            {true, 4, true, 3, 0},
+            {true, 2, true, 3, 1},
+            {true, 3, true, 3, 1},
+        }};
+        for (const TCase& test : cases) {
+            TIntegrityBlock slots[IntegrityPairSlots]{
+                MakeIntegrityBlock(key, ref, chunkGeneration, 0, test.SequenceA, {{0, 0xAA}}),
+                MakeIntegrityBlock(key, ref, chunkGeneration, 0, test.SequenceB, {{0, 0xBB}}),
+            };
+            if (!test.ValidA) {
+                ++slots[0].Checksums[0];
+            }
+            if (!test.ValidB) {
+                ++slots[1].Checksums[0];
+            }
+            UNIT_ASSERT_VALUES_EQUAL(SelectIntegrityBlockWinner(slots, expected), test.ExpectedWinner);
         }
     }
 
@@ -289,8 +555,8 @@ Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
         // Tracked, nothing written: all-zero without disk I/O.
         UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, 0, SmallChunkSize).Kind, TReadPlan::AllZero);
 
-        // Blocks 2..3 written (no checksums).
-        manager.OnBlocksWritten(key, 2 * IntegrityUnitSize, 2 * IntegrityUnitSize, {});
+        // Blocks 2..3 written with mandatory checksums.
+        manager.BeginBlocksWrite(key, 2 * IntegrityUnitSize, 2 * IntegrityUnitSize, {0xA, 0xB});
 
         // Whole written range: passthrough (no zeroing needed).
         UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, 2 * IntegrityUnitSize, 2 * IntegrityUnitSize).Kind,
@@ -320,14 +586,13 @@ Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
         UNIT_ASSERT_EQUAL(manager.MakeReadPlan(TKey{99, 99}, 0, IntegrityUnitSize).Kind, TReadPlan::Passthrough);
     }
 
-    Y_UNIT_TEST(UnalignedWritesRoundOutward) {
+    Y_UNIT_TEST(AlignedWritesMarkExactBlocks) {
         TIntegrityManager manager(SmallChunkSize, TestDDiskId, TestPDiskGuid);
         const TKey key{.TabletId = 4, .VChunkIndex = 0};
         TChunkIdx nextIntegrityChunkIdx = 730;
         MakeReady(manager, key, 400, &nextIntegrityChunkIdx);
 
-        // A write of [2048, 6144) touches blocks 0 and 1: both must count as used.
-        manager.OnBlocksWritten(key, 2048, 4096, {});
+        manager.BeginBlocksWrite(key, 0, 2 * IntegrityUnitSize, {0xA, 0xB});
         const TReadPlan plan = manager.MakeReadPlan(key, 0, 3 * IntegrityUnitSize);
         UNIT_ASSERT_EQUAL(plan.Kind, TReadPlan::Mixed);
         UNIT_ASSERT(plan.UsedBlocks.Get(0));
@@ -345,9 +610,9 @@ Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
         const ui64 generation = manager.FindExtentRef(key)->VChunkGeneration;
 
         // Blocks 0..1 with checksums, plus one block in the second TIntegrityBlock.
-        manager.OnBlocksWritten(key, 0, 2 * IntegrityUnitSize, {0xA, 0xB});
+        manager.BeginBlocksWrite(key, 0, 2 * IntegrityUnitSize, {0xA, 0xB});
         const ui32 farBlock = ChecksumsPerIntegrityBlock; // first block of digest index 1
-        manager.OnBlocksWritten(key, farBlock * IntegrityUnitSize, IntegrityUnitSize, {0xC});
+        manager.BeginBlocksWrite(key, farBlock * IntegrityUnitSize, IntegrityUnitSize, {0xC});
 
         ui64 checksum = 0;
         UNIT_ASSERT(manager.GetBlockChecksum(key, 0, &checksum));
@@ -366,18 +631,87 @@ Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
         UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 2), 0);
 
         // Overwrite block 0: digest must be updated incrementally (UpdateRoot semantics).
-        manager.OnBlocksWritten(key, 0, IntegrityUnitSize, {0xD});
+        manager.BeginBlocksWrite(key, 0, IntegrityUnitSize, {0xD});
         ui64 expected = Contribution(generation, 0, 0xA) ^ Contribution(generation, 1, 0xB);
         UpdateRoot(expected, generation, 0, 0xA, 0xD);
         UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 0), expected);
         UNIT_ASSERT_VALUES_EQUAL(expected, Contribution(generation, 0, 0xD) ^ Contribution(generation, 1, 0xB));
 
-        // Overwrite block 1 without checksums: its contribution is retired, block stays used.
-        manager.OnBlocksWritten(key, IntegrityUnitSize, IntegrityUnitSize, {});
-        UNIT_ASSERT(!manager.GetBlockChecksum(key, 1, &checksum));
-        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 0), Contribution(generation, 0, 0xD));
+        // Overwrite block 1 with its mandatory checksum.
+        manager.BeginBlocksWrite(key, IntegrityUnitSize, IntegrityUnitSize, {0xE});
+        UNIT_ASSERT(manager.GetBlockChecksum(key, 1, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(checksum, 0xE);
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 0),
+            Contribution(generation, 0, 0xD) ^ Contribution(generation, 1, 0xE));
         UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, IntegrityUnitSize, IntegrityUnitSize).Kind,
             TReadPlan::Passthrough);
+    }
+
+    Y_UNIT_TEST(ExactIntegrityPairBoundaryAndBitmapTail) {
+        TIntegrityManager manager(PairBoundaryChunkSize, TestDDiskId, TestPDiskGuid);
+        UNIT_ASSERT_VALUES_EQUAL(manager.DataBlocksInChunk(), ChecksumsPerIntegrityBlock + 1);
+        UNIT_ASSERT_VALUES_EQUAL(manager.BlocksPerExtent(), 2);
+
+        const TKey key{.TabletId = 6, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 745;
+        MakeReady(manager, key, 550, &nextIntegrityChunkIdx);
+
+        std::vector<ui64> firstPairChecksums(ChecksumsPerIntegrityBlock);
+        for (ui32 i = 0; i < firstPairChecksums.size(); ++i) {
+            firstPairChecksums[i] = 0x10000 + i;
+        }
+        const ui64 firstOperation = manager.BeginBlocksWrite(
+            key, 0, ChecksumsPerIntegrityBlock * IntegrityUnitSize, firstPairChecksums);
+        TActionLog firstWrite = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(firstWrite.Writes.size(), 1);
+        TIntegrityBlock firstImage;
+        memcpy(&firstImage, firstWrite.Writes[0].Data.data(), sizeof(firstImage));
+        UNIT_ASSERT_VALUES_EQUAL(firstImage.Header.ChecksumBlockIdx, 0);
+        UNIT_ASSERT_VALUES_EQUAL(firstImage.Header.UsedBlocksBitmap[61], 0x0f);
+        manager.OnIoCompleted(firstWrite.Writes[0].IoId);
+        UNIT_ASSERT_VALUES_EQUAL(TakeOnlyCompletion(manager).OperationId, firstOperation);
+
+        const ui64 finalChecksum = 0x20000;
+        const ui64 finalOperation = manager.BeginBlocksWrite(
+            key, ChecksumsPerIntegrityBlock * IntegrityUnitSize, IntegrityUnitSize, {finalChecksum});
+        TActionLog finalWrite = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(finalWrite.Writes.size(), 1);
+        TIntegrityBlock finalImage;
+        memcpy(&finalImage, finalWrite.Writes[0].Data.data(), sizeof(finalImage));
+        UNIT_ASSERT_VALUES_EQUAL(finalImage.Header.ChecksumBlockIdx, 1);
+        UNIT_ASSERT_VALUES_EQUAL(finalImage.Header.UsedBlocksBitmap[0], 1);
+        for (size_t i = 1; i < sizeof(finalImage.Header.UsedBlocksBitmap); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL_C(finalImage.Header.UsedBlocksBitmap[i], 0, "bitmap byte " << i);
+        }
+        for (ui32 slot = 1; slot < ChecksumsPerIntegrityBlock; ++slot) {
+            UNIT_ASSERT_VALUES_EQUAL_C(finalImage.Checksums[slot], 0, "checksum slot " << slot);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(finalImage.Checksums[0],
+            SealBlockChecksum(finalChecksum, TestDDiskId, TestPDiskGuid,
+                key.TabletId, key.VChunkIndex, ChecksumsPerIntegrityBlock));
+        manager.OnIoCompleted(finalWrite.Writes[0].IoId);
+        UNIT_ASSERT_VALUES_EQUAL(TakeOnlyCompletion(manager).OperationId, finalOperation);
+
+        const TKey crossingKey{.TabletId = 6, .VChunkIndex = 1};
+        MakeReady(manager, crossingKey, 551, &nextIntegrityChunkIdx);
+        std::vector<ui64> crossingChecksums(ChecksumsPerIntegrityBlock + 1);
+        for (ui32 i = 0; i < crossingChecksums.size(); ++i) {
+            crossingChecksums[i] = 0x30000 + i;
+        }
+        const ui64 crossingOperation = manager.BeginBlocksWrite(
+            crossingKey, 0, PairBoundaryChunkSize, crossingChecksums);
+        TActionLog crossingWrites = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(crossingWrites.Writes.size(), 2);
+        std::array<bool, 2> seenPairs{};
+        for (const TWriteIo& write : crossingWrites.Writes) {
+            TIntegrityBlock image;
+            memcpy(&image, write.Data.data(), sizeof(image));
+            UNIT_ASSERT(image.Header.ChecksumBlockIdx < seenPairs.size());
+            seenPairs[image.Header.ChecksumBlockIdx] = true;
+            manager.OnIoCompleted(write.IoId);
+        }
+        UNIT_ASSERT(seenPairs[0] && seenPairs[1]);
+        UNIT_ASSERT_VALUES_EQUAL(TakeOnlyCompletion(manager).OperationId, crossingOperation);
     }
 
     Y_UNIT_TEST(SparseBlockStateAllocation) {
@@ -389,19 +723,14 @@ Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
         MakeReady(manager, key, 800, &nextIntegrityChunkIdx);
         UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 0);
 
-        // Checksum-less writes mark blocks used but allocate no checksum state.
-        manager.OnBlocksWritten(key, 0, IntegrityUnitSize, {});
-        UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 0);
-        UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, 0, IntegrityUnitSize).Kind, TReadPlan::Passthrough);
-
         // A checksummed write allocates exactly one state, covering its whole TIntegrityBlock.
-        manager.OnBlocksWritten(key, 0, IntegrityUnitSize, {0xA});
+        manager.BeginBlocksWrite(key, 0, IntegrityUnitSize, {0xA});
         UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 1);
-        manager.OnBlocksWritten(key, IntegrityUnitSize, IntegrityUnitSize, {0xB});
+        manager.BeginBlocksWrite(key, IntegrityUnitSize, IntegrityUnitSize, {0xB});
         UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 1);
 
         // A write into the second TIntegrityBlock's range allocates the second state.
-        manager.OnBlocksWritten(key, ChecksumsPerIntegrityBlock * IntegrityUnitSize, IntegrityUnitSize, {0xC});
+        manager.BeginBlocksWrite(key, ChecksumsPerIntegrityBlock * IntegrityUnitSize, IntegrityUnitSize, {0xC});
         UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 2);
     }
 
@@ -420,16 +749,26 @@ Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
         const ui32 block1 = ChecksumsPerIntegrityBlock;     // first block of TIntegrityBlock 1
         const ui32 block2 = 2 * ChecksumsPerIntegrityBlock; // first block of TIntegrityBlock 2
 
-        // Fill all three TIntegrityBlocks: the oldest state (block 0's) is evicted.
-        manager.OnBlocksWritten(key, 0, IntegrityUnitSize, {0xA});
-        manager.OnBlocksWritten(key, block1 * IntegrityUnitSize, IntegrityUnitSize, {0xB});
-        manager.OnBlocksWritten(key, block2 * IntegrityUnitSize, IntegrityUnitSize, {0xC});
+        auto persist = [&](TKey target, ui32 block, ui64 checksum) {
+            manager.BeginBlocksWrite(target, block * IntegrityUnitSize, IntegrityUnitSize, {checksum});
+            TActionLog actions = Drain(manager);
+            UNIT_ASSERT_VALUES_EQUAL(actions.Writes.size(), 1);
+            manager.OnIoCompleted(actions.Writes[0].IoId);
+            Y_UNUSED(manager.TakeCompletedOperations());
+        };
+
+        // Fill all three TIntegrityBlocks durably: the oldest checksum array (block 0's) is
+        // evicted, while its pinned digest survives.
+        persist(key, 0, 0xA);
+        persist(key, block1, 0xB);
+        persist(key, block2, 0xC);
         UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 2);
 
-        // Evicted: checksum unknown and digest reset, together.
+        // Evicted checksum array, pinned digest retained for lost-write detection.
         ui64 checksum = 0;
         UNIT_ASSERT(!manager.GetBlockChecksum(key, 0, &checksum));
-        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 0), 0);
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 0),
+            Contribution(generation, 0, 0xA));
 
         // The survivors are intact.
         UNIT_ASSERT(manager.GetBlockChecksum(key, block1, &checksum));
@@ -444,14 +783,15 @@ Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
 
         // Touching a state protects it: overwrite in TIntegrityBlock 1, then allocate a state in a
         // second data chunk - TIntegrityBlock 2's state (now the LRU) is the one evicted.
-        manager.OnBlocksWritten(key, block1 * IntegrityUnitSize, IntegrityUnitSize, {0xD});
+        persist(key, block1, 0xD);
         const TKey key2{.TabletId = 10, .VChunkIndex = 1};
         MakeReady(manager, key2, 811, &nextIntegrityChunkIdx);
-        manager.OnBlocksWritten(key2, 0, IntegrityUnitSize, {0xE});
+        persist(key2, 0, 0xE);
         UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 2);
 
         UNIT_ASSERT(!manager.GetBlockChecksum(key, block2, &checksum));
-        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 2), 0);
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 2),
+            Contribution(generation, block2, 0xC));
         UNIT_ASSERT(manager.GetBlockChecksum(key, block1, &checksum));
         UNIT_ASSERT_VALUES_EQUAL(checksum, 0xD);
         UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 1),
@@ -460,13 +800,81 @@ Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
         UNIT_ASSERT_VALUES_EQUAL(checksum, 0xE);
     }
 
+    Y_UNIT_TEST(ReadModifyWriteAfterEvictionPreservesUntouchedChecksums) {
+        TIntegrityManager manager(MultiBlockChunkSize, TestDDiskId, TestPDiskGuid,
+            TIntegrityManager::BlockStateApproxBytes);
+        const TKey key{.TabletId = 17, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 796;
+        MakeReady(manager, key, 830, &nextIntegrityChunkIdx);
+        const auto ref = *manager.FindExtentRef(key);
+        const ui64 chunkGeneration =
+            manager.GetIntegrityChunkGeneration(ref.IntegrityChunkIdx);
+        const ui64 generation = ref.VChunkGeneration;
+
+        auto persist = [&](ui32 block, ui32 blocks, const std::vector<ui64>& checksums) {
+            const ui64 operationId = manager.BeginBlocksWrite(
+                key, block * IntegrityUnitSize, blocks * IntegrityUnitSize, checksums);
+            TActionLog actions = Drain(manager);
+            UNIT_ASSERT_VALUES_EQUAL(actions.Reads.size(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(actions.Writes.size(), 1);
+            manager.OnIoCompleted(actions.Writes[0].IoId);
+            UNIT_ASSERT_VALUES_EQUAL(TakeOnlyCompletion(manager).OperationId, operationId);
+        };
+
+        persist(0, 2, {0xAA, 0xBB});
+        persist(ChecksumsPerIntegrityBlock, 1, {0xCC});
+        UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 1);
+        ui64 checksum = 0;
+        UNIT_ASSERT(!manager.GetBlockChecksum(key, 0, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 0),
+            Contribution(generation, 0, 0xAA) ^ Contribution(generation, 1, 0xBB));
+
+        const ui64 operationId =
+            manager.BeginBlocksWrite(key, 0, IntegrityUnitSize, {0xDD});
+        TActionLog read = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(read.Reads.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(read.Writes.size(), 0);
+        manager.OnReadIoCompleted(read.Reads[0].IoId, MakeIntegrityPair(
+            MakeIntegrityBlock(key, ref, chunkGeneration, 0, 2, {{0, 0xAA}, {1, 0xBB}}),
+            MakeIntegrityBlock(key, ref, chunkGeneration, 0, 1, {})));
+
+        TActionLog write = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(write.Writes.size(), 1);
+        TIntegrityBlock image;
+        memcpy(&image, write.Writes[0].Data.data(), sizeof(image));
+        UNIT_ASSERT_VALUES_EQUAL(image.Header.ChecksumBlockIdx, 0);
+        UNIT_ASSERT_VALUES_EQUAL(image.Header.PairSequenceNumber, 3);
+        UNIT_ASSERT_VALUES_EQUAL(image.Header.UsedBlocksBitmap[0] & 3, 3);
+        UNIT_ASSERT_VALUES_EQUAL(
+            UnsealBlockChecksum(image.Checksums[0], TestDDiskId, TestPDiskGuid,
+                key.TabletId, key.VChunkIndex, 0),
+            0xDD);
+        UNIT_ASSERT_VALUES_EQUAL(
+            UnsealBlockChecksum(image.Checksums[1], TestDDiskId, TestPDiskGuid,
+                key.TabletId, key.VChunkIndex, 1),
+            0xBB);
+        const ui64 expectedDigest =
+            Contribution(generation, 0, 0xDD) ^ Contribution(generation, 1, 0xBB);
+        UNIT_ASSERT_VALUES_EQUAL(image.Header.IntegrityBlockDigest, expectedDigest);
+
+        manager.OnIoCompleted(write.Writes[0].IoId);
+        const auto result = TakeOnlyCompletion(manager);
+        UNIT_ASSERT_VALUES_EQUAL(result.OperationId, operationId);
+        UNIT_ASSERT_EQUAL(result.Status, TIntegrityManager::EOperationStatus::Ok);
+        UNIT_ASSERT(manager.GetBlockChecksum(key, 0, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(checksum, 0xDD);
+        UNIT_ASSERT(manager.GetBlockChecksum(key, 1, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(checksum, 0xBB);
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 0), expectedDigest);
+    }
+
     Y_UNIT_TEST(BlockStatesDroppedOnDelete) {
         TIntegrityManager manager(SmallChunkSize, TestDDiskId, TestPDiskGuid);
         const TKey key{.TabletId = 11, .VChunkIndex = 0};
         TChunkIdx nextIntegrityChunkIdx = 795;
         MakeReady(manager, key, 820, &nextIntegrityChunkIdx);
 
-        manager.OnBlocksWritten(key, 0, IntegrityUnitSize, {0xA});
+        manager.BeginBlocksWrite(key, 0, IntegrityUnitSize, {0xA});
         UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 1);
 
         manager.PrepareTabletChunksDeletion(11);
@@ -488,7 +896,7 @@ Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
         TChunkIdx nextIntegrityChunkIdx = 750;
 
         MakeReady(manager, key, 600, &nextIntegrityChunkIdx);
-        manager.OnBlocksWritten(key, 0, IntegrityUnitSize, {});
+        manager.BeginBlocksWrite(key, 0, IntegrityUnitSize, {0xA});
         {
             const auto* ref = manager.FindExtentRef(key);
             UNIT_ASSERT_VALUES_EQUAL(ref->ExtentSlot, 0);
@@ -743,15 +1151,26 @@ Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
         UNIT_ASSERT_VALUES_EQUAL(restored.GetIntegrityChunkGeneration(771), 7);
         UNIT_ASSERT_VALUES_EQUAL(restored.GetGenerationCounter(), 8);
 
-        // Restored extents have unknown bitmaps: reads pass through unchanged even though nothing
-        // was written since the restore (the previous incarnation's bitmap is lost); new writes
-        // are tracked again (checksums recorded) but do not change the read plan.
+        // Restored extents start with unknown bitmaps. A write first reads the pair, then performs
+        // a durable RMW and makes the bitmap/checksum state exact.
         UNIT_ASSERT_EQUAL(restored.MakeReadPlan(keys[0], 0, TinyChunkSize).Kind, TReadPlan::Passthrough);
-        restored.OnBlocksWritten(keys[0], 0, IntegrityUnitSize, {0xA});
+        const ui64 operationId = restored.BeginBlocksWrite(keys[0], 0, IntegrityUnitSize, {0xA});
+        TActionLog read = Drain(restored);
+        UNIT_ASSERT_VALUES_EQUAL(read.Reads.size(), 1);
+        const auto restoredRef = *restored.FindExtentRef(keys[0]);
+        const ui64 restoredChunkGeneration =
+            restored.GetIntegrityChunkGeneration(restoredRef.IntegrityChunkIdx);
+        restored.OnReadIoCompleted(read.Reads[0].IoId, MakeIntegrityPair(
+            MakeIntegrityBlock(keys[0], restoredRef, restoredChunkGeneration, 0, 0, {}),
+            MakeIntegrityBlock(keys[0], restoredRef, restoredChunkGeneration, 0, 1, {})));
+        TActionLog write = Drain(restored);
+        UNIT_ASSERT_VALUES_EQUAL(write.Writes.size(), 1);
+        restored.OnIoCompleted(write.Writes[0].IoId);
+        UNIT_ASSERT_VALUES_EQUAL(TakeOnlyCompletion(restored).OperationId, operationId);
         ui64 checksum = 0;
         UNIT_ASSERT(restored.GetBlockChecksum(keys[0], 0, &checksum));
         UNIT_ASSERT_VALUES_EQUAL(checksum, 0xA);
-        UNIT_ASSERT_EQUAL(restored.MakeReadPlan(keys[0], 0, TinyChunkSize).Kind, TReadPlan::Passthrough);
+        UNIT_ASSERT_EQUAL(restored.MakeReadPlan(keys[0], 0, TinyChunkSize).Kind, TReadPlan::Mixed);
 
         // The restored manager keeps allocating into the remaining free slots of known chunks
         // without requesting new integrity chunks (6 used out of 8 -> 2 slots left).
@@ -967,6 +1386,310 @@ Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
         const auto* ref = restored.FindExtentRef(key);
         UNIT_ASSERT(ref);
         UNIT_ASSERT_VALUES_EQUAL(ref->VChunkGeneration, 3);
+    }
+
+    Y_UNIT_TEST(ChecksumPersistenceSealsAndPingPongs) {
+        TIntegrityManager manager(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 40, .VChunkIndex = 7};
+        TChunkIdx nextIntegrityChunkIdx = 900;
+        MakeReady(manager, key, 1600, &nextIntegrityChunkIdx);
+        const auto ref = *manager.FindExtentRef(key);
+
+        const ui64 firstOperation = manager.BeginBlocksWrite(
+            key, 0, 2 * IntegrityUnitSize, {0x111, 0x222});
+        TActionLog first = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(first.Reads.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(first.Writes.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(first.Writes[0].OffsetInBytes, manager.ExtentOffset(ref.ExtentSlot));
+
+        TIntegrityBlock firstImage;
+        memcpy(&firstImage, first.Writes[0].Data.data(), sizeof(firstImage));
+        UNIT_ASSERT_VALUES_EQUAL(firstImage.Header.PairSequenceNumber, 2);
+        UNIT_ASSERT(firstImage.Header.UsedBlocksBitmap[0] & 1);
+        UNIT_ASSERT(firstImage.Header.UsedBlocksBitmap[0] & 2);
+        UNIT_ASSERT_VALUES_EQUAL(firstImage.Checksums[0],
+            SealBlockChecksum(
+                0x111, TestDDiskId, TestPDiskGuid, key.TabletId, key.VChunkIndex, 0));
+        UNIT_ASSERT_VALUES_EQUAL(firstImage.Checksums[1],
+            SealBlockChecksum(
+                0x222, TestDDiskId, TestPDiskGuid, key.TabletId, key.VChunkIndex, 1));
+        UNIT_ASSERT_VALUES_EQUAL(firstImage.Header.IntegrityBlockDigest,
+            Contribution(ref.VChunkGeneration, 0, 0x111)
+                ^ Contribution(ref.VChunkGeneration, 1, 0x222));
+
+        manager.OnIoCompleted(first.Writes[0].IoId);
+        auto completion = TakeOnlyCompletion(manager);
+        UNIT_ASSERT_VALUES_EQUAL(completion.OperationId, firstOperation);
+        UNIT_ASSERT_EQUAL(completion.Status, TIntegrityManager::EOperationStatus::Ok);
+
+        const ui64 secondOperation = manager.BeginBlocksWrite(
+            key, IntegrityUnitSize, IntegrityUnitSize, {0x333});
+        TActionLog second = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(second.Writes.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(second.Writes[0].OffsetInBytes,
+            manager.ExtentOffset(ref.ExtentSlot) + IntegrityUnitSize);
+        TIntegrityBlock secondImage;
+        memcpy(&secondImage, second.Writes[0].Data.data(), sizeof(secondImage));
+        UNIT_ASSERT_VALUES_EQUAL(secondImage.Header.PairSequenceNumber, 3);
+        manager.OnIoCompleted(second.Writes[0].IoId);
+        UNIT_ASSERT_VALUES_EQUAL(TakeOnlyCompletion(manager).OperationId, secondOperation);
+
+        const ui64 readOperation = manager.BeginChecksumRead(key, 0, 2 * IntegrityUnitSize);
+        completion = TakeOnlyCompletion(manager);
+        UNIT_ASSERT_VALUES_EQUAL(completion.OperationId, readOperation);
+        UNIT_ASSERT_VALUES_EQUAL(completion.Checksums.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(completion.Checksums[0], 0x111);
+        UNIT_ASSERT_VALUES_EQUAL(completion.Checksums[1], 0x333);
+    }
+
+    Y_UNIT_TEST(PairWritesSerializeAndCoalesce) {
+        TIntegrityManager manager(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 41, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 910;
+        MakeReady(manager, key, 1700, &nextIntegrityChunkIdx);
+
+        const ui64 firstOperation = manager.BeginBlocksWrite(key, 0, IntegrityUnitSize, {0xA});
+        TActionLog first = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(first.Writes.size(), 1);
+
+        const ui64 secondOperation = manager.BeginBlocksWrite(
+            key, IntegrityUnitSize, IntegrityUnitSize, {0xB});
+        UNIT_ASSERT_VALUES_EQUAL(Drain(manager).Writes.size(), 0);
+
+        manager.OnIoCompleted(first.Writes[0].IoId);
+        auto completed = manager.TakeCompletedOperations();
+        UNIT_ASSERT_VALUES_EQUAL(completed.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(completed[0].OperationId, firstOperation);
+
+        TActionLog second = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(second.Writes.size(), 1);
+        TIntegrityBlock image;
+        memcpy(&image, second.Writes[0].Data.data(), sizeof(image));
+        UNIT_ASSERT_VALUES_EQUAL(image.Header.PairSequenceNumber, 3);
+        UNIT_ASSERT(image.Header.UsedBlocksBitmap[0] & 1);
+        UNIT_ASSERT(image.Header.UsedBlocksBitmap[0] & 2);
+        manager.OnIoCompleted(second.Writes[0].IoId);
+        UNIT_ASSERT_VALUES_EQUAL(TakeOnlyCompletion(manager).OperationId, secondOperation);
+    }
+
+    Y_UNIT_TEST(RestoredPairSelectsWinnerAndRestoresBitmap) {
+        TIntegrityManager original(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 42, .VChunkIndex = 3};
+        TChunkIdx nextIntegrityChunkIdx = 920;
+        MakeReady(original, key, 1800, &nextIntegrityChunkIdx);
+        const auto snapshot = original.SnapshotMapping();
+        const auto ref = *original.FindExtentRef(key);
+        const ui64 chunkGeneration = original.GetIntegrityChunkGeneration(ref.IntegrityChunkIdx);
+
+        TIntegrityManager restored(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        restored.ApplyMappingSnapshot(snapshot);
+        const ui64 operationId = restored.BeginChecksumRead(key, 0, 4 * IntegrityUnitSize);
+        TActionLog actions = Drain(restored);
+        UNIT_ASSERT_VALUES_EQUAL(actions.Reads.size(), 1);
+        const auto a = MakeIntegrityBlock(key, ref, chunkGeneration, 0, 2, {{0, 0x10}});
+        const auto b = MakeIntegrityBlock(key, ref, chunkGeneration, 0, 3, {{2, 0x30}});
+        restored.OnReadIoCompleted(actions.Reads[0].IoId, MakeIntegrityPair(a, b));
+
+        const auto result = TakeOnlyCompletion(restored);
+        UNIT_ASSERT_VALUES_EQUAL(result.OperationId, operationId);
+        UNIT_ASSERT_VALUES_EQUAL(result.Checksums.size(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(result.Checksums[0], GetZeroBlockChecksum());
+        UNIT_ASSERT_VALUES_EQUAL(result.Checksums[2], 0x30);
+        const auto plan = restored.MakeReadPlan(key, 0, 4 * IntegrityUnitSize);
+        UNIT_ASSERT_EQUAL(plan.Kind, TReadPlan::Mixed);
+        UNIT_ASSERT(!plan.UsedBlocks.Get(0));
+        UNIT_ASSERT(plan.UsedBlocks.Get(2));
+    }
+
+    Y_UNIT_TEST(BothInvalidSlotsReportCorruption) {
+        TIntegrityManager original(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 43, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 930;
+        MakeReady(original, key, 1900, &nextIntegrityChunkIdx);
+        const auto snapshot = original.SnapshotMapping();
+        const auto ref = *original.FindExtentRef(key);
+        const ui64 chunkGeneration = original.GetIntegrityChunkGeneration(ref.IntegrityChunkIdx);
+
+        TIntegrityManager restored(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        restored.ApplyMappingSnapshot(snapshot);
+        const ui64 operationId = restored.BeginChecksumRead(key, 0, IntegrityUnitSize);
+        TActionLog actions = Drain(restored);
+        auto a = MakeIntegrityBlock(key, ref, chunkGeneration, 0, 2, {{0, 1}});
+        auto b = MakeIntegrityBlock(key, ref, chunkGeneration, 0, 3, {{0, 2}});
+        ++a.Checksums[0];
+        ++b.Checksums[0];
+        restored.OnReadIoCompleted(actions.Reads[0].IoId, MakeIntegrityPair(a, b));
+        const auto result = TakeOnlyCompletion(restored);
+        UNIT_ASSERT_VALUES_EQUAL(result.OperationId, operationId);
+        UNIT_ASSERT_EQUAL(result.Status, TIntegrityManager::EOperationStatus::Corrupted);
+        UNIT_ASSERT(!result.LostWriteDetected);
+    }
+
+    Y_UNIT_TEST(PendingMultiPairReadPinsChecksumStates) {
+        TIntegrityManager original(MultiBlockChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 45, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 950;
+        MakeReady(original, key, 2100, &nextIntegrityChunkIdx);
+        const auto snapshot = original.SnapshotMapping();
+
+        TIntegrityManager restored(MultiBlockChunkSize, TestDDiskId, TestPDiskGuid,
+            TIntegrityManager::BlockStateApproxBytes);
+        restored.ApplyMappingSnapshot(snapshot);
+        const auto ref = *restored.FindExtentRef(key);
+        const ui64 chunkGeneration =
+            restored.GetIntegrityChunkGeneration(ref.IntegrityChunkIdx);
+        const ui32 blocks = ChecksumsPerIntegrityBlock + 1;
+
+        const ui64 operationId =
+            restored.BeginChecksumRead(key, 0, blocks * IntegrityUnitSize);
+        TActionLog reads = Drain(restored);
+        UNIT_ASSERT_VALUES_EQUAL(reads.Reads.size(), 2);
+
+        restored.OnReadIoCompleted(reads.Reads[0].IoId, MakeIntegrityPair(
+            MakeIntegrityBlock(key, ref, chunkGeneration, 0, 0, {{0, 0xAA}}),
+            MakeIntegrityBlock(key, ref, chunkGeneration, 0, 1, {{0, 0xAA}})));
+        UNIT_ASSERT_VALUES_EQUAL(restored.CachedBlockStates(), 1);
+        UNIT_ASSERT(restored.TakeCompletedOperations().empty());
+
+        restored.OnReadIoCompleted(reads.Reads[1].IoId, MakeIntegrityPair(
+            MakeIntegrityBlock(key, ref, chunkGeneration, 1, 0, {{0, 0xBB}}),
+            MakeIntegrityBlock(key, ref, chunkGeneration, 1, 1, {{0, 0xBB}})));
+        auto result = TakeOnlyCompletion(restored);
+        UNIT_ASSERT_VALUES_EQUAL(result.OperationId, operationId);
+        UNIT_ASSERT_EQUAL(result.Status, TIntegrityManager::EOperationStatus::Ok);
+        UNIT_ASSERT_VALUES_EQUAL(result.Checksums.size(), blocks);
+        UNIT_ASSERT_VALUES_EQUAL(result.Checksums.front(), 0xAA);
+        UNIT_ASSERT_VALUES_EQUAL(result.Checksums.back(), 0xBB);
+        UNIT_ASSERT_VALUES_EQUAL(restored.CachedBlockStates(), 1);
+    }
+
+    Y_UNIT_TEST(PendingMultiPairWritePinsChecksumStates) {
+        TIntegrityManager original(MultiBlockChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 47, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 970;
+        MakeReady(original, key, 2300, &nextIntegrityChunkIdx);
+        const auto snapshot = original.SnapshotMapping();
+
+        TIntegrityManager restored(MultiBlockChunkSize, TestDDiskId, TestPDiskGuid,
+            TIntegrityManager::BlockStateApproxBytes);
+        restored.ApplyMappingSnapshot(snapshot);
+        const auto ref = *restored.FindExtentRef(key);
+        const ui64 chunkGeneration =
+            restored.GetIntegrityChunkGeneration(ref.IntegrityChunkIdx);
+        const ui32 blocks = ChecksumsPerIntegrityBlock + 1;
+        std::vector<ui64> checksums(blocks);
+        for (ui32 i = 0; i < blocks; ++i) {
+            checksums[i] = 0x1000 + i;
+        }
+
+        const ui64 operationId =
+            restored.BeginBlocksWrite(key, 0, blocks * IntegrityUnitSize, checksums);
+        TActionLog reads = Drain(restored);
+        UNIT_ASSERT_VALUES_EQUAL(reads.Reads.size(), 2);
+
+        restored.OnReadIoCompleted(reads.Reads[0].IoId, MakeIntegrityPair(
+            MakeIntegrityBlock(key, ref, chunkGeneration, 0, 0, {{0, 0xAA}}),
+            MakeIntegrityBlock(key, ref, chunkGeneration, 0, 1, {{0, 0xAA}})));
+        UNIT_ASSERT(restored.TakeCompletedOperations().empty());
+
+        restored.OnReadIoCompleted(reads.Reads[1].IoId, MakeIntegrityPair(
+            MakeIntegrityBlock(key, ref, chunkGeneration, 1, 0, {{0, 0xBB}}),
+            MakeIntegrityBlock(key, ref, chunkGeneration, 1, 1, {{0, 0xBB}})));
+        TActionLog writes = Drain(restored);
+        UNIT_ASSERT_VALUES_EQUAL(writes.Writes.size(), 2);
+
+        ui64 expectedPair0Digest = 0;
+        for (ui32 i = 0; i < ChecksumsPerIntegrityBlock; ++i) {
+            expectedPair0Digest ^= Contribution(ref.VChunkGeneration, i, checksums[i]);
+        }
+        const ui64 expectedPair1Digest = Contribution(
+            ref.VChunkGeneration, ChecksumsPerIntegrityBlock, checksums.back());
+        for (const auto& write : writes.Writes) {
+            TIntegrityBlock block;
+            memcpy(&block, write.Data.data(), sizeof(block));
+            const ui64 expected = block.Header.ChecksumBlockIdx == 0
+                ? expectedPair0Digest
+                : expectedPair1Digest;
+            UNIT_ASSERT_VALUES_EQUAL(block.Header.IntegrityBlockDigest, expected);
+            restored.OnIoCompleted(write.IoId);
+        }
+
+        auto result = TakeOnlyCompletion(restored);
+        UNIT_ASSERT_VALUES_EQUAL(result.OperationId, operationId);
+        UNIT_ASSERT_EQUAL(result.Status, TIntegrityManager::EOperationStatus::Ok);
+    }
+
+    Y_UNIT_TEST(MultiPairCorruptionKeepsDeletionBusyForSiblingIo) {
+        TIntegrityManager original(MultiBlockChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 46, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 960;
+        MakeReady(original, key, 2200, &nextIntegrityChunkIdx);
+        const auto snapshot = original.SnapshotMapping();
+
+        TIntegrityManager restored(MultiBlockChunkSize, TestDDiskId, TestPDiskGuid);
+        restored.ApplyMappingSnapshot(snapshot);
+        const auto ref = *restored.FindExtentRef(key);
+        const ui64 chunkGeneration =
+            restored.GetIntegrityChunkGeneration(ref.IntegrityChunkIdx);
+        const ui32 blocks = ChecksumsPerIntegrityBlock + 1;
+
+        restored.BeginChecksumRead(key, 0, blocks * IntegrityUnitSize);
+        TActionLog reads = Drain(restored);
+        UNIT_ASSERT_VALUES_EQUAL(reads.Reads.size(), 2);
+
+        auto invalid = TRcBuf::UninitializedPageAligned(
+            IntegrityPairSlots * sizeof(TIntegrityBlock));
+        memset(invalid.GetDataMut(), 0, invalid.size());
+        restored.OnReadIoCompleted(reads.Reads[1].IoId, TRope(std::move(invalid)));
+        UNIT_ASSERT_EQUAL(
+            TakeOnlyCompletion(restored).Status,
+            TIntegrityManager::EOperationStatus::Corrupted);
+        UNIT_ASSERT(restored.HasInFlightOperationsForTablet(key.TabletId));
+
+        restored.OnReadIoCompleted(reads.Reads[0].IoId, MakeIntegrityPair(
+            MakeIntegrityBlock(key, ref, chunkGeneration, 0, 0, {}),
+            MakeIntegrityBlock(key, ref, chunkGeneration, 0, 1, {})));
+        UNIT_ASSERT(!restored.HasInFlightOperationsForTablet(key.TabletId));
+
+        // The known corruption is detected before any sibling pair read is queued.
+        restored.BeginChecksumRead(key, 0, blocks * IntegrityUnitSize);
+        UNIT_ASSERT(Drain(restored).Reads.empty());
+        UNIT_ASSERT_EQUAL(
+            TakeOnlyCompletion(restored).Status,
+            TIntegrityManager::EOperationStatus::Corrupted);
+
+        restored.PrepareTabletChunksDeletion(key.TabletId);
+        restored.CommitTabletChunksDeletion(key.TabletId);
+    }
+
+    Y_UNIT_TEST(PinnedDigestDetectsLostWriteAfterEviction) {
+        TIntegrityManager manager(MultiBlockChunkSize, TestDDiskId, TestPDiskGuid,
+            TIntegrityManager::BlockStateApproxBytes);
+        const TKey key{.TabletId = 44, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 940;
+        MakeReady(manager, key, 2000, &nextIntegrityChunkIdx);
+        const auto ref = *manager.FindExtentRef(key);
+        const ui64 chunkGeneration = manager.GetIntegrityChunkGeneration(ref.IntegrityChunkIdx);
+
+        manager.BeginBlocksWrite(key, 0, IntegrityUnitSize, {0xAA});
+        TActionLog pair0Write = Drain(manager);
+        manager.OnIoCompleted(pair0Write.Writes[0].IoId);
+        Y_UNUSED(manager.TakeCompletedOperations());
+
+        const ui32 pair1Block = ChecksumsPerIntegrityBlock;
+        manager.BeginBlocksWrite(key, pair1Block * IntegrityUnitSize, IntegrityUnitSize, {0xBB});
+        Y_UNUSED(Drain(manager)); // creating pair 1 evicts the now-idle checksum array of pair 0
+
+        const ui64 readOperation = manager.BeginChecksumRead(key, 0, IntegrityUnitSize);
+        TActionLog read = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(read.Reads.size(), 1);
+        const auto stale = MakeIntegrityBlock(key, ref, chunkGeneration, 0, 1, {});
+        manager.OnReadIoCompleted(read.Reads[0].IoId, MakeIntegrityPair(stale, stale));
+        const auto result = TakeOnlyCompletion(manager);
+        UNIT_ASSERT_VALUES_EQUAL(result.OperationId, readOperation);
+        UNIT_ASSERT_EQUAL(result.Status, TIntegrityManager::EOperationStatus::Corrupted);
+        UNIT_ASSERT(result.ErrorReason.Contains("digest mismatch"));
+        UNIT_ASSERT(result.LostWriteDetected);
     }
 
 } // Y_UNIT_TEST_SUITE(TIntegrityManagerTest)

--- a/ydb/core/blobstorage/ddisk/ut/integrity_manager_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/integrity_manager_ut.cpp
@@ -1,0 +1,974 @@
+#include <ydb/core/blobstorage/ddisk/integrity_manager.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/overloaded.h>
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+namespace NKikimr::NDDisk {
+
+namespace {
+
+using TKey = TIntegrityManager::TDataChunkKey;
+using TWriteIo = TIntegrityManager::TWriteIo;
+using TReadPlan = TIntegrityManager::TReadPlan;
+
+constexpr ui64 TestDDiskId = 0xDD15C1D;
+constexpr ui64 TestPDiskGuid = 0x9D15C6151D;
+
+// Small geometries so tests don't need 128 MiB chunks:
+//   1 MiB chunk  -> 256 data blocks, 1 TIntegrityBlock per extent (8 KiB pair on disk), 112 extents/chunk
+//   160 KiB chunk -> 40 data blocks, 1 block per extent, 4 extents/chunk (fast slot exhaustion)
+//   4 MiB chunk  -> 1024 data blocks, 3 blocks per extent (multi-digest coverage)
+constexpr ui64 ProductionChunkSize = 128_MB;
+constexpr ui64 SmallChunkSize = 1_MB;
+constexpr ui64 TinyChunkSize = 160_KB;
+constexpr ui64 MultiBlockChunkSize = 4_MB;
+
+struct TActionLog {
+    ui32 AllocateRequests = 0;
+    std::vector<TWriteIo> Writes;
+};
+
+TActionLog Drain(TIntegrityManager& manager) {
+    TActionLog log;
+    for (auto& action : manager.TakeActions()) {
+        std::visit(TOverloaded{
+            [&](TIntegrityManager::TAllocateIntegrityChunk&) {
+                ++log.AllocateRequests;
+            },
+            [&](TWriteIo& io) {
+                log.Writes.push_back(std::move(io));
+            },
+        }, action);
+    }
+    return log;
+}
+
+std::vector<TKey> CompleteWrites(TIntegrityManager& manager, const std::vector<TWriteIo>& writes) {
+    std::vector<TKey> readyKeys;
+    for (const auto& io : writes) {
+        for (const auto& key : manager.OnIoCompleted(io.IoId)) {
+            readyKeys.push_back(key);
+        }
+    }
+    return readyKeys;
+}
+
+// Drives the full allocation cycle for one data chunk, fulfilling chunk allocations from
+// nextIntegrityChunkIdx, until the extent is Ready.
+void MakeReady(TIntegrityManager& manager, TKey key, TChunkIdx dataChunkIdx, TChunkIdx* nextIntegrityChunkIdx) {
+    manager.OnDataChunkAllocated(key, dataChunkIdx);
+    while (!manager.IsExtentReady(key)) {
+        TActionLog log = Drain(manager);
+        for (ui32 i = 0; i < log.AllocateRequests; ++i) {
+            manager.OnIntegrityChunkAllocated((*nextIntegrityChunkIdx)++);
+        }
+        CompleteWrites(manager, log.Writes);
+        UNIT_ASSERT_C(log.AllocateRequests || !log.Writes.empty() || manager.IsExtentReady(key),
+            "allocation is stuck");
+    }
+    Y_UNUSED(manager.TakePlacedKeys());
+}
+
+void CheckChunkHeader(const TWriteIo& io, TChunkIdx chunkIdx, ui64 generation) {
+    UNIT_ASSERT_VALUES_EQUAL(io.ChunkIdx, chunkIdx);
+    UNIT_ASSERT_VALUES_EQUAL(io.Data.size(), sizeof(TIntegrityChunkHeader));
+
+    TIntegrityChunkHeader header;
+    memcpy(&header, io.Data.data(), sizeof(header));
+    UNIT_ASSERT_VALUES_EQUAL(header.Magic, MagicIntegrityChunkHeader);
+    UNIT_ASSERT_VALUES_EQUAL(header.FormatVersion, static_cast<ui32>(EIntegrityFormatVersion::BaseAwupf4KiB));
+    UNIT_ASSERT_VALUES_EQUAL(header.HeaderSize, sizeof(TIntegrityChunkHeader));
+    UNIT_ASSERT_VALUES_EQUAL(header.DDiskId, TestDDiskId);
+    UNIT_ASSERT_VALUES_EQUAL(header.PDiskGuid, TestPDiskGuid);
+    UNIT_ASSERT_VALUES_EQUAL(header.IntegrityChunkId, chunkIdx);
+    UNIT_ASSERT_VALUES_EQUAL(header.IntegrityChunkGeneration, generation);
+
+    const ui64 checksum = std::exchange(header.HeaderChecksum, 0);
+    UNIT_ASSERT_VALUES_EQUAL(checksum, CalculateRawChecksum(&header, sizeof(header)));
+}
+
+void SplitWrites(const std::vector<TWriteIo>& writes, std::vector<TWriteIo>* headers, std::vector<TWriteIo>* extents) {
+    for (const auto& io : writes) {
+        if (io.Data.size() == sizeof(TIntegrityChunkHeader)) {
+            headers->push_back(io);
+        } else {
+            extents->push_back(io);
+        }
+    }
+}
+
+void CheckExtentFormat(const TIntegrityManager& manager, const TWriteIo& io, TKey key,
+        const TIntegrityManager::TExtentRef& ref, ui64 integrityChunkGeneration) {
+    UNIT_ASSERT_VALUES_EQUAL(io.ChunkIdx, ref.IntegrityChunkIdx);
+    UNIT_ASSERT_VALUES_EQUAL(io.OffsetInBytes, manager.ExtentOffset(ref.ExtentSlot));
+    UNIT_ASSERT_VALUES_EQUAL(io.Data.size(), manager.ExtentOnDiskSize());
+
+    for (ui32 pair = 0; pair < manager.BlocksPerExtent(); ++pair) {
+        for (ui32 slot = 0; slot < IntegrityPairSlots; ++slot) {
+            TIntegrityBlock block;
+            memcpy(&block, io.Data.data() + (pair * IntegrityPairSlots + slot) * sizeof(block), sizeof(block));
+
+            const TIntegrityBlockHeader& header = block.Header;
+            UNIT_ASSERT_VALUES_EQUAL(header.Magic, MagicIntegrityBlock);
+            UNIT_ASSERT_VALUES_EQUAL(header.FormatVersion,
+                static_cast<ui16>(EIntegrityFormatVersion::BaseAwupf4KiB));
+            UNIT_ASSERT_VALUES_EQUAL(header.ChecksumBlockIdx, pair);
+            UNIT_ASSERT_VALUES_EQUAL(header.OwnerId, key.TabletId);
+            UNIT_ASSERT_VALUES_EQUAL(header.VChunkId, key.VChunkIndex);
+            UNIT_ASSERT_VALUES_EQUAL(header.VChunkGeneration, ref.VChunkGeneration);
+            UNIT_ASSERT_VALUES_EQUAL(header.IntegrityChunkId, ref.IntegrityChunkIdx);
+            UNIT_ASSERT_VALUES_EQUAL(header.IntegrityExtentId, ref.ExtentSlot);
+            UNIT_ASSERT_VALUES_EQUAL(header.IntegrityChunkGeneration, integrityChunkGeneration);
+            UNIT_ASSERT_VALUES_EQUAL(header.PairSequenceNumber, slot); // slot B (seq 1) starts current
+            UNIT_ASSERT_VALUES_EQUAL(header.IntegrityBlockDigest, 0);
+
+            for (size_t i = 0; i < sizeof(header.UsedBlocksBitmap); ++i) {
+                UNIT_ASSERT_VALUES_EQUAL(header.UsedBlocksBitmap[i], 0);
+            }
+            for (ui32 i = 0; i < ChecksumsPerIntegrityBlock; ++i) {
+                UNIT_ASSERT_VALUES_EQUAL(block.Checksums[i], 0);
+            }
+
+            TIntegrityBlock copy = block;
+            const ui64 checksum = std::exchange(copy.Header.BlockChecksum, 0);
+            UNIT_ASSERT_VALUES_EQUAL(checksum, CalculateRawChecksum(&copy, sizeof(copy)));
+        }
+    }
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TIntegrityManagerTest) {
+
+    Y_UNIT_TEST(Geometry) {
+        {
+            TIntegrityManager manager(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+            UNIT_ASSERT_VALUES_EQUAL(manager.DataBlocksInChunk(), 256);
+            UNIT_ASSERT_VALUES_EQUAL(manager.BlocksPerExtent(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(manager.ExtentOnDiskSize(), 2 * IntegrityUnitSize);
+            UNIT_ASSERT_VALUES_EQUAL(manager.ExtentsPerChunk(),
+                (SmallChunkSize - IntegrityChunkHeaderRegionSize) / (2 * IntegrityUnitSize));
+        }
+        {
+            // The runtime geometry for the default PDisk chunk size must match the RFC example.
+            TIntegrityManager manager(ProductionChunkSize, TestDDiskId, TestPDiskGuid);
+            UNIT_ASSERT_VALUES_EQUAL(manager.DataBlocksInChunk(), 32768);
+            UNIT_ASSERT_VALUES_EQUAL(manager.BlocksPerExtent(), 67);
+            UNIT_ASSERT_VALUES_EQUAL(manager.ExtentOnDiskSize(), 536_KB);
+            UNIT_ASSERT_VALUES_EQUAL(manager.ExtentsPerChunk(), 244);
+        }
+    }
+
+    Y_UNIT_TEST(FirstChunkAllocationAndFormatting) {
+        TIntegrityManager manager(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 1, .VChunkIndex = 5};
+
+        manager.OnDataChunkAllocated(key, 100);
+        UNIT_ASSERT(!manager.IsExtentReady(key));
+        UNIT_ASSERT(!manager.FindExtentRef(key));
+
+        // First data chunk: exactly one integrity chunk allocation is requested, no writes yet.
+        TActionLog log = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(log.AllocateRequests, 1);
+        UNIT_ASSERT_VALUES_EQUAL(log.Writes.size(), 0);
+
+        // Chunk arrives: header replicas and the extent format write are issued in parallel, and
+        // the extent is already placed (IntegrityChunk found) even though nothing is Ready yet.
+        manager.OnIntegrityChunkAllocated(500);
+        UNIT_ASSERT(manager.FindExtentRef(key));
+        UNIT_ASSERT(!manager.IsExtentReady(key));
+        {
+            const auto placed = manager.TakePlacedKeys();
+            UNIT_ASSERT_VALUES_EQUAL(placed.size(), 1);
+            UNIT_ASSERT(placed[0] == key);
+        }
+
+        log = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(log.AllocateRequests, 0);
+        std::vector<TWriteIo> headers;
+        std::vector<TWriteIo> extents;
+        SplitWrites(log.Writes, &headers, &extents);
+        UNIT_ASSERT_VALUES_EQUAL(headers.size(), TIntegrityManager::ChunkHeaderReplicaCount);
+        UNIT_ASSERT_VALUES_EQUAL(extents.size(), 1);
+
+        const ui64 chunkGeneration = manager.GetIntegrityChunkGeneration(500);
+        UNIT_ASSERT_VALUES_EQUAL(chunkGeneration, 2); // the data chunk consumed generation 1
+
+        std::vector<ui32> offsets;
+        for (const auto& io : headers) {
+            CheckChunkHeader(io, 500, chunkGeneration);
+            offsets.push_back(io.OffsetInBytes);
+            UNIT_ASSERT_VALUES_EQUAL(io.OffsetInBytes % IntegrityUnitSize, 0);
+            UNIT_ASSERT(io.OffsetInBytes + io.Data.size() <= IntegrityChunkHeaderRegionSize);
+        }
+        std::sort(offsets.begin(), offsets.end());
+        UNIT_ASSERT(std::unique(offsets.begin(), offsets.end()) == offsets.end());
+
+        const auto* ref = manager.FindExtentRef(key);
+        UNIT_ASSERT(ref);
+        UNIT_ASSERT_VALUES_EQUAL(ref->IntegrityChunkIdx, 500);
+        UNIT_ASSERT_VALUES_EQUAL(ref->ExtentSlot, 0);
+        UNIT_ASSERT_VALUES_EQUAL(ref->VChunkGeneration, 1);
+        CheckExtentFormat(manager, extents[0], key, *ref, chunkGeneration);
+
+        // The extent write may finish before the parallel header writes. It must remain not Ready
+        // through the first two header completions and become Ready only on the final replica.
+        UNIT_ASSERT_VALUES_EQUAL(CompleteWrites(manager, extents).size(), 0);
+        UNIT_ASSERT(!manager.IsExtentReady(key));
+
+        for (ui32 i = 0; i + 1 < headers.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(manager.OnIoCompleted(headers[i].IoId).size(), 0);
+            UNIT_ASSERT(!manager.IsExtentReady(key));
+        }
+        const auto readyKeys = manager.OnIoCompleted(headers.back().IoId);
+        UNIT_ASSERT_VALUES_EQUAL(readyKeys.size(), 1);
+        UNIT_ASSERT(readyKeys[0] == key);
+        UNIT_ASSERT(manager.IsExtentReady(key));
+        UNIT_ASSERT(!manager.HasActions());
+    }
+
+    Y_UNIT_TEST(SlotReuseAndExhaustion) {
+        TIntegrityManager manager(TinyChunkSize, TestDDiskId, TestPDiskGuid);
+        UNIT_ASSERT_VALUES_EQUAL(manager.ExtentsPerChunk(), 4);
+
+        TChunkIdx nextIntegrityChunkIdx = 700;
+
+        // The first four data chunks fit into one integrity chunk, slots 0..3.
+        for (ui32 i = 0; i < 4; ++i) {
+            MakeReady(manager, TKey{1, i}, 100 + i, &nextIntegrityChunkIdx);
+            const auto* ref = manager.FindExtentRef(TKey{1, i});
+            UNIT_ASSERT(ref);
+            UNIT_ASSERT_VALUES_EQUAL(ref->IntegrityChunkIdx, 700);
+            UNIT_ASSERT_VALUES_EQUAL(ref->ExtentSlot, i);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(nextIntegrityChunkIdx, 701); // exactly one chunk was allocated
+
+        // Slot exhaustion: the fifth data chunk triggers a second integrity chunk.
+        MakeReady(manager, TKey{1, 4}, 104, &nextIntegrityChunkIdx);
+        UNIT_ASSERT_VALUES_EQUAL(nextIntegrityChunkIdx, 702);
+        const auto* ref = manager.FindExtentRef(TKey{1, 4});
+        UNIT_ASSERT(ref);
+        UNIT_ASSERT_VALUES_EQUAL(ref->IntegrityChunkIdx, 701);
+        UNIT_ASSERT_VALUES_EQUAL(ref->ExtentSlot, 0);
+    }
+
+    Y_UNIT_TEST(PendingDemandBatchesChunkAllocations) {
+        TIntegrityManager manager(TinyChunkSize, TestDDiskId, TestPDiskGuid); // 4 extents per chunk
+
+        // Five data chunks allocated before any integrity chunk arrives: demand of 5 extents
+        // must produce exactly two chunk allocation requests (4 + 1), not five.
+        for (ui32 i = 0; i < 5; ++i) {
+            manager.OnDataChunkAllocated(TKey{2, i}, 200 + i);
+        }
+        TActionLog log = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(log.AllocateRequests, 2);
+        UNIT_ASSERT_VALUES_EQUAL(log.Writes.size(), 0);
+
+        // Fulfill both; all five extents must eventually become ready.
+        manager.OnIntegrityChunkAllocated(710);
+        manager.OnIntegrityChunkAllocated(711);
+        for (ui32 round = 0; round < 10 && manager.HasActions(); ++round) {
+            CompleteWrites(manager, Drain(manager).Writes);
+        }
+        for (ui32 i = 0; i < 5; ++i) {
+            UNIT_ASSERT(manager.IsExtentReady(TKey{2, i}));
+        }
+    }
+
+    Y_UNIT_TEST(ReadPlans) {
+        TIntegrityManager manager(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 3, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 720;
+        MakeReady(manager, key, 300, &nextIntegrityChunkIdx);
+
+        // Tracked, nothing written: all-zero without disk I/O.
+        UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, 0, SmallChunkSize).Kind, TReadPlan::AllZero);
+
+        // Blocks 2..3 written (no checksums).
+        manager.OnBlocksWritten(key, 2 * IntegrityUnitSize, 2 * IntegrityUnitSize, {});
+
+        // Whole written range: passthrough (no zeroing needed).
+        UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, 2 * IntegrityUnitSize, 2 * IntegrityUnitSize).Kind,
+            TReadPlan::Passthrough);
+
+        // Untouched range: all-zero.
+        UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, 0, 2 * IntegrityUnitSize).Kind, TReadPlan::AllZero);
+        UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, 4 * IntegrityUnitSize, 8 * IntegrityUnitSize).Kind,
+            TReadPlan::AllZero);
+
+        // Partially written range: mixed with exact per-block bits.
+        {
+            const TReadPlan plan = manager.MakeReadPlan(key, 0, 6 * IntegrityUnitSize);
+            UNIT_ASSERT_EQUAL(plan.Kind, TReadPlan::Mixed);
+            for (ui32 i = 0; i < 6; ++i) {
+                UNIT_ASSERT_VALUES_EQUAL_C(plan.UsedBlocks.Get(i), (i == 2 || i == 3), "block " << i);
+            }
+        }
+
+        // Sub-block boundary within the used region: still passthrough.
+        {
+            const TReadPlan plan = manager.MakeReadPlan(key, 3 * IntegrityUnitSize, IntegrityUnitSize);
+            UNIT_ASSERT_EQUAL(plan.Kind, TReadPlan::Passthrough);
+        }
+
+        // Unknown chunk: passthrough (safe fallback).
+        UNIT_ASSERT_EQUAL(manager.MakeReadPlan(TKey{99, 99}, 0, IntegrityUnitSize).Kind, TReadPlan::Passthrough);
+    }
+
+    Y_UNIT_TEST(UnalignedWritesRoundOutward) {
+        TIntegrityManager manager(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 4, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 730;
+        MakeReady(manager, key, 400, &nextIntegrityChunkIdx);
+
+        // A write of [2048, 6144) touches blocks 0 and 1: both must count as used.
+        manager.OnBlocksWritten(key, 2048, 4096, {});
+        const TReadPlan plan = manager.MakeReadPlan(key, 0, 3 * IntegrityUnitSize);
+        UNIT_ASSERT_EQUAL(plan.Kind, TReadPlan::Mixed);
+        UNIT_ASSERT(plan.UsedBlocks.Get(0));
+        UNIT_ASSERT(plan.UsedBlocks.Get(1));
+        UNIT_ASSERT(!plan.UsedBlocks.Get(2));
+    }
+
+    Y_UNIT_TEST(ChecksumsAndDigests) {
+        TIntegrityManager manager(MultiBlockChunkSize, TestDDiskId, TestPDiskGuid);
+        UNIT_ASSERT_VALUES_EQUAL(manager.BlocksPerExtent(), 3);
+
+        const TKey key{.TabletId = 5, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 740;
+        MakeReady(manager, key, 500, &nextIntegrityChunkIdx);
+        const ui64 generation = manager.FindExtentRef(key)->VChunkGeneration;
+
+        // Blocks 0..1 with checksums, plus one block in the second TIntegrityBlock.
+        manager.OnBlocksWritten(key, 0, 2 * IntegrityUnitSize, {0xA, 0xB});
+        const ui32 farBlock = ChecksumsPerIntegrityBlock; // first block of digest index 1
+        manager.OnBlocksWritten(key, farBlock * IntegrityUnitSize, IntegrityUnitSize, {0xC});
+
+        ui64 checksum = 0;
+        UNIT_ASSERT(manager.GetBlockChecksum(key, 0, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(checksum, 0xA);
+        UNIT_ASSERT(manager.GetBlockChecksum(key, 1, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(checksum, 0xB);
+        UNIT_ASSERT(manager.GetBlockChecksum(key, farBlock, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(checksum, 0xC);
+        UNIT_ASSERT(!manager.GetBlockChecksum(key, 2, &checksum)); // never written
+
+        // Digests match manual Contribution() accumulation per RFC.
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 0),
+            Contribution(generation, 0, 0xA) ^ Contribution(generation, 1, 0xB));
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 1),
+            Contribution(generation, farBlock, 0xC));
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 2), 0);
+
+        // Overwrite block 0: digest must be updated incrementally (UpdateRoot semantics).
+        manager.OnBlocksWritten(key, 0, IntegrityUnitSize, {0xD});
+        ui64 expected = Contribution(generation, 0, 0xA) ^ Contribution(generation, 1, 0xB);
+        UpdateRoot(expected, generation, 0, 0xA, 0xD);
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 0), expected);
+        UNIT_ASSERT_VALUES_EQUAL(expected, Contribution(generation, 0, 0xD) ^ Contribution(generation, 1, 0xB));
+
+        // Overwrite block 1 without checksums: its contribution is retired, block stays used.
+        manager.OnBlocksWritten(key, IntegrityUnitSize, IntegrityUnitSize, {});
+        UNIT_ASSERT(!manager.GetBlockChecksum(key, 1, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 0), Contribution(generation, 0, 0xD));
+        UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, IntegrityUnitSize, IntegrityUnitSize).Kind,
+            TReadPlan::Passthrough);
+    }
+
+    Y_UNIT_TEST(SparseBlockStateAllocation) {
+        TIntegrityManager manager(MultiBlockChunkSize, TestDDiskId, TestPDiskGuid);
+        UNIT_ASSERT_VALUES_EQUAL(manager.BlocksPerExtent(), 3);
+
+        const TKey key{.TabletId = 9, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 780;
+        MakeReady(manager, key, 800, &nextIntegrityChunkIdx);
+        UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 0);
+
+        // Checksum-less writes mark blocks used but allocate no checksum state.
+        manager.OnBlocksWritten(key, 0, IntegrityUnitSize, {});
+        UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 0);
+        UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, 0, IntegrityUnitSize).Kind, TReadPlan::Passthrough);
+
+        // A checksummed write allocates exactly one state, covering its whole TIntegrityBlock.
+        manager.OnBlocksWritten(key, 0, IntegrityUnitSize, {0xA});
+        UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 1);
+        manager.OnBlocksWritten(key, IntegrityUnitSize, IntegrityUnitSize, {0xB});
+        UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 1);
+
+        // A write into the second TIntegrityBlock's range allocates the second state.
+        manager.OnBlocksWritten(key, ChecksumsPerIntegrityBlock * IntegrityUnitSize, IntegrityUnitSize, {0xC});
+        UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 2);
+    }
+
+    Y_UNIT_TEST(BlockStateLruEviction) {
+        // Budget of exactly two cached states.
+        TIntegrityManager manager(MultiBlockChunkSize, TestDDiskId, TestPDiskGuid,
+            2 * TIntegrityManager::BlockStateApproxBytes);
+        UNIT_ASSERT_VALUES_EQUAL(manager.MaxCachedBlockStates(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(manager.BlocksPerExtent(), 3);
+
+        const TKey key{.TabletId = 10, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 790;
+        MakeReady(manager, key, 810, &nextIntegrityChunkIdx);
+        const ui64 generation = manager.FindExtentRef(key)->VChunkGeneration;
+
+        const ui32 block1 = ChecksumsPerIntegrityBlock;     // first block of TIntegrityBlock 1
+        const ui32 block2 = 2 * ChecksumsPerIntegrityBlock; // first block of TIntegrityBlock 2
+
+        // Fill all three TIntegrityBlocks: the oldest state (block 0's) is evicted.
+        manager.OnBlocksWritten(key, 0, IntegrityUnitSize, {0xA});
+        manager.OnBlocksWritten(key, block1 * IntegrityUnitSize, IntegrityUnitSize, {0xB});
+        manager.OnBlocksWritten(key, block2 * IntegrityUnitSize, IntegrityUnitSize, {0xC});
+        UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 2);
+
+        // Evicted: checksum unknown and digest reset, together.
+        ui64 checksum = 0;
+        UNIT_ASSERT(!manager.GetBlockChecksum(key, 0, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 0), 0);
+
+        // The survivors are intact.
+        UNIT_ASSERT(manager.GetBlockChecksum(key, block1, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(checksum, 0xB);
+        UNIT_ASSERT(manager.GetBlockChecksum(key, block2, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(checksum, 0xC);
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 1),
+            Contribution(generation, block1, 0xB));
+
+        // UsedBlocks are unaffected by eviction: reads of the written block still pass through.
+        UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, 0, IntegrityUnitSize).Kind, TReadPlan::Passthrough);
+
+        // Touching a state protects it: overwrite in TIntegrityBlock 1, then allocate a state in a
+        // second data chunk - TIntegrityBlock 2's state (now the LRU) is the one evicted.
+        manager.OnBlocksWritten(key, block1 * IntegrityUnitSize, IntegrityUnitSize, {0xD});
+        const TKey key2{.TabletId = 10, .VChunkIndex = 1};
+        MakeReady(manager, key2, 811, &nextIntegrityChunkIdx);
+        manager.OnBlocksWritten(key2, 0, IntegrityUnitSize, {0xE});
+        UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 2);
+
+        UNIT_ASSERT(!manager.GetBlockChecksum(key, block2, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 2), 0);
+        UNIT_ASSERT(manager.GetBlockChecksum(key, block1, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(checksum, 0xD);
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityBlockDigest(key, 1),
+            Contribution(generation, block1, 0xD));
+        UNIT_ASSERT(manager.GetBlockChecksum(key2, 0, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(checksum, 0xE);
+    }
+
+    Y_UNIT_TEST(BlockStatesDroppedOnDelete) {
+        TIntegrityManager manager(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 11, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 795;
+        MakeReady(manager, key, 820, &nextIntegrityChunkIdx);
+
+        manager.OnBlocksWritten(key, 0, IntegrityUnitSize, {0xA});
+        UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 1);
+
+        manager.PrepareTabletChunksDeletion(11);
+        manager.CommitTabletChunksDeletion(11);
+        UNIT_ASSERT_VALUES_EQUAL(manager.CachedBlockStates(), 0);
+
+        // Reallocation starts clean: no stale checksums or bitmap.
+        manager.OnDataChunkAllocated(key, 821);
+        CompleteWrites(manager, Drain(manager).Writes);
+        UNIT_ASSERT(manager.IsExtentReady(key));
+        UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, 0, IntegrityUnitSize).Kind, TReadPlan::AllZero);
+        ui64 checksum = 0;
+        UNIT_ASSERT(!manager.GetBlockChecksum(key, 0, &checksum));
+    }
+
+    Y_UNIT_TEST(DeleteAndReuse) {
+        TIntegrityManager manager(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 7, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 750;
+
+        MakeReady(manager, key, 600, &nextIntegrityChunkIdx);
+        manager.OnBlocksWritten(key, 0, IntegrityUnitSize, {});
+        {
+            const auto* ref = manager.FindExtentRef(key);
+            UNIT_ASSERT_VALUES_EQUAL(ref->ExtentSlot, 0);
+            UNIT_ASSERT_VALUES_EQUAL(ref->VChunkGeneration, 1);
+        }
+
+        manager.PrepareTabletChunksDeletion(7);
+        manager.CommitTabletChunksDeletion(7);
+        UNIT_ASSERT(!manager.IsExtentReady(key));
+        UNIT_ASSERT(!manager.FindExtentRef(key));
+        // The chunk is now unknown to the manager: reads pass through.
+        UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, 0, IntegrityUnitSize).Kind, TReadPlan::Passthrough);
+
+        // Reallocation reuses the freed slot without a new integrity chunk and bumps the generation
+        // (VChunk and integrity chunk generations share one counter: 1 = first VChunk allocation,
+        // 2 = the integrity chunk, so the reallocation draws 3).
+        manager.OnDataChunkAllocated(key, 601);
+        TActionLog log = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(log.AllocateRequests, 0);
+        UNIT_ASSERT_VALUES_EQUAL(log.Writes.size(), 1); // extent format only, chunk header already written
+        const auto* ref = manager.FindExtentRef(key);
+        UNIT_ASSERT(ref);
+        UNIT_ASSERT_VALUES_EQUAL(ref->IntegrityChunkIdx, 750);
+        UNIT_ASSERT_VALUES_EQUAL(ref->ExtentSlot, 0);
+        UNIT_ASSERT_VALUES_EQUAL(ref->VChunkGeneration, 3);
+        CheckExtentFormat(manager, log.Writes[0], key, *ref, 2);
+
+        const auto readyKeys = CompleteWrites(manager, log.Writes);
+        UNIT_ASSERT_VALUES_EQUAL(readyKeys.size(), 1);
+        UNIT_ASSERT(manager.IsExtentReady(key));
+        // Old bitmap must not leak into the reallocated chunk.
+        UNIT_ASSERT_EQUAL(manager.MakeReadPlan(key, 0, IntegrityUnitSize).Kind, TReadPlan::AllZero);
+    }
+
+    Y_UNIT_TEST(PreparedDeletionQuarantinesSlotsUntilCommit) {
+        TIntegrityManager manager(TinyChunkSize, TestDDiskId, TestPDiskGuid); // 4 extents per chunk
+        TChunkIdx nextIntegrityChunkIdx = 755;
+        for (ui32 i = 0; i < 4; ++i) {
+            MakeReady(manager, TKey{40, i}, 650 + i, &nextIntegrityChunkIdx);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(nextIntegrityChunkIdx, 756);
+
+        manager.PrepareTabletChunksDeletion(40);
+
+        // Prepared mappings disappear from the next durable snapshot, but all four physical
+        // slots remain quarantined while that snapshot is in flight.
+        UNIT_ASSERT_VALUES_EQUAL(manager.SnapshotMapping().Extents.size(), 0);
+        UNIT_ASSERT(!manager.FindExtentRef(TKey{40, 0}));
+        UNIT_ASSERT(manager.TakeReleasableIntegrityChunks().empty());
+
+        const TKey pendingKey{.TabletId = 41, .VChunkIndex = 0};
+        manager.OnDataChunkAllocated(pendingKey, 660);
+        TActionLog pendingLog = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(pendingLog.Writes.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(pendingLog.AllocateRequests, 1);
+        UNIT_ASSERT(!manager.FindExtentRef(pendingKey));
+
+        // Only the durable commit releases the old slots. Reclamation gives slot 0 to the pending
+        // extent before considering the integrity chunk for release.
+        manager.CommitTabletChunksDeletion(40);
+        UNIT_ASSERT(manager.TakeReleasableIntegrityChunks().empty());
+        TActionLog formatLog = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(formatLog.Writes.size(), 1);
+        const auto* ref = manager.FindExtentRef(pendingKey);
+        UNIT_ASSERT(ref);
+        UNIT_ASSERT_VALUES_EQUAL(ref->IntegrityChunkIdx, 755);
+        UNIT_ASSERT_VALUES_EQUAL(ref->ExtentSlot, 0);
+        UNIT_ASSERT_VALUES_EQUAL(ref->VChunkGeneration, 6);
+        UNIT_ASSERT_VALUES_EQUAL(CompleteWrites(manager, formatLog.Writes).size(), 1);
+        UNIT_ASSERT(manager.IsExtentReady(pendingKey));
+    }
+
+    Y_UNIT_TEST(PreparedDeletionWaitsForDurabilityAfterFormattingCompletes) {
+        TIntegrityManager manager(TinyChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 42, .VChunkIndex = 0};
+
+        manager.OnDataChunkAllocated(key, 670);
+        Drain(manager);
+        manager.OnIntegrityChunkAllocated(757);
+        TActionLog log = Drain(manager);
+        std::vector<TWriteIo> headers;
+        std::vector<TWriteIo> formatLogWrites;
+        SplitWrites(log.Writes, &headers, &formatLogWrites);
+        UNIT_ASSERT_VALUES_EQUAL(headers.size(), TIntegrityManager::ChunkHeaderReplicaCount);
+        UNIT_ASSERT_VALUES_EQUAL(formatLogWrites.size(), 1);
+        CompleteWrites(manager, headers);
+
+        manager.PrepareTabletChunksDeletion(42);
+        // The physical write may finish first, but it must neither publish readiness nor release
+        // its slot/chunk before the deletion snapshot is acknowledged.
+        UNIT_ASSERT_VALUES_EQUAL(CompleteWrites(manager, formatLogWrites).size(), 0);
+        UNIT_ASSERT(manager.TakeReleasableIntegrityChunks().empty());
+
+        manager.CommitTabletChunksDeletion(42);
+        const auto released = manager.TakeReleasableIntegrityChunks();
+        UNIT_ASSERT_VALUES_EQUAL(released.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(released[0], 757);
+    }
+
+    Y_UNIT_TEST(DeleteWhileFormatInFlight) {
+        TIntegrityManager manager(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 8, .VChunkIndex = 0};
+
+        manager.OnDataChunkAllocated(key, 700);
+        Drain(manager);
+        manager.OnIntegrityChunkAllocated(760);
+        TActionLog log = Drain(manager);
+        std::vector<TWriteIo> headers;
+        std::vector<TWriteIo> formatLog;
+        SplitWrites(log.Writes, &headers, &formatLog);
+        UNIT_ASSERT_VALUES_EQUAL(formatLog.size(), 1);
+        CompleteWrites(manager, headers);
+
+        // The tablet's chunks are deleted while the extent format write is in flight.
+        manager.PrepareTabletChunksDeletion(8);
+        manager.CommitTabletChunksDeletion(8);
+        UNIT_ASSERT_VALUES_EQUAL(CompleteWrites(manager, formatLog).size(), 0);
+        UNIT_ASSERT(!manager.IsExtentReady(key));
+
+        // The slot is reusable afterwards.
+        manager.OnDataChunkAllocated(key, 701);
+        TActionLog reuseLog = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(reuseLog.AllocateRequests, 0);
+        UNIT_ASSERT_VALUES_EQUAL(reuseLog.Writes.size(), 1);
+        const auto readyKeys = CompleteWrites(manager, reuseLog.Writes);
+        UNIT_ASSERT_VALUES_EQUAL(readyKeys.size(), 1);
+        UNIT_ASSERT(manager.IsExtentReady(key));
+        UNIT_ASSERT_VALUES_EQUAL(manager.FindExtentRef(key)->VChunkGeneration, 3);
+    }
+
+    Y_UNIT_TEST(StaleFormatCompletionDoesNotCompleteReusedExtent) {
+        TIntegrityManager manager(TinyChunkSize, TestDDiskId, TestPDiskGuid); // 4 extents per chunk
+        const TKey key{.TabletId = 12, .VChunkIndex = 0};
+
+        manager.OnDataChunkAllocated(key, 900);
+        Drain(manager);
+        manager.OnIntegrityChunkAllocated(765);
+        TActionLog staleDrain = Drain(manager);
+        std::vector<TWriteIo> staleHeaders;
+        std::vector<TWriteIo> staleFormatWrites;
+        SplitWrites(staleDrain.Writes, &staleHeaders, &staleFormatWrites);
+        UNIT_ASSERT_VALUES_EQUAL(staleFormatWrites.size(), 1);
+        CompleteWrites(manager, staleHeaders);
+
+        // Free the extent while its format write is in flight and immediately reallocate the key.
+        manager.PrepareTabletChunksDeletion(12);
+        manager.CommitTabletChunksDeletion(12);
+        manager.OnDataChunkAllocated(key, 901);
+        TActionLog newFormat = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(newFormat.AllocateRequests, 0);
+        UNIT_ASSERT_VALUES_EQUAL(newFormat.Writes.size(), 1);
+
+        // Slot 0 is withheld until the stale write settles: the new extent gets slot 1.
+        const auto* ref = manager.FindExtentRef(key);
+        UNIT_ASSERT(ref);
+        UNIT_ASSERT_VALUES_EQUAL(ref->ExtentSlot, 1);
+        UNIT_ASSERT_VALUES_EQUAL(ref->VChunkGeneration, 3);
+
+        // The stale completion must not mark the reallocated extent ready.
+        UNIT_ASSERT_VALUES_EQUAL(CompleteWrites(manager, staleFormatWrites).size(), 0);
+        UNIT_ASSERT(!manager.IsExtentReady(key));
+
+        // Only the extent's own format write completes it.
+        const auto readyKeys = CompleteWrites(manager, newFormat.Writes);
+        UNIT_ASSERT_VALUES_EQUAL(readyKeys.size(), 1);
+        UNIT_ASSERT(manager.IsExtentReady(key));
+
+        // The stale write has settled, so slot 0 is reusable by the next allocation.
+        const TKey key2{.TabletId = 12, .VChunkIndex = 1};
+        manager.OnDataChunkAllocated(key2, 902);
+        TActionLog log2 = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(log2.AllocateRequests, 0);
+        UNIT_ASSERT_VALUES_EQUAL(log2.Writes.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(manager.FindExtentRef(key2)->ExtentSlot, 0);
+        CompleteWrites(manager, log2.Writes);
+        UNIT_ASSERT(manager.IsExtentReady(key2));
+    }
+
+    Y_UNIT_TEST(PendingExtentWaitsForOrphanedSlot) {
+        // All four slots taken, one extent freed mid-format: a pending extent must wait for the
+        // orphaned write to settle rather than reuse the slot early, and must then be assigned
+        // to it (no new chunk needed).
+        TIntegrityManager manager(TinyChunkSize, TestDDiskId, TestPDiskGuid); // 4 extents per chunk
+        TChunkIdx nextIntegrityChunkIdx = 768;
+        for (ui32 i = 0; i < 3; ++i) {
+            MakeReady(manager, TKey{13, i}, 910 + i, &nextIntegrityChunkIdx);
+        }
+
+        // The fourth extent (a different tablet) occupies slot 3 with its format write in flight.
+        const TKey inFlightKey{.TabletId = 15, .VChunkIndex = 0};
+        manager.OnDataChunkAllocated(inFlightKey, 913);
+        TActionLog staleFormat = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(staleFormat.Writes.size(), 1);
+
+        // Free it mid-format. A new allocation finds no free slot (slot 3 is withheld) and no
+        // format write can be issued yet - but capacity accounting may request a chunk.
+        manager.PrepareTabletChunksDeletion(15);
+        manager.CommitTabletChunksDeletion(15);
+        const TKey pendingKey{.TabletId = 14, .VChunkIndex = 0};
+        manager.OnDataChunkAllocated(pendingKey, 920);
+        TActionLog log = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(log.Writes.size(), 0);
+        UNIT_ASSERT(!manager.IsExtentReady(pendingKey));
+
+        // The orphaned write settles: slot 3 is released and the pending extent takes it.
+        CompleteWrites(manager, staleFormat.Writes);
+        TActionLog formatLog = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(formatLog.Writes.size(), 1);
+        const auto* ref = manager.FindExtentRef(pendingKey);
+        UNIT_ASSERT(ref);
+        UNIT_ASSERT_VALUES_EQUAL(ref->ExtentSlot, 3);
+        CompleteWrites(manager, formatLog.Writes);
+        UNIT_ASSERT(manager.IsExtentReady(pendingKey));
+    }
+
+    Y_UNIT_TEST(SnapshotRoundTrip) {
+        TIntegrityManager manager(TinyChunkSize, TestDDiskId, TestPDiskGuid); // 4 extents per chunk
+        TChunkIdx nextIntegrityChunkIdx = 770;
+
+        // Six extents across two tablets -> two integrity chunks.
+        std::vector<TKey> keys;
+        for (ui32 i = 0; i < 3; ++i) {
+            keys.push_back(TKey{10, i});
+            keys.push_back(TKey{11, i});
+        }
+        for (ui32 i = 0; i < keys.size(); ++i) {
+            MakeReady(manager, keys[i], 800 + i, &nextIntegrityChunkIdx);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(nextIntegrityChunkIdx, 772);
+
+        const auto snapshot = manager.SnapshotMapping();
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.IntegrityChunks.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Extents.size(), keys.size());
+        // Six VChunk generations and two integrity chunk generations were drawn from the shared
+        // counter, so the persisted watermark is 8.
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.GenerationCounter, 8);
+
+        // Apply to a fresh manager: same refs, all ready, no actions.
+        TIntegrityManager restored(TinyChunkSize, TestDDiskId, TestPDiskGuid);
+        restored.ApplyMappingSnapshot(snapshot);
+        UNIT_ASSERT(!restored.HasActions());
+        for (const auto& key : keys) {
+            UNIT_ASSERT(restored.IsExtentReady(key));
+            const auto* origRef = manager.FindExtentRef(key);
+            const auto* restoredRef = restored.FindExtentRef(key);
+            UNIT_ASSERT(origRef && restoredRef);
+            UNIT_ASSERT_VALUES_EQUAL(restoredRef->IntegrityChunkIdx, origRef->IntegrityChunkIdx);
+            UNIT_ASSERT_VALUES_EQUAL(restoredRef->ExtentSlot, origRef->ExtentSlot);
+            UNIT_ASSERT_VALUES_EQUAL(restoredRef->VChunkGeneration, origRef->VChunkGeneration);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(restored.GetIntegrityChunkGeneration(770), 2);
+        UNIT_ASSERT_VALUES_EQUAL(restored.GetIntegrityChunkGeneration(771), 7);
+        UNIT_ASSERT_VALUES_EQUAL(restored.GetGenerationCounter(), 8);
+
+        // Restored extents have unknown bitmaps: reads pass through unchanged even though nothing
+        // was written since the restore (the previous incarnation's bitmap is lost); new writes
+        // are tracked again (checksums recorded) but do not change the read plan.
+        UNIT_ASSERT_EQUAL(restored.MakeReadPlan(keys[0], 0, TinyChunkSize).Kind, TReadPlan::Passthrough);
+        restored.OnBlocksWritten(keys[0], 0, IntegrityUnitSize, {0xA});
+        ui64 checksum = 0;
+        UNIT_ASSERT(restored.GetBlockChecksum(keys[0], 0, &checksum));
+        UNIT_ASSERT_VALUES_EQUAL(checksum, 0xA);
+        UNIT_ASSERT_EQUAL(restored.MakeReadPlan(keys[0], 0, TinyChunkSize).Kind, TReadPlan::Passthrough);
+
+        // The restored manager keeps allocating into the remaining free slots of known chunks
+        // without requesting new integrity chunks (6 used out of 8 -> 2 slots left).
+        for (ui32 i = 0; i < 2; ++i) {
+            const TKey key{12, i};
+            restored.OnDataChunkAllocated(key, 900 + i);
+            TActionLog log = Drain(restored);
+            UNIT_ASSERT_VALUES_EQUAL(log.AllocateRequests, 0);
+            UNIT_ASSERT_VALUES_EQUAL(log.Writes.size(), 1);
+            CompleteWrites(restored, log.Writes);
+            UNIT_ASSERT(restored.IsExtentReady(key));
+        }
+        // And the ninth extent overflows into a new chunk.
+        restored.OnDataChunkAllocated(TKey{12, 2}, 902);
+        UNIT_ASSERT_VALUES_EQUAL(Drain(restored).AllocateRequests, 1);
+
+        // Deleting a restored tablet and reallocating bumps VChunkGeneration past the persisted
+        // watermark (generations 9..11 were drawn by tablet 12 above).
+        restored.PrepareTabletChunksDeletion(10);
+        restored.CommitTabletChunksDeletion(10);
+        restored.OnDataChunkAllocated(TKey{10, 0}, 950);
+        Drain(restored);
+        const auto* ref = restored.FindExtentRef(TKey{10, 0});
+        UNIT_ASSERT(ref);
+        UNIT_ASSERT_VALUES_EQUAL(ref->VChunkGeneration, 12);
+        UNIT_ASSERT(ref->VChunkGeneration > snapshot.GenerationCounter);
+    }
+
+    Y_UNIT_TEST(SnapshotExcludesFormattingChunks) {
+        TIntegrityManager manager(TinyChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 16, .VChunkIndex = 0};
+
+        manager.OnDataChunkAllocated(key, 960);
+        UNIT_ASSERT_VALUES_EQUAL(Drain(manager).AllocateRequests, 1);
+        manager.OnIntegrityChunkAllocated(775);
+        const TActionLog formatting = Drain(manager);
+
+        // ApplyMappingSnapshot restores every listed chunk as Ready, so a chunk whose headers are
+        // still in flight must not be exported.
+        const auto inFlightSnapshot = manager.SnapshotMapping();
+        UNIT_ASSERT_VALUES_EQUAL(inFlightSnapshot.IntegrityChunks.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(inFlightSnapshot.Extents.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(inFlightSnapshot.GenerationCounter, 2);
+
+        const auto readyKeys = CompleteWrites(manager, formatting.Writes);
+        UNIT_ASSERT_VALUES_EQUAL(readyKeys.size(), 1);
+        const auto readySnapshot = manager.SnapshotMapping();
+        UNIT_ASSERT_VALUES_EQUAL(readySnapshot.IntegrityChunks.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(readySnapshot.IntegrityChunks[0].ChunkIdx, 775);
+        UNIT_ASSERT_VALUES_EQUAL(readySnapshot.Extents.size(), 1);
+    }
+
+    Y_UNIT_TEST(ReleasableIntegrityChunks) {
+        TIntegrityManager manager(TinyChunkSize, TestDDiskId, TestPDiskGuid); // 4 extents per chunk
+        TChunkIdx nextIntegrityChunkIdx = 850;
+
+        // Five extents -> two chunks (850 full, 851 holds one).
+        for (ui32 i = 0; i < 5; ++i) {
+            MakeReady(manager, TKey{30, i}, 1000 + i, &nextIntegrityChunkIdx);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(nextIntegrityChunkIdx, 852);
+
+        // Nothing is releasable while extents are in place.
+        UNIT_ASSERT(manager.TakeReleasableIntegrityChunks().empty());
+
+        // Delete the tablet: both chunks become fully free and are handed back for deallocation.
+        manager.PrepareTabletChunksDeletion(30);
+        manager.CommitTabletChunksDeletion(30);
+        auto released = manager.TakeReleasableIntegrityChunks();
+        std::sort(released.begin(), released.end());
+        UNIT_ASSERT_VALUES_EQUAL(released.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(released[0], 850);
+        UNIT_ASSERT_VALUES_EQUAL(released[1], 851);
+        UNIT_ASSERT_VALUES_EQUAL(manager.GetIntegrityChunkGeneration(850), 0); // forgotten
+        UNIT_ASSERT(!manager.HasActions());
+
+        // The next allocation requests a fresh integrity chunk again.
+        manager.OnDataChunkAllocated(TKey{30, 0}, 1010);
+        UNIT_ASSERT_VALUES_EQUAL(Drain(manager).AllocateRequests, 1);
+    }
+
+    Y_UNIT_TEST(ReleasableChunksServePendingExtentsFirst) {
+        TIntegrityManager manager(TinyChunkSize, TestDDiskId, TestPDiskGuid); // 4 extents per chunk
+        TChunkIdx nextIntegrityChunkIdx = 860;
+        for (ui32 i = 0; i < 4; ++i) {
+            MakeReady(manager, TKey{31, i}, 1100 + i, &nextIntegrityChunkIdx);
+        }
+
+        // A fifth extent (another tablet) goes pending: all slots taken, a chunk allocation is
+        // queued - and genuinely needed, so it must not be cancellable.
+        manager.OnDataChunkAllocated(TKey{32, 0}, 1104);
+        TActionLog log = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(log.AllocateRequests, 1);
+        UNIT_ASSERT_VALUES_EQUAL(log.Writes.size(), 0);
+        UNIT_ASSERT(!manager.CancelChunkAllocationIfExcess());
+
+        // Deleting the first tablet frees all four slots, but the pending extent takes one before
+        // releasability is decided: the chunk stays owned and the extent's format write goes out.
+        manager.PrepareTabletChunksDeletion(31);
+        manager.CommitTabletChunksDeletion(31);
+        UNIT_ASSERT(manager.TakeReleasableIntegrityChunks().empty());
+        log = Drain(manager);
+        UNIT_ASSERT_VALUES_EQUAL(log.Writes.size(), 1);
+        UNIT_ASSERT(manager.FindExtentRef(TKey{32, 0}));
+
+        // With three slots left free and no pending extents, the queued allocation is now excess.
+        UNIT_ASSERT(manager.CancelChunkAllocationIfExcess());
+
+        CompleteWrites(manager, log.Writes);
+        UNIT_ASSERT(manager.IsExtentReady(TKey{32, 0}));
+    }
+
+    Y_UNIT_TEST(OrphanedFormatWriteBlocksChunkRelease) {
+        TIntegrityManager manager(TinyChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 33, .VChunkIndex = 0};
+
+        // Bring one chunk to Ready with the extent's format write still in flight.
+        manager.OnDataChunkAllocated(key, 1200);
+        Drain(manager);
+        manager.OnIntegrityChunkAllocated(870);
+        TActionLog formatDrain = Drain(manager);
+        std::vector<TWriteIo> headers;
+        std::vector<TWriteIo> formatLogWrites;
+        SplitWrites(formatDrain.Writes, &headers, &formatLogWrites);
+        UNIT_ASSERT_VALUES_EQUAL(formatLogWrites.size(), 1);
+        CompleteWrites(manager, headers);
+
+        // Delete while the format write is in flight: its slot is withheld, so the chunk must not
+        // be released - the write could still land on it after PDisk reassigns the chunk.
+        manager.PrepareTabletChunksDeletion(33);
+        manager.CommitTabletChunksDeletion(33);
+        UNIT_ASSERT(manager.TakeReleasableIntegrityChunks().empty());
+
+        // Once the orphaned write settles the chunk is fully free and releasable.
+        CompleteWrites(manager, formatLogWrites);
+        const auto released = manager.TakeReleasableIntegrityChunks();
+        UNIT_ASSERT_VALUES_EQUAL(released.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(released[0], 870);
+    }
+
+    Y_UNIT_TEST(FormattingChunkNotReleasable) {
+        TIntegrityManager manager(TinyChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 34, .VChunkIndex = 0};
+
+        manager.OnDataChunkAllocated(key, 1300);
+        Drain(manager);
+        manager.OnIntegrityChunkAllocated(880);
+        TActionLog headerLog = Drain(manager);
+        UNIT_ASSERT(headerLog.Writes.size() >= 1);
+
+        // The extent is freed while the chunk is still writing its headers (and possibly the
+        // extent format): the chunk is not releasable until every in-flight write settles.
+        manager.PrepareTabletChunksDeletion(34);
+        manager.CommitTabletChunksDeletion(34);
+        UNIT_ASSERT(manager.TakeReleasableIntegrityChunks().empty());
+
+        CompleteWrites(manager, headerLog.Writes);
+        while (manager.HasActions()) {
+            CompleteWrites(manager, Drain(manager).Writes);
+        }
+        const auto released = manager.TakeReleasableIntegrityChunks();
+        UNIT_ASSERT_VALUES_EQUAL(released.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(released[0], 880);
+    }
+
+    Y_UNIT_TEST(RestoredChunksAreReadyAndHostNewExtents) {
+        TIntegrityManager manager(TinyChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 35, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 890;
+        MakeReady(manager, key, 1400, &nextIntegrityChunkIdx);
+
+        const auto snapshot = manager.SnapshotMapping();
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.IntegrityChunks.size(), 1);
+
+        TIntegrityManager restored(TinyChunkSize, TestDDiskId, TestPDiskGuid);
+        restored.ApplyMappingSnapshot(snapshot);
+        UNIT_ASSERT(!restored.HasActions());
+        UNIT_ASSERT(restored.IsExtentReady(key));
+        UNIT_ASSERT(restored.IsIntegrityChunkFormatted(890));
+
+        const TKey key2{.TabletId = 35, .VChunkIndex = 1};
+        restored.OnDataChunkAllocated(key2, 1401);
+        UNIT_ASSERT(restored.FindExtentRef(key2));
+        TActionLog log = Drain(restored);
+        UNIT_ASSERT_VALUES_EQUAL(log.AllocateRequests, 0);
+        UNIT_ASSERT_VALUES_EQUAL(log.Writes.size(), 1);
+        CompleteWrites(restored, log.Writes);
+        UNIT_ASSERT(restored.IsExtentReady(key2));
+    }
+
+    Y_UNIT_TEST(GenerationWatermarkSurvivesRestart) {
+        TIntegrityManager manager(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        const TKey key{.TabletId = 36, .VChunkIndex = 0};
+        TChunkIdx nextIntegrityChunkIdx = 895;
+        MakeReady(manager, key, 1500, &nextIntegrityChunkIdx);
+        UNIT_ASSERT_VALUES_EQUAL(manager.FindExtentRef(key)->VChunkGeneration, 1);
+
+        // Delete the tablet: the extent vanishes from the mapping, so after a restart only the
+        // watermark can prevent the generation from being reused.
+        manager.PrepareTabletChunksDeletion(36);
+        manager.CommitTabletChunksDeletion(36);
+        const auto snapshot = manager.SnapshotMapping();
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.Extents.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(snapshot.GenerationCounter, 2);
+
+        TIntegrityManager restored(SmallChunkSize, TestDDiskId, TestPDiskGuid);
+        restored.ApplyMappingSnapshot(snapshot);
+
+        // Reallocating the same key must draw a fresh generation, not reuse 1.
+        restored.OnDataChunkAllocated(key, 1501);
+        TActionLog log = Drain(restored);
+        UNIT_ASSERT_VALUES_EQUAL(log.AllocateRequests, 0); // the restored chunk has free slots
+        const auto* ref = restored.FindExtentRef(key);
+        UNIT_ASSERT(ref);
+        UNIT_ASSERT_VALUES_EQUAL(ref->VChunkGeneration, 3);
+    }
+
+} // Y_UNIT_TEST_SUITE(TIntegrityManagerTest)
+
+} // namespace NKikimr::NDDisk

--- a/ydb/core/blobstorage/ddisk/ut/persistent_buffer_barriers_manager_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/persistent_buffer_barriers_manager_ut.cpp
@@ -32,6 +32,54 @@ static constexpr ui32 MaxRawLsns = TPersistentBufferFastErases::ErasesBufferSize
 
 Y_UNIT_TEST_SUITE(TPersistentBufferBarriersManagerTest) {
 
+    Y_UNIT_TEST(RestoreKeepsBarriersWithoutRecords) {
+        auto mgr = MakeManager();
+        auto alloc = MakeAllocator();
+        TPersistentBufferBarriers header{};
+        header.Header.Flags = TPersistentBufferHeader::IS_BARRIER;
+        header.Header.RecordLsn = 1;
+        header.Barriers[0] = {100, 0, 0, 1};
+        header.Barriers[1] = {100, 3, 42, 2};
+        header.Barriers[2] = {100, Max<ui32>(), Max<ui64>(), 3};
+        UNIT_ASSERT(mgr.AddBarrier(&header.Header, 0, 1));
+        std::map<TPersistentBufferId, TPersistentBuffer> buffers;
+        mgr.RestoreBarriers(buffers, alloc);
+
+        UNIT_ASSERT_VALUES_EQUAL(mgr.PersistentBufferBarriersLocation.size(), 3);
+        UNIT_ASSERT(mgr.PersistentBufferBarriersLocation.contains({100, 1}));
+        UNIT_ASSERT_VALUES_EQUAL(mgr.GetBarrier(100, 2).Generation, 3);
+        UNIT_ASSERT_VALUES_EQUAL(mgr.GetBarrier(100, 2).Lsn, 42);
+        UNIT_ASSERT_VALUES_EQUAL(mgr.GetBarrier(100, 3).Generation, Max<ui32>());
+        UNIT_ASSERT_VALUES_EQUAL(mgr.GetBarrier(100, 3).Lsn, Max<ui64>());
+        UNIT_ASSERT(mgr.PersistentBufferBarrierHoles.empty());
+
+        // Allocating another namespace must not overwrite a recovered empty namespace.
+        mgr.MoveBarrier(200, 1, 1, MakeSector(0, 2));
+        UNIT_ASSERT_VALUES_EQUAL(mgr.PersistentBufferBarriersLocation.size(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(mgr.GetBarrier(100, 2).Lsn, 42);
+        UNIT_ASSERT_VALUES_EQUAL(mgr.GetBarrier(100, 3).Lsn, Max<ui64>());
+    }
+
+    Y_UNIT_TEST(RestoreKeepsBarrierAcrossRestartsAfterLastRecordErased) {
+        TPersistentBufferBarriers header{};
+        header.Header.Flags = TPersistentBufferHeader::IS_BARRIER;
+        header.Header.RecordLsn = 1;
+        header.Barriers[0] = {100, 2, 10, 0};
+        std::map<TPersistentBufferId, TPersistentBuffer> buffers;
+        buffers[{100, 2}].Records[5] = {};
+
+        for (ui32 restart = 0; restart != 2; ++restart) {
+            auto mgr = MakeManager();
+            auto alloc = MakeAllocator();
+            UNIT_ASSERT(mgr.AddBarrier(&header.Header, 0, 1));
+            mgr.RestoreBarriers(buffers, alloc);
+            UNIT_ASSERT(buffers.empty());
+            UNIT_ASSERT_VALUES_EQUAL(mgr.GetBarrier(100).Generation, 2);
+            UNIT_ASSERT_VALUES_EQUAL(mgr.GetBarrier(100).Lsn, 10);
+            UNIT_ASSERT(mgr.PersistentBufferBarrierHoles.empty());
+        }
+    }
+
     Y_UNIT_TEST(CompactDoesNotSetFlagWhenFitsRaw) {
         auto mgr = MakeManager();
 

--- a/ydb/core/blobstorage/ddisk/ut/ya.make
+++ b/ydb/core/blobstorage/ddisk/ut/ya.make
@@ -18,6 +18,7 @@ SRCS(
     ddisk_actor_checksum_ut.cpp
     ddisk_actor_pdisk_ut.cpp
     ddisk_sync_ut.cpp
+    integrity_manager_ut.cpp
     persistent_buffer_barriers_manager_ut.cpp
     persistent_buffer_space_allocator_ut.cpp
     segment_manager_ut.cpp

--- a/ydb/core/blobstorage/ddisk/write_persistent_buffers_request_actor.cpp
+++ b/ydb/core/blobstorage/ddisk/write_persistent_buffers_request_actor.cpp
@@ -148,10 +148,10 @@ namespace NKikimr::NDDisk {
         auto msg = std::make_unique<TEvWritePersistentBuffers>(creds, selector, inflight.Lsn, NDDisk::TWriteInstruction(0),
             inflight.PersistentBufferIds, inflight.Timeout);
         msg->AddPayload(TRope(payload));
-        // Forward the checksums persisted on the source record, if any (TEvReadPersistentBufferResult
-        // carries them opt-in, see TPersistentBuffer::TRecord::PayloadChecksums). Without this, records
-        // re-replicated via TEvReadThenWritePersistentBuffers would silently lose their checksums on
-        // every target PB, exactly the recovery scenario where corruption detection matters most.
+        // Forward the checksums persisted on the source record. Successful writes always store them,
+        // so a successful source read returns exactly one checksum per aligned block. Without this,
+        // TEvReadThenWritePersistentBuffers would re-replicate a record that the destination would
+        // then reject as a checksum-less write.
         msg->Record.MutableChecksums()->CopyFrom(record.GetChecksums());
         auto h = std::make_unique<IEventHandle>(SelfId(), inflight.Sender, msg.release(), 0, inflight.Cookie);
         TActivationContext::Send(h.release());

--- a/ydb/core/blobstorage/ddisk/ya.make
+++ b/ydb/core/blobstorage/ddisk/ya.make
@@ -15,6 +15,8 @@ LIBRARY()
         ddisk_actor_read_write.cpp
         ddisk_actor_sync.cpp
         direct_io_op.cpp
+        integrity_manager.cpp
+        integrity_manager.h
         persistent_buffer_barriers_manager.cpp
         persistent_buffer_space_allocator.cpp
         persistent_buffer_mon.cpp

--- a/ydb/core/blobstorage/ut_blobstorage/ddisk.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/ddisk.cpp
@@ -204,7 +204,7 @@ Y_UNIT_TEST_SUITE(DDisk) {
 
             std::unique_ptr<NDDisk::TEvWrite> ev(new NDDisk::TEvWrite(Creds,
                 {VChunkIndex, offset, size}, {0}));
-            ev->AddPayload(TRope(std::move(buf)));
+            ev->AddPayloadThenChecksum(TRope(std::move(buf)));
             Env.Runtime->Send(new IEventHandle(ServiceId, Edge, ev.release()), Edge.NodeId());
             auto res = Env.WaitForEdgeActorEvent<NDDisk::TEvWriteResult>(Edge, false);
 
@@ -231,7 +231,14 @@ Y_UNIT_TEST_SUITE(DDisk) {
             UNIT_ASSERT_VALUES_EQUAL(rr2.GetPayloadId(), 0);
             TRope rope = res->Get()->GetPayload(0);
             UNIT_ASSERT_VALUES_EQUAL(rope.size(), size);
-            UNIT_ASSERT_VALUES_EQUAL(rope.ConvertToString(), Surface.substr(offset, size));
+            const TString expected = Surface.substr(offset, size);
+            UNIT_ASSERT_VALUES_EQUAL(rope.ConvertToString(), expected);
+            const ui32 expectedChecksumCount = size / BlockSize;
+            UNIT_ASSERT_VALUES_EQUAL(static_cast<ui32>(rr.ChecksumsSize()), expectedChecksumCount);
+            for (ui32 i = 0; i < expectedChecksumCount; ++i) {
+                UNIT_ASSERT_VALUES_EQUAL(rr.GetChecksums(i),
+                    NDDisk::CalculateRawChecksum(expected.data() + i * BlockSize, BlockSize));
+            }
         }
 
         void ListPB() {
@@ -291,7 +298,7 @@ Y_UNIT_TEST_SUITE(DDisk) {
 
             std::unique_ptr<NDDisk::TEvWritePersistentBuffer> ev(new NDDisk::TEvWritePersistentBuffer(
                 PBCreds[tabletIdx], {VChunkIndex, offset, size}, lsn, {0}));
-            ev->AddPayload(TRope(std::move(update)));
+            ev->AddPayloadThenChecksum(TRope(std::move(update)));
             Env.Runtime->Send(new IEventHandle(PBServiceId, Edge, ev.release()), Edge.NodeId());
             auto res = Env.WaitForEdgeActorEvent<NDDisk::TEvWritePersistentBufferResult>(Edge, false);
             UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
@@ -380,7 +387,7 @@ Y_UNIT_TEST_SUITE(DDisk) {
 
             std::unique_ptr<NDDisk::TEvWritePersistentBuffer> ev(new NDDisk::TEvWritePersistentBuffer(
                 creds, {VChunkIndex, offset, size}, lsn, {0}));
-            ev->AddPayload(TRope(std::move(update)));
+            ev->AddPayloadThenChecksum(TRope(std::move(update)));
             Env.Runtime->Send(new IEventHandle(PBServiceId, Edge, ev.release()), Edge.NodeId());
             auto res = Env.WaitForEdgeActorEvent<NDDisk::TEvWritePersistentBufferResult>(Edge, false);
             UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrBlobStorage::NDDisk::TReplyStatus::OK);

--- a/ydb/core/blobstorage/ut_blobstorage/ddisk.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/ddisk.cpp
@@ -1060,17 +1060,21 @@ Y_UNIT_TEST_SUITE(DDisk) {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
             UNIT_ASSERT(b.size() == 3);
-            UNIT_ASSERT((b[{f.PBCreds[6].TabletId, static_cast<ui8>(f.PBCreds[6].DirectBlockGroupIndex)}] == 300)); // Hole
-            UNIT_ASSERT((b[{f.PBCreds[4].TabletId, static_cast<ui8>(f.PBCreds[4].DirectBlockGroupIndex)}] == 100)); // Hole
+            // Barriers survive recovery even without live records for the namespace.
+            UNIT_ASSERT((b[{f.PBCreds[6].TabletId, static_cast<ui8>(f.PBCreds[6].DirectBlockGroupIndex)}] == 300));
+            UNIT_ASSERT((b[{f.PBCreds[4].TabletId, static_cast<ui8>(f.PBCreds[4].DirectBlockGroupIndex)}] == 100));
             UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
         f.ErasePB(2000, 7); // clear PB space to write more
         {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
-            UNIT_ASSERT(b.size() == 3);
-            UNIT_ASSERT((b[{f.PBCreds[7].TabletId, static_cast<ui8>(f.PBCreds[7].DirectBlockGroupIndex)}] == 2000)); // Hole replaced
-            UNIT_ASSERT((b[{f.PBCreds[4].TabletId, static_cast<ui8>(f.PBCreds[4].DirectBlockGroupIndex)}] == 100)); // Hole
+            // Preserved barriers are not reused by other tablets, so a new barrier
+            // slot is allocated for tablet7 rather than replacing tablet6's/tablet4's.
+            UNIT_ASSERT(b.size() == 4);
+            UNIT_ASSERT((b[{f.PBCreds[7].TabletId, static_cast<ui8>(f.PBCreds[7].DirectBlockGroupIndex)}] == 2000)); // New
+            UNIT_ASSERT((b[{f.PBCreds[6].TabletId, static_cast<ui8>(f.PBCreds[6].DirectBlockGroupIndex)}] == 300));
+            UNIT_ASSERT((b[{f.PBCreds[4].TabletId, static_cast<ui8>(f.PBCreds[4].DirectBlockGroupIndex)}] == 100));
             UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
         f.WritePB(0, 128, 8);
@@ -1080,9 +1084,11 @@ Y_UNIT_TEST_SUITE(DDisk) {
         {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
-            UNIT_ASSERT(b.size() == 3);
+            UNIT_ASSERT(b.size() == 5);
             UNIT_ASSERT((b[{f.PBCreds[7].TabletId, static_cast<ui8>(f.PBCreds[7].DirectBlockGroupIndex)}] == 2000));
-            UNIT_ASSERT((b[{f.PBCreds[8].TabletId, static_cast<ui8>(f.PBCreds[8].DirectBlockGroupIndex)}] == 2551)); // Hole replaced
+            UNIT_ASSERT((b[{f.PBCreds[8].TabletId, static_cast<ui8>(f.PBCreds[8].DirectBlockGroupIndex)}] == 2551)); // New
+            UNIT_ASSERT((b[{f.PBCreds[6].TabletId, static_cast<ui8>(f.PBCreds[6].DirectBlockGroupIndex)}] == 300));
+            UNIT_ASSERT((b[{f.PBCreds[4].TabletId, static_cast<ui8>(f.PBCreds[4].DirectBlockGroupIndex)}] == 100));
             UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
         f.WritePB(0, 128, 8);
@@ -1091,9 +1097,11 @@ Y_UNIT_TEST_SUITE(DDisk) {
         {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
-            UNIT_ASSERT(b.size() == 3);
+            UNIT_ASSERT(b.size() == 5);
             UNIT_ASSERT((b[{f.PBCreds[7].TabletId, static_cast<ui8>(f.PBCreds[7].DirectBlockGroupIndex)}] == 2000));
-            UNIT_ASSERT((b[{f.PBCreds[8].TabletId, static_cast<ui8>(f.PBCreds[8].DirectBlockGroupIndex)}] == 3500)); // Same place used
+            UNIT_ASSERT((b[{f.PBCreds[8].TabletId, static_cast<ui8>(f.PBCreds[8].DirectBlockGroupIndex)}] == 3500)); // Same place used (own barrier updated)
+            UNIT_ASSERT((b[{f.PBCreds[6].TabletId, static_cast<ui8>(f.PBCreds[6].DirectBlockGroupIndex)}] == 300));
+            UNIT_ASSERT((b[{f.PBCreds[4].TabletId, static_cast<ui8>(f.PBCreds[4].DirectBlockGroupIndex)}] == 100));
             UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
         f.WritePB(0, 128, 9);
@@ -1102,21 +1110,82 @@ Y_UNIT_TEST_SUITE(DDisk) {
         {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
-            UNIT_ASSERT(b.size() == 4);
+            UNIT_ASSERT(b.size() == 6);
             UNIT_ASSERT((b[{f.PBCreds[9].TabletId, static_cast<ui8>(f.PBCreds[9].DirectBlockGroupIndex)}] == 6000)); // One new
-            UNIT_ASSERT((b[{f.PBCreds[7].TabletId, static_cast<ui8>(f.PBCreds[7].DirectBlockGroupIndex)}] == 2000));
             UNIT_ASSERT((b[{f.PBCreds[8].TabletId, static_cast<ui8>(f.PBCreds[8].DirectBlockGroupIndex)}] == 3500));
+            UNIT_ASSERT((b[{f.PBCreds[7].TabletId, static_cast<ui8>(f.PBCreds[7].DirectBlockGroupIndex)}] == 2000));
+            UNIT_ASSERT((b[{f.PBCreds[6].TabletId, static_cast<ui8>(f.PBCreds[6].DirectBlockGroupIndex)}] == 300));
+            UNIT_ASSERT((b[{f.PBCreds[4].TabletId, static_cast<ui8>(f.PBCreds[4].DirectBlockGroupIndex)}] == 100));
             UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
         f.RestartNode();
         {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
-            UNIT_ASSERT(b.size() == 4);
+            UNIT_ASSERT(b.size() == 6);
             UNIT_ASSERT((b[{f.PBCreds[9].TabletId, static_cast<ui8>(f.PBCreds[9].DirectBlockGroupIndex)}] == 6000));
-            UNIT_ASSERT((b[{f.PBCreds[7].TabletId, static_cast<ui8>(f.PBCreds[7].DirectBlockGroupIndex)}] == 2000));
             UNIT_ASSERT((b[{f.PBCreds[8].TabletId, static_cast<ui8>(f.PBCreds[8].DirectBlockGroupIndex)}] == 3500));
+            UNIT_ASSERT((b[{f.PBCreds[7].TabletId, static_cast<ui8>(f.PBCreds[7].DirectBlockGroupIndex)}] == 2000));
+            UNIT_ASSERT((b[{f.PBCreds[6].TabletId, static_cast<ui8>(f.PBCreds[6].DirectBlockGroupIndex)}] == 300));
+            UNIT_ASSERT((b[{f.PBCreds[4].TabletId, static_cast<ui8>(f.PBCreds[4].DirectBlockGroupIndex)}] == 100));
             UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
+        }
+    }
+
+    // End-to-end regression test for the barrier-preservation fix: a write that
+    // was already covered by a barrier (and whose underlying record was erased
+    // by the barrier move) must keep being rejected as OUTDATED even after the
+    // namespace has no live records and the node is restarted more than once.
+    // With the previous (buggy) behavior the barrier slot was dropped by
+    // RestoreBarriers on the second restart (since after the first restart the
+    // namespace had no live persistent-buffer records left), and the replayed
+    // write would have been incorrectly accepted, breaking the exact-once
+    // write guarantee.
+    Y_UNIT_TEST(PersistentBufferReplayedWriteOutdatedAfterRestarts) {
+        TDDiskTestContext f(1_MB);
+        auto groups = f.AllocateDDiskBlockGroup();
+        auto& node = groups.begin()->GetNodes(0);
+        f.ChangeTestingNode(node);
+
+        const ui32 offset = 0;
+        const ui32 numBlocks = 4;
+        const ui32 size = numBlocks * f.BlockSize;
+        auto makePayload = [&] {
+            TString update = TString::Uninitialized(size);
+            memset(update.Detach(), 'X', update.size());
+            return update;
+        };
+
+        const ui64 lsn = f.NextLsn++;
+
+        // Original write.
+        {
+            std::unique_ptr<NDDisk::TEvWritePersistentBuffer> ev(new NDDisk::TEvWritePersistentBuffer(
+                f.PBCreds[0], {f.VChunkIndex, offset, size}, lsn, {0}));
+            ev->AddPayloadThenChecksum(TRope(makePayload()));
+            f.Env.Runtime->Send(new IEventHandle(f.PBServiceId, f.Edge, ev.release()), f.Edge.NodeId());
+            auto res = f.Env.WaitForEdgeActorEvent<NDDisk::TEvWritePersistentBufferResult>(f.Edge, false);
+            UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
+        }
+
+        // Move the barrier past this LSN: the (only) record for this namespace
+        // is erased, leaving the namespace with no live records but a barrier
+        // that must still be honored.
+        f.ErasePB(lsn);
+
+        // Restart twice in a row: this is the exact scenario that used to lose
+        // the barrier on the second restart.
+        f.RestartNode();
+        f.RestartNode();
+
+        // Replaying the exact same write must be rejected as OUTDATED.
+        {
+            std::unique_ptr<NDDisk::TEvWritePersistentBuffer> ev(new NDDisk::TEvWritePersistentBuffer(
+                f.PBCreds[0], {f.VChunkIndex, offset, size}, lsn, {0}));
+            ev->AddPayloadThenChecksum(TRope(makePayload()));
+            f.Env.Runtime->Send(new IEventHandle(f.PBServiceId, f.Edge, ev.release()), f.Edge.NodeId());
+            auto res = f.Env.WaitForEdgeActorEvent<NDDisk::TEvWritePersistentBufferResult>(f.Edge, false);
+            UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrBlobStorage::NDDisk::TReplyStatus::OUTDATED);
         }
     }
 

--- a/ydb/core/blobstorage/ut_blobstorage/ddisk.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/ddisk.cpp
@@ -975,7 +975,7 @@ Y_UNIT_TEST_SUITE(DDisk) {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
             UNIT_ASSERT(b.size() == 1);
-            UNIT_ASSERT(b.begin()->first == f.PBCreds[0].TabletId);
+            UNIT_ASSERT(b.begin()->first.first == f.PBCreds[0].TabletId);
         }
         f.ListPB();
         f.RestartNode();
@@ -984,7 +984,7 @@ Y_UNIT_TEST_SUITE(DDisk) {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
             UNIT_ASSERT(b.size() == 1);
-            UNIT_ASSERT(b.begin()->first == f.PBCreds[0].TabletId);
+            UNIT_ASSERT(b.begin()->first.first == f.PBCreds[0].TabletId);
         }
     }
 
@@ -999,7 +999,7 @@ Y_UNIT_TEST_SUITE(DDisk) {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
             UNIT_ASSERT(b.size() == 1);
-            UNIT_ASSERT(b[f.PBCreds[0].TabletId] == 1);
+            UNIT_ASSERT((b[{f.PBCreds[0].TabletId, static_cast<ui8>(f.PBCreds[0].DirectBlockGroupIndex)}] == 1));
         }
     }
 
@@ -1021,16 +1021,16 @@ Y_UNIT_TEST_SUITE(DDisk) {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
             UNIT_ASSERT(b.size() == 2);
-            UNIT_ASSERT(b[f.PBCreds[4].TabletId] == 100);
-            UNIT_ASSERT(b[f.PBCreds[1].TabletId] == 5);
+            UNIT_ASSERT((b[{f.PBCreds[4].TabletId, static_cast<ui8>(f.PBCreds[4].DirectBlockGroupIndex)}] == 100));
+            UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
         f.RestartNode();
         {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
             UNIT_ASSERT(b.size() == 2);
-            UNIT_ASSERT(b[f.PBCreds[4].TabletId] == 100); // Barrier was not deleted, because record was not overwritten
-            UNIT_ASSERT(b[f.PBCreds[1].TabletId] == 5);
+            UNIT_ASSERT((b[{f.PBCreds[4].TabletId, static_cast<ui8>(f.PBCreds[4].DirectBlockGroupIndex)}] == 100)); // Barrier was not deleted, because record was not overwritten
+            UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
 
         f.WritePB(0, 128, 6);
@@ -1044,27 +1044,27 @@ Y_UNIT_TEST_SUITE(DDisk) {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
             UNIT_ASSERT(b.size() == 3);
-            UNIT_ASSERT(b[f.PBCreds[6].TabletId] == 300);
-            UNIT_ASSERT(b[f.PBCreds[4].TabletId] == 100);
-            UNIT_ASSERT(b[f.PBCreds[1].TabletId] == 5);
+            UNIT_ASSERT((b[{f.PBCreds[6].TabletId, static_cast<ui8>(f.PBCreds[6].DirectBlockGroupIndex)}] == 300));
+            UNIT_ASSERT((b[{f.PBCreds[4].TabletId, static_cast<ui8>(f.PBCreds[4].DirectBlockGroupIndex)}] == 100));
+            UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
         f.RestartNode();
         {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
             UNIT_ASSERT(b.size() == 3);
-            UNIT_ASSERT(b[f.PBCreds[6].TabletId] == 300); // Hole
-            UNIT_ASSERT(b[f.PBCreds[4].TabletId] == 100); // Hole
-            UNIT_ASSERT(b[f.PBCreds[1].TabletId] == 5);
+            UNIT_ASSERT((b[{f.PBCreds[6].TabletId, static_cast<ui8>(f.PBCreds[6].DirectBlockGroupIndex)}] == 300)); // Hole
+            UNIT_ASSERT((b[{f.PBCreds[4].TabletId, static_cast<ui8>(f.PBCreds[4].DirectBlockGroupIndex)}] == 100)); // Hole
+            UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
         f.ErasePB(2000, 7); // clear PB space to write more
         {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
             UNIT_ASSERT(b.size() == 3);
-            UNIT_ASSERT(b[f.PBCreds[7].TabletId] == 2000); // Hole replaced
-            UNIT_ASSERT(b[f.PBCreds[4].TabletId] == 100); // Hole
-            UNIT_ASSERT(b[f.PBCreds[1].TabletId] == 5);
+            UNIT_ASSERT((b[{f.PBCreds[7].TabletId, static_cast<ui8>(f.PBCreds[7].DirectBlockGroupIndex)}] == 2000)); // Hole replaced
+            UNIT_ASSERT((b[{f.PBCreds[4].TabletId, static_cast<ui8>(f.PBCreds[4].DirectBlockGroupIndex)}] == 100)); // Hole
+            UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
         f.WritePB(0, 128, 8);
         f.WritePB(0, 128, 8);
@@ -1074,9 +1074,9 @@ Y_UNIT_TEST_SUITE(DDisk) {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
             UNIT_ASSERT(b.size() == 3);
-            UNIT_ASSERT(b[f.PBCreds[7].TabletId] == 2000);
-            UNIT_ASSERT(b[f.PBCreds[8].TabletId] == 2551); // Hole replaced
-            UNIT_ASSERT(b[f.PBCreds[1].TabletId] == 5);
+            UNIT_ASSERT((b[{f.PBCreds[7].TabletId, static_cast<ui8>(f.PBCreds[7].DirectBlockGroupIndex)}] == 2000));
+            UNIT_ASSERT((b[{f.PBCreds[8].TabletId, static_cast<ui8>(f.PBCreds[8].DirectBlockGroupIndex)}] == 2551)); // Hole replaced
+            UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
         f.WritePB(0, 128, 8);
         f.WritePB(0, 128, 8);
@@ -1085,9 +1085,9 @@ Y_UNIT_TEST_SUITE(DDisk) {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
             UNIT_ASSERT(b.size() == 3);
-            UNIT_ASSERT(b[f.PBCreds[7].TabletId] == 2000);
-            UNIT_ASSERT(b[f.PBCreds[8].TabletId] == 3500); // Same place used
-            UNIT_ASSERT(b[f.PBCreds[1].TabletId] == 5);
+            UNIT_ASSERT((b[{f.PBCreds[7].TabletId, static_cast<ui8>(f.PBCreds[7].DirectBlockGroupIndex)}] == 2000));
+            UNIT_ASSERT((b[{f.PBCreds[8].TabletId, static_cast<ui8>(f.PBCreds[8].DirectBlockGroupIndex)}] == 3500)); // Same place used
+            UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
         f.WritePB(0, 128, 9);
         f.WritePB(0, 128, 9);
@@ -1096,20 +1096,20 @@ Y_UNIT_TEST_SUITE(DDisk) {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
             UNIT_ASSERT(b.size() == 4);
-            UNIT_ASSERT(b[f.PBCreds[9].TabletId] == 6000); // One new
-            UNIT_ASSERT(b[f.PBCreds[7].TabletId] == 2000);
-            UNIT_ASSERT(b[f.PBCreds[8].TabletId] == 3500);
-            UNIT_ASSERT(b[f.PBCreds[1].TabletId] == 5);
+            UNIT_ASSERT((b[{f.PBCreds[9].TabletId, static_cast<ui8>(f.PBCreds[9].DirectBlockGroupIndex)}] == 6000)); // One new
+            UNIT_ASSERT((b[{f.PBCreds[7].TabletId, static_cast<ui8>(f.PBCreds[7].DirectBlockGroupIndex)}] == 2000));
+            UNIT_ASSERT((b[{f.PBCreds[8].TabletId, static_cast<ui8>(f.PBCreds[8].DirectBlockGroupIndex)}] == 3500));
+            UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
         f.RestartNode();
         {
             auto info = f.GetPBInfo(false, true);
             auto& b = info->Get()->EraseBarriers;
             UNIT_ASSERT(b.size() == 4);
-            UNIT_ASSERT(b[f.PBCreds[9].TabletId] == 6000);
-            UNIT_ASSERT(b[f.PBCreds[7].TabletId] == 2000);
-            UNIT_ASSERT(b[f.PBCreds[8].TabletId] == 3500);
-            UNIT_ASSERT(b[f.PBCreds[1].TabletId] == 5);
+            UNIT_ASSERT((b[{f.PBCreds[9].TabletId, static_cast<ui8>(f.PBCreds[9].DirectBlockGroupIndex)}] == 6000));
+            UNIT_ASSERT((b[{f.PBCreds[7].TabletId, static_cast<ui8>(f.PBCreds[7].DirectBlockGroupIndex)}] == 2000));
+            UNIT_ASSERT((b[{f.PBCreds[8].TabletId, static_cast<ui8>(f.PBCreds[8].DirectBlockGroupIndex)}] == 3500));
+            UNIT_ASSERT((b[{f.PBCreds[1].TabletId, static_cast<ui8>(f.PBCreds[1].DirectBlockGroupIndex)}] == 5));
         }
     }
 

--- a/ydb/core/grpc_services/audit_log.cpp
+++ b/ydb/core/grpc_services/audit_log.cpp
@@ -6,6 +6,8 @@
 #include "base/base.h"
 #include "audit_log.h"
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::GRPC_SERVER
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -27,12 +29,11 @@ void AuditLogConn(const IRequestProxyCtx* ctx, const TString& database, const TS
     );
 
     // and transitional, to be removed, output to the common log
-    LOG_NOTICE_S(TlsActivationContext->AsActorContext(), NKikimrServices::GRPC_SERVER, "AUDIT: "
-        << "request name: " << ctx->GetRequestName()
-        << ", database: " << database
-        << ", peer: " << ctx->GetPeerName()
-        << ", subject: " << (userSID ? userSID : "no subject")
-    );
+    YDB_LOG_NOTICE("AUDIT: request",
+        {"name", ctx->GetRequestName()},
+        {"database", database},
+        {"peer", ctx->GetPeerName()},
+        {"subject", (userSID ? userSID : "no subject")});
 }
 
 void AuditLog(std::optional<ui32> status, const TAuditLogParts& parts)

--- a/ydb/core/grpc_services/db_metadata_cache.h
+++ b/ydb/core/grpc_services/db_metadata_cache.h
@@ -80,7 +80,8 @@ private:
 
     void UpdateActiveNode() {
         ActiveNode = PickActiveNode(BoardInfo);
-        LOG_DEBUG_S(TActivationContext::AsActorContext(), NKikimrServices::DB_METADATA_CACHE, "Active node is " << ActiveNode);
+        YDB_LOG_DEBUG_CTX_COMP(TActivationContext::AsActorContext(), NKikimrServices::DB_METADATA_CACHE, "Active node",
+            {"activeNode", ActiveNode});
         bool areWeActive = (ActiveNode == SelfId().NodeId());
         if (areWeActive && CurrentStateFunc() != &TThis::StateActive) {
             RefreshCache();
@@ -132,13 +133,13 @@ private:
     }
 
     void Handle(NHealthCheck::TEvSelfCheckRequestProto::TPtr& ev) {
-        LOG_DEBUG_S(TActivationContext::AsActorContext(), NKikimrServices::DB_METADATA_CACHE, "Got request");
+        YDB_LOG_DEBUG_CTX_COMP(TActivationContext::AsActorContext(), NKikimrServices::DB_METADATA_CACHE, "Got request");
         TInstant now = TActivationContext::Now();
         if (Result && now - LastResultUpdate <= 2 * RefreshPeriod) {
-            LOG_DEBUG_S(TActivationContext::AsActorContext(), NKikimrServices::DB_METADATA_CACHE, "Replying now");
+            YDB_LOG_DEBUG_CTX_COMP(TActivationContext::AsActorContext(), NKikimrServices::DB_METADATA_CACHE, "Replying now");
             Reply(ev);
         } else {
-            LOG_DEBUG_S(TActivationContext::AsActorContext(), NKikimrServices::DB_METADATA_CACHE, "Answer not ready, waiting");
+            YDB_LOG_DEBUG_CTX_COMP(TActivationContext::AsActorContext(), NKikimrServices::DB_METADATA_CACHE, "Answer not ready, waiting");
             SendRequest();
             Requests.emplace_back(std::move(ev));
         }
@@ -200,7 +201,7 @@ public:
     }
 
     void Bootstrap() {
-        LOG_DEBUG_S(TActivationContext::AsActorContext(), NKikimrServices::DB_METADATA_CACHE, "Starting db metadata cache actor");
+        YDB_LOG_DEBUG_CTX_COMP(TActivationContext::AsActorContext(), NKikimrServices::DB_METADATA_CACHE, "Starting db metadata cache actor");
         Become(&TThis::StateInactive);
         ApplyConfig(AppData()->MetadataCacheConfig, AppData()->FeatureFlags);
         Send(NConsole::MakeConfigsDispatcherID(SelfId().NodeId()),

--- a/ydb/core/grpc_services/grpc_endpoint_publish_actor.cpp
+++ b/ydb/core/grpc_services/grpc_endpoint_publish_actor.cpp
@@ -10,6 +10,8 @@
 #include <ydb/core/base/location.h>
 #include <ydb/core/base/statestorage.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::GRPC_SERVER
+
 namespace NKikimr::NGRpcService {
 
 using namespace NActors;
@@ -66,7 +68,8 @@ class TGRpcEndpointPublishActor : public TActorBootstrapped<TGRpcEndpointPublish
 
     void PassAway() override {
         if (PublishActor) {
-            LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "Stop publish endpoints for database: " << AppData()->TenantName);
+            YDB_LOG_NOTICE("Stop publish endpoints",
+                {"database", AppData()->TenantName});
             Send(PublishActor, new TEvents::TEvPoisonPill());
         }
 

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -101,7 +101,7 @@ class TGrpcRequestCheckActor
 
 public:
     void OnAccessDenied(const TEvTicketParser::TError& error, const TActorContext& ctx) {
-        LOG_INFO(ctx, NKikimrServices::GRPC_SERVER, error.ToString());
+        YDB_LOG_INFO_CTX_COMP(ctx, NKikimrServices::GRPC_SERVER, error.ToString());
         if (error.Retryable) {
             GrpcRequestBaseCtx_->UpdateAuthState(NYdbGrpc::TAuthState::AS_UNAVAILABLE);
         } else {
@@ -219,7 +219,7 @@ public:
             TBase::SetSecurityToken(authToken.GetRef());
         } else {
             if (TlsActivationContext) {
-                LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY, "Ydb token was not provided. Try to auth by certificate");
+                YDB_LOG_DEBUG_COMP(NKikimrServices::GRPC_PROXY, "Ydb token was not provided. Try to auth by certificate");
             }
             const auto& clientCertificates = GrpcRequestBaseCtx_->FindClientCertPropertyValues();
             if (!clientCertificates.empty()) {
@@ -273,8 +273,7 @@ public:
 
     void SetTokenAndDie() {
         if (GrpcRequestBaseCtx_->IsClientLost()) {
-            LOG_DEBUG(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
-                "Client was disconnected before processing request (check actor)");
+            YDB_LOG_DEBUG_CTX_COMP(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "Client was disconnected before processing request (check actor)");
             const NYql::TIssues issues;
             ReplyUnavailableAndDie(issues);
         } else {
@@ -297,15 +296,16 @@ public:
         Y_ABORT_UNLESS(navigate->ResultSet.size() == 1);
         const auto& entry = navigate->ResultSet.front();
 
-        LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
-            "Handle " << ev->Get()->ToString() << ": entry# " << entry.ToString());
+        YDB_LOG_DEBUG_COMP(NKikimrServices::GRPC_SERVER, "Handle",
+            {"ev", ev->Get()->ToString()},
+            {"entry", entry});
 
         switch (entry.Status) {
         case NSchemeCache::TSchemeCacheNavigate::EStatus::Ok:
             break;
         default:
-            LOG_WARN_S(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
-                "Unexpected status" << ": entry# " << entry.ToString());
+            YDB_LOG_WARN_COMP(NKikimrServices::GRPC_SERVER, "Unexpected status",
+                {"entry", entry});
             return ReplyUnauthenticatedAndDie();
         }
 
@@ -447,13 +447,14 @@ private:
             switch (resp.operation().status()) {
                 case Ydb::StatusIds::SUCCESS:
                     Counters_->ReportThrottleDelay(delay);
-                    LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "Request delayed for " << delay << " by ratelimiter");
+                    YDB_LOG_DEBUG_COMP(NKikimrServices::GRPC_SERVER, "Request delayed by ratelimiter",
+                        {"delay", delay});
                     SetTokenAndDie();
                     break;
                 case Ydb::StatusIds::TIMEOUT:
                 case Ydb::StatusIds::CANCELLED:
                     Counters_->IncDatabaseRateLimitedCounter();
-                    LOG_INFO(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "Throughput limit exceeded");
+                    YDB_LOG_INFO_CTX_COMP(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "Throughput limit exceeded");
                     ReplyOverloadedAndDie(MakeIssue(NKikimrIssues::TIssuesIds::YDB_RESOURCE_USAGE_LIMITED, "Throughput limit exceeded"));
                     break;
                 default:
@@ -463,7 +464,8 @@ private:
                                               resp.operation().status(),
                                               CheckedDatabaseName_.c_str(),
                                               issues.ToString().c_str());
-                        LOG_ERROR(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "%s", error.c_str());
+                        YDB_LOG_ERROR_CTX_COMP(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "RateLimiter error",
+                            {"error", error});
 
                         ReplyUnavailableAndDie(issues); // same as cloud-go serverless proxy
                     }
@@ -488,9 +490,10 @@ private:
         auto counters = Counters_;
         return [req{std::move(req)}, databasename, token, counters](TRespHookCtx::TPtr ctx) mutable {
 
-            LOG_DEBUG(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
-                "Response hook called to report RU usage, database: %s, request: %s, consumed: %d",
-                databasename.c_str(), ctx->GetRequestName().c_str(), ctx->GetConsumedRu());
+            YDB_LOG_DEBUG_CTX_COMP(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "Response hook called to report RU usage",
+                {"database", databasename},
+                {"request", ctx->GetRequestName()},
+                {"consumed", ctx->GetConsumedRu()});
 
             counters->AddConsumedRequestUnits(ctx->GetConsumedRu());
 
@@ -679,11 +682,10 @@ private:
         }
 
         if (SkipCheckConnectRights_) {
-            LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS,
-                        "Skip check permission connect db, AllowYdbRequestsWithoutDatabase is off, there is no db provided from user"
-                        << ", database: " << CheckedDatabaseName_
-                        << ", user: " << TBase::GetUserSID()
-                        << ", from ip: " << GrpcRequestBaseCtx_->GetPeerName());
+            YDB_LOG_DEBUG_COMP(NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS, "Skip check permission connect db, AllowYdbRequestsWithoutDatabase is off, there is no db provided from user",
+                {"database", CheckedDatabaseName_},
+                {"user", TBase::GetUserSID()},
+                {"ip", GrpcRequestBaseCtx_->GetPeerName()});
             return {false, std::nullopt};
         }
 
@@ -691,20 +693,18 @@ private:
         // as the EnforceUserTokenRequirement and EnforceUserTokenCheckRequirement flags have already been
         // validated earlier in the request processing pipeline.
         if (!TBase::GetParsedToken()) {
-            LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS,
-                        "Skip check permission connect db, anonymous requests allowed"
-                        << ", database: " << CheckedDatabaseName_
-                        << ", user: " << TBase::GetUserSID()
-                        << ", from ip: " << GrpcRequestBaseCtx_->GetPeerName());
+            YDB_LOG_DEBUG_COMP(NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS, "Skip check permission connect db, anonymous requests allowed",
+                {"database", CheckedDatabaseName_},
+                {"user", TBase::GetUserSID()},
+                {"ip", GrpcRequestBaseCtx_->GetPeerName()});
             return {false, std::nullopt};
         }
 
         if (!SecurityObject_) {
-            LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS,
-                        "Skip check permission connect db, no SecurityObject_"
-                        << ", database: " << CheckedDatabaseName_
-                        << ", user: " << TBase::GetUserSID()
-                        << ", from ip: " << GrpcRequestBaseCtx_->GetPeerName());
+            YDB_LOG_DEBUG_COMP(NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS, "Skip check permission connect db, no SecurityObject_",
+                {"database", CheckedDatabaseName_},
+                {"user", TBase::GetUserSID()},
+                {"ip", GrpcRequestBaseCtx_->GetPeerName()});
             return {false, std::nullopt};
         }
 
@@ -716,11 +716,10 @@ private:
         // - database admin -- to their database
         const bool isAdmin = TBase::IsUserAdmin() || (parsedToken && IsDatabaseAdministrator(parsedToken.Get(), databaseOwner));
         if (isAdmin) {
-            LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS,
-                        "Skip check permission connect db, user is a admin"
-                        << ", database: " << CheckedDatabaseName_
-                        << ", user: " << TBase::GetUserSID()
-                        << ", from ip: " << GrpcRequestBaseCtx_->GetPeerName());
+            YDB_LOG_DEBUG_COMP(NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS, "Skip check permission connect db, user is a admin",
+                {"database", CheckedDatabaseName_},
+                {"user", TBase::GetUserSID()},
+                {"ip", GrpcRequestBaseCtx_->GetPeerName()});
             return {false, std::nullopt};
         }
 
@@ -745,12 +744,10 @@ private:
 
 
         const TString error = "No permission to connect to the database";
-        LOG_INFO_S(TlsActivationContext->AsActorContext(), NKikimrServices::GRPC_SERVER,
-            error
-            << ": " << CheckedDatabaseName_
-            << ", user: " << TBase::GetUserSID()
-            << ", from ip: " << GrpcRequestBaseCtx_->GetPeerName()
-        );
+        YDB_LOG_INFO_COMP(NKikimrServices::GRPC_SERVER, error,
+            {"checkedDatabaseName", CheckedDatabaseName_},
+            {"user", TBase::GetUserSID()},
+            {"ip", GrpcRequestBaseCtx_->GetPeerName()});
 
         return {true, MakeIssue(NKikimrIssues::TIssuesIds::ACCESS_DENIED, error)};;
     }

--- a/ydb/core/grpc_services/grpc_request_proxy.cpp
+++ b/ydb/core/grpc_services/grpc_request_proxy.cpp
@@ -15,6 +15,8 @@
 #include <ydb/library/wilson_ids/wilson.h>
 #include <ydb/core/protos/table_service_config.pb.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::GRPC_SERVER
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -140,7 +142,7 @@ private:
         IRequestProxyCtx* requestBaseCtx = event->Get();
         if (!SchemeCache) {
             const TString error = "Grpc proxy is not ready to accept request, no proxy service";
-            LOG_ERROR_S(ctx, NKikimrServices::GRPC_SERVER, error);
+            YDB_LOG_ERROR_CTX(ctx, error);
             const auto issue = MakeIssue(NKikimrIssues::TIssuesIds::GENERIC_TXPROXY_ERROR, error);
             requestBaseCtx->RaiseIssue(issue);
             requestBaseCtx->ReplyWithYdbStatus(Ydb::StatusIds::UNAVAILABLE);
@@ -222,7 +224,8 @@ private:
                 if (!DeferAndStartUpdate(databaseName, event, requestBaseCtx)) {
                     Counters->IncDatabaseUnavailableCounter();
                     const TString error = "Grpc proxy is not ready to accept request, database unknown";
-                    LOG_ERROR(ctx, NKikimrServices::GRPC_SERVER, "Limit for deferred events per database %s reached", databaseName.c_str());
+                    YDB_LOG_ERROR_CTX(ctx, "Limit for deferred events per database reached",
+                        {"databaseName", databaseName});
                     const auto issue = MakeIssue(NKikimrIssues::TIssuesIds::YDB_DB_NOT_READY, error);
                     requestBaseCtx->RaiseIssue(issue);
                     requestBaseCtx->ReplyWithYdbStatus(Ydb::StatusIds::UNAVAILABLE);
@@ -238,7 +241,7 @@ private:
             if (rootIt == Databases.end() || !rootIt->second.IsDatabaseReady() || !rootIt->second.SchemeBoardResult) {
                 Counters->IncDatabaseUnavailableCounter();
                 const TString error = "Grpc proxy is not ready to accept request, root database unknown";
-                LOG_ERROR(ctx, NKikimrServices::GRPC_SERVER, error);
+                YDB_LOG_ERROR_CTX(ctx, error);
                 const auto issue = MakeIssue(NKikimrIssues::TIssuesIds::YDB_DB_NOT_READY, error);
                 requestBaseCtx->RaiseIssue(issue);
                 requestBaseCtx->ReplyWithYdbStatus(Ydb::StatusIds::UNAVAILABLE);
@@ -261,7 +264,7 @@ private:
                         error << "Unexpected node to perform query on database: " << databaseName
                               << ", domain: " << domain.GetDomainKey().ShortDebugString()
                               << ", resource domain: " << domain.GetResourcesDomainKey().ShortDebugString();
-                        LOG_ERROR(ctx, NKikimrServices::GRPC_SERVER, error);
+                        YDB_LOG_ERROR_CTX(ctx, error);
                         auto issue = MakeIssue(NKikimrIssues::TIssuesIds::ACCESS_DENIED, error);
                         requestBaseCtx->RaiseIssue(issue);
                         requestBaseCtx->ReplyWithYdbStatus(Ydb::StatusIds::UNAUTHORIZED);
@@ -281,8 +284,7 @@ private:
 
             if (requestBaseCtx->IsClientLost()) {
                 // Any status here
-                LOG_DEBUG(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
-                    "Client was disconnected before processing request (grpc request proxy)");
+                YDB_LOG_DEBUG_CTX(*TlsActivationContext, "Client was disconnected before processing request (grpc request proxy)");
                 requestBaseCtx->ReplyWithYdbStatus(Ydb::StatusIds::UNAVAILABLE);
                 return;
             }
@@ -363,8 +365,9 @@ void TGRpcRequestProxyImpl::Bootstrap(const TActorContext& ctx) {
 
     if (AppData()->DynamicNameserviceConfig) {
         DynamicNode = nodeID > AppData()->DynamicNameserviceConfig->MaxStaticNodeId;
-        LOG_NOTICE(ctx, NKikimrServices::GRPC_SERVER, "Grpc request proxy started, nodeid# %d, serve as %s node",
-            nodeID, (DynamicNode ? "dynamic" : "static"));
+        YDB_LOG_NOTICE_CTX(ctx, "Grpc request proxy started",
+            {"nodeId", nodeID},
+            {"nodeType", (DynamicNode ? "dynamic" : "static")});
     }
 
     Counters = CreateGRpcProxyCounters(AppData()->Counters);
@@ -400,7 +403,7 @@ void TGRpcRequestProxyImpl::ReplayEvents(const TString& databaseName, const TAct
 }
 
 void TGRpcRequestProxyImpl::HandleConfig(NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse::TPtr&) {
-    LOG_INFO(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "Subscribed for config changes");
+    YDB_LOG_INFO_CTX(*TlsActivationContext, "Subscribed for config changes");
 }
 
 void TGRpcRequestProxyImpl::HandleConfig(NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr& ev) {
@@ -408,7 +411,7 @@ void TGRpcRequestProxyImpl::HandleConfig(NConsole::TEvConsole::TEvConfigNotifica
 
     ChannelBufferSize.store(
         event.GetConfig().GetTableServiceConfig().GetResourceManager().GetChannelBufferSize());
-    LOG_INFO(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "Updated app config");
+    YDB_LOG_INFO_CTX(*TlsActivationContext, "Updated app config");
 
     auto responseEv = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationResponse>(event);
     Send(ev->Sender, responseEv.Release(), IEventHandle::FlagTrackDelivery, ev->Cookie);
@@ -416,23 +419,20 @@ void TGRpcRequestProxyImpl::HandleConfig(NConsole::TEvConsole::TEvConfigNotifica
 
 void TGRpcRequestProxyImpl::HandleProxyService(TEvTxUserProxy::TEvGetProxyServicesResponse::TPtr& ev) {
     SchemeCache = ev->Get()->Services.SchemeCache;
-    LOG_DEBUG(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
-        "Got proxy service configuration");
+    YDB_LOG_DEBUG_CTX(*TlsActivationContext, "Got proxy service configuration");
 }
 
 void TGRpcRequestProxyImpl::HandleUndelivery(TEvents::TEvUndelivered::TPtr& ev) {
     switch (ev->Get()->SourceType) {
         case NConsole::TEvConfigsDispatcher::EvSetConfigSubscriptionRequest:
-            LOG_CRIT(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
-                "Failed to deliver subscription request to config dispatcher");
+            YDB_LOG_CRIT_CTX(*TlsActivationContext, "Failed to deliver subscription request to config dispatcher");
             break;
         case NConsole::TEvConsole::EvConfigNotificationResponse:
-            LOG_ERROR(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
-                "Failed to deliver config notification response");
+            YDB_LOG_ERROR_CTX(*TlsActivationContext, "Failed to deliver config notification response");
             break;
         default:
-            LOG_ERROR(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
-                "Undelivered event with unexpected source type: %d", ev->Get()->SourceType);
+            YDB_LOG_ERROR_CTX(*TlsActivationContext, "Undelivered event with unexpected source type",
+                {"type", ev->Get()->SourceType});
             break;
     }
 }
@@ -462,8 +462,7 @@ void TGRpcRequestProxyImpl::HandleBootstrapClusterEvent(TAutoPtr<TEventHandle<TE
     IRequestProxyCtx* requestProxyCtx = event->Get();
     if (requestProxyCtx->IsClientLost()) {
         // Any status here
-        LOG_DEBUG(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
-            "Client was disconnected before processing request (grpc request proxy)");
+        YDB_LOG_DEBUG_CTX(*TlsActivationContext, "Client was disconnected before processing request (grpc request proxy)");
         requestProxyCtx->ReplyWithYdbStatus(Ydb::StatusIds::UNAVAILABLE);
         return;
     }
@@ -526,7 +525,8 @@ void TGRpcRequestProxyImpl::MaybeStartTracing(TAutoPtr<TEventHandle<TEvent>>& ev
 
 void TGRpcRequestProxyImpl::HandleSchemeBoard(TSchemeBoardEvents::TEvNotifyUpdate::TPtr& ev, const TActorContext& ctx) {
     TString databaseName = ev->Get()->Path;
-    LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "SchemeBoardUpdate " << databaseName);
+    YDB_LOG_DEBUG("SchemeBoardUpdate",
+        {"databaseName", databaseName});
     auto itDatabase = Databases.try_emplace(CanonizePath(databaseName));
     TDatabaseInfo& database = itDatabase.first->second;
     database.SchemeBoardResult = ev->Release();
@@ -546,17 +546,21 @@ void TGRpcRequestProxyImpl::HandleSchemeBoard(TSchemeBoardEvents::TEvNotifyUpdat
         && describeScheme.GetPathDescription().GetDomainDescription().HasSecurityState())
     {
         const auto& securityState = describeScheme.GetPathDescription().GetDomainDescription().GetSecurityState();
-        LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "Updating SecurityState for " << databaseName);
+        YDB_LOG_DEBUG("Updating SecurityState",
+            {"databaseName", databaseName});
         if (securityState.PublicKeysSize() > 0) {
             Send(MakeTicketParserID(), new TEvTicketParser::TEvUpdateLoginSecurityState(securityState));
         } else {
-            LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "Can't update SecurityState for " << databaseName << " - no PublicKeys");
+            YDB_LOG_DEBUG("Can't update SecurityState for database - no PublicKeys",
+                {"databaseName", databaseName});
         }
     } else {
         if (!describeScheme.GetPathDescription().HasDomainDescription()) {
-            LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "Can't update SecurityState for " << databaseName << " - no DomainDescription");
+            YDB_LOG_DEBUG("Can't update SecurityState for database - no DomainDescription",
+                {"databaseName", databaseName});
         } else if (!describeScheme.GetPathDescription().GetDomainDescription().HasSecurityState()) {
-            LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "Can't update SecurityState for " << databaseName << " - no SecurityState");
+            YDB_LOG_DEBUG("Can't update SecurityState for database - no SecurityState",
+                {"databaseName", databaseName});
         }
     }
 
@@ -566,8 +570,9 @@ void TGRpcRequestProxyImpl::HandleSchemeBoard(TSchemeBoardEvents::TEvNotifyUpdat
 }
 
 void TGRpcRequestProxyImpl::HandleSchemeBoard(TSchemeBoardEvents::TEvNotifyDelete::TPtr& ev) {
-    LOG_WARN_S(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
-        "SchemeBoardDelete " << ev->Get()->Path << " Strong=" << ev->Get()->Strong);
+    YDB_LOG_WARN("SchemeBoardDelete",
+        {"path", ev->Get()->Path},
+        {"strong", ev->Get()->Strong});
 
     if (ev->Get()->Strong) {
         ForgetDatabase(ev->Get()->Path);
@@ -594,7 +599,8 @@ void TGRpcRequestProxyImpl::ForgetDatabase(const TString& database) {
 }
 
 void TGRpcRequestProxyImpl::SubscribeToDatabase(const TString& database) {
-    LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "Subscribe to " << database);
+    YDB_LOG_DEBUG("Subscribe",
+        {"database", database});
 
     TActorId subscriberId = Register(CreateSchemeBoardSubscriber(SelfId(), database));
     auto itSubscriber = Subscribers.emplace(database, subscriberId);
@@ -629,10 +635,10 @@ void LogRequest(const TEvent& event) {
     };
 
     if constexpr (std::is_same_v<TEvListEndpointsRequest::TPtr, TEvent>) {
-        LOG_INFO(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "%s", getDebugString().c_str());
+        YDB_LOG_INFO_CTX(*TlsActivationContext, getDebugString());
     }
     else {
-        LOG_DEBUG(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "%s", getDebugString().c_str());
+        YDB_LOG_DEBUG_CTX(*TlsActivationContext, getDebugString());
     }
 }
 

--- a/ydb/core/grpc_services/grpc_request_proxy_simple.cpp
+++ b/ydb/core/grpc_services/grpc_request_proxy_simple.cpp
@@ -8,6 +8,8 @@
 
 #include <util/system/hostname.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::GRPC_SERVER
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -157,7 +159,8 @@ private:
 void TGRpcRequestProxySimple::Bootstrap(const TActorContext& ctx) {
     auto nodeID = SelfId().NodeId();
 
-    LOG_NOTICE(ctx, NKikimrServices::GRPC_SERVER, "Grpc simple request proxy started, nodeid# %d", nodeID);
+    YDB_LOG_NOTICE_CTX(ctx, "Grpc simple request proxy started",
+        {"nodeid", nodeID});
 
     Counters = CreateGRpcProxyCounters(AppData()->Counters);
     InitializeGRpcProxyDbCountersRegistry(ctx.ActorSystem());
@@ -168,8 +171,8 @@ void TGRpcRequestProxySimple::Bootstrap(const TActorContext& ctx) {
 void TGRpcRequestProxySimple::HandleUndelivery(TEvents::TEvUndelivered::TPtr& ev) {
     switch (ev->Get()->SourceType) {
         default:
-            LOG_ERROR(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
-                "Undelivered event with unexpected source type: %d", ev->Get()->SourceType);
+            YDB_LOG_ERROR_CTX(*TlsActivationContext, "Undelivered event with unexpected source type",
+                {"type", ev->Get()->SourceType});
             break;
     }
 }
@@ -214,10 +217,10 @@ void LogRequest(const TEvent& event) {
     };
 
     if constexpr (std::is_same_v<TEvListEndpointsRequest::TPtr, TEvent>) {
-        LOG_INFO(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "%s", getDebugString().c_str());
+        YDB_LOG_INFO_CTX(*TlsActivationContext, getDebugString());
     }
     else {
-        LOG_DEBUG(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "%s", getDebugString().c_str());
+        YDB_LOG_DEBUG_CTX(*TlsActivationContext, getDebugString());
     }
 }
 

--- a/ydb/core/grpc_services/operation_helpers.cpp
+++ b/ydb/core/grpc_services/operation_helpers.cpp
@@ -27,13 +27,6 @@
 namespace NKikimr {
 namespace NGRpcService {
 
-#define LOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
-#define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
-#define LOG_I(stream) LOG_INFO_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
-#define LOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
-#define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
-#define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
-
 TActorId CreatePipeClient(ui64 id, const TActorContext& ctx) {
     NTabletPipe::TClientConfig clientConfig;
     clientConfig.RetryPolicy = {.RetryLimitCount = 3};

--- a/ydb/core/grpc_services/query/rpc_execute_query.cpp
+++ b/ydb/core/grpc_services/query/rpc_execute_query.cpp
@@ -15,6 +15,8 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/wilson_ids/wilson.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::RPC_REQUEST
+
 
 namespace NKikimr::NGRpcService {
 
@@ -346,11 +348,12 @@ private:
     }
 
     void Handle(TRpcServices::TEvGrpcNextReply::TPtr& ev, const TActorContext& ctx) {
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " NextReply"
-            << ", left: " << ev->Get()->LeftInQueue
-            << ", queue: " << FlowControl_.QueueSize()
-            << ", inflight bytes: " << FlowControl_.InflightBytes()
-            << ", limit bytes: " << FlowControl_.InflightLimitBytes());
+        YDB_LOG_DEBUG_CTX(ctx, "NextReply",
+            {"selfId", this->SelfId()},
+            {"left", ev->Get()->LeftInQueue},
+            {"queue", FlowControl_.QueueSize()},
+            {"inflightBytes", FlowControl_.InflightBytes()},
+            {"limitBytes", FlowControl_.InflightLimitBytes()});
 
         while (FlowControl_.QueueSize() > ev->Get()->LeftInQueue) {
             FlowControl_.PopResponse();
@@ -360,10 +363,11 @@ private:
         if (freeSpaceBytes > 0) {
             for (auto& [channelId, channel] : StreamChannels_) {
                 if (channel.ResumeIfStopped(SelfId(), freeSpaceBytes)) {
-                    LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << "Resume execution, "
-                        << ", channel: " << channelId
-                        << ", seqNo: " << channel.LastSeqNo
-                        << ", freeSpace: " << freeSpaceBytes);
+                    YDB_LOG_DEBUG_CTX(ctx, "Resume execution",
+                        {"selfId", this->SelfId()},
+                        {"channel", channelId},
+                        {"seqNo", channel.LastSeqNo},
+                        {"freeSpace", freeSpaceBytes});
                 }
             }
         }
@@ -396,11 +400,12 @@ private:
         channel.AckedFreeSpaceBytes = freeSpaceBytes;
         channel.ChannelId = ev->Get()->Record.GetChannelId();
 
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << "Send stream data ack"
-            << ", seqNo: " << ev->Get()->Record.GetSeqNo()
-            << ", freeSpace: " << freeSpaceBytes
-            << ", to: " << ev->Sender
-            << ", queue: " << FlowControl_.QueueSize());
+        YDB_LOG_DEBUG_CTX(ctx, "Send stream data ack",
+            {"selfId", this->SelfId()},
+            {"seqNo", ev->Get()->Record.GetSeqNo()},
+            {"freeSpace", freeSpaceBytes},
+            {"actorId", ev->Sender},
+            {"queue", FlowControl_.QueueSize()});
 
         channel.SendAck(SelfId());
     }
@@ -496,7 +501,7 @@ private:
 
 private:
     void HandleClientLost(const TActorContext& ctx) {
-        LOG_WARN_S(ctx, NKikimrServices::RPC_REQUEST, "Client lost");
+        YDB_LOG_WARN_CTX(ctx, "Client lost");
 
         // We must try to finish stream otherwise grpc will not free allocated memory
         // If stream already scheduled to be finished (ReplyFinishStream already called)
@@ -533,8 +538,8 @@ private:
     void ReplyFinishStream(Ydb::StatusIds::StatusCode status,
         const google::protobuf::RepeatedPtrField<TYdbIssueMessageType>& message)
     {
-        ALOG_INFO(NKikimrServices::RPC_REQUEST, "Finish grpc stream, status: "
-            << Ydb::StatusIds::StatusCode_Name(status));
+        YDB_LOG_INFO("Finish grpc stream",
+            {"status", Ydb::StatusIds::StatusCode_Name(status)});
 
         // Skip sending empty result in case of success status - simplify client logic
         if (status != Ydb::StatusIds::SUCCESS || message.size() > 0) {
@@ -553,7 +558,8 @@ private:
     }
 
     void InternalError(const TString& message) {
-        ALOG_ERROR(NKikimrServices::RPC_REQUEST, "Internal error, message: " << message);
+        YDB_LOG_ERROR("Internal error",
+            {"message", message});
 
         auto issue = MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, message);
         ReplyFinishStream(Ydb::StatusIds::INTERNAL_ERROR, issue);

--- a/ydb/core/grpc_services/query/rpc_execute_script.cpp
+++ b/ydb/core/grpc_services/query/rpc_execute_script.cpp
@@ -14,6 +14,8 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::RPC_REQUEST
+
 namespace NKikimr::NGRpcService {
 
 namespace {
@@ -159,8 +161,9 @@ private:
     }
 
     void Reply(Ydb::StatusIds::StatusCode status, Ydb::Operations::Operation&& result, const NYql::TIssues& issues = {}) {
-        LOG_INFO_S(TActivationContext::AsActorContext(), NKikimrServices::RPC_REQUEST, "Execute script, status: "
-            << Ydb::StatusIds::StatusCode_Name(status) << (issues ? ". Issues: " : "") << issues.ToOneLineString());
+        YDB_LOG_INFO_CTX(TActivationContext::AsActorContext(), "Execute script",
+            {"status", Ydb::StatusIds::StatusCode_Name(status)},
+            {"issues", issues.ToOneLineString()});
 
         google::protobuf::RepeatedPtrField<TYdbIssueMessageType> issuesMessage;
         for (const auto& issue : issues) {

--- a/ydb/core/grpc_services/query/rpc_fetch_script_results.cpp
+++ b/ydb/core/grpc_services/query/rpc_fetch_script_results.cpp
@@ -15,6 +15,8 @@
 #include <ydb/library/ydb_issue/issue_helpers.h>
 #include <ydb/public/api/protos/ydb_query.pb.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::RPC_REQUEST
+
 namespace NKikimr::NGRpcService {
 
 namespace {
@@ -98,8 +100,9 @@ private:
     }
 
     void Reply(Ydb::StatusIds::StatusCode status, Ydb::Query::FetchScriptResultsResponse&& result, const NYql::TIssues& issues = {}) {
-        LOG_INFO_S(TActivationContext::AsActorContext(), NKikimrServices::RPC_REQUEST, "Fetch script results, status: "
-            << Ydb::StatusIds::StatusCode_Name(status) << (issues ? ". Issues: " : "") << issues.ToOneLineString());
+        YDB_LOG_INFO_CTX(TActivationContext::AsActorContext(), "Fetch script results",
+            {"status", Ydb::StatusIds::StatusCode_Name(status)},
+            {"issues", issues.ToOneLineString()});
 
         for (const auto& issue : issues) {
             auto item = result.add_issues();

--- a/ydb/core/grpc_services/query/rpc_kqp_tx.cpp
+++ b/ydb/core/grpc_services/query/rpc_kqp_tx.cpp
@@ -10,6 +10,8 @@
 
 #include <ydb/public/api/protos/ydb_query.pb.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::RPC_REQUEST
+
 namespace NKikimr::NGRpcService {
 
 namespace {
@@ -143,7 +145,8 @@ private:
     }
 
     void InternalError(const TString& message) {
-        ALOG_ERROR(NKikimrServices::RPC_REQUEST, "Internal error, message: " << message);
+        YDB_LOG_ERROR("Internal error",
+            {"message", message});
 
         Request->RaiseIssue(MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, message));
         Reply(Ydb::StatusIds::INTERNAL_ERROR);
@@ -245,7 +248,8 @@ private:
     }
 
     void InternalError(const TString& message) {
-        ALOG_ERROR(NKikimrServices::RPC_REQUEST, "Internal error, message: " << message);
+        YDB_LOG_ERROR("Internal error",
+            {"message", message});
 
         Request->RaiseIssue(MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, message));
         Reply(Ydb::StatusIds::INTERNAL_ERROR);

--- a/ydb/core/grpc_services/rpc_alter_table.cpp
+++ b/ydb/core/grpc_services/rpc_alter_table.cpp
@@ -19,13 +19,6 @@
 
 #include <util/generic/hash_set.h>
 
-#define TXLOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
-#define TXLOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
-#define TXLOG_I(stream) LOG_INFO_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
-#define TXLOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
-#define TXLOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
-#define TXLOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
-
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -145,9 +138,7 @@ private:
 
     void Handle(TEvents::TEvUndelivered::TPtr &/*ev*/, const TActorContext &ctx)
     {
-        LOG_CRIT_S(ctx, NKikimrServices::GRPC_PROXY,
-            "TAlterTableRPC: cannot deliver config request to Configs Dispatcher"
-            " (empty default profile is available only)");
+        YDB_LOG_CRIT_CTX_COMP(ctx, NKikimrServices::GRPC_PROXY, "TAlterTableRPC: cannot deliver config request to Configs Dispatcher (empty default profile is available only)");
         AlterTable(ctx);
         Become(&TAlterTableRPC::AlterStateWork);
     }
@@ -163,7 +154,7 @@ private:
     void HandleWakeup(TEvents::TEvWakeup::TPtr &ev, const TActorContext &ctx) {
         switch (ev->Get()->Tag) {
         case WakeupTagGetConfig: {
-            LOG_CRIT_S(ctx, NKikimrServices::GRPC_PROXY, "TAlterTableRPC: cannot get table profiles (timeout)");
+            YDB_LOG_CRIT_CTX_COMP(ctx, NKikimrServices::GRPC_PROXY, "TAlterTableRPC: cannot get table profiles (timeout)");
             NYql::TIssues issues;
             issues.AddIssue(NYql::TIssue("Tables profiles config not available."));
             return Reply(StatusIds::UNAVAILABLE, issues, ctx);
@@ -187,7 +178,8 @@ private:
     }
 
     void Handle(TEvTxUserProxy::TEvAllocateTxIdResult::TPtr& ev) {
-        TXLOG_D("Handle TEvTxUserProxy::TEvAllocateTxIdResult");
+        YDB_LOG_DEBUG_COMP(NKikimrServices::TX_PROXY, "Handle TEvTxUserProxy::TEvAllocateTxIdResult",
+            {"logPrefix", LogPrefix});
 
         const auto* msg = ev->Get();
         TxId = msg->TxId;
@@ -239,8 +231,9 @@ private:
     }
 
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev, const TActorContext& ctx) {
-        TXLOG_D("Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult"
-                    << ", errors# " << ev->Get()->Request.Get()->ErrorCount);
+        YDB_LOG_DEBUG_COMP(NKikimrServices::TX_PROXY, "Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult",
+            {"logPrefix", LogPrefix},
+            {"errors", ev->Get()->Request.Get()->ErrorCount});
 
         NSchemeCache::TSchemeCacheNavigate* resp = ev->Get()->Request.Get();
 
@@ -255,7 +248,8 @@ private:
             }
 
             TString error(builder);
-            TXLOG_E(error);
+            YDB_LOG_ERROR_COMP(NKikimrServices::TX_PROXY, error,
+                {"logPrefix", LogPrefix});
             Request_->RaiseIssue(MakeIssue(NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR, error));
             return Reply(Ydb::StatusIds::SCHEME_ERROR, ctx);
         }
@@ -313,7 +307,8 @@ private:
                 return std::make_unique<NSchemeShard::TEvSetColumnConstraint::TEvCreateRequest>(TxId, DatabaseName, std::move(SetColumnConstraintSettings));
             });
         default:
-            TXLOG_E("Got unexpected cache response");
+            YDB_LOG_ERROR_COMP(NKikimrServices::TX_PROXY, "Got unexpected cache response",
+                {"logPrefix", LogPrefix});
             return Reply(Ydb::StatusIds::INTERNAL_ERROR, ctx);
         }
     }
@@ -328,7 +323,8 @@ private:
             return true;
         }
 
-        TXLOG_W("Access check failed");
+        YDB_LOG_WARN_COMP(NKikimrServices::TX_PROXY, "Access check failed",
+            {"logPrefix", LogPrefix});
         Reply(Ydb::StatusIds::UNAUTHORIZED,
             TStringBuilder() << "Access denied"
                 << " for# " << UserToken->GetUserSID()
@@ -345,7 +341,8 @@ private:
 
         const auto& domainInfo = entry.DomainInfo;
         if (!domainInfo) {
-            TXLOG_E("Got empty domain info");
+            YDB_LOG_ERROR_COMP(NKikimrServices::TX_PROXY, "Got empty domain info",
+                {"logPrefix", LogPrefix});
             return Reply(Ydb::StatusIds::INTERNAL_ERROR, ctx);
         }
 
@@ -372,10 +369,11 @@ private:
             return issues.ToString();
         };
 
-        TXLOG_D("Handle TEvIndexBuilder::TEvCreateResponse"
-            << ", status# " << status
-            << ", issues# " << getDebugIssues()
-            << ", Id# " << response.GetIndexBuild().GetId());
+        YDB_LOG_DEBUG_COMP(NKikimrServices::TX_PROXY, "Handle TEvIndexBuilder::TEvCreateResponse",
+            {"logPrefix", LogPrefix},
+            {"status", status},
+            {"issues", getDebugIssues()},
+            {"id", response.GetIndexBuild().GetId()});
 
         if (status == Ydb::StatusIds::SUCCESS) {
             if (response.HasSchemeStatus() && response.GetSchemeStatus() == NKikimrScheme::EStatus::StatusAlreadyExists) {
@@ -405,10 +403,11 @@ private:
             return issues.ToString();
         };
 
-        TXLOG_D("Handle TEvForcedCompaction::TEvCreateResponse"
-            << ", status# " << status
-            << ", issues# " << getDebugIssues()
-            << ", Id# " << response.GetForcedCompaction().GetId());
+        YDB_LOG_DEBUG_COMP(NKikimrServices::TX_PROXY, "Handle TEvForcedCompaction::TEvCreateResponse",
+            {"logPrefix", LogPrefix},
+            {"status", status},
+            {"issues", getDebugIssues()},
+            {"id", response.GetForcedCompaction().GetId()});
 
         if (status == Ydb::StatusIds::SUCCESS) {
             if (GetOperationMode() == Ydb::Operations::OperationParams::SYNC) {
@@ -453,7 +452,9 @@ private:
     void Handle(NSchemeShard::TEvIndexBuilder::TEvGetResponse::TPtr& ev, const TActorContext& ctx) {
         const auto& record = ev->Get()->Record;
 
-        TXLOG_D("Handle TEvIndexBuilder::TEvGetResponse: record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG_COMP(NKikimrServices::TX_PROXY, "Handle TEvIndexBuilder::TEvGetResponse",
+            {"logPrefix", LogPrefix},
+            {"record", record.ShortDebugString()});
 
         if (record.GetStatus() != Ydb::StatusIds::SUCCESS) {
             Request_->ReplyWithYdbStatus(record.GetStatus());
@@ -468,7 +469,9 @@ private:
     void Handle(NSchemeShard::TEvForcedCompaction::TEvGetResponse::TPtr& ev, const TActorContext& ctx) {
         const auto& record = ev->Get()->Record;
 
-        TXLOG_D("Handle TEvForcedCompaction::TEvGetResponse: record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG_COMP(NKikimrServices::TX_PROXY, "Handle TEvForcedCompaction::TEvGetResponse",
+            {"logPrefix", LogPrefix},
+            {"record", record.ShortDebugString()});
 
         if (record.GetStatus() != Ydb::StatusIds::SUCCESS) {
             Request_->ReplyWithYdbStatus(record.GetStatus());

--- a/ydb/core/grpc_services/rpc_cancel_operation.cpp
+++ b/ydb/core/grpc_services/rpc_cancel_operation.cpp
@@ -17,6 +17,8 @@
 
 #include <yql/essentials/public/issue/yql_issue_message.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_PROXY
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -160,8 +162,11 @@ class TCancelOperationRPC: public TRpcOperationRequestActor<TCancelOperationRPC,
     void Handle(TEvExport::TEvCancelExportResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record.GetResponse();
 
-        LOG_D("Handle TEvExport::TEvCancelExportResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvExport::TEvCancelExportResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         Reply(record.GetStatus(), record.GetIssues());
     }
@@ -169,8 +174,11 @@ class TCancelOperationRPC: public TRpcOperationRequestActor<TCancelOperationRPC,
     void Handle(TEvImport::TEvCancelImportResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record.GetResponse();
 
-        LOG_D("Handle TEvImport::TEvCancelImportResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvImport::TEvCancelImportResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         Reply(record.GetStatus(), record.GetIssues());
     }
@@ -178,8 +186,11 @@ class TCancelOperationRPC: public TRpcOperationRequestActor<TCancelOperationRPC,
     void Handle(TEvIndexBuilder::TEvCancelResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvIndexBuilder::TEvCancelResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvIndexBuilder::TEvCancelResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         Reply(record.GetStatus(), record.GetIssues());
     }
@@ -187,8 +198,11 @@ class TCancelOperationRPC: public TRpcOperationRequestActor<TCancelOperationRPC,
     void Handle(TEvForcedCompaction::TEvCancelResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvForcedCompaction::TEvCancelResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvForcedCompaction::TEvCancelResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         Reply(record.GetStatus(), record.GetIssues());
     }
@@ -196,8 +210,11 @@ class TCancelOperationRPC: public TRpcOperationRequestActor<TCancelOperationRPC,
     void Handle(TEvSetColumnConstraint::TEvCancelResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvSetColumnConstraint::TEvCancelResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvSetColumnConstraint::TEvCancelResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         Reply(record.GetStatus(), record.GetIssues());
     }

--- a/ydb/core/grpc_services/rpc_common/rpc_common_kqp_session.cpp
+++ b/ydb/core/grpc_services/rpc_common/rpc_common_kqp_session.cpp
@@ -16,6 +16,8 @@
 
 #include <ydb/public/api/protos/ydb_query.pb.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::GRPC_PROXY
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -46,8 +48,9 @@ public:
         const auto& deadline = Request->GetDeadline();
 
         if (deadline <= now) {
-            LOG_WARN_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY,
-                SelfId() << " Request deadline has expired for " << now - deadline << " seconds");
+            YDB_LOG_WARN("Request deadline has expired",
+                {"selfId", SelfId()},
+                {"expiredTimeSeconds", now - deadline});
 
             Reply(Ydb::StatusIds::TIMEOUT);
             return;
@@ -111,8 +114,10 @@ private:
         auto actorId = NRpcService::DoLocalRpcSameMailbox<TEvDeleteSessionRequest>(
             std::move(request), std::move(cb), database, Request->GetSerializedToken(), ctx);
 
-        LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY,
-            SelfId() << " Client lost, session " << sessionId << " will be closed by " << actorId);
+        YDB_LOG_NOTICE("Client lost, session will be closed by actor",
+            {"selfId", SelfId()},
+            {"sessionId", sessionId},
+            {"actorId", actorId});
     }
 
     void Handle(NKqp::TEvKqp::TEvCreateSessionResponse::TPtr& ev, const TActorContext& ctx) {

--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -15,6 +15,8 @@
 #include <ydb/core/cms/console/configs_dispatcher.h>
 #include <ydb/library/services/services.pb.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::GRPC_SERVER
+
 namespace {
 
 TString DescribeConfigIdentity(const Ydb::DynamicConfig::ConfigIdentity& id)
@@ -124,9 +126,8 @@ bool ConvertGetConfigToFetchConfigResult(
             default:
                 // Any other value that comes from a newer Console is skipped with a warning
                 // so we don't fail on forward-compatible additions
-                ALOG_NOTICE(NKikimrServices::GRPC_SERVER,
-                    "Convert Ydb::DynamicConfig::ConfigIdentity to Ydb::Config::FetchConfigResult: "
-                    << "skipped unknown config identity '" << DescribeConfigIdentity(srcIdentity) << "'" );
+                YDB_LOG_NOTICE("Convert Ydb::DynamicConfig::ConfigIdentity to Ydb::Config::FetchConfigResult: skipped unknown config identity",
+                    {"srcIdentity", DescribeConfigIdentity(srcIdentity)});
                 break;
         }
     }

--- a/ydb/core/grpc_services/rpc_create_table.cpp
+++ b/ydb/core/grpc_services/rpc_create_table.cpp
@@ -17,6 +17,8 @@
 #include <ydb/core/ydb_convert/table_description.h>
 #include <ydb/core/ydb_convert/table_profiles.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::GRPC_PROXY
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -62,9 +64,7 @@ private:
 
     void Handle(TEvents::TEvUndelivered::TPtr &/*ev*/, const TActorContext &ctx)
     {
-        LOG_CRIT_S(ctx, NKikimrServices::GRPC_PROXY,
-                   "TCreateTableRPC: cannot deliver config request to Configs Dispatcher"
-                   " (empty default profile is available only)");
+        YDB_LOG_CRIT_CTX(ctx, "TCreateTableRPC: cannot deliver config request to Configs Dispatcher (empty default profile is available only)");
         SendProposeRequest(ctx);
         Become(&TCreateTableRPC::StateWork);
     }
@@ -80,7 +80,7 @@ private:
     void HandleWakeup(TEvents::TEvWakeup::TPtr &ev, const TActorContext &ctx) {
         switch (ev->Get()->Tag) {
             case WakeupTagGetConfig: {
-                LOG_CRIT_S(ctx, NKikimrServices::GRPC_PROXY, "TCreateTableRPC: cannot get table profiles (timeout)");
+                YDB_LOG_CRIT_CTX(ctx, "TCreateTableRPC: cannot get table profiles (timeout)");
                 NYql::TIssues issues;
                 issues.AddIssue(NYql::TIssue("Tables profiles config not available."));
                 return Reply(StatusIds::UNAVAILABLE, issues, ctx);
@@ -279,14 +279,14 @@ private:
                 }
                 case Ydb::Table::TableIndex::kLocalMinMaxIndex: {
                     if (!AppData()->FeatureFlags.GetEnableLocalMinMaxIndex()) {
-                        LOG_ERROR_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY, NKikimr::NOlap::NIndexes::NMinMax::FeatureFlagDisabledErrorMessage);
+                        YDB_LOG_ERROR(NKikimr::NOlap::NIndexes::NMinMax::FeatureFlagDisabledErrorMessage);
                         issues.AddIssue(NYql::TIssue(NKikimr::NOlap::NIndexes::NMinMax::FeatureFlagDisabledErrorMessage));
                         code = StatusIds::BAD_REQUEST;
                         return false;
-                    } 
+                    }
 
                     if (!AppData()->FeatureFlags.GetEnableLocalIndexAsSchemeObject()) {
-                        LOG_ERROR_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY, NKikimr::NOlap::NIndexes::NMinMax::SchemeObjectFeatureFlagDisabledErrorMessage);
+                        YDB_LOG_ERROR(NKikimr::NOlap::NIndexes::NMinMax::SchemeObjectFeatureFlagDisabledErrorMessage);
                         issues.AddIssue(NYql::TIssue(NKikimr::NOlap::NIndexes::NMinMax::SchemeObjectFeatureFlagDisabledErrorMessage));
                         code = StatusIds::BAD_REQUEST;
                         return false;
@@ -295,7 +295,7 @@ private:
                     olapIndex->SetClassName(NKikimr::NOlap::NIndexes::NMinMax::kMinMaxClassName);
                     auto* min_max = olapIndex->MutableMinMaxIndex();
                     if (index.index_columns().size() != 1) {
-                        LOG_ERROR_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY, NKikimr::NOlap::NIndexes::NMinMax::IncorrectIndexColumnsErrorMessage(index.index_columns()));
+                        YDB_LOG_ERROR(NKikimr::NOlap::NIndexes::NMinMax::IncorrectIndexColumnsErrorMessage(index.index_columns()));
                         issues.AddIssue(NYql::TIssue(NKikimr::NOlap::NIndexes::NMinMax::IncorrectIndexColumnsErrorMessage(index.index_columns())));
                         code = StatusIds::BAD_REQUEST;
                         return false;
@@ -314,7 +314,7 @@ private:
                         for (const auto& col: schema->GetColumns()) {
                             tableColumnNames.push_back(col.GetName());
                         }
-                        LOG_ERROR_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY, NKikimr::NOlap::NIndexes::NMinMax::UnknownIndexColumnNameErrorMessage(index.index_columns(0), tableColumnNames));
+                        YDB_LOG_ERROR(NKikimr::NOlap::NIndexes::NMinMax::UnknownIndexColumnNameErrorMessage(index.index_columns(0), tableColumnNames));
                         issues.AddIssue(NYql::TIssue(NKikimr::NOlap::NIndexes::NMinMax::UnknownIndexColumnNameErrorMessage(index.index_columns(0), tableColumnNames)));
                         code = StatusIds::BAD_REQUEST;
                         return false;
@@ -324,7 +324,7 @@ private:
                     min_max->SetColumnId(it->second);
                     NKikimr::NOlap::NIndexes::NMinMax::SetAppropriateStoregeIdAndInheritPortionStorageBasedOnType(*olapIndex, columnDesc->GetType());
                     break;
-                }                
+                }
                 case Ydb::Table::TableIndex::TYPE_NOT_SET:
                 case Ydb::Table::TableIndex::kGlobalIndex:
                 case Ydb::Table::TableIndex::kGlobalAsyncIndex:

--- a/ydb/core/grpc_services/rpc_describe_system_view.cpp
+++ b/ydb/core/grpc_services/rpc_describe_system_view.cpp
@@ -7,6 +7,8 @@
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/ydb_convert/table_description.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::GRPC_SERVER
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -65,7 +67,7 @@ private:
                 if (!FillSysViewDescription(describeSysViewResult, pathDescription, status, error)) {
                     switch (status) {
                     case Ydb::StatusIds::INTERNAL_ERROR:
-                        LOG_ERROR(ctx, NKikimrServices::GRPC_SERVER, error);
+                        YDB_LOG_ERROR_CTX(ctx, error);
                         [[fallthrough]];
                     case Ydb::StatusIds::SCHEME_ERROR:
                         [[fallthrough]];
@@ -109,7 +111,9 @@ private:
 
     void ReplyOnException(const std::exception& ex, const char* logPrefix) noexcept {
         auto& ctx = TlsActivationContext->AsActorContext();
-        LOG_ERROR(ctx, NKikimrServices::GRPC_SERVER, "%s: %s", logPrefix, ex.what());
+        YDB_LOG_ERROR_CTX(ctx, "Reply on exception",
+            {"logPrefix", logPrefix},
+            {"exception", ex.what()});
         Request_->RaiseIssue(NYql::ExceptionToIssue(ex));
         return Reply(Ydb::StatusIds::INTERNAL_ERROR, ctx);
     }

--- a/ydb/core/grpc_services/rpc_describe_table.cpp
+++ b/ydb/core/grpc_services/rpc_describe_table.cpp
@@ -11,6 +11,8 @@
 #include <ydb/core/ydb_convert/table_description.h>
 #include <ydb/core/ydb_convert/ydb_convert.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::GRPC_SERVER
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -171,7 +173,8 @@ private:
                 StatusIds::StatusCode code = StatusIds::SUCCESS;
                 TString error;
                 if (!FillSequenceDescription(describeTableResult, tableDescription, code, error)) {
-                    LOG_ERROR(ctx, NKikimrServices::GRPC_SERVER, "Unable to fill sequence description: %s", error.c_str());
+                    YDB_LOG_ERROR_CTX(ctx, "Unable to fill sequence description",
+                        {"error", error});
                     Request_->RaiseIssue(NYql::TIssue(error));
                     return Reply(Ydb::StatusIds::INTERNAL_ERROR, ctx);
                 }
@@ -296,7 +299,9 @@ private:
 
     void ReplyOnException(const std::exception& ex, const char* logPrefix) noexcept {
         auto& ctx = TlsActivationContext->AsActorContext();
-        LOG_ERROR(ctx, NKikimrServices::GRPC_SERVER, "%s: %s", logPrefix, ex.what());
+        YDB_LOG_ERROR_CTX(ctx, "Reply on exception",
+            {"logPrefix", logPrefix},
+            {"exception", ex.what()});
         Request_->RaiseIssue(NYql::ExceptionToIssue(ex));
         return Reply(Ydb::StatusIds::INTERNAL_ERROR, ctx);
     }

--- a/ydb/core/grpc_services/rpc_describe_table_options.cpp
+++ b/ydb/core/grpc_services/rpc_describe_table_options.cpp
@@ -10,6 +10,8 @@
 #include <ydb/core/protos/console_config.pb.h>
 #include <ydb/core/ydb_convert/table_profiles.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::GRPC_PROXY
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -55,8 +57,7 @@ private:
 
     void Handle(TEvents::TEvUndelivered::TPtr &/*ev*/, const TActorContext &ctx)
     {
-        LOG_CRIT_S(ctx, NKikimrServices::GRPC_PROXY,
-                   "TDescribeTableOptionsRPC: cannot deliver config request to Configs Dispatcher");
+        YDB_LOG_CRIT_CTX(ctx, "TDescribeTableOptionsRPC: cannot deliver config request to Configs Dispatcher");
          NYql::TIssues issues;
          issues.AddIssue(NYql::TIssue("Cannot get table profiles (service unavailable)"));
          Reply(Ydb::StatusIds::UNAVAILABLE, issues, ctx);
@@ -184,8 +185,7 @@ private:
     void HandleWakeup(TEvents::TEvWakeup::TPtr &ev, const TActorContext &ctx) {
         switch (ev->Get()->Tag) {
             case WakeupTagGetConfig: {
-                LOG_CRIT_S(ctx, NKikimrServices::GRPC_PROXY,
-                   "TDescribeTableOptionsRPC: cannot get table profiles (timeout)");
+                YDB_LOG_CRIT_CTX(ctx, "TDescribeTableOptionsRPC: cannot get table profiles (timeout)");
                 NYql::TIssues issues;
                 issues.AddIssue(NYql::TIssue("Tables profiles config not available."));
                 return Reply(Ydb::StatusIds::UNAVAILABLE, issues, ctx);

--- a/ydb/core/grpc_services/rpc_export.cpp
+++ b/ydb/core/grpc_services/rpc_export.cpp
@@ -19,6 +19,8 @@
 #include <util/generic/ptr.h>
 #include <util/string/builder.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_PROXY
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -344,8 +346,11 @@ class TExportRPC: public TRpcOperationRequestActor<TDerived, TEvRequest, true>, 
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
         const auto& request = ev->Get()->Request;
 
-        LOG_D("Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult"
-            << ": request# " << (request ? request->ToString(*AppData()->TypeRegistry) : "nullptr"));
+        YDB_LOG_DEBUG("Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"request", (request ? request->ToString(*AppData()->TypeRegistry) : "nullptr")});
 
         if (request->ResultSet.empty()) {
             return this->Reply(StatusIds::SCHEME_ERROR, TIssuesIds::GENERIC_RESOLVE_ERROR);
@@ -488,7 +493,10 @@ class TExportRPC: public TRpcOperationRequestActor<TDerived, TEvRequest, true>, 
             }
 
             if (!entry.DomainInfo) {
-                LOG_E("Got empty domain info");
+                YDB_LOG_ERROR("Got empty domain info",
+                    {"logPrefix", GetLogPrefix()},
+                    {"selfId", this->SelfId()},
+                    {"txId", this->TxId});
                 return this->Reply(StatusIds::INTERNAL_ERROR, TIssuesIds::GENERIC_RESOLVE_ERROR);
             }
 
@@ -511,8 +519,11 @@ class TExportRPC: public TRpcOperationRequestActor<TDerived, TEvRequest, true>, 
     void Handle(TEvExport::TEvCreateExportResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record.GetResponse();
 
-        LOG_D("Handle TEvExport::TEvCreateExportResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvExport::TEvCreateExportResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         this->Reply(TExportConv::ToOperation(record.GetEntry()));
     }

--- a/ydb/core/grpc_services/rpc_forget_operation.cpp
+++ b/ydb/core/grpc_services/rpc_forget_operation.cpp
@@ -17,6 +17,8 @@
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/operation_id/operation_id.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_PROXY
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -171,8 +173,11 @@ class TForgetOperationRPC: public TRpcOperationRequestActor<TForgetOperationRPC,
     void Handle(TEvExport::TEvForgetExportResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record.GetResponse();
 
-        LOG_D("Handle TEvExport::TEvForgetExportResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvExport::TEvForgetExportResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         Reply(record.GetStatus(), record.GetIssues());
     }
@@ -180,8 +185,11 @@ class TForgetOperationRPC: public TRpcOperationRequestActor<TForgetOperationRPC,
     void Handle(TEvImport::TEvForgetImportResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record.GetResponse();
 
-        LOG_D("Handle TEvImport::TEvForgetImportResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvImport::TEvForgetImportResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         Reply(record.GetStatus(), record.GetIssues());
     }
@@ -189,8 +197,11 @@ class TForgetOperationRPC: public TRpcOperationRequestActor<TForgetOperationRPC,
     void Handle(TEvIndexBuilder::TEvForgetResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvIndexBuilder::TEvForgetResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvIndexBuilder::TEvForgetResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         Reply(record.GetStatus(), record.GetIssues());
     }
@@ -198,8 +209,11 @@ class TForgetOperationRPC: public TRpcOperationRequestActor<TForgetOperationRPC,
     void Handle(TEvForcedCompaction::TEvForgetResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvForcedCompaction::TEvForgetResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvForcedCompaction::TEvForgetResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         Reply(record.GetStatus(), record.GetIssues());
     }
@@ -207,8 +221,11 @@ class TForgetOperationRPC: public TRpcOperationRequestActor<TForgetOperationRPC,
     void Handle(TEvSetColumnConstraint::TEvForgetResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvSetColumnConstraint::TEvForgetResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvSetColumnConstraint::TEvForgetResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         Reply(record.GetStatus(), record.GetIssues());
     }
@@ -216,8 +233,11 @@ class TForgetOperationRPC: public TRpcOperationRequestActor<TForgetOperationRPC,
     void Handle(NKqp::TEvForgetScriptExecutionOperationResponse::TPtr& ev) {
         google::protobuf::RepeatedPtrField<Ydb::Issue::IssueMessage> issuesProto;
         NYql::IssuesToMessage(ev->Get()->Issues, &issuesProto);
-        LOG_D("Handle NKqp::TEvForgetScriptExecutionOperationResponse response"
-            << ": status# " << ev->Get()->Status);
+        YDB_LOG_DEBUG("Handle NKqp::TEvForgetScriptExecutionOperationResponse response",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"status", ev->Get()->Status});
         Reply(ev->Get()->Status, issuesProto);
     }
 
@@ -228,8 +248,11 @@ class TForgetOperationRPC: public TRpcOperationRequestActor<TForgetOperationRPC,
     void Handle(TEvBackup::TEvForgetIncrementalBackupResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvBackup::TEvForgetIncrementalBackupResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvBackup::TEvForgetIncrementalBackupResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         Reply(record.GetStatus(), record.GetIssues());
     }
@@ -237,8 +260,11 @@ class TForgetOperationRPC: public TRpcOperationRequestActor<TForgetOperationRPC,
     void Handle(TEvBackup::TEvForgetBackupCollectionRestoreResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvBackup::TEvForgetBackupCollectionRestoreResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvBackup::TEvForgetBackupCollectionRestoreResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         Reply(record.GetStatus(), record.GetIssues());
     }
@@ -246,8 +272,11 @@ class TForgetOperationRPC: public TRpcOperationRequestActor<TForgetOperationRPC,
     void Handle(TEvBackup::TEvForgetFullBackupResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvBackup::TEvForgetFullBackupResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvBackup::TEvForgetFullBackupResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         Reply(record.GetStatus(), record.GetIssues());
     }

--- a/ydb/core/grpc_services/rpc_get_operation.cpp
+++ b/ydb/core/grpc_services/rpc_get_operation.cpp
@@ -32,6 +32,8 @@
 
 #include <util/string/cast.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_PROXY
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -350,8 +352,11 @@ private:
     void Handle(NSchemeShard::TEvExport::TEvGetExportResponse::TPtr& ev, const TActorContext& ctx) {
         const auto& record = ev->Get()->Record.GetResponse();
 
-        LOG_D("Handle TEvExport::TEvGetExportResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvExport::TEvGetExportResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TEvGetOperationRequest::TResponse resp;
         *resp.mutable_operation() = TExportConv::ToOperation(record.GetEntry());
@@ -361,8 +366,11 @@ private:
     void Handle(NSchemeShard::TEvImport::TEvGetImportResponse::TPtr& ev, const TActorContext& ctx) {
         const auto& record = ev->Get()->Record.GetResponse();
 
-        LOG_D("Handle TEvImport::TEvGetImportResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvImport::TEvGetImportResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TEvGetOperationRequest::TResponse resp;
         *resp.mutable_operation() = TImportConv::ToOperation(record.GetEntry());
@@ -372,8 +380,11 @@ private:
     void Handle(NSchemeShard::TEvIndexBuilder::TEvGetResponse::TPtr& ev, const TActorContext& ctx) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvIndexBuilder::TEvGetResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvIndexBuilder::TEvGetResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         if (record.GetStatus() != Ydb::StatusIds::SUCCESS) {
             ReplyGetOperationResponse(true, ctx, record.GetStatus());
@@ -388,8 +399,11 @@ private:
     void Handle(NSchemeShard::TEvForcedCompaction::TEvGetResponse::TPtr& ev, const TActorContext& ctx) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvForcedCompaction::TEvGetResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvForcedCompaction::TEvGetResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         if (record.GetStatus() != Ydb::StatusIds::SUCCESS) {
             ReplyGetOperationResponse(true, ctx, record.GetStatus());
@@ -404,8 +418,11 @@ private:
     void Handle(NSchemeShard::TEvSetColumnConstraint::TEvGetResponse::TPtr& ev, const TActorContext& ctx) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvSetColumnConstraint::TEvGetResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvSetColumnConstraint::TEvGetResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         if (record.GetStatus() != Ydb::StatusIds::SUCCESS) {
             ReplyGetOperationResponse(true, ctx, record.GetStatus());
@@ -439,8 +456,11 @@ private:
     void Handle(NSchemeShard::TEvBackup::TEvGetIncrementalBackupResponse::TPtr& ev, const TActorContext& ctx) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvBackup::TEvGetIncrementalBackupResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvBackup::TEvGetIncrementalBackupResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TEvGetOperationRequest::TResponse resp;
         *resp.mutable_operation() = TIncrementalBackupConv::ToOperation(record.GetIncrementalBackup());
@@ -450,8 +470,11 @@ private:
     void Handle(NSchemeShard::TEvBackup::TEvGetBackupCollectionRestoreResponse::TPtr& ev, const TActorContext& ctx) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvBackup::TEvGetBackupCollectionRestoreResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvBackup::TEvGetBackupCollectionRestoreResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TEvGetOperationRequest::TResponse resp;
         *resp.mutable_operation() = TBackupCollectionRestoreConv::ToOperation(record.GetBackupCollectionRestore());
@@ -461,8 +484,11 @@ private:
     void Handle(NSchemeShard::TEvBackup::TEvGetFullBackupResponse::TPtr& ev, const TActorContext& ctx) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvBackup::TEvGetFullBackupResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvBackup::TEvGetFullBackupResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TEvGetOperationRequest::TResponse resp;
         *resp.mutable_operation() = TFullBackupConv::ToOperation(record.GetFullBackup());

--- a/ydb/core/grpc_services/rpc_import.cpp
+++ b/ydb/core/grpc_services/rpc_import.cpp
@@ -19,6 +19,8 @@
 #include <util/generic/ptr.h>
 #include <util/string/builder.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_PROXY
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -112,8 +114,11 @@ class TImportRPC: public TRpcOperationRequestActor<TDerived, TEvRequest, true>, 
     void Handle(TEvImport::TEvCreateImportResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record.GetResponse();
 
-        LOG_D("Handle TEvImport::TEvCreateImportResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvImport::TEvCreateImportResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         this->Reply(TImportConv::ToOperation(record.GetEntry()));
     }

--- a/ydb/core/grpc_services/rpc_kh_describe.cpp
+++ b/ydb/core/grpc_services/rpc_kh_describe.cpp
@@ -21,6 +21,8 @@
 #include <util/string/vector.h>
 #include <util/generic/hash.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::RPC_REQUEST
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -126,8 +128,9 @@ private:
     }
 
     void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev,  const TActorContext& ctx) {
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Got TEvDeliveryProblem, TabletId: " << ev->Get()->TabletId
-                << ", NotDelivered: " << ev->Get()->NotDelivered);
+        YDB_LOG_DEBUG_CTX(ctx, "Got TEvDeliveryProblem",
+            {"tabletId", ev->Get()->TabletId},
+            {"notDelivered", ev->Get()->NotDelivered});
         return ReplyWithError(Ydb::StatusIds::UNAVAILABLE, "Invalid table path specified", ctx);
     }
 
@@ -306,9 +309,9 @@ private:
             return JoinVectorIntoString(shards, ", ");
         };
 
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Table ["
-                    << TEvKikhouseDescribeTableRequest::GetProtoRequest(Request)->path()
-                    << "] shards: " << getShardsString(KeyRange->GetPartitions()));
+        YDB_LOG_DEBUG_CTX(ctx, "Table",
+            {"path", TEvKikhouseDescribeTableRequest::GetProtoRequest(Request)->path()},
+            {"shards", getShardsString(KeyRange->GetPartitions())});
 
         for (const TKeyDesc::TPartitionInfo& partition : KeyRange->GetPartitions()) {
             auto* p = Result.add_partitions();

--- a/ydb/core/grpc_services/rpc_list_objects_in_s3_export.cpp
+++ b/ydb/core/grpc_services/rpc_list_objects_in_s3_export.cpp
@@ -7,12 +7,7 @@
 #include <ydb/core/tx/schemeshard/schemeshard_import.h>
 #include <ydb/public/api/protos/ydb_import.pb.h>
 
-#define LOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << " " << stream)
-#define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << " " << stream)
-#define LOG_I(stream) LOG_INFO_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << " " << stream)
-#define LOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << " " << stream)
-#define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << " " << stream)
-#define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << " " << stream)
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_PROXY
 
 namespace NKikimr::NGRpcService {
 
@@ -53,8 +48,9 @@ public:
     }
 
     void ResolveDatabase() {
-        LOG_D("Resolve database"
-            << ": name# " << Request_->GetDatabaseName());
+        YDB_LOG_DEBUG("[ListObjectsInS3Export] Resolve database",
+            {"selfId", SelfId()},
+            {"name", Request_->GetDatabaseName()});
 
         auto request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
         request->DatabaseName = *Request_->GetDatabaseName();
@@ -69,8 +65,9 @@ public:
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
         const auto& request = ev->Get()->Request;
 
-        LOG_D("Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult"
-            << ": request# " << (request ? request->ToString(*AppData()->TypeRegistry) : "nullptr"));
+        YDB_LOG_DEBUG("[ListObjectsInS3Export] Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult",
+            {"selfId", SelfId()},
+            {"request", (request ? request->ToString(*AppData()->TypeRegistry) : "nullptr")});
 
         if (request->ResultSet.empty()) {
             return Reply(Ydb::StatusIds::SCHEME_ERROR, "Scheme error", NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR, NActors::TActivationContext::AsActorContext());
@@ -101,7 +98,8 @@ public:
 
         auto domainInfo = entry.DomainInfo;
         if (!domainInfo) {
-            LOG_E("Got empty domain info");
+            YDB_LOG_ERROR("[ListObjectsInS3Export] Got empty domain info",
+                {"selfId", SelfId()});
             return Reply(Ydb::StatusIds::INTERNAL_ERROR, "Internal error", NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR, NActors::TActivationContext::AsActorContext());
         }
 
@@ -131,7 +129,9 @@ public:
     }
 
     void SendRequestToSchemeShard() {
-        LOG_D("Send request: schemeShardId# " << SchemeShardId);
+        YDB_LOG_DEBUG("[ListObjectsInS3Export] Send request",
+            {"selfId", SelfId()},
+            {"schemeShardId", SchemeShardId});
 
         if (!PipeClient) {
             NTabletPipe::TClientConfig config;
@@ -152,8 +152,9 @@ public:
     void Handle(NKikimr::NSchemeShard::TEvImport::TEvListObjectsInS3ExportResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TListObjectsInS3ExportRPC::TEvListObjectsInS3ExportResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("[ListObjectsInS3Export] Handle TListObjectsInS3ExportRPC::TEvListObjectsInS3ExportResponse",
+            {"selfId", SelfId()},
+            {"record", record.ShortDebugString()});
 
         if (record.GetStatus() != Ydb::StatusIds::SUCCESS) {
             return Reply(record.GetStatus(), record.GetIssues(), NActors::TActivationContext::AsActorContext());
@@ -173,7 +174,8 @@ public:
     }
 
     void DeliveryProblem() {
-        LOG_W("Delivery problem");
+        YDB_LOG_WARN("[ListObjectsInS3Export] Delivery problem",
+            {"selfId", SelfId()});
         Reply(Ydb::StatusIds::UNAVAILABLE, "Delivery problem", NKikimrIssues::TIssuesIds::DEFAULT_ERROR, NActors::TActivationContext::AsActorContext());
     }
 

--- a/ydb/core/grpc_services/rpc_list_operations.cpp
+++ b/ydb/core/grpc_services/rpc_list_operations.cpp
@@ -24,6 +24,8 @@
 
 #include <yql/essentials/public/issue/yql_issue_message.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_PROXY
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -104,8 +106,11 @@ class TListOperationsRPC
     void Handle(TEvExport::TEvListExportsResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record.GetResponse();
 
-        LOG_D("Handle TEvExport::TEvListExportsResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvExport::TEvListExportsResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TResponse response;
         response.set_status(record.GetStatus());
@@ -122,8 +127,11 @@ class TListOperationsRPC
     void Handle(TEvImport::TEvListImportsResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record.GetResponse();
 
-        LOG_D("Handle TEvImport::TEvListImportsResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvImport::TEvListImportsResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TResponse response;
         response.set_status(record.GetStatus());
@@ -140,8 +148,11 @@ class TListOperationsRPC
     void Handle(TEvIndexBuilder::TEvListResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvIndexBuilder::TEvListResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvIndexBuilder::TEvListResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TResponse response;
 
@@ -160,8 +171,11 @@ class TListOperationsRPC
     void Handle(TEvForcedCompaction::TEvListResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvForcedCompaction::TEvListResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvForcedCompaction::TEvListResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TResponse response;
 
@@ -180,7 +194,11 @@ class TListOperationsRPC
     void Handle(NSchemeShard::NBackground::TEvListResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvSchemeShard::TEvBGTasksListResponse: record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvSchemeShard::TEvBGTasksListResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TResponse response;
 
@@ -284,7 +302,11 @@ class TListOperationsRPC
     void Handle(NStat::TEvStatistics::TEvAnalyzeOpListResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvAnalyzeOpListResponse: record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvAnalyzeOpListResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TResponse response;
         response.set_status(record.GetStatus());
@@ -322,8 +344,11 @@ class TListOperationsRPC
     void Handle(TEvBackup::TEvListIncrementalBackupsResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvBackup::TEvListIncrementalBackupsResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvBackup::TEvListIncrementalBackupsResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TResponse response;
         response.set_status(record.GetStatus());
@@ -340,8 +365,11 @@ class TListOperationsRPC
     void Handle(TEvBackup::TEvListBackupCollectionRestoresResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvBackup::TEvListBackupCollectionRestoresResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvBackup::TEvListBackupCollectionRestoresResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TResponse response;
         response.set_status(record.GetStatus());
@@ -358,8 +386,11 @@ class TListOperationsRPC
     void Handle(TEvBackup::TEvListFullBackupsResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvBackup::TEvListFullBackupsResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvBackup::TEvListFullBackupsResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TResponse response;
         response.set_status(record.GetStatus());
@@ -376,8 +407,11 @@ class TListOperationsRPC
     void Handle(TEvSetColumnConstraint::TEvListResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
 
-        LOG_D("Handle TEvSetColumnConstraint::TEvListResponse"
-            << ": record# " << record.ShortDebugString());
+        YDB_LOG_DEBUG("Handle TEvSetColumnConstraint::TEvListResponse",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"record", record.ShortDebugString()});
 
         TResponse response;
 

--- a/ydb/core/grpc_services/rpc_log_store.cpp
+++ b/ydb/core/grpc_services/rpc_log_store.cpp
@@ -12,6 +12,8 @@
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/public/api/grpc/draft/ydb_logstore_v1.pb.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::GRPC_SERVER
+
 namespace NKikimr::NGRpcService {
 
 using namespace NActors;
@@ -210,7 +212,8 @@ private:
             auto* toSchemaPreset = create->AddSchemaPresets();
             toSchemaPreset->SetName(schemaPreset.name());
             if (!ConvertSchemaFromPublicToInternal(schemaPreset.schema(), *toSchemaPreset->MutableSchema(), status, error)) {
-                LOG_DEBUG(ctx, NKikimrServices::GRPC_SERVER, "LogStore schema error: %s", error.c_str());
+                YDB_LOG_DEBUG_CTX(ctx, "LogStore schema error",
+                    {"error", error});
                 return Reply(status, error, NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ctx);
             }
         }
@@ -267,7 +270,8 @@ private:
                     Ydb::StatusIds::StatusCode status;
                     TString error;
                     if (!ConvertSchemaFromInternalToPublic(schemaPreset.GetSchema(), *toSchemaPreset->mutable_schema(), status, error)) {
-                        LOG_DEBUG(ctx, NKikimrServices::GRPC_SERVER, "LogStore schema error: %s", error.c_str());
+                        YDB_LOG_DEBUG_CTX(ctx, "LogStore schema error",
+                            {"error", error});
                         return Reply(status, error, NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ctx);
                     }
                 }
@@ -426,7 +430,8 @@ private:
         }
         if (req->has_schema()) {
             if (!ConvertSchemaFromPublicToInternal(req->schema(), *create->MutableSchema(), status, error)) {
-                LOG_DEBUG(ctx, NKikimrServices::GRPC_SERVER, "LogTable schema error: %s", error.c_str());
+                YDB_LOG_DEBUG_CTX(ctx, "LogTable schema error",
+                    {"error", error});
                 return Reply(status, error, NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ctx);
             }
         }
@@ -499,7 +504,8 @@ private:
                 Ydb::StatusIds::StatusCode status;
                 TString error;
                 if (!ConvertSchemaFromInternalToPublic(tableDescription.GetSchema(), *describeLogTableResult.mutable_schema(), status, error)) {
-                    LOG_DEBUG(ctx, NKikimrServices::GRPC_SERVER, "LogTable schema error: %s", error.c_str());
+                    YDB_LOG_DEBUG_CTX(ctx, "LogTable schema error",
+                        {"error", error});
                     return Reply(status, error, NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ctx);
                 }
                 if (tableDescription.HasSchemaPresetName()) {

--- a/ydb/core/grpc_services/rpc_nbs.cpp
+++ b/ydb/core/grpc_services/rpc_nbs.cpp
@@ -12,7 +12,6 @@
 
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/api/service.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct.h>
-#include <ydb/core/nbs/cloud/blockstore/config/protos/storage.pb.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/api/ss_proxy.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/core/request_info.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/core/volume_label.h>
@@ -20,6 +19,9 @@
 #include <ydb/core/nbs/cloud/storage/core/protos/media.pb.h>
 #include <ydb/core/protos/blockstore_config.pb.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/flat_tx_scheme.pb.h>
+
+#include <util/string/cast.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::NBS_PARTITION
 
@@ -44,28 +46,58 @@ using namespace NYdb::NBS::NStorage;
 
 namespace {
 
-Ydb::StatusIds::StatusCode StatusFromNbsError(const NYdb::NBS::NProto::TError& error)
+Ydb::StatusIds::StatusCode NbsErrorToYdbStatus(
+    const NYdb::NBS::NProto::TError& error)
 {
-    // ModifyScheme maps StatusMultipleModifications / StatusNotAvailable to
-    // E_REJECTED (retriable). The tablet uses the same code for wipe/deallocate
-    // failures that the client may retry.
-    if (error.GetCode() == NYdb::NBS::E_REJECTED) {
-        return Ydb::StatusIds::UNAVAILABLE;
-    }
-    if (error.GetCode() == NYdb::NBS::E_TIMEOUT) {
-        return Ydb::StatusIds::TIMEOUT;
-    }
-    if (FACILITY_FROM_CODE(error.GetCode()) == NYdb::NBS::FACILITY_SCHEMESHARD) {
-        const auto schemeStatus = static_cast<NKikimrScheme::EStatus>(
-            STATUS_FROM_CODE(error.GetCode()));
-        if (schemeStatus == NKikimrScheme::StatusPathDoesNotExist) {
+    switch (error.GetCode()) {
+        case NYdb::NBS::S_ALREADY:
+            return Ydb::StatusIds::ALREADY_EXISTS;
+        case NYdb::NBS::E_ARGUMENT:
+            return Ydb::StatusIds::BAD_REQUEST;
+        case NYdb::NBS::E_NOT_FOUND:
             return Ydb::StatusIds::NOT_FOUND;
+        case NYdb::NBS::E_UNAUTHORIZED:
+            return Ydb::StatusIds::UNAUTHORIZED;
+        case NYdb::NBS::E_NOT_IMPLEMENTED:
+            return Ydb::StatusIds::UNSUPPORTED;
+        case NYdb::NBS::E_ABORTED:
+            return Ydb::StatusIds::ABORTED;
+        case NYdb::NBS::E_REJECTED:
+        case NYdb::NBS::E_TRY_AGAIN:
+            return Ydb::StatusIds::UNAVAILABLE;
+        case NYdb::NBS::E_TIMEOUT:
+        case NYdb::NBS::E_RETRY_TIMEOUT:
+            return Ydb::StatusIds::TIMEOUT;
+        case NYdb::NBS::E_CANCELLED:
+            return Ydb::StatusIds::CANCELLED;
+        case NYdb::NBS::E_PRECONDITION_FAILED:
+            return Ydb::StatusIds::PRECONDITION_FAILED;
+        default:
+            break;
+    }
+
+    if (FACILITY_FROM_CODE(error.GetCode()) == NYdb::NBS::FACILITY_SCHEMESHARD) {
+        switch (static_cast<NKikimrScheme::EStatus>(
+            STATUS_FROM_CODE(error.GetCode())))
+        {
+            case NKikimrScheme::StatusPathDoesNotExist:
+                return Ydb::StatusIds::NOT_FOUND;
+            case NKikimrScheme::StatusAlreadyExists:
+            case NKikimrScheme::StatusNameConflict:
+                return Ydb::StatusIds::ALREADY_EXISTS;
+            default:
+                break;
         }
     }
+
+    if (!NYdb::NBS::HasError(error)) {
+        return Ydb::StatusIds::SUCCESS;
+    }
+
     return Ydb::StatusIds::GENERIC_ERROR;
 }
 
-} // namespace
+}   // namespace
 
 class TCreatePartitionRequest
     : public TRpcOperationRequestActor<TCreatePartitionRequest, TEvCreatePartitionRequest> {
@@ -86,14 +118,6 @@ public:
         const ui32 blockSize = request->GetBlockSize() ? request->GetBlockSize() : 4096;
         const ui64 blocksCount = request->GetBlocksCount() ? request->GetBlocksCount() : 32768;
         const ui32 storageMedia = request->GetStorageMedia();
-        const ui32 syncRequestsBatchSize = request->GetSyncRequestsBatchSize();
-
-        NYdb::NBS::NProto::TStorageServiceConfig storageConfig;
-        storageConfig.SetDDiskPoolName(storagePoolName);
-        storageConfig.SetPersistentBufferDDiskPoolName(storagePoolName);
-        // One trace per 1s should be sufficient for observability.
-        storageConfig.SetTraceSamplePeriod(1000);
-        storageConfig.SetSyncRequestsBatchSize(syncRequestsBatchSize);
 
         NKikimrBlockStore::TVolumeConfig volumeConfig;
         volumeConfig.SetBlockSize(blockSize);
@@ -135,6 +159,7 @@ private:
     TString DiskId;
     ui32 DescribeAttempts = 0;
     static constexpr ui32 MaxDescribeAttempts = 10;
+    Ydb::StatusIds::StatusCode CreateStatus = Ydb::StatusIds::SUCCESS;
 
     STFUNC(StateCreate) {
         switch (ev->GetTypeRewrite()) {
@@ -165,22 +190,32 @@ private:
     void HandleCreateVolume(TEvSSProxy::TEvCreateVolumeResponse::TPtr& ev) {
         const auto& ctx = TActivationContext::AsActorContext();
         const auto& response = *ev->Get();
+        const auto& error = response.GetError();
 
         YDB_LOG_DEBUG_CTX(ctx, "Grpc service: received TEvCreateVolumeResponse from ss proxy",
             {"sender", ev->Sender},
+            {"error", NYdb::NBS::FormatError(error)},
             {"status", static_cast<int>(response.Status)},
-            {"reason", response.Reason});
+            {"reason", response.Reason},
+            {"tabletId", response.TabletId});
 
-        if (response.Status != NKikimrScheme::StatusSuccess) {
-            if (!response.Reason.empty()) {
-                auto issue = NYql::TIssue(response.Reason);
-                Request_->RaiseIssue(issue);
-            }
-            Reply(Ydb::StatusIds::GENERIC_ERROR, ctx);
+        const auto status = NbsErrorToYdbStatus(error);
+        if (status != Ydb::StatusIds::SUCCESS &&
+            status != Ydb::StatusIds::ALREADY_EXISTS)
+        {
+            Request_->RaiseIssue(NYql::TIssue(NYdb::NBS::FormatError(error)));
+            Reply(status, ctx);
             return;
         }
 
-        // Resolve the partition tablet id for CreatePartitionResult.TabletId.
+        Ydb::Nbs::CreatePartitionResult result;
+        if (response.TabletId != 0) {
+            result.SetTabletId(ToString(response.TabletId));
+            ReplyWithResult(status, result, ctx);
+            return;
+        }
+
+        CreateStatus = status;
         Become(&TThis::StateDescribe);
         SendDescribeScheme(ctx);
     }
@@ -195,11 +230,7 @@ private:
         if (NYdb::NBS::HasError(error)) {
             YDB_LOG_ERROR_CTX(ctx, "CreatePartition: DescribeScheme failed after create",
                 {"error", NYdb::NBS::FormatError(error)});
-            auto issue = NYql::TIssue(
-                error.GetMessage().empty()
-                    ? NYdb::NBS::FormatError(error)
-                    : error.GetMessage());
-            Request_->RaiseIssue(issue);
+            Request_->RaiseIssue(NYql::TIssue(NYdb::NBS::FormatError(error)));
             Reply(Ydb::StatusIds::GENERIC_ERROR, ctx);
             return;
         }
@@ -227,7 +258,7 @@ private:
             .GetPartitions(0)
             .GetTabletId();
         result.SetTabletId(ToString(tabletId));
-        ReplyWithResult(Ydb::StatusIds::SUCCESS, result, ctx);
+        ReplyWithResult(CreateStatus, result, ctx);
     }
 };
 
@@ -309,7 +340,7 @@ private:
                     ? NYdb::NBS::FormatError(error)
                     : error.GetMessage());
             Request_->RaiseIssue(issue);
-            Reply(StatusFromNbsError(error), ActorContext());
+            Reply(NbsErrorToYdbStatus(error), ActorContext());
             return;
         }
 
@@ -393,7 +424,7 @@ private:
         if (ev->Get()->GetError().GetCode() != 0) {
             auto issue = NYql::TIssue(ev->Get()->GetErrorReason());
             Request_->RaiseIssue(issue);
-            Reply(StatusFromNbsError(ev->Get()->GetError()), ActorContext());
+            Reply(NbsErrorToYdbStatus(ev->Get()->GetError()), ActorContext());
             return;
         }
 
@@ -420,7 +451,7 @@ private:
                     ? NYdb::NBS::FormatError(error)
                     : error.GetMessage());
             Request_->RaiseIssue(issue);
-            Reply(StatusFromNbsError(error), ActorContext());
+            Reply(NbsErrorToYdbStatus(error), ActorContext());
             return;
         }
 

--- a/ydb/core/grpc_services/rpc_nbs.cpp
+++ b/ydb/core/grpc_services/rpc_nbs.cpp
@@ -19,6 +19,8 @@
 #include <ydb/core/protos/blockstore_config.pb.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::NBS_PARTITION
+
 namespace NKikimr::NGRpcService {
 
 using TEvCreatePartitionRequest =
@@ -92,8 +94,7 @@ public:
         auto createVolumeRequest = std::make_unique<TEvSSProxy::TEvCreateVolumeRequest>(
             std::move(volumeConfig));
 
-        LOG_DEBUG(ctx, NKikimrServices::NBS_PARTITION,
-            "Sending createvolume request for volume testDiskId");
+        YDB_LOG_DEBUG_CTX(ctx, "Sending createvolume request for volume testDiskId");
 
         NYdb::NBS::Send(
             ctx,
@@ -112,11 +113,10 @@ private:
     void Handle(TEvSSProxy::TEvCreateVolumeResponse::TPtr& ev) {
         const auto& response = *ev->Get();
 
-        LOG_DEBUG(TActivationContext::AsActorContext(), NKikimrServices::NBS_PARTITION,
-            "Grpc service: received TEvCreateVolumeResponse from ss proxy: %s, status: %d, reason: %s",
-            ev->Sender.ToString().data(),
-            static_cast<int>(response.Status),
-            response.Reason.data());
+        YDB_LOG_DEBUG_CTX(TActivationContext::AsActorContext(), "Grpc service: received TEvCreateVolumeResponse from ss",
+            {"proxy", ev->Sender},
+            {"status", static_cast<int>(response.Status)},
+            {"reason", response.Reason.data()});
 
         Ydb::Nbs::CreatePartitionResult result;
 
@@ -321,9 +321,8 @@ public:
         const auto* request = GetProtoRequest();
         const TString diskId = request->GetDiskId();
 
-        LOG_DEBUG(ctx, NKikimrServices::NBS_PARTITION,
-            "GetLoadActorAdapterActorId: sending DescribeScheme request for disk %s",
-            diskId.data());
+        YDB_LOG_DEBUG_CTX(ctx, "GetLoadActorAdapterActorId: sending DescribeScheme request for disk",
+            {"diskId", diskId.data()});
 
         auto describeRequest = std::make_unique<TEvSSProxy::TEvDescribeSchemeRequest>(diskId);
 
@@ -359,16 +358,15 @@ private:
         const auto& ctx = TActivationContext::AsActorContext();
         const auto& response = *ev->Get();
 
-        LOG_DEBUG(ctx, NKikimrServices::NBS_PARTITION,
-            "GetLoadActorAdapterActorId: received DescribeScheme response: %s", response.ToString().data());
+        YDB_LOG_DEBUG_CTX(ctx, "GetLoadActorAdapterActorId: received DescribeScheme",
+            {"response", response});
 
         const auto& pathDescription = response.PathDescription;
         const auto pathType = pathDescription.GetSelf().GetPathType();
 
         if (pathType != NKikimrSchemeOp::EPathTypeBlockStoreVolume) {
-            LOG_ERROR(ctx, NKikimrServices::NBS_PARTITION,
-                "GetLoadActorAdapterActorId: path is not a BlockStoreVolume (type=%d)",
-                static_cast<int>(pathType));
+            YDB_LOG_ERROR_CTX(ctx, "GetLoadActorAdapterActorId: path is not a BlockStoreVolume",
+                {"type", static_cast<int>(pathType)});
             auto issue = NYql::TIssue("Path is not a BlockStoreVolume");
             Request_->RaiseIssue(issue);
             Reply(Ydb::StatusIds::BAD_REQUEST, ActorContext());
@@ -378,8 +376,7 @@ private:
         const auto& volumeDescription = pathDescription.GetBlockStoreVolumeDescription();
 
         if (volumeDescription.PartitionsSize() == 0) {
-            LOG_ERROR(ctx, NKikimrServices::NBS_PARTITION,
-                "GetLoadActorAdapterActorId: volume has no partitions");
+            YDB_LOG_ERROR_CTX(ctx, "GetLoadActorAdapterActorId: volume has no partitions");
             auto issue = NYql::TIssue("Volume has no partitions");
             Request_->RaiseIssue(issue);
             Reply(Ydb::StatusIds::BAD_REQUEST, ActorContext());
@@ -389,9 +386,8 @@ private:
         const auto& partition = volumeDescription.GetPartitions(0);
         ui64 tabletId = partition.GetTabletId();
 
-        LOG_DEBUG(ctx, NKikimrServices::NBS_PARTITION,
-            "GetLoadActorAdapterActorId: extracted partition tablet id %lu, creating pipe",
-            tabletId);
+        YDB_LOG_DEBUG_CTX(ctx, "GetLoadActorAdapterActorId: extracted partition tablet id, creating pipe",
+            {"tabletId", tabletId});
 
         Become(&TThis::StateWork);
 
@@ -410,31 +406,27 @@ private:
         const auto& ctx = TActivationContext::AsActorContext();
 
         if (ev->Get()->Status != NKikimrProto::OK) {
-            LOG_ERROR(ctx, NKikimrServices::NBS_PARTITION,
-                "GetLoadActorAdapterActorId: failed to connect to partition tablet");
+            YDB_LOG_ERROR_CTX(ctx, "GetLoadActorAdapterActorId: failed to connect to partition tablet");
             auto issue = NYql::TIssue("Failed to connect to partition tablet");
             Request_->RaiseIssue(issue);
             Reply(Ydb::StatusIds::UNAVAILABLE, ActorContext());
             return;
         }
 
-        LOG_DEBUG(ctx, NKikimrServices::NBS_PARTITION,
-            "GetLoadActorAdapterActorId: connected to partition tablet");
+        YDB_LOG_DEBUG_CTX(ctx, "GetLoadActorAdapterActorId: connected to partition tablet");
     }
 
     void HandleDisconnect(TEvTabletPipe::TEvClientDestroyed::TPtr& ev) {
         Y_UNUSED(ev);
         const auto& ctx = TActivationContext::AsActorContext();
 
-        LOG_WARN(ctx, NKikimrServices::NBS_PARTITION,
-            "GetLoadActorAdapterActorId: pipe to partition tablet destroyed");
+        YDB_LOG_WARN_CTX(ctx, "GetLoadActorAdapterActorId: pipe to partition tablet destroyed");
     }
 
     void Handle(NYdb::NBS::NBlockStore::TEvService::TEvGetLoadActorAdapterActorIdResponse::TPtr& ev) {
         const auto& ctx = TActivationContext::AsActorContext();
 
-        LOG_DEBUG(ctx, NKikimrServices::NBS_PARTITION,
-            "GetLoadActorAdapterActorId: received response from partition tablet");
+        YDB_LOG_DEBUG_CTX(ctx, "GetLoadActorAdapterActorId: received response from partition tablet");
 
         if (PipeClient) {
             NTabletPipe::CloseClient(ctx, PipeClient);

--- a/ydb/core/grpc_services/rpc_nbs.cpp
+++ b/ydb/core/grpc_services/rpc_nbs.cpp
@@ -8,6 +8,8 @@
 #include <ydb/core/tablet_flat/tablet_flat_executed.h>
 #include <ydb/core/base/tablet_pipe.h>
 
+#include <ydb/library/actors/core/events.h>
+
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/api/service.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct.h>
 #include <ydb/core/nbs/cloud/blockstore/config/protos/storage.pb.h>
@@ -40,6 +42,30 @@ using namespace NActors;
 using namespace Ydb;
 using namespace NYdb::NBS::NStorage;
 
+namespace {
+
+Ydb::StatusIds::StatusCode StatusFromNbsError(const NYdb::NBS::NProto::TError& error)
+{
+    // ModifyScheme maps StatusMultipleModifications / StatusNotAvailable to
+    // E_REJECTED (retriable). The tablet uses the same code for wipe/deallocate
+    // failures that the client may retry.
+    if (error.GetCode() == NYdb::NBS::E_REJECTED) {
+        return Ydb::StatusIds::UNAVAILABLE;
+    }
+    if (error.GetCode() == NYdb::NBS::E_TIMEOUT) {
+        return Ydb::StatusIds::TIMEOUT;
+    }
+    if (FACILITY_FROM_CODE(error.GetCode()) == NYdb::NBS::FACILITY_SCHEMESHARD) {
+        const auto schemeStatus = static_cast<NKikimrScheme::EStatus>(
+            STATUS_FROM_CODE(error.GetCode()));
+        if (schemeStatus == NKikimrScheme::StatusPathDoesNotExist) {
+            return Ydb::StatusIds::NOT_FOUND;
+        }
+    }
+    return Ydb::StatusIds::GENERIC_ERROR;
+}
+
+} // namespace
 
 class TCreatePartitionRequest
     : public TRpcOperationRequestActor<TCreatePartitionRequest, TEvCreatePartitionRequest> {
@@ -51,10 +77,11 @@ public:
     void Bootstrap() {
         const auto& ctx = TActivationContext::AsActorContext();
 
-        Become(&TThis::StateWork);
+        Become(&TThis::StateCreate);
 
         // Extract parameters from request
         const auto* request = GetProtoRequest();
+        DiskId = request->GetDiskId();
         const TString storagePoolName = request->GetStoragePoolName();
         const ui32 blockSize = request->GetBlockSize() ? request->GetBlockSize() : 4096;
         const ui64 blocksCount = request->GetBlocksCount() ? request->GetBlocksCount() : 32768;
@@ -80,7 +107,7 @@ public:
         volumeConfig.SetBlockSize(blockSize);
 
         // volume identifier
-        volumeConfig.SetDiskId(request->GetDiskId());
+        volumeConfig.SetDiskId(DiskId);
         // user folder Id, used for billing
         volumeConfig.SetFolderId("testFolderId");
         // owner information
@@ -94,7 +121,8 @@ public:
         auto createVolumeRequest = std::make_unique<TEvSSProxy::TEvCreateVolumeRequest>(
             std::move(volumeConfig));
 
-        YDB_LOG_DEBUG_CTX(ctx, "Sending createvolume request for volume testDiskId");
+        YDB_LOG_DEBUG_CTX(ctx, "Sending createvolume request for volume",
+            {"diskId", DiskId});
 
         NYdb::NBS::Send(
             ctx,
@@ -104,31 +132,102 @@ public:
     }
 
 private:
-    STFUNC(StateWork) {
+    TString DiskId;
+    ui32 DescribeAttempts = 0;
+    static constexpr ui32 MaxDescribeAttempts = 10;
+
+    STFUNC(StateCreate) {
         switch (ev->GetTypeRewrite()) {
-            hFunc(TEvSSProxy::TEvCreateVolumeResponse, Handle);
+            hFunc(TEvSSProxy::TEvCreateVolumeResponse, HandleCreateVolume);
+            default:
+                break;
         }
     }
 
-    void Handle(TEvSSProxy::TEvCreateVolumeResponse::TPtr& ev) {
+    STFUNC(StateDescribe) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvSSProxy::TEvDescribeSchemeResponse, HandleDescribeScheme);
+            hFunc(TEvents::TEvWakeup, HandleDescribeRetry);
+            default:
+                break;
+        }
+    }
+
+    void SendDescribeScheme(const TActorContext& ctx) {
+        auto describeRequest = std::make_unique<TEvSSProxy::TEvDescribeSchemeRequest>(DiskId);
+        NYdb::NBS::Send(ctx, MakeSSProxyServiceId(), std::move(describeRequest), 0);
+    }
+
+    void HandleDescribeRetry(TEvents::TEvWakeup::TPtr&) {
+        SendDescribeScheme(TActivationContext::AsActorContext());
+    }
+
+    void HandleCreateVolume(TEvSSProxy::TEvCreateVolumeResponse::TPtr& ev) {
+        const auto& ctx = TActivationContext::AsActorContext();
         const auto& response = *ev->Get();
 
-        YDB_LOG_DEBUG_CTX(TActivationContext::AsActorContext(), "Grpc service: received TEvCreateVolumeResponse from ss",
-            {"proxy", ev->Sender},
+        YDB_LOG_DEBUG_CTX(ctx, "Grpc service: received TEvCreateVolumeResponse from ss proxy",
+            {"sender", ev->Sender},
             {"status", static_cast<int>(response.Status)},
-            {"reason", response.Reason.data()});
+            {"reason", response.Reason});
 
-        Ydb::Nbs::CreatePartitionResult result;
-
-        if (response.Status == NKikimrScheme::StatusSuccess) {
-            ReplyWithResult(Ydb::StatusIds::SUCCESS, result, ActorContext());
-        } else {
+        if (response.Status != NKikimrScheme::StatusSuccess) {
             if (!response.Reason.empty()) {
                 auto issue = NYql::TIssue(response.Reason);
                 Request_->RaiseIssue(issue);
             }
-            Reply(Ydb::StatusIds::GENERIC_ERROR, ActorContext());
+            Reply(Ydb::StatusIds::GENERIC_ERROR, ctx);
+            return;
         }
+
+        // Resolve the partition tablet id for CreatePartitionResult.TabletId.
+        Become(&TThis::StateDescribe);
+        SendDescribeScheme(ctx);
+    }
+
+    void HandleDescribeScheme(TEvSSProxy::TEvDescribeSchemeResponse::TPtr& ev) {
+        const auto& ctx = TActivationContext::AsActorContext();
+        const auto& response = *ev->Get();
+
+        Ydb::Nbs::CreatePartitionResult result;
+
+        const auto& error = response.GetError();
+        if (NYdb::NBS::HasError(error)) {
+            YDB_LOG_ERROR_CTX(ctx, "CreatePartition: DescribeScheme failed after create",
+                {"error", NYdb::NBS::FormatError(error)});
+            auto issue = NYql::TIssue(
+                error.GetMessage().empty()
+                    ? NYdb::NBS::FormatError(error)
+                    : error.GetMessage());
+            Request_->RaiseIssue(issue);
+            Reply(Ydb::StatusIds::GENERIC_ERROR, ctx);
+            return;
+        }
+
+        const auto& pathDescription = response.PathDescription;
+        if (pathDescription.GetSelf().GetPathType() != NKikimrSchemeOp::EPathTypeBlockStoreVolume ||
+            pathDescription.GetBlockStoreVolumeDescription().PartitionsSize() == 0)
+        {
+            if (DescribeAttempts < MaxDescribeAttempts) {
+                ++DescribeAttempts;
+                YDB_LOG_DEBUG_CTX(ctx, "CreatePartition: describe returned no partitions, retry",
+                    {"attempt", DescribeAttempts},
+                    {"maxAttempts", MaxDescribeAttempts});
+                ctx.Schedule(TDuration::MilliSeconds(200), new TEvents::TEvWakeup());
+                return;
+            }
+            auto issue = NYql::TIssue(
+                "CreatePartition: volume describe returned no partitions");
+            Request_->RaiseIssue(issue);
+            Reply(Ydb::StatusIds::GENERIC_ERROR, ctx);
+            return;
+        }
+
+        const ui64 tabletId = pathDescription.GetBlockStoreVolumeDescription()
+            .GetPartitions(0)
+            .GetTabletId();
+        result.SetTabletId(ToString(tabletId));
+        ReplyWithResult(Ydb::StatusIds::SUCCESS, result, ctx);
     }
 };
 
@@ -147,9 +246,8 @@ public:
         const auto* request = GetProtoRequest();
         const TString diskId = request->GetDiskId();
 
-        LOG_DEBUG(ctx, NKikimrServices::NBS_PARTITION,
-            "DeletePartition: sending DescribeScheme request for disk %s",
-            diskId.data());
+        YDB_LOG_DEBUG_CTX(ctx, "DeletePartition: sending DescribeScheme request for disk",
+            {"diskId", diskId});
 
         auto describeRequest = std::make_unique<TEvSSProxy::TEvDescribeSchemeRequest>(diskId);
 
@@ -182,33 +280,36 @@ private:
         }
     }
 
+    STFUNC(StateDestroyVolume) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvSSProxy::TEvDestroyVolumeResponse, HandleDestroyVolume);
+            hFunc(TEvTabletPipe::TEvClientDestroyed, HandleIgnoredDisconnect);
+            default:
+                break;
+        }
+    }
+
+    void HandleIgnoredDisconnect(TEvTabletPipe::TEvClientDestroyed::TPtr& ev) {
+        Y_UNUSED(ev);
+    }
+
     void HandleDescribeScheme(TEvSSProxy::TEvDescribeSchemeResponse::TPtr& ev) {
         const auto& ctx = TActivationContext::AsActorContext();
         const auto& response = *ev->Get();
 
-        LOG_DEBUG(ctx, NKikimrServices::NBS_PARTITION,
-            "DeletePartition: received DescribeScheme response: %s", response.ToString().data());
+        YDB_LOG_DEBUG_CTX(ctx, "DeletePartition: received DescribeScheme response",
+            {"response", response.ToString()});
 
         const auto& error = response.GetError();
         if (NYdb::NBS::HasError(error)) {
-            LOG_ERROR(ctx, NKikimrServices::NBS_PARTITION,
-                "DeletePartition: DescribeScheme failed: %s",
-                NYdb::NBS::FormatError(error).data());
+            YDB_LOG_ERROR_CTX(ctx, "DeletePartition: DescribeScheme failed",
+                {"error", NYdb::NBS::FormatError(error)});
             auto issue = NYql::TIssue(
                 error.GetMessage().empty()
                     ? NYdb::NBS::FormatError(error)
                     : error.GetMessage());
             Request_->RaiseIssue(issue);
-
-            auto status = Ydb::StatusIds::GENERIC_ERROR;
-            if (FACILITY_FROM_CODE(error.GetCode()) == NYdb::NBS::FACILITY_SCHEMESHARD) {
-                const auto schemeStatus = static_cast<NKikimrScheme::EStatus>(
-                    STATUS_FROM_CODE(error.GetCode()));
-                if (schemeStatus == NKikimrScheme::StatusPathDoesNotExist) {
-                    status = Ydb::StatusIds::NOT_FOUND;
-                }
-            }
-            Reply(status, ActorContext());
+            Reply(StatusFromNbsError(error), ActorContext());
             return;
         }
 
@@ -216,9 +317,8 @@ private:
         const auto pathType = pathDescription.GetSelf().GetPathType();
 
         if (pathType != NKikimrSchemeOp::EPathTypeBlockStoreVolume) {
-            LOG_ERROR(ctx, NKikimrServices::NBS_PARTITION,
-                "DeletePartition: path is not a BlockStoreVolume (type=%d)",
-                static_cast<int>(pathType));
+            YDB_LOG_ERROR_CTX(ctx, "DeletePartition: path is not a BlockStoreVolume",
+                {"type", static_cast<int>(pathType)});
             auto issue = NYql::TIssue("Path is not a BlockStoreVolume");
             Request_->RaiseIssue(issue);
             Reply(Ydb::StatusIds::BAD_REQUEST, ActorContext());
@@ -228,8 +328,7 @@ private:
         const auto& volumeDescription = pathDescription.GetBlockStoreVolumeDescription();
 
         if (volumeDescription.PartitionsSize() == 0) {
-            LOG_ERROR(ctx, NKikimrServices::NBS_PARTITION,
-                "DeletePartition: volume has no partitions");
+            YDB_LOG_ERROR_CTX(ctx, "DeletePartition: volume has no partitions");
             auto issue = NYql::TIssue("Volume has no partitions");
             Request_->RaiseIssue(issue);
             Reply(Ydb::StatusIds::BAD_REQUEST, ActorContext());
@@ -240,10 +339,9 @@ private:
         const auto& partition = volumeDescription.GetPartitions(0);
         const ui64 tabletId = partition.GetTabletId();
 
-        LOG_DEBUG(ctx, NKikimrServices::NBS_PARTITION,
-            "DeletePartition: extracted partition tablet id %lu for disk %s, creating pipe",
-            tabletId,
-            DiskId.data());
+        YDB_LOG_DEBUG_CTX(ctx, "DeletePartition: extracted partition tablet id, creating pipe",
+            {"tabletId", tabletId},
+            {"diskId", DiskId});
 
         Become(&TThis::StateWork);
 
@@ -260,24 +358,21 @@ private:
         const auto& ctx = TActivationContext::AsActorContext();
 
         if (ev->Get()->Status != NKikimrProto::OK) {
-            LOG_ERROR(ctx, NKikimrServices::NBS_PARTITION,
-                "DeletePartition: failed to connect to partition tablet");
+            YDB_LOG_ERROR_CTX(ctx, "DeletePartition: failed to connect to partition tablet");
             auto issue = NYql::TIssue("Failed to connect to partition tablet");
             Request_->RaiseIssue(issue);
             Reply(Ydb::StatusIds::UNAVAILABLE, ActorContext());
             return;
         }
 
-        LOG_DEBUG(ctx, NKikimrServices::NBS_PARTITION,
-            "DeletePartition: connected to partition tablet");
+        YDB_LOG_DEBUG_CTX(ctx, "DeletePartition: connected to partition tablet");
     }
 
     void HandleDisconnect(TEvTabletPipe::TEvClientDestroyed::TPtr& ev) {
         Y_UNUSED(ev);
         const auto& ctx = TActivationContext::AsActorContext();
 
-        LOG_ERROR(ctx, NKikimrServices::NBS_PARTITION,
-            "DeletePartition: pipe to partition tablet destroyed before response");
+        YDB_LOG_ERROR_CTX(ctx, "DeletePartition: pipe to partition tablet destroyed before response");
         auto issue = NYql::TIssue("Pipe to partition tablet destroyed");
         Request_->RaiseIssue(issue);
         Reply(Ydb::StatusIds::UNAVAILABLE, ActorContext());
@@ -286,19 +381,51 @@ private:
     void Handle(NYdb::NBS::NBlockStore::TEvService::TEvDeletePartitionResponse::TPtr& ev) {
         const auto& ctx = TActivationContext::AsActorContext();
 
-        LOG_DEBUG(ctx, NKikimrServices::NBS_PARTITION,
-            "DeletePartition: received response from partition tablet");
+        YDB_LOG_DEBUG_CTX(ctx, "DeletePartition: received response from partition tablet");
+
+        Become(&TThis::StateDestroyVolume);
 
         if (PipeClient) {
             NTabletPipe::CloseClient(ctx, PipeClient);
+            PipeClient = {};
         }
 
         if (ev->Get()->GetError().GetCode() != 0) {
             auto issue = NYql::TIssue(ev->Get()->GetErrorReason());
             Request_->RaiseIssue(issue);
-            Reply(Ydb::StatusIds::GENERIC_ERROR, ActorContext());
+            Reply(StatusFromNbsError(ev->Get()->GetError()), ActorContext());
             return;
         }
+
+        // Wipe + BSC deallocate succeeded; drop the volume so SchemeShard
+        // deletes the volume and partition tablets.
+
+        YDB_LOG_DEBUG_CTX(ctx, "DeletePartition: sending DestroyVolume for disk",
+            {"diskId", DiskId});
+
+        auto destroyRequest = std::make_unique<TEvSSProxy::TEvDestroyVolumeRequest>(DiskId);
+        NYdb::NBS::Send(ctx, MakeSSProxyServiceId(), std::move(destroyRequest), 0);
+    }
+
+    void HandleDestroyVolume(TEvSSProxy::TEvDestroyVolumeResponse::TPtr& ev) {
+        const auto& ctx = TActivationContext::AsActorContext();
+        const auto& error = ev->Get()->GetError();
+
+        if (NYdb::NBS::HasError(error)) {
+            YDB_LOG_ERROR_CTX(ctx, "DeletePartition: DestroyVolume failed",
+                {"diskId", DiskId},
+                {"error", NYdb::NBS::FormatError(error)});
+            auto issue = NYql::TIssue(
+                error.GetMessage().empty()
+                    ? NYdb::NBS::FormatError(error)
+                    : error.GetMessage());
+            Request_->RaiseIssue(issue);
+            Reply(StatusFromNbsError(error), ActorContext());
+            return;
+        }
+
+        YDB_LOG_DEBUG_CTX(ctx, "DeletePartition: DestroyVolume succeeded",
+            {"diskId", DiskId});
 
         Ydb::Nbs::DeletePartitionResult result;
         result.SetDiskId(DiskId);

--- a/ydb/core/grpc_services/rpc_nbs_io.cpp
+++ b/ydb/core/grpc_services/rpc_nbs_io.cpp
@@ -6,6 +6,8 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/api/service.h>
 #include <ydb/public/api/protos/draft/ydb_nbs.pb.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::NBS_PARTITION
+
 namespace NKikimr::NGRpcService {
 
 
@@ -52,9 +54,8 @@ public:
         // Send event to partition actor
         ctx.Send(new IEventHandle(tabletId, ctx.SelfID, request.release()));
 
-        LOG_DEBUG(TActivationContext::AsActorContext(), NKikimrServices::NBS_PARTITION,
-            "Grpc service: sent WriteBlocksRequest to partition: %s",
-            diskIdStr.data());
+        YDB_LOG_DEBUG_CTX(TActivationContext::AsActorContext(), "Grpc service: sent WriteBlocksRequest to partition",
+            {"partition", diskIdStr.data()});
     }
 
 private:
@@ -65,9 +66,8 @@ private:
     }
 
     void Handle(NYdb::NBS::NBlockStore::TEvService::TEvWriteBlocksResponse::TPtr& ev) {
-        LOG_DEBUG(TActivationContext::AsActorContext(), NKikimrServices::NBS_PARTITION,
-            "Grpc service: received WriteBlocksResponse from partition: %s",
-            ev->Sender.ToString().data());
+        YDB_LOG_DEBUG_CTX(TActivationContext::AsActorContext(), "Grpc service: received WriteBlocksResponse from partition",
+            {"partition", ev->Sender});
         ReplyWithResult(Ydb::StatusIds::SUCCESS, ev->Get()->Record, ActorContext());
     }
 };
@@ -101,9 +101,8 @@ public:
         // Send event to partition actor
         ctx.Send(new IEventHandle(tabletId, ctx.SelfID, request.release()));
 
-        LOG_DEBUG(TActivationContext::AsActorContext(), NKikimrServices::NBS_PARTITION,
-            "Grpc service: sent ReadBlocksRequest to partition: %s",
-            diskIdStr.data());
+        YDB_LOG_DEBUG_CTX(TActivationContext::AsActorContext(), "Grpc service: sent ReadBlocksRequest to partition",
+            {"partition", diskIdStr.data()});
     }
 
 private:
@@ -114,9 +113,8 @@ private:
     }
 
     void Handle(NYdb::NBS::NBlockStore::TEvService::TEvReadBlocksResponse::TPtr& ev) {
-        LOG_DEBUG(TActivationContext::AsActorContext(), NKikimrServices::NBS_PARTITION,
-            "Grpc service: received ReadBlocksResponse from partition: %s",
-            ev->Sender.ToString().data());
+        YDB_LOG_DEBUG_CTX(TActivationContext::AsActorContext(), "Grpc service: received ReadBlocksResponse from partition",
+            {"partition", ev->Sender});
 
         // Convert from NYdb::NBS::NProto::TReadBlocksResponse to Ydb::Nbs::ReadBlocksResult
         Ydb::Nbs::ReadBlocksResult result;

--- a/ydb/core/grpc_services/rpc_object_storage.cpp
+++ b/ydb/core/grpc_services/rpc_object_storage.cpp
@@ -19,6 +19,8 @@
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::RPC_REQUEST
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -522,8 +524,8 @@ private:
             return JoinVectorIntoString(shards, ", ");
         };
 
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Range shards: "
-            << getShardsString(KeyRange->GetPartitions()));
+        YDB_LOG_DEBUG_CTX(ctx, "Range",
+            {"shards", getShardsString(KeyRange->GetPartitions())});
 
         if (KeyRange->GetPartitions().size() > 0) {
             CurrentShardIdx = 0;
@@ -587,7 +589,8 @@ private:
             }
         }
 
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Sending request to shards " << shardId);
+        YDB_LOG_DEBUG_CTX(ctx, "Sending request to shards",
+            {"shardId", shardId});
 
         ctx.Send(LeaderPipeCache, new TEvPipeCache::TEvForward(ev.Release(), shardId, true), IEventHandle::FlagTrackDelivery, 0, Span.GetTraceId());
 
@@ -684,7 +687,8 @@ private:
 
         for (size_t i = 0; i < shardResponse.CommonPrefixesRowsSize(); ++i) {
             if (!CommonPrefixesRows.empty() && CommonPrefixesRows.back() == shardResponse.GetCommonPrefixesRows(i)) {
-                LOG_ERROR_S(ctx, NKikimrServices::RPC_REQUEST, "S3 listing got duplicate common prefix from shard " << shardResponse.GetTabletID());
+                YDB_LOG_ERROR_CTX(ctx, "S3 listing got duplicate common prefix from shard",
+                    {"tabletId", shardResponse.GetTabletID()});
             }
             CommonPrefixesRows.emplace_back(shardResponse.GetCommonPrefixesRows(i));
         }
@@ -754,7 +758,8 @@ private:
                 if (colMeta.PType.GetTypeId() == NScheme::NTypeIds::Pg) {
                     const NPg::TConvertResult& pgResult = NPg::PgNativeTextFromNativeBinary(cell.AsBuf(), colMeta.PType.GetPgTypeDesc());
                     if (pgResult.Error) {
-                        LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, "PgNativeTextFromNativeBinary error " << *pgResult.Error);
+                        YDB_LOG_DEBUG("PgNativeTextFromNativeBinary error",
+                            {"pgResult", *pgResult.Error});
                     }
                     const NYdb::TPgValue pgValue{cell.IsNull() ? NYdb::TPgValue::VK_NULL : NYdb::TPgValue::VK_TEXT, pgResult.Str, getPgTypeFromColMeta(colMeta)};
                     vb.Pg(pgValue);

--- a/ydb/core/grpc_services/rpc_operation_request_base.h
+++ b/ydb/core/grpc_services/rpc_operation_request_base.h
@@ -10,13 +10,6 @@
 namespace NKikimr {
 namespace NGRpcService {
 
-#define LOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, GetLogPrefix() << " " << this->SelfId() << " [" << this->TxId << "] " << stream)
-#define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TX_PROXY, GetLogPrefix() << " " << this->SelfId() << " [" << this->TxId << "] " << stream)
-#define LOG_I(stream) LOG_INFO_S(*TlsActivationContext, NKikimrServices::TX_PROXY, GetLogPrefix() << " " << this->SelfId() << " [" << this->TxId << "] " << stream)
-#define LOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, GetLogPrefix() << " " << this->SelfId() << " [" << this->TxId << "] " << stream)
-#define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TX_PROXY, GetLogPrefix() << " " << this->SelfId() << " [" << this->TxId << "] " << stream)
-#define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_PROXY, GetLogPrefix() << " " << this->SelfId() << " [" << this->TxId << "] " << stream)
-
 template <typename TDerived, typename TEvRequest, bool HasOperation = false>
 class TRpcOperationRequestActor: public TRpcRequestActor<TDerived, TEvRequest, HasOperation> {
 protected:
@@ -37,20 +30,29 @@ protected:
     }
 
     void AllocateTxId() {
-        LOG_D("Allocate txId");
+        YDB_LOG_DEBUG_COMP(NKikimrServices::TX_PROXY, "Allocate txId",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId});
         this->Send(MakeTxProxyID(), new TEvTxUserProxy::TEvAllocateTxId);
     }
 
     void Handle(TEvTxUserProxy::TEvAllocateTxIdResult::TPtr& ev) {
         TxId = ev->Get()->TxId;
 
-        LOG_D("TEvTxUserProxy::TEvAllocateTxIdResult");
+        YDB_LOG_DEBUG_COMP(NKikimrServices::TX_PROXY, "TEvTxUserProxy::TEvAllocateTxIdResult",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId});
         ResolveDatabase();
     }
 
     void ResolveDatabase() {
-        LOG_D("Resolve database"
-            << ": name# " << this->GetDatabaseName());
+        YDB_LOG_DEBUG_COMP(NKikimrServices::TX_PROXY, "Resolve database",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"databaseName", this->GetDatabaseName()});
 
         auto request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
         request->DatabaseName = this->GetDatabaseName();
@@ -65,8 +67,11 @@ protected:
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
         const auto& request = ev->Get()->Request;
 
-        LOG_D("Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult"
-            << ": request# " << (request ? request->ToString(*AppData()->TypeRegistry) : "nullptr"));
+        YDB_LOG_DEBUG_COMP(NKikimrServices::TX_PROXY, "Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"request", (request ? request->ToString(*AppData()->TypeRegistry) : "nullptr")});
 
         if (request->ResultSet.empty()) {
             return this->Reply(Ydb::StatusIds::SCHEME_ERROR, NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR);
@@ -97,7 +102,10 @@ protected:
 
         auto domainInfo = entry.DomainInfo;
         if (!domainInfo) {
-            LOG_E("Got empty domain info");
+            YDB_LOG_ERROR_COMP(NKikimrServices::TX_PROXY, "Got empty domain info",
+                {"logPrefix", GetLogPrefix()},
+                {"selfId", this->SelfId()},
+                {"txId", this->TxId});
             return this->Reply(Ydb::StatusIds::INTERNAL_ERROR, NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR);
         }
 
@@ -105,8 +113,11 @@ protected:
     }
 
     void SendRequest(ui64 schemeShardId) {
-        LOG_D("Send request"
-            << ": schemeShardId# " << schemeShardId);
+        YDB_LOG_DEBUG_COMP(NKikimrServices::TX_PROXY, "Send request",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId},
+            {"schemeShardId", schemeShardId});
 
         if (!PipeClient) {
             NTabletPipe::TClientConfig config;
@@ -128,7 +139,10 @@ protected:
     }
 
     void DeliveryProblem() {
-        LOG_W("Delivery problem");
+        YDB_LOG_WARN_COMP(NKikimrServices::TX_PROXY, "Delivery problem",
+            {"logPrefix", GetLogPrefix()},
+            {"selfId", this->SelfId()},
+            {"txId", this->TxId});
         this->Reply(Ydb::StatusIds::UNAVAILABLE);
     }
 

--- a/ydb/core/grpc_services/rpc_ping.cpp
+++ b/ydb/core/grpc_services/rpc_ping.cpp
@@ -10,6 +10,8 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/executor_thread.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::RPC_REQUEST
+
 namespace NKikimr::NGRpcService {
 
 using namespace Ydb;
@@ -52,15 +54,18 @@ private:
     }
 
     void Proceed(const TActorContext &ctx) {
-        LOG_TRACE_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " sending ping to KQP proxy");
+        YDB_LOG_TRACE_CTX(ctx, "Sending ping to KQP proxy",
+            {"selfId", this->SelfId()});
         if (!ctx.Send(NKqp::MakeKqpProxyID(ctx.SelfID.NodeId()), new NKqp::TEvKqp::TEvProxyPingRequest())) {
-            LOG_ERROR_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " failed to send ping");
+            YDB_LOG_ERROR_CTX(ctx, "Failed to send ping",
+                {"selfId", this->SelfId()});
             ReplyWithResult(StatusIds::INTERNAL_ERROR, ctx);
         }
     }
 
     void Handle(NKqp::TEvKqp::TEvProxyPingResponse::TPtr&, const TActorContext& ctx) {
-        LOG_TRACE_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " got ping response");
+        YDB_LOG_TRACE_CTX(ctx, "Got ping response",
+            {"selfId", this->SelfId()});
         ReplyWithResult(StatusIds::SUCCESS, ctx);
     }
 
@@ -71,7 +76,8 @@ private:
     }
 
     void InternalError(const TString& message) {
-        ALOG_ERROR(NKikimrServices::RPC_REQUEST, "Internal error, message: " << message);
+        YDB_LOG_ERROR("Internal error",
+            {"message", message});
         ReplyWithResult(StatusIds::INTERNAL_ERROR, TActivationContext::AsActorContext());
     }
 
@@ -118,17 +124,20 @@ private:
     }
 
     void Proceed(const TActorContext &ctx) {
-        LOG_TRACE_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " sending ping to SchemeCache");
+        YDB_LOG_TRACE_CTX(ctx, "Sending ping to SchemeCache",
+            {"selfId", this->SelfId()});
 
         auto* request = new TEvTxProxySchemeCache::TEvNavigateKeySet(new NSchemeCache::TSchemeCacheNavigate());
         if (!ctx.Send(MakeSchemeCacheID(), request)) {
-            LOG_ERROR_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " failed to send ping to SchemeCache");
+            YDB_LOG_ERROR_CTX(ctx, "Failed to send ping to SchemeCache",
+                {"selfId", this->SelfId()});
             ReplyWithResult(StatusIds::INTERNAL_ERROR, ctx);
         }
     }
 
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&, const TActorContext& ctx) {
-        LOG_TRACE_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " got ping response from SchemeCache");
+        YDB_LOG_TRACE_CTX(ctx, "Got ping response from SchemeCache",
+            {"selfId", this->SelfId()});
         ReplyWithResult(StatusIds::SUCCESS, ctx);
     }
 
@@ -139,7 +148,8 @@ private:
     }
 
     void InternalError(const TString& message) {
-        ALOG_ERROR(NKikimrServices::RPC_REQUEST, "Internal error, message: " << message);
+        YDB_LOG_ERROR("Internal error",
+            {"message", message});
         ReplyWithResult(StatusIds::INTERNAL_ERROR, TActivationContext::AsActorContext());
     }
 
@@ -186,15 +196,18 @@ private:
     }
 
     void Proceed(const TActorContext &ctx) {
-        LOG_TRACE_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " sending ping to TxProxy");
+        YDB_LOG_TRACE_CTX(ctx, "Sending ping to TxProxy",
+            {"selfId", this->SelfId()});
         if (!ctx.Send(MakeTxProxyID(), new TEvTxUserProxy::TEvAllocateTxId)) {
-            LOG_ERROR_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " failed to send ping to TxProxy");
+            YDB_LOG_ERROR_CTX(ctx, "Failed to send ping to TxProxy",
+                {"selfId", this->SelfId()});
             ReplyWithResult(StatusIds::INTERNAL_ERROR, ctx);
         }
     }
 
     void Handle(TEvTxUserProxy::TEvAllocateTxIdResult::TPtr&, const TActorContext& ctx) {
-        LOG_TRACE_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " got ping response from TxProxy");
+        YDB_LOG_TRACE_CTX(ctx, "Got ping response from TxProxy",
+            {"selfId", this->SelfId()});
         ReplyWithResult(StatusIds::SUCCESS, ctx);
     }
 
@@ -205,7 +218,8 @@ private:
     }
 
     void InternalError(const TString& message) {
-        ALOG_ERROR(NKikimrServices::RPC_REQUEST, "Internal error, message: " << message);
+        YDB_LOG_ERROR("Internal error",
+            {"message", message});
         ReplyWithResult(StatusIds::INTERNAL_ERROR, TActivationContext::AsActorContext());
     }
 
@@ -268,8 +282,10 @@ private:
         }
 
         void Proceed(const TActorContext &ctx) {
-            LOG_TRACE_S(ctx, NKikimrServices::RPC_REQUEST, SelfId() << " chain worker with "
-                << ChainsLeft << " next chains and " << ReplyTo << " prev actor bootstrapped");
+            YDB_LOG_TRACE_CTX(ctx, "Chain worker with next chains and prev actor bootstrapped",
+                {"selfId", SelfId()},
+                {"chainsLeft", ChainsLeft},
+                {"replyTo", ReplyTo});
 
             if (ChainsLeft == 0) {
                 WorkAndDie();
@@ -306,14 +322,17 @@ private:
         }
 
         void Handle(TEvPrivate::TEvChainItemComplete::TPtr&, const TActorContext& ctx) {
-            LOG_TRACE_S(ctx, NKikimrServices::RPC_REQUEST, SelfId() << " chain worker with "
-                << ChainsLeft << " next chains and " << ReplyTo << " prev actor got chain reply");
+            YDB_LOG_TRACE_CTX(ctx, "Chain worker with next chains and prev actor got chain reply",
+                {"selfId", SelfId()},
+                {"chainsLeft", ChainsLeft},
+                {"replyTo", ReplyTo});
 
             WorkAndDie();
         }
 
         void InternalError(const TString& message) {
-            ALOG_ERROR(NKikimrServices::RPC_REQUEST, "Internal error, message: " << message);
+            YDB_LOG_ERROR("Internal error",
+                {"message", message});
             Send<ESendingType::Tail>(ReplyTo, new TEvPrivate::TEvChainItemComplete());
             PassAway();
         }
@@ -371,8 +390,10 @@ private:
 
         bool noTailChain = req->GetNoTailChain();
 
-        LOG_TRACE_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId()
-            << " sending ping to ActorChain of length " << chainLength << " with work " << workUsec << " usec");
+        YDB_LOG_TRACE_CTX(ctx, "Sending ping to ActorChain of length with work usec",
+            {"selfId", this->SelfId()},
+            {"chainLength", chainLength},
+            {"workUsec", workUsec});
 
         auto* nextChainActor = new TChainWorkerActor(this->SelfId(), chainLength, workUsec, noTailChain);
         TActorId nextChainActorId;
@@ -387,13 +408,15 @@ private:
         }
 
         if (!nextChainActorId) {
-            LOG_ERROR_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " failed to send ping to ActorChain");
+            YDB_LOG_ERROR_CTX(ctx, "Failed to send ping to ActorChain",
+                {"selfId", this->SelfId()});
             ReplyWithResult(StatusIds::INTERNAL_ERROR, ctx);
         }
     }
 
     void Handle(TEvPrivate::TEvChainItemComplete::TPtr&, const TActorContext& ctx) {
-        LOG_TRACE_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " got ping response from full ActorChain");
+        YDB_LOG_TRACE_CTX(ctx, "Got ping response from full ActorChain",
+            {"selfId", this->SelfId()});
         ReplyWithResult(StatusIds::SUCCESS, ctx);
     }
 
@@ -404,7 +427,8 @@ private:
     }
 
     void InternalError(const TString& message) {
-        ALOG_ERROR(NKikimrServices::RPC_REQUEST, "Internal error, message: " << message);
+        YDB_LOG_ERROR("Internal error",
+            {"message", message});
         ReplyWithResult(StatusIds::INTERNAL_ERROR, TActivationContext::AsActorContext());
     }
 

--- a/ydb/core/grpc_services/rpc_read_columns.cpp
+++ b/ydb/core/grpc_services/rpc_read_columns.cpp
@@ -18,6 +18,8 @@
 
 #include <util/string/vector.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::RPC_REQUEST
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -379,7 +381,8 @@ private:
         ev->Record.SetMaxRows(proto->max_rows());
         ev->Record.SetMaxBytes(proto->max_bytes());
 
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Sending request to tablet " << tabletId);
+        YDB_LOG_DEBUG_CTX(ctx, "Sending request to tablet",
+            {"tabletId", tabletId});
 
         ctx.Send(LeaderPipeCache, new TEvPipeCache::TEvForward(ev.release(), tabletId, true), IEventHandle::FlagTrackDelivery);
 
@@ -419,7 +422,7 @@ private:
 
                 // Skip rows before MinKey just in case (because currently sys view scan ignores key range)
                 if (cmp > 0 || (cmp == 0 && !MinKeyInclusive)) {
-                    LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Skipped rows by sys view scan");
+                    YDB_LOG_DEBUG_CTX(ctx, "Skipped rows by sys view scan");
                     continue;
                 } else {
                     skippedBeforeMinKey = true;
@@ -585,9 +588,9 @@ private:
         TTableRange range(MinKey.GetCells(), true, MinKey.GetCells(), true, false);
         KeyRange.Reset(new TKeyDesc(entry.TableId, range, TKeyDesc::ERowOperation::Read, KeyColumnTypes, columns));
 
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Resolving range: "
-                    << " fromKey: " << PrintKey(MinKey.GetBuffer(), *AppData(ctx)->TypeRegistry)
-                    << " fromInclusive: " << true);
+        YDB_LOG_DEBUG_CTX(ctx, "Resolving range",
+            {"fromKey", PrintKey(MinKey.GetBuffer(), *AppData(ctx)->TypeRegistry)},
+            {"fromInclusive", true});
 
         TAutoPtr<NSchemeCache::TSchemeCacheRequest> request(new NSchemeCache::TSchemeCacheRequest());
         request->DatabaseName = Request->GetDatabaseName().GetOrElse("");
@@ -634,8 +637,8 @@ private:
             return JoinVectorIntoString(shards, ", ");
         };
 
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Range shards: "
-            << getShardsString(KeyRange->GetPartitions()));
+        YDB_LOG_DEBUG_CTX(ctx, "Range",
+            {"shards", getShardsString(KeyRange->GetPartitions())});
 
         MakeShardRequests(ctx);
     }
@@ -662,7 +665,8 @@ private:
 
         ui64 shardId = KeyRange->GetPartitions()[0].ShardId;
 
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Sending request to shards " << shardId);
+        YDB_LOG_DEBUG_CTX(ctx, "Sending request to shards",
+            {"shardId", shardId});
 
         ctx.Send(LeaderPipeCache, new TEvPipeCache::TEvForward(ev.release(), shardId, true), IEventHandle::FlagTrackDelivery);
 
@@ -734,9 +738,10 @@ private:
         Result.set_last_key_inclusive(shardResponse.GetLastKeyInclusive());
         Result.set_eos(shardResponse.GetLastKey().empty()); // TODO: ??
 
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Got reply from shard: " << shardResponse.GetTabletID()
-                    << " lastKey: " << PrintKey(shardResponse.GetLastKey(), *AppData(ctx)->TypeRegistry)
-                    << " inclusive: " << shardResponse.GetLastKeyInclusive());
+        YDB_LOG_DEBUG_CTX(ctx, "Got reply",
+            {"shard", shardResponse.GetTabletID()},
+            {"lastKey", PrintKey(shardResponse.GetLastKey(), *AppData(ctx)->TypeRegistry)},
+            {"inclusive", shardResponse.GetLastKeyInclusive()});
 
         if (ShardReplyCount == ShardRequestCount)
             ReplySuccess(ctx);
@@ -760,9 +765,10 @@ private:
         Result.set_last_key_inclusive(shardResponse.GetLastKeyInclusive());
         Result.set_eos(shardResponse.GetLastKey().empty()); // TODO: ??
 
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Got reply from shard: " << shardResponse.GetTabletID()
-                    << " lastKey: " << PrintKey(shardResponse.GetLastKey(), *AppData(ctx)->TypeRegistry)
-                    << " inclusive: " << shardResponse.GetLastKeyInclusive());
+        YDB_LOG_DEBUG_CTX(ctx, "Got reply",
+            {"shard", shardResponse.GetTabletID()},
+            {"lastKey", PrintKey(shardResponse.GetLastKey(), *AppData(ctx)->TypeRegistry)},
+            {"inclusive", shardResponse.GetLastKeyInclusive()});
 
         if (ShardReplyCount == ShardRequestCount)
             ReplySuccess(ctx);

--- a/ydb/core/grpc_services/rpc_read_rows.cpp
+++ b/ydb/core/grpc_services/rpc_read_rows.cpp
@@ -25,6 +25,8 @@
 #include <util/string/vector.h>
 #include <util/generic/size_literals.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::RPC_REQUEST
+
 namespace NKikimr::NGRpcService {
 
 using namespace NActors;
@@ -338,7 +340,7 @@ public:
         TimeoutTimerActorId = CreateLongTimer(ctx, std::min(clientTimeout, DEFAULT_TIMEOUT), new IEventHandle(ctx.SelfID, ctx.SelfID, new TEvents::TEvWakeup()));
         Become(&TThis::MainState);
 
-        LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, "TReadRowsRPC bootstraped ");
+        YDB_LOG_DEBUG("TReadRowsRPC bootstrapped");
 
         auto selfId = ctx.SelfID;
         auto* actorSystem = ctx.ActorSystem();
@@ -372,7 +374,9 @@ public:
         Y_ABORT_UNLESS(request.ResultSet.size() == 1);
         const auto& entry = request.ResultSet.front();
 
-        LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, "TEvNavigateKeySetResult, " << " OwnerId: " << OwnerId << " TableId: " << TableId);
+        YDB_LOG_DEBUG("TEvNavigateKeySetResult",
+            {"ownerId", OwnerId},
+            {"tableId", TableId});
         switch (entry.Status) {
             case NSchemeCache::TSchemeCacheNavigate::EStatus::Ok:
                 break;
@@ -402,8 +406,8 @@ public:
 
         auto& resolveNamesResult = ev->Get()->Request;
 
-        LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST,
-            "TReadRowsRPC going to create keys to read from proto: " << GetProto()->DebugString());
+        YDB_LOG_DEBUG("TReadRowsRPC going to create keys to read from proto",
+            {"proto", GetProto()->DebugString()});
 
         TString errorMessage;
         if (!CheckAccess(resolveNamesResult.Get(), errorMessage)) {
@@ -503,7 +507,9 @@ public:
             request->Keys.emplace_back(TSerializedCellVec::Serialize(keys[i]));
         }
 
-        LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, "TReadRowsRPC send TEvRead shardId : " << shardId << " keys.size(): " << keys.size());
+        YDB_LOG_DEBUG("TReadRowsRPC send TEvRead shardId",
+            {"shardId", shardId},
+            {"keysSize", keys.size()});
         Send(PipeCache, new TEvPipeCache::TEvForward(request.release(), shardId, true), IEventHandle::FlagTrackDelivery, 0, Span.GetTraceId());
         ++ReadsInFlight;
     }
@@ -578,7 +584,8 @@ public:
                 it->second.Status = statusCode;
             }
         }
-        LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, "TReadRowsRPC TEvReadResult RowsCount: " << msg->GetRowsCount());
+        YDB_LOG_DEBUG("TReadRowsRPC TEvReadResult",
+            {"rowsCount", msg->GetRowsCount()});
 
         EvReadResults.emplace_back(ev->Release().Release());
 
@@ -638,16 +645,16 @@ public:
                 for (size_t i = 0; i < RequestedColumnsMeta.size(); ++i) {
                     const auto& colMeta = RequestedColumnsMeta[i];
                     const auto type = getTypeFromColMeta(colMeta);
-                    LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, "TReadRowsRPC "
-                        << " name: " << colMeta.Name
-                    );
+                    YDB_LOG_DEBUG("TReadRowsRPC",
+                        {"name", colMeta.Name});
                     const auto& cell = row[i];
                     vb.AddMember(colMeta.Name);
                     switch (colMeta.Type.GetTypeId()) {
                     case NScheme::NTypeIds::Pg: {
                         const NPg::TConvertResult& pgResult = NPg::PgNativeTextFromNativeBinary(cell.AsBuf(), colMeta.Type.GetPgTypeDesc());
                         if (pgResult.Error) {
-                            LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, "PgNativeTextFromNativeBinary error " << *pgResult.Error);
+                            YDB_LOG_DEBUG("PgNativeTextFromNativeBinary error",
+                                {"pgResult", *pgResult.Error});
                         }
                         const NYdb::TPgValue pgValue{cell.IsNull() ? NYdb::TPgValue::VK_NULL : NYdb::TPgValue::VK_TEXT, pgResult.Str, getPgTypeFromColMeta(colMeta)};
                         vb.Pg(pgValue);
@@ -704,7 +711,8 @@ public:
         }
 
         RuCost = NKqp::NRuCalc::CalcRequestUnit(stats);
-        LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, "TReadRowsRPC created ReadRowsResponse " << response->DebugString());
+        YDB_LOG_DEBUG("TReadRowsRPC created ReadRowsResponse",
+            {"response", response->DebugString()});
     }
 
     void SendResult(const Ydb::StatusIds::StatusCode& status, const TString& errorMsg,
@@ -729,7 +737,7 @@ public:
             FillResultRows(resp);
         }
 
-        LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, "TReadRowsRPC sent result");
+        YDB_LOG_DEBUG("TReadRowsRPC sent result");
         Request->Reply(resp, status);
         PassAway();
     }
@@ -756,7 +764,7 @@ public:
         ss << "]";
 
         if (hasActiveReads) {
-            LOG_WARN_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, ss.Str());
+            YDB_LOG_WARN(ss.Str());
         }
     }
 
@@ -810,7 +818,7 @@ public:
         if (logAppendix) {
             message << *logAppendix;
         }
-        LOG_ERROR_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, message);
+        YDB_LOG_ERROR(message);
         SendResult(status, errorMsg, issues);
     }
 
@@ -832,7 +840,8 @@ public:
     }
 
     STFUNC(MainState) {
-        LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, "TReadRowsRPC got: " << ev->GetTypeName());
+        YDB_LOG_DEBUG("TReadRowsRPC",
+            {"got", ev->GetTypeName()});
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
             hFunc(TEvTxProxySchemeCache::TEvResolveKeySetResult, Handle);

--- a/ydb/core/grpc_services/rpc_read_table.cpp
+++ b/ydb/core/grpc_services/rpc_read_table.cpp
@@ -26,6 +26,8 @@
 
 #include <ydb/core/protos/stream.pb.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::READ_TABLE_API
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -113,7 +115,7 @@ public:
         auto actorId = SelfId();
         const TActorSystem* const as = ctx.ActorSystem();
         auto clientLostCb = [actorId, as]() {
-            LOG_WARN(*as, NKikimrServices::READ_TABLE_API, "ForgetAction occurred, send TEvPoisonPill");
+            YDB_LOG_WARN_CTX(*as, "ForgetAction occurred, send TEvPoisonPill");
             as->Send(actorId, new TEvents::TEvPoisonPill());
         };
         Request_->SetFinishAction(std::move(clientLostCb));
@@ -176,8 +178,7 @@ private:
                     if (msg->Record.HasReadTableResponseVersion()) {
                         str << " , got: " << msg->Record.GetReadTableResponseVersion();
                     }
-                    LOG_ERROR(ctx, NKikimrServices::READ_TABLE_API,
-                              "%s", str.Str().data());
+                    YDB_LOG_ERROR_CTX(ctx, str.Str().data());
                     const NYql::TIssue& issue = MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, str.Str());
                     auto tmp = issueMessage.Add();
                     NYql::IssueToMessage(issue, tmp);
@@ -261,10 +262,10 @@ private:
     }
 
     void Handle(TEvTxProcessing::TEvStreamQuotaRequest::TPtr& ev, const TActorContext& ctx) {
-        LOG_DEBUG_S(ctx, NKikimrServices::READ_TABLE_API,
-                    SelfId() << " Adding quota request to queue ShardId: "
-                    << ev->Get()->Record.GetShardId() << ", TxId: "
-                    << ev->Get()->Record.GetTxId());
+        YDB_LOG_DEBUG_CTX(ctx, "Adding quota request to queue",
+            {"selfId", SelfId()},
+            {"shardId", ev->Get()->Record.GetShardId()},
+            {"txId", ev->Get()->Record.GetTxId()});
 
         QuotaRequestQueue_.push_back(ev);
         TryToAllocateQuota();
@@ -274,9 +275,10 @@ private:
         ui64 shardId = ev->Get()->Record.GetShardId();
         ui64 txId = ev->Get()->Record.GetTxId();
 
-        LOG_DEBUG_S(ctx, NKikimrServices::READ_TABLE_API,
-                    SelfId() << " Release quota for ShardId: " << shardId
-                    << ", TxId: " << txId);
+        YDB_LOG_DEBUG_CTX(ctx, "Release quota",
+            {"selfId", SelfId()},
+            {"shardId", shardId},
+            {"txId", txId});
 
         ReleasedShards_.insert(shardId);
 
@@ -310,8 +312,9 @@ private:
     }
 
     void Handle(TEvents::TEvSubscribe::TPtr& ev, const TActorContext &ctx) {
-        LOG_DEBUG_S(ctx, NKikimrServices::READ_TABLE_API,
-                    SelfId() << " Add stream subscriber " << ev->Sender);
+        YDB_LOG_DEBUG_CTX(ctx, "Add stream subscriber",
+            {"selfId", SelfId()},
+            {"sender", ev->Sender});
 
         StreamSubscribers_.insert(ev->Sender);
     }
@@ -334,10 +337,10 @@ private:
     }
 
     void ProcessRlSendAllowed(const TActorContext& ctx) {
-        LOG_DEBUG_S(ctx, NKikimrServices::READ_TABLE_API,
-                    SelfId() << " Success rate limiter response, we got "
-                    << SendBuffer_.size() << " pending messages,"
-                    " pending success# " << HasPendingSuccess);
+        YDB_LOG_DEBUG_CTX(ctx, "Success rate limiter response",
+            {"selfId", SelfId()},
+            {"sendBufferSize", SendBuffer_.size()},
+            {"success", HasPendingSuccess});
         TBuffEntry& entry = SendBuffer_.front();
 
         DoSendStreamResult(std::move(entry.Buf), entry.ShardId, entry.TxId, entry.StartTime, ctx);
@@ -353,11 +356,10 @@ private:
     void ProcessRlNoResource(const TActorContext& ctx) {
         const NYql::TIssue& issue = MakeIssue(NKikimrIssues::TIssuesIds::YDB_RESOURCE_USAGE_LIMITED,
             "Throughput limit exceeded for read table request");
-        LOG_NOTICE_S(ctx, NKikimrServices::READ_TABLE_API,
-                    SelfId() << " Throughput limit exceeded, we got "
-                    << SendBuffer_.size() << " pending messages,"
-                    " pending success# " << HasPendingSuccess
-                    << " stream will be terminated");
+        YDB_LOG_NOTICE_CTX(ctx, "Throughput limit exceeded, we got stream will be terminated",
+            {"selfId", SelfId()},
+            {"sendBufferSize", SendBuffer_.size()},
+            {"success", HasPendingSuccess});
 
         google::protobuf::RepeatedPtrField<TYdbIssueMessageType> message;
         NYql::IssueToMessage(issue, message.Add());
@@ -378,7 +380,7 @@ private:
             TStringStream ss;
             ss << SelfId() << " Client cannot process data in " << processTime
                 << " which exceeds client timeout " << InactiveClientTimeout_;
-            LOG_NOTICE_S(ctx, NKikimrServices::READ_TABLE_API, ss.Str());
+            YDB_LOG_NOTICE_CTX(ctx, ss.Str());
             return HandleStreamTimeout(ctx, ss.Str());
         }
 
@@ -404,7 +406,7 @@ private:
                 << " QuotaLimit: " << QuotaLimit_
                 << " QuotaReserved: " << QuotaReserved_
                 << " QuotaByShard: " << QuotaByShard_.size() << ")";
-            LOG_NOTICE_S(ctx, NKikimrServices::READ_TABLE_API, ss.Str());
+            YDB_LOG_NOTICE_CTX(ctx, ss.Str());
             return HandleStreamTimeout(ctx, ss.Str());
         } else {
             timeout = InactiveServerTimeout_ - processTime;
@@ -527,8 +529,9 @@ private:
             Request_->SendSerializedResult(std::move(out), status);
         }
         Request_->FinishStream(status);
-        LOG_NOTICE_S(ctx, NKikimrServices::READ_TABLE_API,
-            SelfId() << " Finish grpc stream, status: " << (int)status);
+        YDB_LOG_NOTICE_CTX(ctx, "Finish grpc stream",
+            {"selfId", SelfId()},
+            {"status", (int)status});
 
         // Answer all pending quota requests.
         while (!QuotaRequestQueue_.empty()) {
@@ -543,15 +546,17 @@ private:
             response->Record.SetMessageRowsLimit(MessageRowsLimit);
             response->Record.SetReservedMessages(0);
 
-            LOG_DEBUG_S(ctx, NKikimrServices::READ_TABLE_API,
-                        SelfId() << " Send zero quota to Shard " << rec.GetShardId()
-                        << ", TxId " << rec.GetTxId());
+            YDB_LOG_DEBUG_CTX(ctx, "Send zero quota to shard",
+                {"selfId", SelfId()},
+                {"shardId", rec.GetShardId()},
+                {"txId", rec.GetTxId()});
             ctx.Send(request->Sender, response.Release(), 0, request->Cookie);
         }
 
         for (const auto& id : StreamSubscribers_) {
-            LOG_DEBUG_S(ctx, NKikimrServices::READ_TABLE_API,
-                        SelfId() << " Send dead stream notification to subscriber " << id);
+            YDB_LOG_DEBUG_CTX(ctx, "Send dead stream notification to subscriber",
+                {"selfId", SelfId()},
+                {"subscriberId", id});
             ctx.Send(id, new TEvTxProcessing::TEvStreamIsDead);
         }
 
@@ -559,8 +564,10 @@ private:
     }
 
     void StartInactivityTimer(TActorId& timer, TDuration timeout, EWakeupTag tag, const TActorContext &ctx) {
-        LOG_DEBUG_S(ctx, NKikimrServices::READ_TABLE_API,
-                    SelfId() << " Starting inactivity timer for " << timeout << " with tag " << int(tag));
+        YDB_LOG_DEBUG_CTX(ctx, "Starting inactivity timer",
+            {"selfId", SelfId()},
+            {"timeout", timeout},
+            {"tag", int(tag)});
 
         if (timer) {
             ctx.Send(timer, new TEvents::TEvPoison);
@@ -605,8 +612,8 @@ private:
         QuotaRequestQueue_.pop_front();
 
         if (ReleasedShards_.contains(rec.GetShardId())) {
-            LOG_ERROR_S(*TlsActivationContext, NKikimrServices::READ_TABLE_API,
-                        "Quota request from released shard " << rec.GetShardId());
+            YDB_LOG_ERROR("Quota request from released shard",
+                {"shardId", rec.GetShardId()});
             return TryToAllocateQuota();
         }
 
@@ -622,11 +629,14 @@ private:
         response->Record.SetMessageRowsLimit(MessageRowsLimit);
         response->Record.SetReservedMessages(quotaSize);
 
-        LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::READ_TABLE_API,
-                    SelfId() << " Assign stream quota to Shard " << rec.GetShardId()
-                    << ", Quota " << quotaSize << ", TxId "  << rec.GetTxId()
-                    << " Reserved: " << QuotaReserved_ << " of " << QuotaLimit_
-                    << ", Queued: " << LeftInGRpcAdaptorQueue_);
+        YDB_LOG_DEBUG("Assign stream quota to shard",
+            {"selfId", SelfId()},
+            {"shardId", rec.GetShardId()},
+            {"quotaSize", quotaSize},
+            {"txId", rec.GetTxId()},
+            {"reserved", QuotaReserved_},
+            {"quotaLimit", QuotaLimit_},
+            {"queued", LeftInGRpcAdaptorQueue_});
 
         Send(request->Sender, response.Release(), 0, request->Cookie);
     }
@@ -642,9 +652,11 @@ private:
                 return TString("rate limiter absent");
             }
         };
-        LOG_DEBUG_S(ctx, NKikimrServices::READ_TABLE_API,
-                    SelfId() << " got stream part, size: " << data.size()
-                    << ", RU required: " << ru << " " << getRlPAth());
+        YDB_LOG_DEBUG_CTX(ctx, "Got stream part, RU",
+            {"selfId", SelfId()},
+            {"size", data.size()},
+            {"requestUnits", ru},
+            {"getRlPath", getRlPAth()});
 
         TString out;
         NullSerializeReadTableResponse(data, StatusIds::SUCCESS, PlanStep, TxId, &out);
@@ -667,9 +679,9 @@ private:
                 *Request_.get(), ru, RlMaxDuration,
                 std::move(onSendAllowed), std::move(onSendTimeout), ctx);
 
-            LOG_DEBUG_S(ctx, NKikimrServices::READ_TABLE_API,
-                        SelfId() << " Launch rate limiter actor: "
-                        << rlActor);
+            YDB_LOG_DEBUG_CTX(ctx, "Launch rate limiter",
+                {"selfId", SelfId()},
+                {"actor", rlActor});
         } else {
             DoSendStreamResult(std::move(out), shardId, txId, TInstant(), ctx);
         }
@@ -683,15 +695,17 @@ private:
                 QuotaByShard_.erase(it);
             --QuotaReserved_;
         } else {
-            LOG_ERROR_S(*TlsActivationContext, NKikimrServices::READ_TABLE_API,
-                        SelfId() << " Response out of quota from Shard " << shardId
-                        << ", TxId " << txId);
+            YDB_LOG_ERROR("Response out of quota from Shard",
+                {"selfId", SelfId()},
+                {"shardId", shardId},
+                {"txId", txId});
         }
 
         if (startTime) {
             auto delay = ctx.Now() - startTime;
-            LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::READ_TABLE_API,
-                    SelfId() << " Data response has been delayed for " << delay << " seconds");
+            YDB_LOG_DEBUG("Data response has been delayed for seconds",
+                {"selfId", SelfId()},
+                {"delay", delay});
         }
 
         Request_->SendSerializedResult(std::move(out), StatusIds::SUCCESS);
@@ -706,8 +720,8 @@ private:
 
         LeftInGRpcAdaptorQueue_++;
         if (LeftInGRpcAdaptorQueue_ > QuotaLimit_) {
-            LOG_ERROR_S(*TlsActivationContext, NKikimrServices::READ_TABLE_API,
-                        SelfId() << " TMessageBusServerRequest: response queue limit is exceeded.");
+            YDB_LOG_ERROR("TMessageBusServerRequest: response queue limit is exceeded",
+                {"selfId", SelfId()});
         }
 
         TryToAllocateQuota();

--- a/ydb/core/grpc_services/rpc_stream_execute_scan_query.cpp
+++ b/ydb/core/grpc_services/rpc_stream_execute_scan_query.cpp
@@ -19,6 +19,8 @@
 
 #include <ydb/core/protos/stream.pb.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::RPC_REQUEST
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -268,11 +270,12 @@ private:
     }
 
     void Handle(TRpcServices::TEvGrpcNextReply::TPtr& ev, const TActorContext& ctx) {
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " NextReply"
-            << ", left: " << ev->Get()->LeftInQueue
-            << ", queue: " << FlowControl_.QueueSize()
-            << ", inflight bytes: " << FlowControl_.InflightBytes()
-            << ", limit bytes: " << FlowControl_.InflightLimitBytes());
+        YDB_LOG_DEBUG_CTX(ctx, "NextReply",
+            {"selfId", this->SelfId()},
+            {"left", ev->Get()->LeftInQueue},
+            {"queue", FlowControl_.QueueSize()},
+            {"inflightBytes", FlowControl_.InflightBytes()},
+            {"limitBytes", FlowControl_.InflightLimitBytes()});
 
         while (FlowControl_.QueueSize() > ev->Get()->LeftInQueue) {
             FlowControl_.PopResponse();
@@ -282,10 +285,11 @@ private:
 
         const i64 freeSpaceBytes = FlowControl_.FreeSpaceBytes();
         if (freeSpaceBytes > 0 && LastSeqNo_ && AckedFreeSpaceBytes_ <= 0) {
-            LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " Send stream data ack"
-                << ", seqNo: " << *LastSeqNo_
-                << ", freeSpace: " << freeSpaceBytes
-                << ", to: " << ExecuterActorId_);
+            YDB_LOG_DEBUG_CTX(ctx, "Send stream data ack",
+                {"selfId", this->SelfId()},
+                {"seqNo", *LastSeqNo_},
+                {"freeSpace", freeSpaceBytes},
+                {"to", ExecuterActorId_});
 
             // scan query has single result set, so it's ok to put zero as channelId here.
             auto resp = MakeHolder<NKqp::TEvKqpExecuter::TEvStreamDataAck>(*LastSeqNo_, 0);
@@ -346,9 +350,11 @@ private:
         auto& record = ev->Get()->Record;
         NYql::TIssues issues = ev->Get()->GetIssues();
 
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " Got abort execution event, from: "
-            << ev->Sender << ", code: " << NYql::NDqProto::StatusIds::StatusCode_Name(record.GetStatusCode())
-            << ", message: " << issues.ToOneLineString());
+        YDB_LOG_DEBUG_CTX(ctx, "Got abort execution event",
+            {"selfId", this->SelfId()},
+            {"from", ev->Sender},
+            {"code", NYql::NDqProto::StatusIds::StatusCode_Name(record.GetStatusCode())},
+            {"message", issues.ToOneLineString()});
 
         ReplyFinishStream(NYql::NDq::DqStatusToYdbStatus(record.GetStatusCode()), issues);
     }
@@ -385,11 +391,12 @@ private:
 
         Request_->SendSerializedResult(std::move(out), StatusIds::SUCCESS);
 
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " Send stream data ack"
-            << ", seqNo: " << evRecord.GetSeqNo()
-            << ", freeSpace: " << freeSpaceBytes
-            << ", to: " << ev->Sender
-            << ", queue: " << FlowControl_.QueueSize());
+        YDB_LOG_DEBUG_CTX(ctx, "Send stream data ack",
+            {"selfId", this->SelfId()},
+            {"seqNo", evRecord.GetSeqNo()},
+            {"freeSpace", freeSpaceBytes},
+            {"to", ev->Sender},
+            {"queue", FlowControl_.QueueSize()});
 
         auto resp = MakeHolder<NKqp::TEvKqpExecuter::TEvStreamDataAck>(evRecord.GetSeqNo(), evRecord.GetChannelId());
         resp->Record.SetFreeSpace(freeSpaceBytes);
@@ -399,7 +406,9 @@ private:
 
 private:
     void SetTimeoutTimer(TDuration timeout, const TActorContext& ctx) {
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " Set stream timeout timer for " << timeout);
+        YDB_LOG_DEBUG_CTX(ctx, "Set stream timeout timer",
+            {"selfId", this->SelfId()},
+            {"timeout", timeout});
 
         auto *ev = new IEventHandle(this->SelfId(), this->SelfId(), new TEvents::TEvWakeup(EWakeupTag::TimeoutTag));
         TimeoutTimerCookieHolder_.Reset(ISchedulerCookie::Make2Way());
@@ -407,7 +416,7 @@ private:
     }
 
     void HandleClientLost(const TActorContext& ctx) {
-        LOG_WARN_S(ctx, NKikimrServices::RPC_REQUEST, "Client lost");
+        YDB_LOG_WARN_CTX(ctx, "Client lost");
 
         // We must try to finish stream otherwise grpc will not free allocated memory
         // If stream already scheduled to be finished (ReplyFinishStream already called)
@@ -420,15 +429,16 @@ private:
     void HandleTimeout(const TActorContext& ctx) {
         TInstant now = TAppData::TimeProvider->Now();
         TDuration timeout;
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Got timeout event, InactiveClientTimeout: " << InactiveClientTimeout_
-            << " GRpcResponsesSizeQueue: " << FlowControl_.QueueSize());
+        YDB_LOG_DEBUG_CTX(ctx, "Got timeout event",
+            {"inactiveClientTimeout", InactiveClientTimeout_},
+            {"grpcResponsesSizeQueue", FlowControl_.QueueSize()});
 
         if (InactiveClientTimeout_ && FlowControl_.QueueSize() > 0) {
             TDuration processTime = now - LastDataStreamTimestamp_;
             if (processTime >= InactiveClientTimeout_) {
                 auto message = TStringBuilder() << this->SelfId() << " Client cannot process data in " << processTime
                    << " which exceeds client timeout " << InactiveClientTimeout_;
-                LOG_WARN_S(ctx, NKikimrServices::RPC_REQUEST, message);
+                YDB_LOG_WARN_CTX(ctx, message);
 
                 if (ExecuterActorId_) {
                     auto timeoutEv = MakeHolder<TEvKqp::TEvAbortExecution>(NYql::NDqProto::StatusIds::TIMEOUT, "Client timeout");
@@ -468,8 +478,8 @@ private:
     void ReplyFinishStream(Ydb::StatusIds::StatusCode status,
         const google::protobuf::RepeatedPtrField<TYdbIssueMessageType>& message)
     {
-        ALOG_INFO(NKikimrServices::RPC_REQUEST, "Finish grpc stream, status: "
-            << Ydb::StatusIds::StatusCode_Name(status));
+        YDB_LOG_INFO("Finish grpc stream",
+            {"status", Ydb::StatusIds::StatusCode_Name(status)});
 
         // Skip sending empty result in case of success status - simplify client logic
         if (status != Ydb::StatusIds::SUCCESS) {

--- a/ydb/core/grpc_services/rpc_stream_execute_yql_script.cpp
+++ b/ydb/core/grpc_services/rpc_stream_execute_yql_script.cpp
@@ -17,6 +17,8 @@
 
 #include <ydb/core/protos/stream.pb.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::RPC_REQUEST
+
 namespace NKikimr {
 namespace NGRpcService {
 
@@ -275,11 +277,12 @@ private:
 
         RequestPtr()->SendSerializedResult(std::move(out), StatusIds::SUCCESS);
 
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " Send stream data ack"
-            << ", seqNo: " << ev->Get()->Record.GetSeqNo()
-            << ", freeSpace: " << freeSpaceBytes
-            << ", to: " << ev->Sender
-            << ", queue: " << FlowControl_.QueueSize());
+        YDB_LOG_DEBUG_CTX(ctx, "Send stream data ack",
+            {"selfId", this->SelfId()},
+            {"seqNo", ev->Get()->Record.GetSeqNo()},
+            {"freeSpaceBytes", freeSpaceBytes},
+            {"actorId", ev->Sender},
+            {"queue", FlowControl_.QueueSize()});
 
         auto resp = MakeHolder<NKqp::TEvKqpExecuter::TEvStreamDataAck>(ev->Get()->Record.GetSeqNo(), ev->Get()->Record.GetChannelId());
         resp->Record.SetFreeSpace(freeSpaceBytes);
@@ -288,11 +291,12 @@ private:
     }
 
     void Handle(TRpcServices::TEvGrpcNextReply::TPtr& ev, const TActorContext& ctx) {
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " NextReply"
-            << ", left: " << ev->Get()->LeftInQueue
-            << ", queue: " << FlowControl_.QueueSize()
-            << ", inflight bytes: " << FlowControl_.InflightBytes()
-            << ", limit bytes: " << FlowControl_.InflightLimitBytes());
+        YDB_LOG_DEBUG_CTX(ctx, "NextReply",
+            {"selfId", this->SelfId()},
+            {"left", ev->Get()->LeftInQueue},
+            {"queue", FlowControl_.QueueSize()},
+            {"inflightBytes", FlowControl_.InflightBytes()},
+            {"limitBytes", FlowControl_.InflightLimitBytes()});
         LastDataStreamTimestamp_ = TAppData::TimeProvider->Now();
 
         if (DataQueryStreamContext) {
@@ -316,10 +320,11 @@ private:
 
             const i64 freeSpaceBytes = FlowControl_.FreeSpaceBytes();
             if (freeSpaceBytes > 0 && LastSeqNo_ && AckedFreeSpaceBytes_ <= 0) {
-                LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " Send stream data ack"
-                    << ", seqNo: " << *LastSeqNo_
-                    << ", freeSpace: " << freeSpaceBytes
-                    << ", to: " << GatewayRequestHandlerActorId_);
+                YDB_LOG_DEBUG_CTX(ctx, "Send stream data ack",
+                    {"selfId", this->SelfId()},
+                    {"seqNo", *LastSeqNo_},
+                    {"freeSpaceBytes", freeSpaceBytes},
+                    {"actorId", GatewayRequestHandlerActorId_});
 
                 auto resp = MakeHolder<NKqp::TEvKqpExecuter::TEvStreamDataAck>(*LastSeqNo_, 0);
                 resp->Record.SetFreeSpace(freeSpaceBytes);
@@ -366,7 +371,9 @@ private:
 
 private:
     void SetClientTimeoutTimer(TDuration timeout, const TActorContext& ctx) {
-        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << " Set stream timeout timer for " << timeout);
+        YDB_LOG_DEBUG_CTX(ctx, "Set stream timeout timer",
+            {"selfId", this->SelfId()},
+            {"timeout", timeout});
 
         auto *ev = new IEventHandle(this->SelfId(), this->SelfId(), new TEvents::TEvWakeup(EStreamRpcWakeupTag::ClientTimeoutTag));
         ClientTimeoutTimerCookieHolder_.Reset(ISchedulerCookie::Make2Way());
@@ -374,7 +381,8 @@ private:
     }
 
     void HandleClientLost(const TActorContext& ctx) {
-        LOG_WARN_S(ctx, NKikimrServices::RPC_REQUEST, "Client lost, ActorId: " << SelfId());
+        YDB_LOG_WARN_CTX(ctx, "Client lost",
+            {"actorId", SelfId()});
 
         // We must try to finish stream otherwise grpc will not free allocated memory
         // If stream already scheduled to be finished (ReplyFinishStream already called)
@@ -391,7 +399,7 @@ private:
             if (processTime >= InactiveClientTimeout_) {
                 auto message = TStringBuilder() << this->SelfId() << " Client cannot process data in " << processTime
                    << " which exceeds client timeout " << InactiveClientTimeout_;
-                LOG_WARN_S(ctx, NKikimrServices::RPC_REQUEST, message);
+                YDB_LOG_WARN_CTX(ctx, message);
 
                 CancelationFlag->store(true);
                 auto issue = MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, message);
@@ -407,7 +415,8 @@ private:
     }
 
     void HandleOperationTimeout(const TActorContext& ctx) {
-        LOG_INFO_S(ctx, NKikimrServices::RPC_REQUEST, TStringBuilder() << this->SelfId() << " Operation timeout.");
+        YDB_LOG_INFO_CTX(ctx, "Operation timeout",
+            {"selfId", this->SelfId()});
 
         CancelationFlag->store(true);
         auto issue = MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, "Operation timeout");
@@ -440,8 +449,8 @@ private:
     void ReplyFinishStream(Ydb::StatusIds::StatusCode status,
         const google::protobuf::RepeatedPtrField<TYdbIssueMessageType>& message)
     {
-        ALOG_INFO(NKikimrServices::RPC_REQUEST, "Finish grpc stream, status: "
-            << Ydb::StatusIds::StatusCode_Name(status));
+        YDB_LOG_INFO("Finish grpc stream",
+            {"status", Ydb::StatusIds::StatusCode_Name(status)});
 
         // Skip sending empty result in case of success status - simplify client logic
         if (status != Ydb::StatusIds::SUCCESS) {

--- a/ydb/core/grpc_services/ydb_over_fq/describe_table.cpp
+++ b/ydb/core/grpc_services/ydb_over_fq/describe_table.cpp
@@ -5,6 +5,8 @@
 #include <ydb/core/grpc_services/rpc_deferrable.h>
 #include <ydb/core/grpc_services/local_grpc/local_grpc.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::FQ_INTERNAL_SERVICE
+
 namespace NKikimr::NGRpcService::NYdbOverFq {
 
 class DescribeTableRPC
@@ -41,7 +43,8 @@ public:
         auto& filter = *req.mutable_filter();
         filter.set_name(BindingName_);
 
-        SRC_LOG_T("listing bindings");
+        YDB_LOG_TRACE_CTX(ctx, "Listing bindings",
+            {"logContext", TLogCtx{.Owner_ = *this}});
 
         Become(&DescribeTableRPC::ListBindingsState);
         MakeLocalCall(std::move(req), ctx);
@@ -57,7 +60,8 @@ public:
 
         if (result.next_page_token().empty()) {
             TString errorMsg = TStringBuilder{} << "couldn't find binding with matching name for " << BindingName_;
-            SRC_LOG_I("failed: " << errorMsg);
+            YDB_LOG_INFO_CTX(ctx, errorMsg,
+                {"logContext", TLogCtx{.Owner_ = *this}});
             Reply(
                 Ydb::StatusIds_StatusCode_NOT_FOUND, errorMsg, NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ctx);
             return;
@@ -74,7 +78,9 @@ public:
         FederatedQuery::DescribeBindingRequest req;
         req.set_binding_id(bindingId);
 
-        SRC_LOG_T("describing binding: " << bindingId);
+        YDB_LOG_TRACE_CTX(ctx, "Describing binding",
+            {"logContext", TLogCtx{.Owner_ = *this}},
+            {"bindingId", bindingId});
 
         Become(&DescribeTableRPC::DescribeBindingState);
         MakeLocalCall(std::move(req), ctx);
@@ -96,7 +102,8 @@ public:
         default:
             TString errorMsg = TStringBuilder{} << "binding " << result.binding().meta().id() << " got unexpected type: " <<
                 static_cast<int>(settings.binding_case());
-            SRC_LOG_I("failed: " << errorMsg);
+            YDB_LOG_INFO_CTX(ctx, errorMsg,
+                {"logContext", TLogCtx{.Owner_ = *this}});
             Reply(
                 Ydb::StatusIds_StatusCode_INTERNAL_ERROR, errorMsg, NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ctx);
             return;

--- a/ydb/core/grpc_services/ydb_over_fq/execute_data_query.cpp
+++ b/ydb/core/grpc_services/ydb_over_fq/execute_data_query.cpp
@@ -8,6 +8,8 @@
 #include <ydb/core/grpc_services/rpc_deferrable.h>
 #include <yql/essentials/public/issue/protos/issue_id.pb.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::FQ_INTERNAL_SERVICE
+
 namespace NKikimr::NGRpcService {
 
 namespace NYdbOverFq {
@@ -34,7 +36,8 @@ public:
 
     void CreateQuery(const TActorContext& ctx) {
         if (!TBase::GetProtoRequest()->query().has_yql_text()) {
-            SRC_LOG_I("got request with id instead of text");
+            YDB_LOG_INFO_CTX(ctx, "Got request with id instead of text",
+                {"logContext", TLogCtx{.Owner_ = *this}});
             TBase::Reply(
                 Ydb::StatusIds::BAD_REQUEST,
                 TStringBuilder {} << "query id in " << TDerived::RpcName << " is not supported",
@@ -48,7 +51,9 @@ public:
     }
 
     void Handle(const FederatedQuery::CreateQueryResult& result, const TActorContext& ctx) {
-        SRC_LOG_T("created query: " << result.query_id());
+        YDB_LOG_TRACE_CTX(ctx, "Created query",
+            {"logContext", TLogCtx{.Owner_ = *this}},
+            {"queryId", result.query_id()});
 
         TBase::WaitForTermination(result.query_id(), ctx);
     }
@@ -56,7 +61,9 @@ public:
     // WaitForExecutionImpl
 
     void OnQueryTermination(const TString& queryId, FederatedQuery::QueryMeta_ComputeStatus status, const TActorContext& ctx) {
-        SRC_LOG_I(queryId, "finished query execution with status " << FederatedQuery::QueryMeta::ComputeStatus_Name(status));
+        YDB_LOG_INFO_CTX(ctx, "Finished query execution",
+            {"logContext", (TLogCtx{.Owner_ = *this, .QueryId_ = queryId})},
+            {"status", FederatedQuery::QueryMeta::ComputeStatus_Name(status)});
 
         // Whether query is successful or not, we want to call DescribeQuery
         //   to get either ResultSet size or issues
@@ -70,7 +77,9 @@ public:
         if (status != FederatedQuery::QueryMeta_ComputeStatus_COMPLETED) {
             TString errorMsg = TStringBuilder{} << "created query " << result.query().meta().common().id() <<
                 " finished with non-success status: " << FederatedQuery::QueryMeta::ComputeStatus_Name(status);
-            SRC_LOG_I("error: " << errorMsg);
+            YDB_LOG_INFO_CTX(ctx, "Query finished with non-success status",
+                {"logContext", TLogCtx{.Owner_ = *this}},
+                {"errorMsg", errorMsg});
 
             NYql::TIssues issues;
             issues.AddIssue(std::move(errorMsg));
@@ -203,7 +212,9 @@ public:
             issues.AddIssue("Scan query should have a single result set.");
             issues.back().SetCode(NYql::TIssuesIds::KIKIMR_PRECONDITION_FAILED, NYql::TSeverityIds::S_ERROR);
             Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
-            SRC_LOG_I(queryId, "failed: got " << ResultSetSizes_.size() << " result sets");
+            YDB_LOG_INFO_CTX(ctx, "Failed: scan query has multiple result sets",
+                {"logContext", (TLogCtx{.Owner_ = *this, .QueryId_ = queryId})},
+                {"resultSetCount", ResultSetSizes_.size()});
             return;
         }
 
@@ -224,7 +235,9 @@ public:
                 SentRowsInCurrRS_ << ":" << (SentRowsInCurrRS_ + result.result_set().rows_size()) << "]";
             issues.AddIssue(issueMsg);
             issues.back().SetCode(NYql::TIssuesIds::CORE_EXEC, NYql::TSeverityIds::S_ERROR);
-            SRC_LOG_I("error: " << issueMsg);
+            YDB_LOG_INFO_CTX(ctx, "Failed to serialize result set response",
+                {"logContext", TLogCtx{.Owner_ = *this}},
+                {"errorMsg", issueMsg});
             Reply(Ydb::StatusIds::INTERNAL_ERROR, issues, ctx);
             return;
         }
@@ -233,14 +246,19 @@ public:
         SentRowsInCurrRS_ += result.result_set().rows_size();
 
         if (SentRowsInCurrRS_ < ResultSetSizes_[CurrentResultSet_]) {
-            SRC_LOG_T("RS[" << CurrentResultSet_ << "][" << (SentRowsInCurrRS_ - result.result_set().rows_size()) <<
-                ":" << SentRowsInCurrRS_ << "], still got " << (ResultSetSizes_[CurrentResultSet_] - CurrentResultSet_)
-            );
+            YDB_LOG_TRACE_CTX(ctx, "Sent result set chunk, fetching more rows",
+                {"logContext", TLogCtx{.Owner_ = *this}},
+                {"resultSetIndex", CurrentResultSet_},
+                {"rowsRangeStart", (SentRowsInCurrRS_ - result.result_set().rows_size())},
+                {"rowsRangeEnd", SentRowsInCurrRS_},
+                {"remainingRows", (ResultSetSizes_[CurrentResultSet_] - CurrentResultSet_)});
             MakeLocalCall(CreateResultSetRequest(QueryId_, CurrentResultSet_, SentRowsInCurrRS_), ctx);
         } else {
-            SRC_LOG_T("RS[" << CurrentResultSet_ << "][" <<
-                (SentRowsInCurrRS_ - result.result_set().rows_size()) << ":" << SentRowsInCurrRS_ << "], fully sent"
-            );
+            YDB_LOG_TRACE_CTX(ctx, "Sent result set chunk completely",
+                {"logContext", TLogCtx{.Owner_ = *this}},
+                {"resultSetIndex", CurrentResultSet_},
+                {"rowsRangeStart", (SentRowsInCurrRS_ - result.result_set().rows_size())},
+                {"rowsRangeEnd", SentRowsInCurrRS_});
 
             Y_ABORT_UNLESS(SentRowsInCurrRS_ == ResultSetSizes_[CurrentResultSet_]);
             ++CurrentResultSet_;
@@ -248,7 +266,8 @@ public:
             if (CurrentResultSet_ < static_cast<i64>(ResultSetSizes_.size())) {
                 MakeLocalCall(CreateResultSetRequest(QueryId_, CurrentResultSet_, SentRowsInCurrRS_), ctx);
             } else {
-                SRC_LOG_T("finish");
+                YDB_LOG_TRACE_CTX(ctx, "Finished streaming scan query results",
+                    {"logContext", TLogCtx{.Owner_ = *this}});
                 Request_->FinishStream(Ydb::StatusIds::SUCCESS);
                 this->Die(ctx);
             }

--- a/ydb/core/grpc_services/ydb_over_fq/explain_data_query.cpp
+++ b/ydb/core/grpc_services/ydb_over_fq/explain_data_query.cpp
@@ -1,6 +1,8 @@
 #include "fq_local_grpc_events.h"
 #include "rpc_base.h"
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::FQ_INTERNAL_SERVICE
+
 namespace NKikimr::NGRpcService::NYdbOverFq {
 
 class ExplainDataQueryRPC
@@ -21,14 +23,17 @@ public:
     }
 
     void Handle(const FederatedQuery::CreateQueryResult& result, const TActorContext& ctx) {
-        SRC_LOG_T(result.query_id(), "created query");
+        YDB_LOG_TRACE_CTX(ctx, "Created query",
+            {"logContext", (TLogCtx{.Owner_ = *this, .QueryId_ = result.query_id()})});
 
         WaitForTermination(result.query_id(), ctx);
     }
 
     // WaitForTermination
     void OnQueryTermination(const TString& queryId, FederatedQuery::QueryMeta_ComputeStatus status, const TActorContext& ctx) {
-        SRC_LOG_I(queryId, "finished query execution with status " << FederatedQuery::QueryMeta::ComputeStatus_Name(status));
+        YDB_LOG_INFO_CTX(ctx, "Finished query execution",
+            {"logContext", (TLogCtx{.Owner_ = *this, .QueryId_ = queryId})},
+            {"status", FederatedQuery::QueryMeta::ComputeStatus_Name(status)});
 
         // Whether query is successful or not, we want to call DescribeQuery
         //   to get either AST and statistics or for issues
@@ -41,7 +46,9 @@ public:
         if (status != FederatedQuery::QueryMeta_ComputeStatus_COMPLETED) {
             TString errorMsg = TStringBuilder{} << "created query " << result.query().meta().common().id() <<
                 " finished with non-success status: " << FederatedQuery::QueryMeta::ComputeStatus_Name(status);
-            SRC_LOG_I(result.query().meta().common().id(), "error: " << errorMsg);
+            YDB_LOG_INFO_CTX(ctx, "Query finished with non-success status",
+                {"logContext", (TLogCtx{.Owner_ = *this, .QueryId_ = result.query().meta().common().id()})},
+                {"error", errorMsg});
 
             NYql::TIssues issues;
             issues.AddIssue(std::move(errorMsg));

--- a/ydb/core/grpc_services/ydb_over_fq/list_directory.cpp
+++ b/ydb/core/grpc_services/ydb_over_fq/list_directory.cpp
@@ -4,6 +4,8 @@
 
 #include <ydb/core/grpc_services/rpc_deferrable.h>
 
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::FQ_INTERNAL_SERVICE
+
 namespace NKikimr::NGRpcService::NYdbOverFq {
 
 class ListDirectoryRPC
@@ -31,7 +33,8 @@ public:
         req.set_limit(Limit);
         req.set_page_token(std::move(continuationToken));
 
-        SRC_LOG_T("listing bindings");
+        YDB_LOG_TRACE_CTX(ctx, "Listing bindings",
+            {"logContext", TLogCtx{.Owner_ = *this}});
 
         Become(&ListDirectoryRPC::ListBindingsState);
         MakeLocalCall(std::move(req), ctx);

--- a/ydb/core/grpc_services/ydb_over_fq/rpc_base.h
+++ b/ydb/core/grpc_services/ydb_over_fq/rpc_base.h
@@ -7,25 +7,6 @@
 #include <ydb/core/grpc_services/local_grpc/local_grpc.h>
 #include <ydb/core/grpc_services/rpc_deferrable.h>
 
-#define LOG_WITH_QUERY_ID(LEVEL, QUERY_ID, STRM) LOG_LOG_S(ctx, NActors::NLog::PRI_ ## LEVEL, NKikimrServices::FQ_INTERNAL_SERVICE, (TLogCtx{.Owner_ = *this, .QueryId_ = QUERY_ID}) << STRM)
-
-#define LOG_WITHOUT_QUERY_ID(LEVEL, STRM) LOG_LOG_S(ctx, NActors::NLog::PRI_ ## LEVEL, NKikimrServices::FQ_INTERNAL_SERVICE, TLogCtx{.Owner_ = *this} << STRM)
-
-#define SRC_LOG_CHOICE(_1, _2, _3, NAME, ...) NAME
-
-#define SRC_LOG(...) SRC_LOG_CHOICE(__VA_ARGS__, LOG_WITH_QUERY_ID, LOG_WITHOUT_QUERY_ID)(__VA_ARGS__)
-
-// both should work:
-// * SRC_LOG_T(queryId, some << stream)
-// * SRC_LOG_T(some << stream)
-#define SRC_LOG_T(...) SRC_LOG(TRACE, __VA_ARGS__)
-#define SRC_LOG_D(...) SRC_LOG(DEBUG, __VA_ARGS__)
-#define SRC_LOG_I(...) SRC_LOG(INFO, __VA_ARGS__)
-#define SRC_LOG_W(...) SRC_LOG(WARN, __VA_ARGS__)
-#define SRC_LOG_N(...) SRC_LOG(NOTICE, __VA_ARGS__)
-#define SRC_LOG_E(...) SRC_LOG(ERROR, __VA_ARGS__)
-#define SRC_LOG_C(...) SRC_LOG(CRIT, __VA_ARGS__)
-
 namespace NKikimr::NGRpcService::NYdbOverFq {
 
 template<typename TDerived, typename TReq>
@@ -57,9 +38,11 @@ public:
 
         TString serialized;
         if (!response.SerializeToString(&serialized)) {
-            LOG_ERROR_S(ctx, NKikimrServices::FQ_INTERNAL_SERVICE, "YdbOverFq::" << TDerived::RpcName << " actorId: " << TActorBootstrapped<TDerived>::SelfId().ToString() <<
-                " couldn't serialize response, status: " << Ydb::StatusIds::StatusCode_Name(status) << ", issues: " << issues.ToOneLineString()
-            );
+            YDB_LOG_ERROR_CTX_COMP(ctx, NKikimrServices::FQ_INTERNAL_SERVICE, "Couldn't serialize response",
+                {"rpcName", TDerived::RpcName},
+                {"actorId", TActorBootstrapped<TDerived>::SelfId()},
+                {"status", Ydb::StatusIds::StatusCode_Name(status)},
+                {"issues", issues.ToOneLineString()});
             FinishStream(Ydb::StatusIds::INTERNAL_ERROR, ctx);
             return;
         }
@@ -128,7 +111,8 @@ protected:
         auto& acl = *queryContent.mutable_acl();
         acl.set_visibility(FederatedQuery::Acl_Visibility::Acl_Visibility_SCOPE);
 
-        SRC_LOG_T("creating query");
+        YDB_LOG_TRACE_CTX_COMP(ctx, NKikimrServices::FQ_INTERNAL_SERVICE, "Creating query",
+            {"logContext", TLogCtx{.Owner_ = *this}});
 
         Become(&TRpcBase::CreateQueryState);
         MakeLocalCall(std::move(req), ctx);
@@ -177,8 +161,10 @@ protected:
         resp.operation().result().UnpackTo(&result);
 
         if (!NFq::IsTerminalStatus(result.status())) {
-            SRC_LOG_T("still waiting for query: " << QueryId_ <<
-                ", current status: " << FederatedQuery::QueryMeta::ComputeStatus_Name(result.status()));
+            YDB_LOG_TRACE_CTX_COMP(ctx, NKikimrServices::FQ_INTERNAL_SERVICE, "Still waiting for query",
+                {"logContext", TLogCtx{.Owner_ = *this}},
+                {"queryId", QueryId_},
+                {"status", FederatedQuery::QueryMeta::ComputeStatus_Name(result.status())});
             auto delay = WaitRetryState_->GetNextRetryDelay(result.status());
             if (!delay) {
                 TBase::Reply(Ydb::StatusIds_StatusCode_TIMEOUT,
@@ -219,7 +205,10 @@ protected:
         NYql::IssuesFromMessage(operation.issues(), issues);
 
         TString errorMsg = TStringBuilder{} << "failed to " << opName << " with status: " << Ydb::StatusIds::StatusCode_Name(operation.status());
-        SRC_LOG_I(errorMsg << ", issues: " << issues.ToOneLineString());
+        YDB_LOG_INFO_CTX_COMP(ctx, NKikimrServices::FQ_INTERNAL_SERVICE, "Operation failed",
+            {"logContext", TLogCtx{.Owner_ = *this}},
+            {"errorMsg", errorMsg},
+            {"issues", issues.ToOneLineString()});
         issues.AddIssue(errorMsg);
 
         TBase::Reply(Ydb::StatusIds_StatusCode_INTERNAL_ERROR, issues, ctx);
@@ -251,22 +240,17 @@ protected:
     struct TLogCtx {
         TRpcBase& Owner_;
         TStringBuf QueryId_ = "";
+
+        NActors::NStructuredLog::TStructuredMessage ToStructuredMessage() const {
+            auto result = YDB_LOG_CREATE_MESSAGE({"actorId", Owner_.SelfId()});
+            if (!QueryId_.empty()) {
+                YDB_LOG_UPDATE_MESSAGE(result, {"queryId", QueryId_});
+            } else if (!Owner_.QueryId_.empty()) {
+                YDB_LOG_UPDATE_MESSAGE(result, {"queryId", Owner_.QueryId_});
+            }
+            return result;
+        }
     };
-
-    friend TStringBuilder& operator<<(TStringBuilder& out, const TLogCtx& ctx) {
-        if (ctx.Owner_.LogCtx_.empty()) {
-            ctx.Owner_.LogCtx_ = TStringBuilder{} << "YdbOverFq::" << TDerived::RpcName << " actorId: " << ctx.Owner_.SelfId().ToString();
-        }
-
-        out << ctx.Owner_.LogCtx_;
-        if (!ctx.QueryId_.empty()) {
-            out << " queryId: " << ctx.QueryId_;
-        } else if (!ctx.Owner_.QueryId_.empty()) {
-            out << " queryId: " << ctx.Owner_.QueryId_;
-        }
-        out << ' ';
-        return out;
-    }
 
 private:
     WaitRetryPolicy::IRetryState::TPtr WaitRetryState_;

--- a/ydb/core/load_test/persistent_buffer_write.cpp
+++ b/ydb/core/load_test/persistent_buffer_write.cpp
@@ -403,7 +403,7 @@ public:
             auto ev = std::make_unique<NDDisk::TEvWritePersistentBuffer>(Credentials,
                 NDDisk::TBlockSelector(1, 0, write.Size),
                 requestIdx, NDDisk::TWriteInstruction(0));
-            ev->AddPayload(TRope(write.Data));
+            ev->AddPayloadThenChecksum(TRope(write.Data));
             SendRequest(ctx, std::move(ev), requestIdx);
             ++Write_RequestsSent;
             ++InFlight;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/api/ss_proxy.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/api/ss_proxy.h
@@ -46,12 +46,15 @@ struct TEvSSProxy
     {
         const NKikimrScheme::EStatus Status;
         const TString Reason;
+        const ui64 TabletId;
 
         TCreateVolumeResponse(
             NKikimrScheme::EStatus status = NKikimrScheme::StatusSuccess,
-            TString reason = {})
+            TString reason = {},
+            ui64 tabletId = 0)
             : Status(status)
             , Reason(std::move(reason))
+            , TabletId(tabletId)
         {}
     };
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
@@ -301,7 +301,7 @@ size_t TBaseFixture::ReplyUpdateRequests()
 {
     auto requests = std::move(PartitionDirectService->UpdateConfigRequests);
     for (auto& r: requests) {
-        r.Promise.SetValue();
+        r.Promise.SetValue(EPersistResult::Success);
     }
     return requests.size();
 }
@@ -311,7 +311,7 @@ size_t TBaseFixture::ReplyUpdateDirtyMapStateRequests()
     auto requests =
         std::move(PartitionDirectService->UpdateDirtyMapStateRequests);
     for (auto& r: requests) {
-        r.Promise.SetValue();
+        r.Promise.SetValue(EPersistResult::Success);
     }
     return requests.size();
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/delete_partition.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/delete_partition.cpp
@@ -256,7 +256,21 @@ void TPartitionActor::HandleUpdateVChunkConfigDuringDelete(
         LogTitle.GetWithTime().c_str(),
         ev->Get()->VChunkConfig.DebugPrint().c_str());
 
-    ev->Get()->UpdateCompleted.SetValue();
+    ev->Get()->UpdateCompleted.SetValue(EPersistResult::Cancelled);
+}
+
+void TPartitionActor::HandleUpdateDirtyMapStateDuringDelete(
+    const TEvPartitionDirectPrivate::TEvUpdateDirtyMapState::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s Drop UpdateDirtyMapState during delete: vchunk %u",
+        LogTitle.GetWithTime().c_str(),
+        ev->Get()->VChunkIndex);
+
+    ev->Get()->UpdateCompleted.SetValue(EPersistResult::Cancelled);
 }
 
 // Ignore fast path service shutdown during delete
@@ -331,6 +345,9 @@ STFUNC(TPartitionActor::StateDelete)
         HFunc(
             TEvPartitionDirectPrivate::TEvUpdateVChunkConfig,
             HandleUpdateVChunkConfigDuringDelete);
+        HFunc(
+            TEvPartitionDirectPrivate::TEvUpdateDirtyMapState,
+            HandleUpdateDirtyMapStateDuringDelete);
         // Ignore fast path service shutdown during delete
         HFunc(
             TEvPartitionDirectPrivate::TEvFastPathServiceShutdown,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/delete_partition.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/delete_partition.cpp
@@ -1,25 +1,351 @@
+#include "fast_path_service.h"
+#include "partition_cleanup_actor.h"
 #include "partition_direct_actor.h"
 
+#include <ydb/core/nbs/cloud/blockstore/bootstrap/nbs_service.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/api/service.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/vhost/server.h>
+
+#include <ydb/core/nbs/cloud/storage/core/libs/actors/helpers.h>
+#include <ydb/core/nbs/cloud/storage/core/libs/common/error.h>
+
+#include <ydb/core/base/tablet_pipe.h>
+#include <ydb/core/blobstorage/base/blobstorage_events.h>
 
 #include <ydb/library/services/services.pb.h>
 
+#include <library/cpp/threading/future/future.h>
+
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+using namespace NActors;
+using namespace NKikimr;
+using namespace NThreading;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Handle delete partition request
 void TPartitionActor::HandleDeletePartition(
     const TEvService::TEvDeletePartitionRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    const bool teardownRunning = !InflightDeleteRequests.empty();
+
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s Handle DeletePartition request (teardownRunning=%d)",
+        LogTitle.GetWithTime().c_str(),
+        static_cast<int>(teardownRunning));
+
+    InflightDeleteRequests.push_back(
+        {.Sender = ev->Sender, .Cookie = ev->Cookie});
+    if (!teardownRunning) {
+        StartPartitionTeardown(ctx);
+    }
+}
+
+// Start partition teardown, stop FastPathService first
+void TPartitionActor::StartPartitionTeardown(const NActors::TActorContext& ctx)
+{
+    Become(&TThis::StateDelete);
+
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s Become StateDelete",
+        LogTitle.GetWithTime().c_str());
+
+    // A request already accepted by BSC can still allocate after our
+    // deallocate (residual leak, follow-up).
+    if (AddHostInFlight) {
+        NTabletPipe::CloseClient(ctx, AddHostInFlight->BSPipeClient);
+        AddHostInFlight.reset();
+    }
+
+    // Idempotent: no-op when the endpoint was never started.
+    GetNbsService()->VhostServer->DetachStorage(GetSocketPath());
+
+    if (LoadActorAdapter) {
+        ctx.Send(LoadActorAdapter, new TEvents::TEvPoisonPill());
+        LoadActorAdapter = {};
+    }
+
+    if (!FastPathService) {
+        StartCleanupActor(ctx, DirectBlockGroupsConnections);
+        return;
+    }
+
+    auto actorSystem = TActivationContext::ActorSystem();
+    auto selfId = ctx.SelfID;
+    FastPathService->Stop().Subscribe(
+        [actorSystem, selfId](const TFuture<void>& f)
+        {
+            Y_UNUSED(f);
+            actorSystem->Send(
+                selfId,
+                new TEvPartitionDirectPrivate::TEvFastPathServiceStopped());
+        });
+}
+
+// Fast path service stopped, continue removal of the tablet
+void TPartitionActor::HandleFastPathServiceStoppedDuringDelete(
+    const TEvPartitionDirectPrivate::TEvFastPathServiceStopped::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s FastPathService stopped, starting cleanup",
+        LogTitle.GetWithTime().c_str());
+
+    FastPathService.reset();
+    if (CleanupActor || InflightDeleteRequests.empty()) {
+        return;
+    }
+    StartCleanupActor(ctx, DirectBlockGroupsConnections);
+}
+
+// Start cleanup actor to make most of the work during delete
+void TPartitionActor::StartCleanupActor(
+    const NActors::TActorContext& ctx,
+    TDirectBlockGroupsConnections connections)
+{
+    if (CleanupActor) {
+        LOG_ERROR(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s StartCleanupActor skipped: cleanup already running %s",
+            LogTitle.GetWithTime().c_str(),
+            CleanupActor.ToString().c_str());
+        return;
+    }
+
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s StartCleanupActor groups=%u",
+        LogTitle.GetWithTime().c_str(),
+        connections.DirectBlockGroupConnectionsSize());
+
+    CleanupActor = ctx.Register(CreatePartitionCleanupActor({
+        .Parent = ctx.SelfID,
+        .TabletId = TabletID(),
+        .Generation = Executor()->Generation(),
+        .DiskId = VolumeConfig.GetDiskId(),
+        .Connections = std::move(connections),
+        .DDiskPoolName = StorageConfig->GetDDiskPoolName(),
+        .PersistentBufferDDiskPoolName =
+            StorageConfig->GetPersistentBufferDDiskPoolName(),
+        .DirectBlockGroupsCount = DirectBlockGroupsCount,
+    }));
+}
+
+// CleanupActor completed, handle result
+void TPartitionActor::HandlePartitionCleanupCompleted(
+    const TEvPartitionDirectPrivate::TEvPartitionCleanupCompleted::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    if (ev->Sender != CleanupActor) {
+        LOG_WARN(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s Ignore stale cleanup completion from %s (current %s)",
+            LogTitle.GetWithTime().c_str(),
+            ev->Sender.ToString().c_str(),
+            CleanupActor.ToString().c_str());
+        return;
+    }
+
+    const auto& error = ev->Get()->Error;
+
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s HandlePartitionCleanupCompleted: %s",
+        LogTitle.GetWithTime().c_str(),
+        FormatError(error).c_str());
+
+    CleanupActor = {};
+
+    if (HasError(error)) {
+        const auto replyError = error.GetCode() == E_TIMEOUT
+                                    ? error
+                                    : MakeError(E_REJECTED, FormatError(error));
+        ReplyToDeleteWaiters(ctx, replyError);
+    } else {
+        FinishDelete(ctx);
+    }
+}
+
+// Reply to all delete requests
+void TPartitionActor::ReplyToDeleteWaiters(
+    const NActors::TActorContext& ctx,
+    const NProto::TError& error)
+{
+    TVector<TDeleteWaiter> waiters;
+    waiters.swap(InflightDeleteRequests);
+
+    for (const auto& waiter: waiters) {
+        auto response =
+            std::make_unique<TEvService::TEvDeletePartitionResponse>(error);
+        ctx.Send(waiter.Sender, response.release(), 0, waiter.Cookie);
+    }
+}
+
+// Finish delete, reply to all requests
+void TPartitionActor::FinishDelete(const NActors::TActorContext& ctx)
+{
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s FinishDelete",
+        LogTitle.GetWithTime().c_str());
+
+    ReplyToDeleteWaiters(ctx, {});
+}
+
+// Ignore allocate result during delete
+void TPartitionActor::HandleAllocateResultDuringDelete(
+    const TEvBlobStorage::TEvControllerAllocateDDiskBlockGroupResult::TPtr& ev,
     const NActors::TActorContext& ctx)
 {
     LOG_INFO(
         ctx,
         NKikimrServices::NBS_PARTITION,
-        "%s Handle DeletePartition request",
+        "%s Ignore AllocateDDiskBlockGroupResult during delete: %s",
+        LogTitle.GetWithTime().c_str(),
+        ev->Get()->Record.ShortDebugString().c_str());
+
+    NTabletPipe::CloseAndForgetClient(SelfId(), BSControllerPipeClient);
+    if (AddHostInFlight) {
+        NTabletPipe::CloseClient(ctx, AddHostInFlight->BSPipeClient);
+        AddHostInFlight.reset();
+    }
+}
+
+// Ignore update volume config during delete
+void TPartitionActor::HandleUpdateVolumeConfigDuringDelete(
+    const NKikimr::TEvBlockStore::TEvUpdateVolumeConfig::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s Reject UpdateVolumeConfig: partition is being deleted",
         LogTitle.GetWithTime().c_str());
 
-    auto response = std::make_unique<TEvService::TEvDeletePartitionResponse>();
-    ctx.Send(ev->Sender, response.release(), 0, ev->Cookie);
+    auto response = std::make_unique<
+        NKikimr::TEvBlockStore::TEvUpdateVolumeConfigResponse>();
+    response->Record.SetStatus(NKikimrBlockStore::ERROR);
+    ctx.Send(ev->Sender, response.release());
+}
+
+// Ignore update vchunk config during delete
+void TPartitionActor::HandleUpdateVChunkConfigDuringDelete(
+    const TEvPartitionDirectPrivate::TEvUpdateVChunkConfig::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s Drop UpdateVChunkConfig during delete: %s",
+        LogTitle.GetWithTime().c_str(),
+        ev->Get()->VChunkConfig.DebugPrint().c_str());
+
+    ev->Get()->UpdateCompleted.SetValue();
+}
+
+// Ignore fast path service shutdown during delete
+void TPartitionActor::HandleFastPathServiceShutdownDuringDelete(
+    const TEvPartitionDirectPrivate::TEvFastPathServiceShutdown::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s FastPathServiceShutdown during delete",
+        LogTitle.GetWithTime().c_str());
+
+    Reply(
+        ctx,
+        *ev,
+        std::make_unique<
+            TEvPartitionDirectPrivate::TEvFastPathServiceStopped>());
+}
+
+// Ignore add host to dbg during delete
+void TPartitionActor::HandleAddHostToDBGDuringDelete(
+    const TEvPartitionDirectPrivate::TEvAddHostToDBG::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    const size_t dbgId = ev->Get()->DirectBlockGroupId;
+    if (FastPathService) {
+        RejectAddHost(ctx, dbgId, "partition is being deleted");
+        return;
+    }
+
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s Drop AddHost during delete (dbgId=%lu): FastPathService stopped",
+        LogTitle.GetWithTime().c_str(),
+        dbgId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TPartitionActor::StateDelete)
+{
+    LOG_DEBUG(
+        TActivationContext::AsActorContext(),
+        NKikimrServices::NBS_PARTITION,
+        "%s Processing event: %s from sender: %lu",
+        LogTitle.GetWithTime().c_str(),
+        ev->GetTypeName().data(),
+        ev->Sender.LocalId());
+
+    switch (ev->GetTypeRewrite()) {
+        // One more request to delete partition while we are removing the tablet
+        HFunc(TEvService::TEvDeletePartitionRequest, HandleDeletePartition);
+        // Fast path service stopped, continue teardown
+        HFunc(
+            TEvPartitionDirectPrivate::TEvFastPathServiceStopped,
+            HandleFastPathServiceStoppedDuringDelete);
+        // Cleanup completed, finish delete
+        HFunc(
+            TEvPartitionDirectPrivate::TEvPartitionCleanupCompleted,
+            HandlePartitionCleanupCompleted);
+        // Ignore allocate result during delete
+        HFunc(
+            TEvBlobStorage::TEvControllerAllocateDDiskBlockGroupResult,
+            HandleAllocateResultDuringDelete);
+        // Ignore update volume config during delete
+        HFunc(
+            NKikimr::TEvBlockStore::TEvUpdateVolumeConfig,
+            HandleUpdateVolumeConfigDuringDelete);
+        // Ignore update vchunk config during delete
+        HFunc(
+            TEvPartitionDirectPrivate::TEvUpdateVChunkConfig,
+            HandleUpdateVChunkConfigDuringDelete);
+        // Ignore fast path service shutdown during delete
+        HFunc(
+            TEvPartitionDirectPrivate::TEvFastPathServiceShutdown,
+            HandleFastPathServiceShutdownDuringDelete);
+        // Ignore add host to dbg during delete
+        HFunc(
+            TEvPartitionDirectPrivate::TEvAddHostToDBG,
+            HandleAddHostToDBGDuringDelete);
+        // The Run() future is not cancelled by Stop(); ignore a late ready
+        // signal
+        IgnoreFunc(TEvPartitionDirectPrivate::TEvFastPathServiceReady);
+        default:
+            HandleCommonEvents(ev);
+            break;
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
@@ -248,7 +248,7 @@ size_t TDBGFixture::ReplyUpdateRequests()
 {
     auto requests = std::move(Service->UpdateConfigRequests);
     for (auto& r: requests) {
-        r.Promise.SetValue();
+        r.Promise.SetValue(EPersistResult::Success);
     }
     return requests.size();
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -405,7 +405,7 @@ void TFastPathService::ScheduleAfterDelay(
         std::move(callback));
 }
 
-NThreading::TFuture<void> TFastPathService::UpdateVChunkConfig(
+TPersistResultFuture TFastPathService::UpdateVChunkConfig(
     const TVChunkConfig& cfg)
 {
     auto event =
@@ -415,7 +415,7 @@ NThreading::TFuture<void> TFastPathService::UpdateVChunkConfig(
     return result;
 }
 
-NThreading::TFuture<void> TFastPathService::UpdateDirtyMapState(
+TPersistResultFuture TFastPathService::UpdateDirtyMapState(
     ui32 vChunkIndex,
     TDirtyMapStateProto state)
 {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
@@ -127,10 +127,9 @@ public:
         TDuration delay,
         NYdb::NBS::TCallback callback) override;
 
-    NThreading::TFuture<void> UpdateVChunkConfig(
-        const TVChunkConfig& cfg) override;
+    TPersistResultFuture UpdateVChunkConfig(const TVChunkConfig& cfg) override;
 
-    NThreading::TFuture<void> UpdateDirtyMapState(
+    TPersistResultFuture UpdateDirtyMapState(
         ui32 vChunkIndex,
         TDirtyMapStateProto state) override;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ic_direct_storage_transport_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ic_direct_storage_transport_ut.cpp
@@ -80,6 +80,73 @@ TGuardedSgList MakeSgList(TString& buffer)
     return result;
 }
 
+void CheckDirectWriteChecksums(TDBGFixture& fixture, bool directSession)
+{
+    auto executor = fixture.MakeExecutor();
+    auto transport =
+        std::make_unique<TICStorageTransportTestAdapter>(fixture.Runtime.get());
+    if (directSession) {
+        transport->EnableFakeDirectSession();
+    }
+
+    const auto& ddiskId = transport->GetDDiskIds()[0];
+    auto connect = transport->Connect(MakeDDiskConnection(ddiskId));
+    fixture.WaitFuture(executor, connect.ConnectFuture, WaitTimeout);
+    UNIT_ASSERT(
+        connect.ConnectFuture.GetValueSync().GetStatus() ==
+        NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
+
+    auto connection = MakeDDiskConnection(
+        ddiskId,
+        connect.ConnectFuture.GetValueSync().GetDDiskInstanceGuid());
+
+    TString writeBuf =
+        TString(DefaultBlockSize, 'A') + TString(DefaultBlockSize, 'B');
+    const auto expectedChecksums =
+        NDDisk::CalculatePayloadChecksums(TRope(writeBuf));
+
+    ui32 writeRequests = 0;
+    TString observedPayload;
+    TVector<ui64> observedChecksums;
+    fixture.Runtime->SetObserverFunc(
+        [&](TAutoPtr<NActors::IEventHandle>& ev)
+        {
+            if (ev->GetTypeRewrite() == NDDisk::TEvWrite::EventType) {
+                ++writeRequests;
+                auto* msg = ev->Get<NDDisk::TEvWrite>();
+                UNIT_ASSERT_VALUES_EQUAL(msg->GetPayloadCount(), 1u);
+                observedPayload = msg->GetPayload(0).ConvertToString();
+                observedChecksums.assign(
+                    msg->Record.GetChecksums().begin(),
+                    msg->Record.GetChecksums().end());
+            }
+            return NActors::TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+    auto future = transport->WriteToDDisk(
+        connection,
+        NDDisk::TBlockSelector{0, 0, DefaultBlockSize * 2},
+        NDDisk::TWriteInstruction(0),
+        MakeSgList(writeBuf),
+        nullptr);
+    fixture.WaitFuture(executor, future, WaitTimeout);
+
+    UNIT_ASSERT(
+        future.GetValueSync().GetStatus() ==
+        NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
+    UNIT_ASSERT_VALUES_EQUAL(writeRequests, 1u);
+    UNIT_ASSERT_VALUES_EQUAL(observedPayload, writeBuf);
+    UNIT_ASSERT_VALUES_EQUAL(
+        observedChecksums.size(),
+        expectedChecksums.size());
+    for (size_t i = 0; i < expectedChecksums.size(); ++i) {
+        UNIT_ASSERT_VALUES_EQUAL(observedChecksums[i], expectedChecksums[i]);
+    }
+    UNIT_ASSERT_VALUES_EQUAL(
+        transport->GetFakeDirectSessionSentEventCount(),
+        directSession ? 1u : 0u);
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -116,6 +183,16 @@ Y_UNIT_TEST_SUITE(TICDirectStorageTransportTest)
         UNIT_ASSERT(
             future.GetValueSync().GetStatus() ==
             NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
+    }
+
+    Y_UNIT_TEST_F(ActorPathDirectWriteCarriesPerBlockChecksums, TDBGFixture)
+    {
+        CheckDirectWriteChecksums(*this, /*directSession=*/false);
+    }
+
+    Y_UNIT_TEST_F(DirectSessionWriteCarriesPerBlockChecksums, TDBGFixture)
+    {
+        CheckDirectWriteChecksums(*this, /*directSession=*/true);
     }
 
     // With a fake IDirectSession injected, WriteToDDisk / ReadFromDDisk go

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "partition_direct_service.h"
+
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
@@ -118,14 +120,18 @@ struct TTxPartition
     //
     struct TUpdateVChunkConfig
     {
-        const TVChunkConfig VChunkConfig;
-        NThreading::TPromise<void> UpdateCompleted;
+        struct TUpdateConfigRequest
+        {
+            TVChunkConfig VChunkConfig;
+            TPersistResultPromise UpdateCompleted;
+        };
 
-        explicit TUpdateVChunkConfig(
-            TVChunkConfig vChunkConfig,
-            NThreading::TPromise<void> updateCompleted)
-            : VChunkConfig(std::move(vChunkConfig))
-            , UpdateCompleted(std::move(updateCompleted))
+        using TUpdateConfigRequests = TVector<TUpdateConfigRequest>;
+
+        TUpdateConfigRequests UpdateConfigRequests;
+
+        explicit TUpdateVChunkConfig(TUpdateConfigRequests updateConfigRequests)
+            : UpdateConfigRequests(std::move(updateConfigRequests))
         {}
 
         void Clear()
@@ -139,17 +145,19 @@ struct TTxPartition
     //
     struct TUpdateDirtyMapState
     {
-        const ui32 VChunkIndex;
-        const TDirtyMapStateProto State;
-        NThreading::TPromise<void> UpdateCompleted;
+        struct TUpdateStateRequest
+        {
+            ui32 VChunkIndex;
+            TDirtyMapStateProto State;
+            TPersistResultPromise UpdateCompleted;
+        };
 
-        TUpdateDirtyMapState(
-            ui32 vChunkIndex,
-            TDirtyMapStateProto state,
-            NThreading::TPromise<void> updateCompleted)
-            : VChunkIndex(vChunkIndex)
-            , State(std::move(state))
-            , UpdateCompleted(std::move(updateCompleted))
+        using TUpdateStateRequests = TVector<TUpdateStateRequest>;
+
+        TUpdateStateRequests UpdateStateRequests;
+
+        explicit TUpdateDirtyMapState(TUpdateStateRequests updateStateRequests)
+            : UpdateStateRequests(std::move(updateStateRequests))
         {}
 
         void Clear()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatedirtymapstate.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatedirtymapstate.cpp
@@ -17,7 +17,13 @@ bool TPartitionActor::PrepareUpdateDirtyMapState(
 {
     Y_UNUSED(ctx);
     Y_UNUSED(tx);
-    Y_UNUSED(args);
+
+    Y_DEBUG_ABORT_UNLESS(ExecutingUpdateDirtyMapStatePromises.empty());
+    ExecutingUpdateDirtyMapStatePromises.reserve(
+        args.UpdateStateRequests.size());
+    for (const auto& request: args.UpdateStateRequests) {
+        ExecutingUpdateDirtyMapStatePromises.push_back(request.UpdateCompleted);
+    }
 
     return true;
 }
@@ -30,16 +36,35 @@ void TPartitionActor::ExecuteUpdateDirtyMapState(
     Y_UNUSED(ctx);
 
     TPartitionDatabase db(tx.DB);
-    db.StoreDirtyMapState(args.VChunkIndex, args.State);
+    for (const auto& request: args.UpdateStateRequests) {
+        db.StoreDirtyMapState(request.VChunkIndex, request.State);
+    }
 }
 
 void TPartitionActor::CompleteUpdateDirtyMapState(
     const TActorContext& ctx,
     TTxPartition::TUpdateDirtyMapState& args)
 {
-    Y_UNUSED(ctx);
+    for (auto& request: args.UpdateStateRequests) {
+        request.UpdateCompleted.TrySetValue(EPersistResult::Success);
+    }
+    ExecutingUpdateDirtyMapStatePromises.clear();
+    ExecutingUpdateDirtyMapState = false;
 
-    args.UpdateCompleted.SetValue();
+    if (!PendingUpdateDirtyMapStateRequests.empty()) {
+        LOG_INFO(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s Execute pending UpdateDirtyMapStateRequests %zu",
+            LogTitle.GetWithTime().c_str(),
+            PendingUpdateDirtyMapStateRequests.size());
+
+        ExecutingUpdateDirtyMapState = true;
+        ExecuteTx(
+            ctx,
+            CreateTx<TUpdateDirtyMapState>(
+                std::move(PendingUpdateDirtyMapStateRequests)));
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatevchunkconfig.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatevchunkconfig.cpp
@@ -17,7 +17,13 @@ bool TPartitionActor::PrepareUpdateVChunkConfig(
 {
     Y_UNUSED(ctx);
     Y_UNUSED(tx);
-    Y_UNUSED(args);
+
+    Y_DEBUG_ABORT_UNLESS(ExecutingUpdateVChunkConfigPromises.empty());
+    ExecutingUpdateVChunkConfigPromises.reserve(
+        args.UpdateConfigRequests.size());
+    for (const auto& request: args.UpdateConfigRequests) {
+        ExecutingUpdateVChunkConfigPromises.push_back(request.UpdateCompleted);
+    }
 
     return true;
 }
@@ -30,16 +36,35 @@ void TPartitionActor::ExecuteUpdateVChunkConfig(
     Y_UNUSED(ctx);
 
     TPartitionDatabase db(tx.DB);
-    db.StoreVChunkConfig(args.VChunkConfig);
+    for (const auto& request: args.UpdateConfigRequests) {
+        db.StoreVChunkConfig(request.VChunkConfig);
+    }
 }
 
 void TPartitionActor::CompleteUpdateVChunkConfig(
     const TActorContext& ctx,
     TTxPartition::TUpdateVChunkConfig& args)
 {
-    Y_UNUSED(ctx);
+    for (auto& request: args.UpdateConfigRequests) {
+        request.UpdateCompleted.TrySetValue(EPersistResult::Success);
+    }
+    ExecutingUpdateVChunkConfigPromises.clear();
+    ExecutingUpdateVChunkConfig = false;
 
-    args.UpdateCompleted.SetValue();
+    if (!PendingUpdateVChunkConfigRequests.empty()) {
+        LOG_INFO(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s Execute pending UpdateVChunkConfigRequests %zu",
+            LogTitle.GetWithTime().c_str(),
+            PendingUpdateVChunkConfigRequests.size());
+
+        ExecutingUpdateVChunkConfig = true;
+        ExecuteTx(
+            ctx,
+            CreateTx<TUpdateVChunkConfig>(
+                std::move(PendingUpdateVChunkConfigRequests)));
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_cleanup_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_cleanup_actor.cpp
@@ -1,0 +1,542 @@
+#include "partition_cleanup_actor.h"
+
+#include "partition_direct_events_private.h"
+
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/model/log_title.h>
+
+#include <ydb/core/nbs/cloud/storage/core/libs/common/error.h>
+#include <ydb/core/nbs/cloud/storage/core/libs/common/error_utils.h>
+
+#include <ydb/core/base/blobstorage.h>
+#include <ydb/core/base/services/blobstorage_service_id.h>
+#include <ydb/core/base/tablet_pipe.h>
+#include <ydb/core/blobstorage/base/blobstorage_events.h>
+#include <ydb/core/blobstorage/ddisk/ddisk.h>
+#include <ydb/core/protos/base.pb.h>
+
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/log.h>
+#include <ydb/library/actors/interconnect/interconnect.h>
+#include <ydb/library/services/services.pb.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+#include <util/system/datetime.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+using namespace NActors;
+using namespace NKikimr;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::TError CheckDeallocateResult(
+    const TEvBlobStorage::TEvControllerAllocateDDiskBlockGroupResult& msg)
+{
+    const auto& record = msg.Record;
+
+    if (record.GetStatus() != NKikimrProto::OK) {
+        return MakeError(
+            E_FAIL,
+            TStringBuilder() << "BSController deallocate failed: "
+                             << record.GetErrorReason());
+    }
+
+    for (const auto& group: record.GetDirectBlockGroups()) {
+        if (group.DDiskIdSize() != 0 ||
+            group.PersistentBufferDDiskIdSize() != 0)
+        {
+            return MakeError(
+                E_FAIL,
+                TStringBuilder()
+                    << "BSController deallocate left resources for dbgId="
+                    << group.GetDirectBlockGroupId()
+                    << " ddisks=" << group.DDiskIdSize()
+                    << " pbuffers=" << group.PersistentBufferDDiskIdSize());
+        }
+    }
+
+    return {};
+}
+
+NActors::TActorId MakePBufferServiceId(
+    const NKikimrBlobStorage::NDDisk::TDDiskId& id)
+{
+    return MakeBlobStoragePersistentBufferId(
+        id.GetNodeId(),
+        id.GetPDiskId(),
+        id.GetDDiskSlotId());
+}
+
+NActors::TActorId MakeDDiskServiceId(
+    const NKikimrBlobStorage::NDDisk::TDDiskId& id)
+{
+    return MakeBlobStorageDDiskId(
+        id.GetNodeId(),
+        id.GetPDiskId(),
+        id.GetDDiskSlotId());
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TPartitionCleanupActor: public TActorBootstrapped<TPartitionCleanupActor>
+{
+    enum class ECleanupTarget
+    {
+        PBuffer,
+        DDisk,
+    };
+
+    enum class ECleanupPhase
+    {
+        WipePBuffer,
+        WipeDDisk,
+    };
+
+    struct TRequest
+    {
+        NActors::TActorId Target;
+        ui32 NodeId = 0;
+        ECleanupTarget Kind = ECleanupTarget::PBuffer;
+    };
+
+private:
+    const TPartitionCleanupParams Params;
+    TLogTitle LogTitle;
+
+    THashMap<ui64, TRequest> InFlight;
+    ui64 NextCookie = 1;
+    ECleanupPhase Phase = ECleanupPhase::WipePBuffer;
+    bool Completed = false;
+
+    NActors::TActorId BSControllerPipeClient;
+
+public:
+    explicit TPartitionCleanupActor(TPartitionCleanupParams params)
+        : Params(std::move(params))
+        , LogTitle(
+              GetCycleCount(),
+              TLogTitle::TPartitionDirect{
+                  .DiskId = Params.DiskId,
+                  .TabletId = Params.TabletId,
+                  .Generation = Params.Generation})
+    {}
+
+    void Bootstrap(const TActorContext& ctx)
+    {
+        Become(&TThis::StateWipe);
+
+        LOG_INFO(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s Become StateWipe",
+            LogTitle.GetWithTime().c_str());
+
+        ctx.Schedule(PartitionCleanupTimeout, new TEvents::TEvWakeup());
+        StartPBufferBarrierErase(ctx);
+    }
+
+private:
+    STFUNC(StateWipe)
+    {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(
+                NDDisk::TEvErasePersistentBufferResult,
+                HandleErasePersistentBufferResult);
+            HFunc(
+                NDDisk::TEvDeleteTabletChunksResult,
+                HandleDeleteTabletChunksResult);
+            HFunc(TEvents::TEvUndelivered, HandleUndelivered);
+            HFunc(TEvents::TEvWakeup, HandleTimeout);
+            HFunc(TEvInterconnect::TEvNodeDisconnected, HandleNodeDisconnected);
+            IgnoreFunc(TEvInterconnect::TEvNodeConnected);
+            cFunc(TEvents::TEvPoison::EventType, PassAway);
+            default:
+                LOG_ERROR(
+                    TActivationContext::AsActorContext(),
+                    NKikimrServices::NBS_PARTITION,
+                    "%s Unhandled event type: %u event %s",
+                    LogTitle.GetWithTime().c_str(),
+                    ev->GetTypeRewrite(),
+                    ev->ToString().c_str());
+                break;
+        }
+    }
+
+    STFUNC(StateDeallocate)
+    {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(
+                TEvBlobStorage::TEvControllerAllocateDDiskBlockGroupResult,
+                HandleDeallocateResult);
+            HFunc(TEvTabletPipe::TEvClientConnected, HandleConnect);
+            HFunc(TEvTabletPipe::TEvClientDestroyed, HandleDisconnect);
+            HFunc(TEvents::TEvWakeup, HandleTimeout);
+            cFunc(TEvents::TEvPoison::EventType, PassAway);
+            default:
+                LOG_ERROR(
+                    TActivationContext::AsActorContext(),
+                    NKikimrServices::NBS_PARTITION,
+                    "%s Unhandled event type: %u event %s",
+                    LogTitle.GetWithTime().c_str(),
+                    ev->GetTypeRewrite(),
+                    ev->ToString().c_str());
+                break;
+        }
+    }
+
+    void StartPBufferBarrierErase(const TActorContext& ctx)
+    {
+        Phase = ECleanupPhase::WipePBuffer;
+
+        const auto creds = NDDisk::TQueryCredentials::ForInternal(
+            Params.TabletId,
+            Params.Generation,
+            std::nullopt,
+            0);
+
+        THashSet<TActorId> targets;
+        for (const auto& group:
+             Params.Connections.GetDirectBlockGroupConnections())
+        {
+            for (const auto& connection: group.GetConnections()) {
+                const auto target = MakePBufferServiceId(
+                    connection.GetPersistentBufferDDiskId());
+                if (!targets.insert(target).second) {
+                    continue;
+                }
+                SendWipeRequest(
+                    ctx,
+                    target,
+                    ECleanupTarget::PBuffer,
+                    std::make_unique<NDDisk::TEvErasePersistentBuffer>(
+                        creds,
+                        Max<ui64>()));
+            }
+        }
+
+        if (InFlight.empty()) {
+            StartDDiskChunkDelete(ctx);
+        }
+    }
+
+    void StartDDiskChunkDelete(const TActorContext& ctx)
+    {
+        Phase = ECleanupPhase::WipeDDisk;
+
+        const auto creds = NDDisk::TQueryCredentials::ForInternal(
+            Params.TabletId,
+            Params.Generation,
+            std::nullopt,
+            0);
+
+        THashSet<TActorId> targets;
+        for (const auto& group:
+             Params.Connections.GetDirectBlockGroupConnections())
+        {
+            for (const auto& connection: group.GetConnections()) {
+                const auto target = MakeDDiskServiceId(connection.GetDDiskId());
+                if (!targets.insert(target).second) {
+                    continue;
+                }
+                SendWipeRequest(
+                    ctx,
+                    target,
+                    ECleanupTarget::DDisk,
+                    std::make_unique<NDDisk::TEvDeleteTabletChunks>(creds));
+            }
+        }
+
+        if (InFlight.empty()) {
+            StartDeallocate(ctx);
+        }
+    }
+
+    void SendWipeRequest(
+        const TActorContext& ctx,
+        const TActorId& target,
+        ECleanupTarget kind,
+        std::unique_ptr<IEventBase> event)
+    {
+        const ui64 cookie = NextCookie++;
+        InFlight[cookie] =
+            TRequest{.Target = target, .NodeId = target.NodeId(), .Kind = kind};
+
+        LOG_INFO(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s Send wipe request kind=%s target=%s cookie=%lu",
+            LogTitle.GetWithTime().c_str(),
+            kind == ECleanupTarget::PBuffer ? "PBuffer" : "DDisk",
+            target.ToString().c_str(),
+            cookie);
+
+        auto ev = std::make_unique<IEventHandle>(
+            target,
+            ctx.SelfID,
+            event.release(),
+            IEventHandle::FlagTrackDelivery |
+                IEventHandle::FlagSubscribeOnSession,
+            cookie);
+        ctx.Send(ev.release());
+    }
+
+    void OnWipeResult(
+        const TActorContext& ctx,
+        ui64 cookie,
+        const NProto::TError& error)
+    {
+        auto it = InFlight.find(cookie);
+        if (it == InFlight.end()) {
+            return;
+        }
+
+        InFlight.erase(it);
+
+        if (HasError(error)) {
+            Complete(ctx, error);
+            return;
+        }
+
+        if (!InFlight.empty()) {
+            return;
+        }
+
+        if (Phase == ECleanupPhase::WipePBuffer) {
+            StartDDiskChunkDelete(ctx);
+        } else {
+            StartDeallocate(ctx);
+        }
+    }
+
+    void HandleErasePersistentBufferResult(
+        const NDDisk::TEvErasePersistentBufferResult::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        const auto& record = ev->Get()->Record;
+        LOG_INFO(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s HandleErasePersistentBufferResult cookie=%lu status=%s",
+            LogTitle.GetWithTime().c_str(),
+            ev->Cookie,
+            NKikimrBlobStorage::NDDisk::TReplyStatus_E_Name(record.GetStatus())
+                .c_str());
+
+        OnWipeResult(ctx, ev->Cookie, TranslateError(record));
+    }
+
+    void HandleDeleteTabletChunksResult(
+        const NDDisk::TEvDeleteTabletChunksResult::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        const auto& record = ev->Get()->Record;
+        LOG_INFO(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s HandleDeleteTabletChunksResult cookie=%lu status=%s",
+            LogTitle.GetWithTime().c_str(),
+            ev->Cookie,
+            NKikimrBlobStorage::NDDisk::TReplyStatus_E_Name(record.GetStatus())
+                .c_str());
+
+        OnWipeResult(ctx, ev->Cookie, TranslateError(record));
+    }
+
+    void HandleUndelivered(
+        const TEvents::TEvUndelivered::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        auto it = InFlight.find(ev->Cookie);
+        if (it == InFlight.end()) {
+            return;
+        }
+
+        LOG_ERROR(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s Wipe request undelivered target=%s cookie=%lu",
+            LogTitle.GetWithTime().c_str(),
+            it->second.Target.ToString().c_str(),
+            ev->Cookie);
+
+        Complete(ctx, MakeError(E_REJECTED, "wipe request undelivered"));
+    }
+
+    void HandleNodeDisconnected(
+        TEvInterconnect::TEvNodeDisconnected::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        const ui32 nodeId = ev->Get()->NodeId;
+        for (const auto& [cookie, request]: InFlight) {
+            if (request.NodeId == nodeId) {
+                LOG_ERROR(
+                    ctx,
+                    NKikimrServices::NBS_PARTITION,
+                    "%s Node %u disconnected during wipe cookie=%lu target=%s",
+                    LogTitle.GetWithTime().c_str(),
+                    nodeId,
+                    cookie,
+                    request.Target.ToString().c_str());
+                Complete(
+                    ctx,
+                    MakeError(E_REJECTED, "node disconnected during wipe"));
+                return;
+            }
+        }
+    }
+
+    void HandleTimeout(
+        const TEvents::TEvWakeup::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        Y_UNUSED(ev);
+        Complete(ctx, MakeError(E_TIMEOUT, "partition cleanup timed out"));
+    }
+
+    void StartDeallocate(const TActorContext& ctx)
+    {
+        Become(&TThis::StateDeallocate);
+
+        LOG_INFO(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s Become StateDeallocate",
+            LogTitle.GetWithTime().c_str());
+
+        BSControllerPipeClient = ctx.Register(
+            NTabletPipe::CreateClient(ctx.SelfID, MakeBSControllerID()));
+
+        auto request = std::make_unique<
+            TEvBlobStorage::TEvControllerAllocateDDiskBlockGroup>();
+        request->Record.SetDDiskPoolName(Params.DDiskPoolName);
+        request->Record.SetPersistentBufferDDiskPoolName(
+            Params.PersistentBufferDDiskPoolName);
+        request->Record.SetTabletId(Params.TabletId);
+
+        for (size_t i = 0; i < Params.DirectBlockGroupsCount; ++i) {
+            auto* op = request->Record.AddDirectBlockGroupOperations();
+            op->SetDirectBlockGroupId(i);
+            auto* define = op->MutableDefineDirectBlockGroup();
+            define->SetNumDDisks(0);
+            define->SetNumChunksPerDDisk(0);
+            define->SetNumPersistentBuffers(0);
+        }
+
+        NTabletPipe::SendData(ctx, BSControllerPipeClient, request.release());
+    }
+
+    void HandleDeallocateResult(
+        const TEvBlobStorage::TEvControllerAllocateDDiskBlockGroupResult::TPtr&
+            ev,
+        const TActorContext& ctx)
+    {
+        const auto& record = ev->Get()->Record;
+        LOG_INFO(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s HandleDeallocateResult status=%s reason=%s",
+            LogTitle.GetWithTime().c_str(),
+            NKikimrProto::EReplyStatus_Name(record.GetStatus()).c_str(),
+            record.GetErrorReason().c_str());
+
+        Complete(ctx, CheckDeallocateResult(*ev->Get()));
+    }
+
+    void HandleConnect(
+        TEvTabletPipe::TEvClientConnected::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        const auto* msg = ev->Get();
+        if (msg->ClientId != BSControllerPipeClient) {
+            return;
+        }
+        if (msg->Status == NKikimrProto::OK) {
+            return;
+        }
+
+        LOG_ERROR(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s BSController pipe connect failed during deallocate: %s",
+            LogTitle.GetWithTime().c_str(),
+            NKikimrProto::EReplyStatus_Name(msg->Status).c_str());
+
+        Complete(
+            ctx,
+            MakeError(
+                E_REJECTED,
+                "BSController pipe connect failed during deallocate"));
+    }
+
+    void HandleDisconnect(
+        TEvTabletPipe::TEvClientDestroyed::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        const auto* msg = ev->Get();
+        if (msg->ClientId != BSControllerPipeClient) {
+            return;
+        }
+
+        LOG_ERROR(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s BSController pipe destroyed during deallocate",
+            LogTitle.GetWithTime().c_str());
+
+        Complete(
+            ctx,
+            MakeError(
+                E_REJECTED,
+                "BSController pipe destroyed during deallocate"));
+    }
+
+    void Complete(const TActorContext& ctx, NProto::TError error)
+    {
+        if (Completed) {
+            return;
+        }
+        Completed = true;
+
+        LOG_INFO(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s Cleanup completed: %s",
+            LogTitle.GetWithTime().c_str(),
+            FormatError(error).c_str());
+
+        ctx.Send(
+            Params.Parent,
+            new TEvPartitionDirectPrivate::TEvPartitionCleanupCompleted(
+                std::move(error)));
+        PassAway();
+    }
+
+    void PassAway() override
+    {
+        if (BSControllerPipeClient) {
+            NTabletPipe::CloseClient(
+                TActivationContext::AsActorContext(),
+                BSControllerPipeClient);
+            BSControllerPipeClient = {};
+        }
+        TActorBootstrapped::PassAway();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+IActor* CreatePartitionCleanupActor(TPartitionCleanupParams params)
+{
+    return new TPartitionCleanupActor(std::move(params));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_cleanup_actor.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_cleanup_actor.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/partition_direct.pb.h>
+
+#include <ydb/library/actors/core/actor.h>
+
+#include <util/datetime/base.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr TDuration PartitionCleanupTimeout = TDuration::Seconds(60);
+
+struct TPartitionCleanupParams
+{
+    NActors::TActorId Parent;
+    ui64 TabletId = 0;
+    ui32 Generation = 0;
+    TString DiskId;
+    ::NYdb::NBS::PartitionDirect::NProto::TDirectBlockGroupsConnections
+        Connections;
+    TString DDiskPoolName;
+    TString PersistentBufferDDiskPoolName;
+    size_t DirectBlockGroupsCount = 0;
+};
+
+NActors::IActor* CreatePartitionCleanupActor(TPartitionCleanupParams params);
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -148,9 +148,46 @@ void TPartitionActor::CleanupResources(const TActorContext& ctx)
 
     GetNbsService()->VhostServer->DetachStorage(GetSocketPath());
 
+    // It is assumed that the transaction to the local database is always
+    // successful. If the Tablet finishes its work, then it is necessary to
+    // respond to all pending requests so that there are no leakage resources.
+    // We will do this after the initiator of the request is stopped.
+    auto failUpdateRequests =
+        [executingConfigPromises =
+             std::move(ExecutingUpdateVChunkConfigPromises),
+         pendingConfigRequests = std::move(PendingUpdateVChunkConfigRequests),
+         executingDirtyMapPromises =
+             std::move(ExecutingUpdateDirtyMapStatePromises),
+         pendingDirtyMapRequests =
+             std::move(PendingUpdateDirtyMapStateRequests)]() mutable
+    {
+        for (auto& promise: executingConfigPromises) {
+            promise.TrySetValue(EPersistResult::Cancelled);
+        }
+        for (auto& req: pendingConfigRequests) {
+            req.UpdateCompleted.TrySetValue(EPersistResult::Cancelled);
+        }
+
+        for (auto& promise: executingDirtyMapPromises) {
+            promise.TrySetValue(EPersistResult::Cancelled);
+        }
+        for (auto& req: pendingDirtyMapRequests) {
+            req.UpdateCompleted.TrySetValue(EPersistResult::Cancelled);
+        }
+    };
+
     if (FastPathService) {
-        FastPathService->Stop();
+        auto onStop = FastPathService->Stop();
+        onStop.Subscribe(
+            [failUpdateRequests = std::move(failUpdateRequests)](
+                const NThreading::TFuture<void>& stopFuture) mutable
+            {
+                Y_UNUSED(stopFuture);
+                failUpdateRequests();
+            });
         FastPathService.reset();
+    } else {
+        failUpdateRequests();
     }
 }
 
@@ -698,15 +735,26 @@ void TPartitionActor::HandleUpdateVChunkConfig(
     LOG_INFO(
         ctx,
         NKikimrServices::NBS_PARTITION,
-        "%s Handle UpdateVChunkConfig %s",
+        "%s Handle UpdateVChunkConfig %s %s",
         LogTitle.GetWithTime().c_str(),
-        msg->VChunkConfig.DebugPrint().c_str());
+        msg->VChunkConfig.DebugPrint().c_str(),
+        ExecutingUpdateVChunkConfig ? "later" : "now");
 
-    ExecuteTx(
-        ctx,
-        CreateTx<TUpdateVChunkConfig>(
-            std::move(msg->VChunkConfig),
-            std::move(msg->UpdateCompleted)));
+    if (ExecutingUpdateVChunkConfig) {
+        PendingUpdateVChunkConfigRequests.push_back(
+            {.VChunkConfig = std::move(msg->VChunkConfig),
+             .UpdateCompleted = std::move(msg->UpdateCompleted)});
+    } else {
+        Y_DEBUG_ABORT_UNLESS(PendingUpdateVChunkConfigRequests.empty());
+
+        ExecutingUpdateVChunkConfig = true;
+        ExecuteTx(
+            ctx,
+            CreateTx<TUpdateVChunkConfig>(
+                TTxPartition::TUpdateVChunkConfig::TUpdateConfigRequests{
+                    {.VChunkConfig = std::move(msg->VChunkConfig),
+                     .UpdateCompleted = std::move(msg->UpdateCompleted)}}));
+    }
 }
 
 void TPartitionActor::HandleUpdateDirtyMapState(
@@ -718,16 +766,28 @@ void TPartitionActor::HandleUpdateDirtyMapState(
     LOG_INFO(
         ctx,
         NKikimrServices::NBS_PARTITION,
-        "%s Handle UpdateDirtyMapState vchunk %u",
+        "%s Handle UpdateDirtyMapState vchunk %u %s",
         LogTitle.GetWithTime().c_str(),
-        msg->VChunkIndex);
+        msg->VChunkIndex,
+        ExecutingUpdateDirtyMapState ? "later" : "now");
 
-    ExecuteTx(
-        ctx,
-        CreateTx<TUpdateDirtyMapState>(
-            msg->VChunkIndex,
-            std::move(msg->State),
-            std::move(msg->UpdateCompleted)));
+    if (ExecutingUpdateDirtyMapState) {
+        PendingUpdateDirtyMapStateRequests.push_back(
+            {.VChunkIndex = msg->VChunkIndex,
+             .State = std::move(msg->State),
+             .UpdateCompleted = std::move(msg->UpdateCompleted)});
+    } else {
+        Y_DEBUG_ABORT_UNLESS(PendingUpdateDirtyMapStateRequests.empty());
+
+        ExecutingUpdateDirtyMapState = true;
+        ExecuteTx(
+            ctx,
+            CreateTx<TUpdateDirtyMapState>(
+                TTxPartition::TUpdateDirtyMapState::TUpdateStateRequests{
+                    {.VChunkIndex = msg->VChunkIndex,
+                     .State = std::move(msg->State),
+                     .UpdateCompleted = std::move(msg->UpdateCompleted)}}));
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -81,6 +81,22 @@ void TPartitionActor::OnTabletDead(
     DetachEndpointAddDie(ctx);
 }
 
+// Tablet received poison pill, cleanup resources
+void TPartitionActor::PassAway()
+{
+    const auto& ctx = NActors::TActivationContext::AsActorContext();
+
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s PassAway",
+        LogTitle.GetWithTime().c_str());
+
+    // Do not call Die() here: Die() invokes PassAway() again.
+    CleanupResources(ctx);
+    TActor::PassAway();
+}
+
 void TPartitionActor::OnActivateExecutor(const TActorContext& ctx)
 {
     Become(&TThis::StateWork);
@@ -110,6 +126,34 @@ void TPartitionActor::DefaultSignalTabletActive(const TActorContext& ctx)
     Y_UNUSED(ctx);
 }
 
+void TPartitionActor::CleanupResources(const TActorContext& ctx)
+{
+    if (LoadActorAdapter) {
+        ctx.Send(LoadActorAdapter, new TEvents::TEvPoisonPill());
+        LoadActorAdapter = {};
+    }
+
+    if (CleanupActor) {
+        ctx.Send(CleanupActor, new TEvents::TEvPoisonPill());
+        CleanupActor = {};
+    }
+
+    NTabletPipe::CloseAndForgetClient(SelfId(), BSControllerPipeClient);
+    if (AddHostInFlight) {
+        NTabletPipe::CloseAndForgetClient(
+            SelfId(),
+            AddHostInFlight->BSPipeClient);
+        AddHostInFlight.reset();
+    }
+
+    GetNbsService()->VhostServer->DetachStorage(GetSocketPath());
+
+    if (FastPathService) {
+        FastPathService->Stop();
+        FastPathService.reset();
+    }
+}
+
 void TPartitionActor::DetachEndpointAddDie(const TActorContext& ctx)
 {
     LOG_INFO(
@@ -118,14 +162,7 @@ void TPartitionActor::DetachEndpointAddDie(const TActorContext& ctx)
         "%s DetachEndpointAddDie",
         LogTitle.GetWithTime().c_str());
 
-    ctx.Send(LoadActorAdapter, new TEvents::TEvPoisonPill());
-
-    GetNbsService()->VhostServer->DetachStorage(GetSocketPath());
-
-    if (FastPathService) {
-        FastPathService->Stop();
-    }
-
+    CleanupResources(ctx);
     Die(ctx);
 }
 
@@ -582,7 +619,7 @@ void TPartitionActor::HandleInitialAllocationResult(
             msg->Record.GetErrorReason().data());
     }
 
-    NTabletPipe::CloseClient(ctx, BSControllerPipeClient);
+    NTabletPipe::CloseAndForgetClient(SelfId(), BSControllerPipeClient);
 }
 
 void TPartitionActor::HandleGetLoadActorAdapterActorId(
@@ -695,6 +732,35 @@ void TPartitionActor::HandleUpdateDirtyMapState(
 
 ///////////////////////////////////////////////////////////////////////////////
 
+void TPartitionActor::HandleCommonEvents(TAutoPtr<NActors::IEventHandle>& ev)
+{
+    switch (ev->GetTypeRewrite()) {
+        cFunc(TEvents::TEvPoison::EventType, PassAway);
+        HFunc(TEvTabletPipe::TEvClientConnected, HandleConnect);
+        HFunc(TEvTabletPipe::TEvClientDestroyed, HandleDisconnect);
+        HFunc(TEvTabletPipe::TEvServerConnected, HandleServerConnected);
+        HFunc(TEvTabletPipe::TEvServerDisconnected, HandleServerDisconnected);
+        HFunc(TEvTabletPipe::TEvServerDestroyed, HandleServerDestroyed);
+        HFunc(
+            TEvService::TEvGetLoadActorAdapterActorIdRequest,
+            HandleGetLoadActorAdapterActorId);
+        HFunc(
+            TEvPartitionDirectPrivate::TEvPoison,
+            HandlePoisonByBlockedGeneration);
+        default:
+            if (!HandleDefaultEvents(ev, SelfId())) {
+                LOG_ERROR(
+                    TActivationContext::AsActorContext(),
+                    NKikimrServices::NBS_PARTITION,
+                    "%s Unhandled event type: %u event %s ",
+                    LogTitle.GetWithTime().c_str(),
+                    ev->GetTypeRewrite(),
+                    ev->ToString().c_str());
+            }
+            break;
+    }
+}
+
 STFUNC(TPartitionActor::StateWork)
 {
     LOG_DEBUG(
@@ -706,19 +772,9 @@ STFUNC(TPartitionActor::StateWork)
         ev->Sender.LocalId());
 
     switch (ev->GetTypeRewrite()) {
-        cFunc(TEvents::TEvPoison::EventType, PassAway);
-        HFunc(TEvTabletPipe::TEvClientConnected, HandleConnect);
-        HFunc(TEvTabletPipe::TEvClientDestroyed, HandleDisconnect);
-        HFunc(TEvTabletPipe::TEvServerConnected, HandleServerConnected);
-        HFunc(TEvTabletPipe::TEvServerDisconnected, HandleServerDisconnected);
-        HFunc(TEvTabletPipe::TEvServerDestroyed, HandleServerDestroyed);
-
         HFunc(
             TEvBlobStorage::TEvControllerAllocateDDiskBlockGroupResult,
             HandleControllerAllocateDDiskBlockGroupResult);
-        HFunc(
-            TEvService::TEvGetLoadActorAdapterActorIdRequest,
-            HandleGetLoadActorAdapterActorId);
         HFunc(
             NKikimr::TEvBlockStore::TEvUpdateVolumeConfig,
             HandleUpdateVolumeConfig);
@@ -741,22 +797,10 @@ STFUNC(TPartitionActor::StateWork)
             TEvPartitionDirectPrivate::TEvFastPathServiceStopped,
             HandleFastPathServiceStopped);
 
-        HFunc(
-            TEvPartitionDirectPrivate::TEvPoison,
-            HandlePoisonByBlockedGeneration);
-
         HFunc(TEvService::TEvDeletePartitionRequest, HandleDeletePartition);
 
         default:
-            if (!HandleDefaultEvents(ev, SelfId())) {
-                LOG_ERROR(
-                    TActivationContext::AsActorContext(),
-                    NKikimrServices::NBS_PARTITION,
-                    "%s Unhandled event type: %u event %s ",
-                    LogTitle.GetWithTime().c_str(),
-                    ev->GetTypeRewrite(),
-                    ev->ToString().c_str());
-            }
+            HandleCommonEvents(ev);
             break;
     }
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
@@ -79,6 +79,18 @@ private:
     // At most one add-host runs at a time across the whole partition.
     std::optional<TAddHostInFlight> AddHostInFlight;
 
+    // Batch persisting of vchunk configs.
+    bool ExecutingUpdateVChunkConfig = false;
+    TVector<TPersistResultPromise> ExecutingUpdateVChunkConfigPromises;
+    TTxPartition::TUpdateVChunkConfig::TUpdateConfigRequests
+        PendingUpdateVChunkConfigRequests;
+
+    // Batch persisting of ahead and behind fields.
+    bool ExecutingUpdateDirtyMapState = false;
+    TVector<TPersistResultPromise> ExecutingUpdateDirtyMapStatePromises;
+    TTxPartition::TUpdateDirtyMapState::TUpdateStateRequests
+        PendingUpdateDirtyMapStateRequests;
+
 public:
     TPartitionActor(
         const NActors::TActorId& tablet,
@@ -225,6 +237,10 @@ private:
 
     void HandleUpdateVChunkConfigDuringDelete(
         const TEvPartitionDirectPrivate::TEvUpdateVChunkConfig::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleUpdateDirtyMapStateDuringDelete(
+        const TEvPartitionDirectPrivate::TEvUpdateDirtyMapState::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleFastPathServiceShutdownDuringDelete(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
@@ -60,6 +60,15 @@ private:
 
     TDirectBlockGroupsConnections DirectBlockGroupsConnections;
 
+    struct TDeleteWaiter
+    {
+        NActors::TActorId Sender;
+        ui64 Cookie = 0;
+    };
+
+    TVector<TDeleteWaiter> InflightDeleteRequests;
+    NActors::TActorId CleanupActor;
+
     struct TAddHostInFlight
     {
         size_t DirectBlockGroupId = 0;
@@ -83,6 +92,13 @@ public:
 private:
     void StateInit(TAutoPtr<NActors::IEventHandle>& ev);
     STFUNC(StateWork);
+    // Remove tablet and wipe disk
+    STFUNC(StateDelete);
+
+    // Common handlers in different states
+    void HandleCommonEvents(TAutoPtr<NActors::IEventHandle>& ev);
+
+    void PassAway() override;
 
     // The tablet's own monitoring page, reached via the standard tablet page's
     // "App" link. The base class passes a null event to ask whether that link
@@ -98,6 +114,7 @@ private:
     void OnActivateExecutor(const NActors::TActorContext& ctx) override;
     void DefaultSignalTabletActive(const NActors::TActorContext& ctx) override;
 
+    void CleanupResources(const NActors::TActorContext& ctx);
     void DetachEndpointAddDie(const NActors::TActorContext& ctx);
 
     void HandleConnect(
@@ -182,6 +199,47 @@ private:
         const NYdb::NBS::NBlockStore::TEvService::TEvDeletePartitionRequest::
             TPtr& ev,
         const NActors::TActorContext& ctx);
+
+    void StartPartitionTeardown(const NActors::TActorContext& ctx);
+
+    void HandleFastPathServiceStoppedDuringDelete(
+        const TEvPartitionDirectPrivate::TEvFastPathServiceStopped::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void StartCleanupActor(
+        const NActors::TActorContext& ctx,
+        TDirectBlockGroupsConnections connections);
+
+    void HandlePartitionCleanupCompleted(
+        const TEvPartitionDirectPrivate::TEvPartitionCleanupCompleted::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleAllocateResultDuringDelete(
+        const NKikimr::TEvBlobStorage::
+            TEvControllerAllocateDDiskBlockGroupResult::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleUpdateVolumeConfigDuringDelete(
+        const NKikimr::TEvBlockStore::TEvUpdateVolumeConfig::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleUpdateVChunkConfigDuringDelete(
+        const TEvPartitionDirectPrivate::TEvUpdateVChunkConfig::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleFastPathServiceShutdownDuringDelete(
+        const TEvPartitionDirectPrivate::TEvFastPathServiceShutdown::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleAddHostToDBGDuringDelete(
+        const TEvPartitionDirectPrivate::TEvAddHostToDBG::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void ReplyToDeleteWaiters(
+        const NActors::TActorContext& ctx,
+        const NProto::TError& error);
+
+    void FinishDelete(const NActors::TActorContext& ctx);
 
     // Rejects (logs + notifies the DBG) and returns false if the AddHost
     // request is invalid; true if it may proceed.

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_events_private.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_events_private.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "partition_direct_service.h"
+
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/public.h>
@@ -48,7 +50,8 @@ struct TEvPartitionDirectPrivate
               TEventLocal<TEvUpdateVChunkConfig, EvUpdateVChunkConfig>
     {
         TVChunkConfig VChunkConfig;
-        NThreading::TPromise<void> UpdateCompleted = NThreading::NewPromise();
+        TPersistResultPromise UpdateCompleted =
+            NThreading::NewPromise<EPersistResult>();
 
         explicit TEvUpdateVChunkConfig(TVChunkConfig cfg)
             : VChunkConfig(std::move(cfg))
@@ -61,7 +64,8 @@ struct TEvPartitionDirectPrivate
     {
         ui32 VChunkIndex;
         TDirtyMapStateProto State;
-        NThreading::TPromise<void> UpdateCompleted = NThreading::NewPromise();
+        TPersistResultPromise UpdateCompleted =
+            NThreading::NewPromise<EPersistResult>();
 
         TEvUpdateDirtyMapState(ui32 vChunkIndex, TDirtyMapStateProto state)
             : VChunkIndex(vChunkIndex)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_events_private.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_events_private.h
@@ -4,6 +4,8 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/public.h>
 
+#include <ydb/core/nbs/cloud/storage/core/libs/common/error.h>
+
 #include <ydb/core/base/events.h>
 
 #include <ydb/library/actors/core/event_local.h>
@@ -36,6 +38,7 @@ struct TEvPartitionDirectPrivate
         EvFastPathServiceStopped,
         EvPoisonByBlockedGeneration,
         EvAddHostToDBG,
+        EvPartitionCleanupCompleted,
 
         EvEnd,
     };
@@ -108,6 +111,21 @@ struct TEvPartitionDirectPrivate
         TEvAddHostToDBG(size_t dbgId, size_t newHostIndex)
             : DirectBlockGroupId(dbgId)
             , NewHostIndex(newHostIndex)
+        {}
+    };
+
+    // Cleanup actor reports wipe + BSC deallocate outcome to the tablet.
+    struct TEvPartitionCleanupCompleted
+        : public NActors::TEventLocal<
+              TEvPartitionCleanupCompleted,
+              EvPartitionCleanupCompleted>
+    {
+        NProto::TError Error;
+
+        TEvPartitionCleanupCompleted() = default;
+
+        explicit TEvPartitionCleanupCompleted(NProto::TError error)
+            : Error(std::move(error))
         {}
     };
 };

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service.h
@@ -19,6 +19,18 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Result of an asynchronous request to persist partition state.
+// Cancelled means the partition stopped before it could confirm completion.
+enum class EPersistResult
+{
+    Success,
+    Cancelled,
+};
+using TPersistResultFuture = NThreading::TFuture<EPersistResult>;
+using TPersistResultPromise = NThreading::TPromise<EPersistResult>;
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct IPartitionDirectService
 {
     virtual ~IPartitionDirectService() = default;
@@ -32,12 +44,12 @@ struct IPartitionDirectService
 
     // Asynchronously persists the given vchunk config to the partition's
     // local DB. Caller must ensure cfg.IsValid().
-    virtual NThreading::TFuture<void> UpdateVChunkConfig(
+    virtual TPersistResultFuture UpdateVChunkConfig(
         const NStorage::NPartitionDirect::TVChunkConfig& cfg) = 0;
 
     // Asynchronously persists the given TDirtyMapStateProto to the partition's
     // local DB.
-    virtual NThreading::TFuture<void> UpdateDirtyMapState(
+    virtual TPersistResultFuture UpdateDirtyMapState(
         ui32 vChunkIndex,
         TDirtyMapStateProto state) = 0;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service_mock.h
@@ -24,14 +24,14 @@ struct TPartitionDirectServiceMock: public IPartitionDirectService
     struct TUpdateConfigRequest
     {
         NStorage::NPartitionDirect::TVChunkConfig Config;
-        NThreading::TPromise<void> Promise;
+        TPersistResultPromise Promise;
     };
 
     struct TUpdateDirtyMapStateRequest
     {
         ui32 VChunkIndex = 0;
         TDirtyMapStateProto Proto;
-        NThreading::TPromise<void> Promise;
+        TPersistResultPromise Promise;
     };
 
     explicit TPartitionDirectServiceMock(bool dropScheduledCallbacks = false)
@@ -67,21 +67,23 @@ struct TPartitionDirectServiceMock: public IPartitionDirectService
         executor->ExecuteSimple(std::move(callback));
     }
 
-    NThreading::TFuture<void> UpdateVChunkConfig(
+    TPersistResultFuture UpdateVChunkConfig(
         const NStorage::NPartitionDirect::TVChunkConfig& cfg) override
     {
-        UpdateConfigRequests.emplace_back(cfg, NThreading::NewPromise());
+        UpdateConfigRequests.emplace_back(
+            cfg,
+            NThreading::NewPromise<EPersistResult>());
         return UpdateConfigRequests.back().Promise.GetFuture();
     }
 
-    NThreading::TFuture<void> UpdateDirtyMapState(
+    TPersistResultFuture UpdateDirtyMapState(
         ui32 vChunkIndex,
         TDirtyMapStateProto state) override
     {
         UpdateDirtyMapStateRequests.emplace_back(TUpdateDirtyMapStateRequest{
             .VChunkIndex = vChunkIndex,
             .Proto = std::move(state),
-            .Promise = NThreading::NewPromise()});
+            .Promise = NThreading::NewPromise<EPersistResult>()});
         return UpdateDirtyMapStateRequests.back().Promise.GetFuture();
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
@@ -191,6 +191,66 @@ ui64 CreatePartitionTablet(
     return PartitionTabletId;
 }
 
+TPersistResultFuture SendVChunkConfigUpdate(
+    TEnvironmentSetup& env,
+    ui64 partitionTabletId,
+    ui32 vChunkIndex)
+{
+    auto config = TVChunkConfig::MakeDefault(
+        vChunkIndex,
+        DirectBlockGroupHostCount,
+        DefaultPrimaryCount);
+
+    auto request =
+        std::make_unique<TEvPartitionDirectPrivate::TEvUpdateVChunkConfig>(
+            std::move(config));
+    auto future = request->UpdateCompleted.GetFuture();
+
+    const TActorId sender = env.Runtime->AllocateEdgeActor(
+        env.Settings.ControllerNodeId,
+        __FILE__,
+        __LINE__);
+    env.Runtime->SendToPipe(
+        partitionTabletId,
+        sender,
+        request.release(),
+        0,
+        TTestActorSystem::GetPipeConfigWithRetries());
+    env.Runtime->DestroyActor(sender);
+
+    return future;
+}
+
+TPersistResultFuture SendDirtyMapStateUpdate(
+    TEnvironmentSetup& env,
+    ui64 partitionTabletId,
+    ui32 vChunkIndex,
+    ui32 stateGeneration)
+{
+    TDirtyMapStateProto state;
+    state.SetStateGeneration(stateGeneration);
+
+    auto request =
+        std::make_unique<TEvPartitionDirectPrivate::TEvUpdateDirtyMapState>(
+            vChunkIndex,
+            std::move(state));
+    auto future = request->UpdateCompleted.GetFuture();
+
+    const TActorId sender = env.Runtime->AllocateEdgeActor(
+        env.Settings.ControllerNodeId,
+        __FILE__,
+        __LINE__);
+    env.Runtime->SendToPipe(
+        partitionTabletId,
+        sender,
+        request.release(),
+        0,
+        TTestActorSystem::GetPipeConfigWithRetries());
+    env.Runtime->DestroyActor(sender);
+
+    return future;
+}
+
 NProto::TError DeletePartition(
     TEnvironmentSetup& env,
     ui64 partitionTabletId,
@@ -983,6 +1043,268 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
 
         // The replay re-sent the BSController allocation request.
         UNIT_ASSERT_VALUES_EQUAL(2u, addHostRequestCount);
+    }
+
+    Y_UNIT_TEST(ShouldBatchDirtyMapStateUpdates)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+        const ui64 partition = CreatePartitionTablet(env);
+
+        TVector<std::unique_ptr<IEventHandle>> blockedCommits;
+        THashSet<ui32> releasedCommitSteps;
+        runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev)
+        {
+            if (ev->GetTypeRewrite() == TEvTablet::TEvCommit::EventType) {
+                auto* msg = ev->Get<TEvTablet::TEvCommit>();
+                if (msg->TabletID == partition &&
+                    !releasedCommitSteps.contains(msg->Step))
+                {
+                    blockedCommits.push_back(std::move(ev));
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        auto releaseCommit = [&](size_t index)
+        {
+            UNIT_ASSERT_C(
+                index < blockedCommits.size() && blockedCommits[index],
+                "commit is not blocked");
+            auto* msg = blockedCommits[index]->Get<TEvTablet::TEvCommit>();
+            releasedCommitSteps.insert(msg->Step);
+            runtime->Send(
+                std::move(blockedCommits[index]),
+                env.Settings.ControllerNodeId);
+        };
+
+        auto first = SendDirtyMapStateUpdate(env, partition, 0, 1);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(1u, blockedCommits.size());
+        UNIT_ASSERT(!first.HasValue());
+
+        TVector<TPersistResultFuture> batched;
+        batched.push_back(SendDirtyMapStateUpdate(env, partition, 1, 2));
+        batched.push_back(SendDirtyMapStateUpdate(env, partition, 2, 3));
+        batched.push_back(SendDirtyMapStateUpdate(env, partition, 3, 4));
+        env.Sim(TDuration::Seconds(1));
+
+        // While the first transaction is in flight, the remaining updates do
+        // not start their own transactions.
+        UNIT_ASSERT_VALUES_EQUAL(1u, blockedCommits.size());
+        for (const auto& future: batched) {
+            UNIT_ASSERT(!future.HasValue());
+        }
+
+        releaseCommit(0);
+        env.Sim(TDuration::Seconds(1));
+
+        // All pending updates are persisted by one transaction. Its promises
+        // stay unresolved until the common commit completes.
+        UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommits.size());
+        UNIT_ASSERT(first.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(EPersistResult::Success, first.GetValue());
+        for (const auto& future: batched) {
+            UNIT_ASSERT(!future.HasValue());
+        }
+
+        releaseCommit(1);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommits.size());
+        for (const auto& future: batched) {
+            UNIT_ASSERT(future.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(
+                EPersistResult::Success,
+                future.GetValue());
+        }
+
+        // Completion of a batch resets the in-flight state: a later update
+        // starts and completes a new transaction normally.
+        auto next = SendDirtyMapStateUpdate(env, partition, 4, 5);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(3u, blockedCommits.size());
+        UNIT_ASSERT(!next.HasValue());
+
+        releaseCommit(2);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT(next.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(EPersistResult::Success, next.GetValue());
+
+        runtime->FilterFunction = {};
+    }
+
+    Y_UNIT_TEST(ShouldBatchVChunkConfigUpdates)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+        const ui64 partition = CreatePartitionTablet(env);
+
+        TVector<std::unique_ptr<IEventHandle>> blockedCommits;
+        THashSet<ui32> releasedCommitSteps;
+        runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev)
+        {
+            if (ev->GetTypeRewrite() == TEvTablet::TEvCommit::EventType) {
+                auto* msg = ev->Get<TEvTablet::TEvCommit>();
+                if (msg->TabletID == partition &&
+                    !releasedCommitSteps.contains(msg->Step))
+                {
+                    blockedCommits.push_back(std::move(ev));
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        auto releaseCommit = [&](size_t index)
+        {
+            UNIT_ASSERT_C(
+                index < blockedCommits.size() && blockedCommits[index],
+                "commit is not blocked");
+            auto* msg = blockedCommits[index]->Get<TEvTablet::TEvCommit>();
+            releasedCommitSteps.insert(msg->Step);
+            runtime->Send(
+                std::move(blockedCommits[index]),
+                env.Settings.ControllerNodeId);
+        };
+
+        auto first = SendVChunkConfigUpdate(env, partition, 0);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(1u, blockedCommits.size());
+        UNIT_ASSERT(!first.HasValue());
+
+        TVector<TPersistResultFuture> batched;
+        batched.push_back(SendVChunkConfigUpdate(env, partition, 1));
+        batched.push_back(SendVChunkConfigUpdate(env, partition, 2));
+        batched.push_back(SendVChunkConfigUpdate(env, partition, 3));
+        env.Sim(TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(1u, blockedCommits.size());
+        for (const auto& future: batched) {
+            UNIT_ASSERT(!future.HasValue());
+        }
+
+        releaseCommit(0);
+        env.Sim(TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommits.size());
+        UNIT_ASSERT(first.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(EPersistResult::Success, first.GetValue());
+        for (const auto& future: batched) {
+            UNIT_ASSERT(!future.HasValue());
+        }
+
+        releaseCommit(1);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommits.size());
+        for (const auto& future: batched) {
+            UNIT_ASSERT(future.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(
+                EPersistResult::Success,
+                future.GetValue());
+        }
+
+        auto next = SendVChunkConfigUpdate(env, partition, 4);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(3u, blockedCommits.size());
+        UNIT_ASSERT(!next.HasValue());
+
+        releaseCommit(2);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT(next.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(EPersistResult::Success, next.GetValue());
+    }
+
+    Y_UNIT_TEST(ShouldFailStateUpdatesWhenPartitionStops)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+        TActorId bootstrapperId;
+        const ui64 partition =
+            CreatePartitionTablet(env, 32768, &bootstrapperId);
+
+        TVector<std::unique_ptr<IEventHandle>> blockedCommitResults;
+        bool bootstrapperDeathObserved = false;
+        runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev)
+        {
+            if (ev->GetTypeRewrite() == TEvTablet::TEvCommitResult::EventType) {
+                auto* msg = ev->Get<TEvTablet::TEvCommitResult>();
+                if (msg->TabletID == partition) {
+                    blockedCommitResults.push_back(std::move(ev));
+                    return false;
+                }
+            }
+
+            if (ev->GetTypeRewrite() == TEvTablet::TEvTabletDead::EventType) {
+                auto* msg = ev->Get<TEvTablet::TEvTabletDead>();
+                if (msg->TabletID == partition &&
+                    ev->GetRecipientRewrite() == bootstrapperId)
+                {
+                    bootstrapperDeathObserved = true;
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        auto executingConfig = SendVChunkConfigUpdate(env, partition, 0);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(1u, blockedCommitResults.size());
+
+        auto pendingConfig = SendVChunkConfigUpdate(env, partition, 1);
+        auto executingDirtyMap = SendDirtyMapStateUpdate(env, partition, 0, 1);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommitResults.size());
+
+        auto pendingDirtyMap = SendDirtyMapStateUpdate(env, partition, 1, 2);
+        env.Sim(TDuration::Seconds(1));
+
+        UNIT_ASSERT(!executingConfig.HasValue());
+        UNIT_ASSERT(!pendingConfig.HasValue());
+        UNIT_ASSERT(!executingDirtyMap.HasValue());
+        UNIT_ASSERT(!pendingDirtyMap.HasValue());
+
+        const TActorId sender = runtime->AllocateEdgeActor(
+            env.Settings.ControllerNodeId,
+            __FILE__,
+            __LINE__);
+        runtime->SendToPipe(
+            partition,
+            sender,
+            new TEvPartitionDirectPrivate::TEvPoison("test shutdown"),
+            0,
+            TTestActorSystem::GetPipeConfigWithRetries());
+        runtime->DestroyActor(sender);
+
+        env.Sim(TDuration::Seconds(10));
+
+        UNIT_ASSERT(bootstrapperDeathObserved);
+        for (const auto& future:
+             {executingConfig,
+              pendingConfig,
+              executingDirtyMap,
+              pendingDirtyMap})
+        {
+            UNIT_ASSERT(future.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(
+                EPersistResult::Cancelled,
+                future.GetValue());
+        }
     }
 
     Y_UNIT_TEST(BasicWriteReadPBufferReplication)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
@@ -2,6 +2,7 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/api/service.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_cleanup_actor.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region.h>
 
@@ -14,6 +15,12 @@
 #include <ydb/library/actors/core/mon.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+#include <util/string/builder.h>
+
+#include <set>
 
 using namespace NKikimr;
 
@@ -184,6 +191,62 @@ ui64 CreatePartitionTablet(
     return PartitionTabletId;
 }
 
+NProto::TError DeletePartition(
+    TEnvironmentSetup& env,
+    ui64 partitionTabletId,
+    const TActorId& edge)
+{
+    auto request = std::make_unique<TEvService::TEvDeletePartitionRequest>();
+    env.Runtime->SendToPipe(
+        partitionTabletId,
+        edge,
+        request.release(),
+        0,
+        TTestActorSystem::GetPipeConfigWithRetries());
+
+    auto res =
+        env.WaitForEdgeActorEvent<TEvService::TEvDeletePartitionResponse>(
+            edge,
+            false);
+    UNIT_ASSERT(res);
+    return res->Get()->GetError();
+}
+
+NKikimrBlobStorage::TEvControllerAllocateDDiskBlockGroupResult
+SendBscDirectBlockGroupOperation(
+    TEnvironmentSetup& env,
+    ui64 tabletId,
+    ui64 directBlockGroupId,
+    const std::function<void(
+        NKikimrBlobStorage::TEvControllerAllocateDDiskBlockGroup::
+            TDirectBlockGroupOperation*)>& fill)
+{
+    auto ev = std::make_unique<
+        TEvBlobStorage::TEvControllerAllocateDDiskBlockGroup>();
+    auto& r = ev->Record;
+    r.SetDDiskPoolName(DDiskPoolName);
+    r.SetPersistentBufferDDiskPoolName(PersistentBufferDDiskPoolName);
+    r.SetTabletId(tabletId);
+    auto* op = r.AddDirectBlockGroupOperations();
+    op->SetDirectBlockGroupId(directBlockGroupId);
+    fill(op);
+
+    const TActorId edge = env.Runtime->AllocateEdgeActor(
+        env.Settings.ControllerNodeId,
+        __FILE__,
+        __LINE__);
+    env.Runtime->SendToPipe(
+        MakeBSControllerID(),
+        edge,
+        ev.release(),
+        0,
+        TTestActorSystem::GetPipeConfigWithRetries());
+    auto response = env.WaitForEdgeActorEvent<
+        TEvBlobStorage::TEvControllerAllocateDDiskBlockGroupResult>(edge);
+    UNIT_ASSERT(response);
+    return response->Get()->Record;
+}
+
 void StopFastPathService(
     TEnvironmentSetup& env,
     ui64 partitionTabletId,
@@ -203,7 +266,7 @@ void StopFastPathService(
     UNIT_ASSERT(res);
 }
 
-TActorId GetLoadActorAdapterActorId(
+TActorId TryGetLoadActorAdapterActorId(
     TEnvironmentSetup& env,
     ui64 partitionTabletId,
     const TActorId& edge)
@@ -220,11 +283,20 @@ TActorId GetLoadActorAdapterActorId(
     auto res = env.WaitForEdgeActorEvent<
         TEvService::TEvGetLoadActorAdapterActorIdResponse>(edge, false);
     UNIT_ASSERT(res);
-    UNIT_ASSERT(!res->Get()->Record.GetActorId().empty());
     NActors::TActorId loadActorAdapter;
-    loadActorAdapter.Parse(
-        res->Get()->Record.GetActorId().data(),
-        res->Get()->Record.GetActorId().size());
+    const auto& actorIdStr = res->Get()->Record.GetActorId();
+    UNIT_ASSERT(loadActorAdapter.Parse(actorIdStr.data(), actorIdStr.size()));
+    return loadActorAdapter;
+}
+
+TActorId GetLoadActorAdapterActorId(
+    TEnvironmentSetup& env,
+    ui64 partitionTabletId,
+    const TActorId& edge)
+{
+    auto loadActorAdapter =
+        TryGetLoadActorAdapterActorId(env, partitionTabletId, edge);
+    UNIT_ASSERT(loadActorAdapter);
     return loadActorAdapter;
 }
 
@@ -250,6 +322,53 @@ void WriteBlock(
         S_OK,
         res->Get()->Record.GetError().GetCode(),
         FormatError(res->Get()->Record.GetError()));
+}
+
+void WriteBlockExpectFailure(
+    TEnvironmentSetup& env,
+    const TActorId& loadActorAdapter,
+    const TActorId& edge,
+    ui64 index,
+    const TString& data)
+{
+    auto request = std::make_unique<TEvService::TEvWriteBlocksRequest>();
+    request->Record.SetStartIndex(index);
+    request->Record.MutableBlocks()->AddBuffers(data);
+
+    env.Runtime->Send(
+        new IEventHandle(
+            loadActorAdapter,
+            edge,
+            request.release(),
+            IEventHandle::FlagTrackDelivery),
+        edge.NodeId());
+
+    auto ev = env.Runtime->WaitForEdgeActorEvent({edge});
+    if (ev->GetTypeRewrite() == TEvService::TEvWriteBlocksResponse::EventType) {
+        const auto& error =
+            ev->Get<TEvService::TEvWriteBlocksResponse>()->Record.GetError();
+        UNIT_ASSERT_C(error.GetCode() != S_OK, FormatError(error));
+        return;
+    }
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        NActors::TEvents::TEvUndelivered::EventType,
+        ev->GetTypeRewrite());
+}
+
+TString DDiskKey(const NKikimrBlobStorage::NDDisk::TDDiskId& id)
+{
+    return TStringBuilder() << id.GetNodeId() << ":" << id.GetPDiskId() << ":"
+                            << id.GetDDiskSlotId();
+}
+
+ui32 UniqueDDiskCount(const TVector<NKikimrBlobStorage::NDDisk::TDDiskId>& ids)
+{
+    THashSet<TString> keys;
+    for (const auto& id: ids) {
+        keys.insert(DDiskKey(id));
+    }
+    return keys.size();
 }
 
 TString ReadBlock(
@@ -1794,6 +1913,586 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
         UNIT_ASSERT_VALUES_EQUAL(
             defaultCount + 3,
             roundTrips[3].RequestedNumDDisks);
+    }
+
+    Y_UNIT_TEST(ShouldDeletePartition)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+        runtime->SetLogPriority(
+            NKikimrServices::NBS_PARTITION,
+            NActors::NLog::PRI_DEBUG);
+
+        TVector<NKikimrBlobStorage::NDDisk::TDDiskId> allocatedDDisks;
+        TVector<NKikimrBlobStorage::NDDisk::TDDiskId> allocatedPBuffers;
+        ui32 deallocateRequestCount = 0;
+
+        // Wipe traffic: Max-lsn barrier erase hits every PBuffer;
+        // DeleteTabletChunks hits every DDisk. Match request↔result by
+        // (sender, cookie): request.Sender / result.Recipient are the
+        // cleanup actor. Do not use the DDisk service id — RegisterService
+        // aliases it to a different actor SelfId that appears as result.Sender.
+        using TTransportCookie = std::pair<TActorId, ui64>;
+        THashSet<TTransportCookie> pendingWipeBarriers;
+        THashSet<TTransportCookie> wipeBarrierOks;
+        THashSet<TTransportCookie> pendingDeleteChunks;
+        THashSet<TTransportCookie> deleteChunksOks;
+        bool captureWipeTraffic = false;
+        bool deallocateBeforeWipeDone = false;
+        bool deleteChunksBeforeWipeDone = false;
+        ui32 deallocateOpSize = 0;
+        bool deallocateOpMalformed = false;
+
+        runtime->FilterFunction =
+            [&](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev)
+        {
+            const ui32 type = ev->GetTypeRewrite();
+            if (type ==
+                TEvBlobStorage::TEvControllerAllocateDDiskBlockGroupResult::
+                    EventType)
+            {
+                auto* msg =
+                    ev->Get<TEvBlobStorage::
+                                TEvControllerAllocateDDiskBlockGroupResult>();
+                if (msg->Record.GetStatus() == NKikimrProto::OK &&
+                    allocatedDDisks.empty())
+                {
+                    for (const auto& response: msg->Record.GetResponses()) {
+                        for (const auto& node: response.GetNodes()) {
+                            if (node.HasDDiskId()) {
+                                allocatedDDisks.push_back(node.GetDDiskId());
+                            }
+                            if (node.HasPersistentBufferDDiskId()) {
+                                allocatedPBuffers.push_back(
+                                    node.GetPersistentBufferDDiskId());
+                            }
+                        }
+                    }
+                }
+            }
+            if (type ==
+                TEvBlobStorage::TEvControllerAllocateDDiskBlockGroup::EventType)
+            {
+                auto* msg = ev->Get<
+                    TEvBlobStorage::TEvControllerAllocateDDiskBlockGroup>();
+                if (msg->Record.DirectBlockGroupOperationsSize() > 0 &&
+                    msg->Record.GetDirectBlockGroupOperations(0)
+                        .HasDefineDirectBlockGroup() &&
+                    msg->Record.GetDirectBlockGroupOperations(0)
+                            .GetDefineDirectBlockGroup()
+                            .GetNumDDisks() == 0)
+                {
+                    if (!pendingDeleteChunks.empty()) {
+                        deallocateBeforeWipeDone = true;
+                    }
+                    ++deallocateRequestCount;
+                    deallocateOpSize =
+                        msg->Record.DirectBlockGroupOperationsSize();
+                    for (const auto& op:
+                         msg->Record.GetDirectBlockGroupOperations())
+                    {
+                        if (!op.HasDefineDirectBlockGroup()) {
+                            deallocateOpMalformed = true;
+                            continue;
+                        }
+                        const auto& def = op.GetDefineDirectBlockGroup();
+                        if (def.GetNumDDisks() != 0 ||
+                            def.GetNumChunksPerDDisk() != 0 ||
+                            def.GetNumPersistentBuffers() != 0)
+                        {
+                            deallocateOpMalformed = true;
+                        }
+                    }
+                }
+            }
+            if (captureWipeTraffic) {
+                if (type == NDDisk::TEvErasePersistentBuffer::EventType) {
+                    const auto& record =
+                        ev->Get<NDDisk::TEvErasePersistentBuffer>()->Record;
+                    // Partition wipe sends Max<ui64>(); background cleanup uses
+                    // a finite watermark and must not be counted here.
+                    if (record.GetLsn() == Max<ui64>()) {
+                        pendingWipeBarriers.insert({ev->Sender, ev->Cookie});
+                    }
+                }
+                if (type == NDDisk::TEvErasePersistentBufferResult::EventType) {
+                    const TTransportCookie key{
+                        ev->GetRecipientRewrite(),
+                        ev->Cookie};
+                    if (pendingWipeBarriers.contains(key)) {
+                        const auto& record =
+                            ev->Get<NDDisk::TEvErasePersistentBufferResult>()
+                                ->Record;
+                        if (record.GetStatus() ==
+                            NKikimrBlobStorage::NDDisk::TReplyStatus::OK)
+                        {
+                            wipeBarrierOks.insert(key);
+                        }
+                        pendingWipeBarriers.erase(key);
+                    }
+                }
+                if (type == NDDisk::TEvDeleteTabletChunks::EventType) {
+                    if (!pendingWipeBarriers.empty()) {
+                        deleteChunksBeforeWipeDone = true;
+                    }
+                    pendingDeleteChunks.insert({ev->Sender, ev->Cookie});
+                }
+                if (type == NDDisk::TEvDeleteTabletChunksResult::EventType) {
+                    const TTransportCookie key{
+                        ev->GetRecipientRewrite(),
+                        ev->Cookie};
+                    if (pendingDeleteChunks.contains(key)) {
+                        const auto& record =
+                            ev->Get<NDDisk::TEvDeleteTabletChunksResult>()
+                                ->Record;
+                        if (record.GetStatus() ==
+                            NKikimrBlobStorage::NDDisk::TReplyStatus::OK)
+                        {
+                            deleteChunksOks.insert(key);
+                        }
+                        pendingDeleteChunks.erase(key);
+                    }
+                }
+            }
+            return true;
+        };
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+        auto partition = CreatePartitionTablet(env);
+
+        const TActorId& edge = runtime->AllocateEdgeActor(
+            env.Settings.ControllerNodeId,
+            __FILE__,
+            __LINE__);
+
+        auto loadActorAdapter =
+            GetLoadActorAdapterActorId(env, partition, edge);
+        const TString data = NUnitTest::RandomString(DefaultBlockSize, 42);
+        WriteBlock(env, loadActorAdapter, edge, 0, data);
+
+        UNIT_ASSERT(!allocatedDDisks.empty());
+        UNIT_ASSERT(!allocatedPBuffers.empty());
+
+        captureWipeTraffic = true;
+        const auto error = DeletePartition(env, partition, edge);
+        UNIT_ASSERT_VALUES_EQUAL_C(0u, error.GetCode(), FormatError(error));
+        UNIT_ASSERT_VALUES_EQUAL(1u, deallocateRequestCount);
+        UNIT_ASSERT(!deallocateBeforeWipeDone);
+        UNIT_ASSERT(!deleteChunksBeforeWipeDone);
+        UNIT_ASSERT_VALUES_EQUAL(DirectBlockGroupsCount, deallocateOpSize);
+        UNIT_ASSERT(!deallocateOpMalformed);
+
+        UNIT_ASSERT(!TryGetLoadActorAdapterActorId(env, partition, edge));
+        WriteBlockExpectFailure(
+            env,
+            loadActorAdapter,
+            edge,
+            0,
+            NUnitTest::RandomString(DefaultBlockSize, 7));
+
+        // Every unique allocated PBuffer got a Max-lsn barrier erase and
+        // replied OK.
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            UniqueDDiskCount(allocatedPBuffers),
+            wipeBarrierOks.size(),
+            "wipe barrier-erase OK replies vs unique allocated PBuffers");
+        UNIT_ASSERT_C(
+            pendingWipeBarriers.empty(),
+            "unanswered wipe barrier-erase keys: "
+                << pendingWipeBarriers.size());
+
+        // Every unique allocated DDisk got DeleteTabletChunks and replied OK.
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            UniqueDDiskCount(allocatedDDisks),
+            deleteChunksOks.size(),
+            "DeleteTabletChunks OK replies vs unique allocated DDisks");
+        UNIT_ASSERT_C(
+            pendingDeleteChunks.empty(),
+            "unanswered DeleteTabletChunks keys: "
+                << pendingDeleteChunks.size());
+
+        // BSController must have released every previously allocated entity:
+        // re-deleting any of them returns NOT_FOUND.
+        {
+            const auto& ddisk = allocatedDDisks.front();
+            auto rr = SendBscDirectBlockGroupOperation(
+                env,
+                partition,
+                /*directBlockGroupId=*/0,
+                [&](auto* op)
+                { op->AddDeleteDDisks()->MutableDDiskId()->CopyFrom(ddisk); });
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                NKikimrProto::NOT_FOUND,
+                rr.GetStatus(),
+                rr.GetErrorReason());
+        }
+        {
+            const auto& pbuffer = allocatedPBuffers.front();
+            auto rr = SendBscDirectBlockGroupOperation(
+                env,
+                partition,
+                /*directBlockGroupId=*/0,
+                [&](auto* op)
+                {
+                    op->AddDeletePersistentBuffers()
+                        ->MutablePersistentBufferId()
+                        ->CopyFrom(pbuffer);
+                });
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                NKikimrProto::NOT_FOUND,
+                rr.GetStatus(),
+                rr.GetErrorReason());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldDeletePartitionIdempotently)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+        runtime->SetLogPriority(
+            NKikimrServices::NBS_PARTITION,
+            NActors::NLog::PRI_DEBUG);
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+        auto partition = CreatePartitionTablet(env);
+
+        const TActorId& edge = runtime->AllocateEdgeActor(
+            env.Settings.ControllerNodeId,
+            __FILE__,
+            __LINE__);
+
+        {
+            const auto error = DeletePartition(env, partition, edge);
+            UNIT_ASSERT_VALUES_EQUAL_C(0u, error.GetCode(), FormatError(error));
+        }
+        {
+            // Second delete after teardown finished is a no-op.
+            const auto error = DeletePartition(env, partition, edge);
+            UNIT_ASSERT_VALUES_EQUAL_C(0u, error.GetCode(), FormatError(error));
+        }
+
+        UNIT_ASSERT(!TryGetLoadActorAdapterActorId(env, partition, edge));
+    }
+
+    Y_UNIT_TEST(ShouldFailDeleteWhenBscPipeBreaksDuringDeallocate)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+        runtime->SetLogPriority(
+            NKikimrServices::NBS_PARTITION,
+            NActors::NLog::PRI_DEBUG);
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+
+        TActorId lastBscPipeClient;
+        TActorId lastBscPipeOwner;
+        bool injectPipeBreak = true;
+
+        runtime->FilterFunction =
+            [&](ui32 nodeId, std::unique_ptr<IEventHandle>& ev)
+        {
+            const ui32 type = ev->GetTypeRewrite();
+            if (type == TEvTabletPipe::TEvClientConnected::EventType) {
+                const auto* msg = ev->Get<TEvTabletPipe::TEvClientConnected>();
+                if (msg->TabletId == MakeBSControllerID()) {
+                    lastBscPipeClient = msg->ClientId;
+                    lastBscPipeOwner = ev->GetRecipientRewrite();
+                }
+            }
+            if (injectPipeBreak &&
+                type == TEvBlobStorage::TEvControllerAllocateDDiskBlockGroup::
+                            EventType)
+            {
+                auto* msg = ev->Get<
+                    TEvBlobStorage::TEvControllerAllocateDDiskBlockGroup>();
+                if (msg->Record.DirectBlockGroupOperationsSize() > 0 &&
+                    msg->Record.GetDirectBlockGroupOperations(0)
+                        .HasDefineDirectBlockGroup() &&
+                    msg->Record.GetDirectBlockGroupOperations(0)
+                            .GetDefineDirectBlockGroup()
+                            .GetNumDDisks() == 0 &&
+                    lastBscPipeClient && lastBscPipeOwner)
+                {
+                    injectPipeBreak = false;
+                    // Drop the deallocate and fail the in-flight delete via
+                    // the cleanup actor that owns the BSC pipe.
+                    runtime->Schedule(
+                        TDuration::MilliSeconds(1),
+                        new IEventHandle(
+                            lastBscPipeOwner,
+                            lastBscPipeClient,
+                            new TEvTabletPipe::TEvClientDestroyed(
+                                MakeBSControllerID(),
+                                lastBscPipeClient,
+                                TActorId())),
+                        nullptr,
+                        nodeId);
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        auto partition = CreatePartitionTablet(env);
+        UNIT_ASSERT(lastBscPipeOwner);
+
+        const TActorId& edge = runtime->AllocateEdgeActor(
+            env.Settings.ControllerNodeId,
+            __FILE__,
+            __LINE__);
+        Y_UNUSED(GetLoadActorAdapterActorId(env, partition, edge));
+
+        const auto error = DeletePartition(env, partition, edge);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            error.GetCode(),
+            FormatError(error));
+
+        // A retry after the pipe failure must still be able to finish.
+        const auto error2 = DeletePartition(env, partition, edge);
+        UNIT_ASSERT_VALUES_EQUAL_C(0u, error2.GetCode(), FormatError(error2));
+    }
+
+    Y_UNIT_TEST(ShouldFailDeleteWhenPBufferEraseIsOverloaded)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+        runtime->SetLogPriority(
+            NKikimrServices::NBS_PARTITION,
+            NActors::NLog::PRI_DEBUG);
+
+        bool injectOverload = true;
+        THashSet<std::pair<TActorId, ui64>> wipeCookies;
+        runtime->FilterFunction =
+            [&](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev)
+        {
+            const ui32 type = ev->GetTypeRewrite();
+            if (type == NDDisk::TEvErasePersistentBuffer::EventType) {
+                const auto& record =
+                    ev->Get<NDDisk::TEvErasePersistentBuffer>()->Record;
+                if (record.GetLsn() == Max<ui64>()) {
+                    wipeCookies.insert({ev->Sender, ev->Cookie});
+                }
+                return true;
+            }
+            if (!injectOverload ||
+                type != NDDisk::TEvErasePersistentBufferResult::EventType)
+            {
+                return true;
+            }
+            const std::pair<TActorId, ui64> key{
+                ev->GetRecipientRewrite(),
+                ev->Cookie};
+            if (!wipeCookies.contains(key)) {
+                return true;
+            }
+            auto* msg = ev->Get<NDDisk::TEvErasePersistentBufferResult>();
+            if (msg->Record.GetStatus() !=
+                NKikimrBlobStorage::NDDisk::TReplyStatus::OK)
+            {
+                return true;
+            }
+            injectOverload = false;
+            msg->Record.SetStatus(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::OVERLOADED);
+            msg->Record.SetErrorReason("injected overload");
+            return true;
+        };
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+        auto partition = CreatePartitionTablet(env);
+
+        const TActorId& edge = runtime->AllocateEdgeActor(
+            env.Settings.ControllerNodeId,
+            __FILE__,
+            __LINE__);
+        Y_UNUSED(GetLoadActorAdapterActorId(env, partition, edge));
+
+        const auto error = DeletePartition(env, partition, edge);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            error.GetCode(),
+            FormatError(error));
+
+        const auto error2 = DeletePartition(env, partition, edge);
+        UNIT_ASSERT_VALUES_EQUAL_C(0u, error2.GetCode(), FormatError(error2));
+    }
+
+    Y_UNIT_TEST(ShouldFailDeleteWhenDDiskDeleteChunksIsUndelivered)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+        runtime->SetLogPriority(
+            NKikimrServices::NBS_PARTITION,
+            NActors::NLog::PRI_DEBUG);
+
+        bool injectUndelivery = true;
+        runtime->FilterFunction =
+            [&](ui32 nodeId, std::unique_ptr<IEventHandle>& ev)
+        {
+            if (!injectUndelivery) {
+                return true;
+            }
+            if (ev->GetTypeRewrite() !=
+                NDDisk::TEvDeleteTabletChunks::EventType)
+            {
+                return true;
+            }
+            injectUndelivery = false;
+            runtime->Send(
+                new IEventHandle(
+                    ev->Sender,
+                    ev->GetRecipientRewrite(),
+                    new NActors::TEvents::TEvUndelivered(
+                        NDDisk::TEvDeleteTabletChunks::EventType,
+                        NActors::TEvents::TEvUndelivered::Disconnected),
+                    0,
+                    ev->Cookie),
+                nodeId);
+            return false;
+        };
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+        auto partition = CreatePartitionTablet(env);
+
+        const TActorId& edge = runtime->AllocateEdgeActor(
+            env.Settings.ControllerNodeId,
+            __FILE__,
+            __LINE__);
+        Y_UNUSED(GetLoadActorAdapterActorId(env, partition, edge));
+
+        const auto error = DeletePartition(env, partition, edge);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            error.GetCode(),
+            FormatError(error));
+
+        const auto error2 = DeletePartition(env, partition, edge);
+        UNIT_ASSERT_VALUES_EQUAL_C(0u, error2.GetCode(), FormatError(error2));
+    }
+
+    Y_UNIT_TEST(ShouldReplyToConcurrentDeletePartitionRequests)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+        runtime->SetLogPriority(
+            NKikimrServices::NBS_PARTITION,
+            NActors::NLog::PRI_DEBUG);
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+        auto partition = CreatePartitionTablet(env);
+
+        const TActorId& edge1 = runtime->AllocateEdgeActor(
+            env.Settings.ControllerNodeId,
+            __FILE__,
+            __LINE__);
+        const TActorId& edge2 = runtime->AllocateEdgeActor(
+            env.Settings.ControllerNodeId,
+            __FILE__,
+            __LINE__);
+        Y_UNUSED(GetLoadActorAdapterActorId(env, partition, edge1));
+
+        auto sendDelete = [&](const TActorId& edge)
+        {
+            auto request =
+                std::make_unique<TEvService::TEvDeletePartitionRequest>();
+            runtime->SendToPipe(
+                partition,
+                edge,
+                request.release(),
+                0,
+                TTestActorSystem::GetPipeConfigWithRetries());
+        };
+
+        sendDelete(edge1);
+        sendDelete(edge2);
+
+        // Wait on both edges together so pipe ClientConnected on the second
+        // edge is consumed instead of crashing an unattended edge actor.
+        std::set<TActorId> ids{edge1, edge2};
+        THashMap<TActorId, NProto::TError> errors;
+        while (errors.size() < 2) {
+            auto ev = runtime->WaitForEdgeActorEvent(ids);
+            if (ev->GetTypeRewrite() !=
+                TEvService::TEvDeletePartitionResponse::EventType)
+            {
+                continue;
+            }
+            errors[ev->GetRecipientRewrite()] =
+                ev->Get<TEvService::TEvDeletePartitionResponse>()->GetError();
+        }
+
+        for (const auto& [actorId, error]: errors) {
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                0u,
+                error.GetCode(),
+                FormatError(error) << " from " << actorId);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldFailDeleteWhenWipeReplyIsLost)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+        runtime->SetLogPriority(
+            NKikimrServices::NBS_PARTITION,
+            NActors::NLog::PRI_DEBUG);
+
+        bool dropResult = true;
+        runtime->FilterFunction =
+            [&](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev)
+        {
+            if (!dropResult) {
+                return true;
+            }
+            if (ev->GetTypeRewrite() !=
+                NDDisk::TEvDeleteTabletChunksResult::EventType)
+            {
+                return true;
+            }
+            dropResult = false;
+            return false;
+        };
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+        auto partition = CreatePartitionTablet(env);
+
+        const TActorId& edge = runtime->AllocateEdgeActor(
+            env.Settings.ControllerNodeId,
+            __FILE__,
+            __LINE__);
+        Y_UNUSED(GetLoadActorAdapterActorId(env, partition, edge));
+
+        const auto error = DeletePartition(env, partition, edge);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_TIMEOUT,
+            error.GetCode(),
+            FormatError(error));
+        UNIT_ASSERT_STRING_CONTAINS(error.GetMessage(), "timed out");
+
+        const auto error2 = DeletePartition(env, partition, edge);
+        UNIT_ASSERT_VALUES_EQUAL_C(0u, error2.GetCode(), FormatError(error2));
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -937,9 +937,11 @@ void TVChunk::DoPersistDirtyMap()
         [weakSelf = weak_from_this(),
          executor = Executor,
          stateGeneration]   //
-        (const TFuture<void>& f) mutable
+        (const TPersistResultFuture& f) mutable
         {
-            Y_UNUSED(f);
+            if (f.GetValue() != EPersistResult::Success) {
+                return;
+            }
             executor->ExecuteSimple(
                 [weakSelf = std::move(weakSelf), stateGeneration]()
                 {
@@ -1089,10 +1091,11 @@ void TVChunk::PersistNextPendingConfig()
         PartitionDirectService->UpdateVChunkConfig(pending.Config);
     onPersisted.Subscribe(
         [weakSelf = weak_from_this(), executor = Executor]   //
-        (const TFuture<void>& f)
+        (const TPersistResultFuture& f) mutable
         {
-            Y_UNUSED(f);
-
+            if (f.GetValue() != EPersistResult::Success) {
+                return;
+            }
             executor->ExecuteSimple(
                 [weakSelf = std::move(weakSelf)]()
                 {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 GENERATE_ENUM_SERIALIZATION(ddisk_data_copier.h)
 GENERATE_ENUM_SERIALIZATION(direct_block_group_impl.h)
+GENERATE_ENUM_SERIALIZATION(partition_direct_service.h)
 
 SRCS(
     ddisk_data_copier.cpp

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
@@ -21,6 +21,7 @@ SRCS(
     part_updatevchunkconfig.cpp
     part_updatedirtymapstate.cpp
     part_monitoring.cpp
+    partition_cleanup_actor.cpp
     partition_direct_actor.cpp
     partition_direct.cpp
     read_request_executor.cpp

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_createvolume.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_createvolume.cpp
@@ -31,6 +31,18 @@ ui64 GetBlocksCount(const TVolumeConfig& config)
     return res;
 }
 
+ui64 GetPartitionTabletIdFromPathDesc(
+    const NKikimrSchemeOp::TPathDescription& pathDescription)
+{
+    const auto& volumeDescription =
+        pathDescription.GetBlockStoreVolumeDescription();
+    if (volumeDescription.PartitionsSize() == 0) {
+        return 0;
+    }
+
+    return volumeDescription.GetPartitions(0).GetTabletId();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TCreateVolumeActor final: public TActorBootstrapped<TCreateVolumeActor>
@@ -424,7 +436,10 @@ void TCreateVolumeActor::HandleDescribeVolumeBeforeCreateResponse(
     ReplyAndDie(
         ctx,
         std::make_unique<TEvSSProxy::TEvCreateVolumeResponse>(
-            MakeError(S_ALREADY)));
+            MakeError(S_ALREADY),
+            NKikimrScheme::StatusSuccess,
+            TString(),   // reason
+            GetPartitionTabletIdFromPathDesc(pathDescription)));
 }
 
 void TCreateVolumeActor::HandleCreateVolumeResponse(
@@ -580,7 +595,12 @@ void TCreateVolumeActor::HandleDescribeVolumeAfterCreateResponse(
         return;
     }
 
-    ReplyAndDie(ctx, std::make_unique<TEvSSProxy::TEvCreateVolumeResponse>());
+    ReplyAndDie(
+        ctx,
+        std::make_unique<TEvSSProxy::TEvCreateVolumeResponse>(
+            NKikimrScheme::StatusSuccess,
+            TString(),   // reason
+            GetPartitionTabletIdFromPathDesc(pathDescription)));
 }
 
 void TCreateVolumeActor::ReplyAndDie(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_direct_storage_transport.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_direct_storage_transport.cpp
@@ -488,7 +488,7 @@ TICDirectStorageTransport::WriteToDDisk(
     const auto& sglist = guard.Get();
     TRope rope = TRope::Uninitialized(SgListGetSize(sglist));
     SgListCopy(sglist, CreateSgList(rope));
-    request->AddPayload(std::move(rope));
+    request->AddPayloadThenChecksum(std::move(rope));
 
     auto promise = NewPromise<TEvWriteResult>();
     auto future = promise.GetFuture();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport_actor.cpp
@@ -568,7 +568,7 @@ void TICStorageTransportActor::HandleWriteToDDisk(
         const auto& sglist = guard.Get();
         TRope rope = TRope::Uninitialized(SgListGetSize(sglist));
         SgListCopy(sglist, CreateSgList(rope));
-        request->AddPayload(std::move(rope));
+        request->AddPayloadThenChecksum(std::move(rope));
 
         SendWithUndeliveryTracking(
             ctx,

--- a/ydb/core/protos/blobstorage_ddisk.proto
+++ b/ydb/core/protos/blobstorage_ddisk.proto
@@ -194,8 +194,8 @@ message TEvWrite {
 
     // Sender-computed checksum per MinSectorSize (4 KiB) block of the payload, in order. Each value is a
     // raw XXH3_64(data) over that block only: no tablet/vchunk identity or salt is mixed in (this is a
-    // transport-level checksum, distinct from the on-disk integrity checksums DDisk itself may compute
-    // and store). Optional: if empty, no checksum validation is performed.
+    // transport-level checksum, distinct from the on-disk integrity checksums DDisk itself computes
+    // and stores). Mandatory: writes without exactly one checksum per aligned block are rejected.
     repeated fixed64 Checksums = 4;
 }
 
@@ -214,8 +214,10 @@ message TEvReadResult {
     TReplyStatus.E Status = 1;
     optional string ErrorReason = 2;
     TReadResult ReadResult = 3;
-    // Reserved for checksum piggybacking: same raw XXH3_64(data) per MinSectorSize block of ReadResult
-    // payload as TEvWrite.Checksums, no identity/salt mixed in; not filled yet.
+    // Raw XXH3_64(data) per MinSectorSize block of ReadResult payload, restored from the DDisk
+    // integrity extent with its on-disk identity salt removed. Every successful read returns exactly
+    // one value per aligned block. DDisk does not compare these values with the returned data; the
+    // caller performs that check.
     repeated fixed64 Checksums = 4;
 }
 
@@ -237,8 +239,8 @@ message TEvWritePersistentBuffer {
 
     // Sender-computed checksum per MinSectorSize (4 KiB) block of the payload, in order. Each value is a
     // raw XXH3_64(data) over that block only: no tablet/vchunk identity or salt is mixed in (this is a
-    // transport-level checksum, distinct from the on-disk integrity checksums DDisk itself may compute
-    // and store). Optional: if empty, no checksum validation is performed.
+    // transport-level checksum, distinct from the on-disk integrity checksums DDisk itself computes
+    // and stores). Mandatory: writes without exactly one checksum per aligned block are rejected.
     repeated fixed64 Checksums = 5;
 }
 
@@ -267,9 +269,9 @@ message TEvWritePersistentBuffers {
 
     // Sender-computed checksum per MinSectorSize (4 KiB) block of the payload, in order. Each value is a
     // raw XXH3_64(data) over that block only: no tablet/vchunk identity or salt is mixed in (this is a
-    // transport-level checksum, distinct from the on-disk integrity checksums DDisk itself may compute
-    // and store). Optional: if empty, no checksum validation is performed. Forwarded as-is to every
-    // fanned-out TEvWritePersistentBuffer sent to each PersistentBufferIds entry.
+    // transport-level checksum, distinct from the on-disk integrity checksums DDisk itself computes
+    // and stores). Mandatory: writes without exactly one checksum per aligned block are rejected.
+    // Forwarded as-is to every fanned-out TEvWritePersistentBuffer sent to each PersistentBufferIds entry.
     repeated fixed64 Checksums = 7;
 }
 
@@ -298,10 +300,10 @@ message TEvReadPersistentBufferResult {
     uint32 OffsetInBytes = 5;
     uint32 SizeInBytes = 6;
     // Same raw XXH3_64(data) per MinSectorSize block of ReadResult payload as
-    // TEvWritePersistentBuffer.Checksums, no identity/salt mixed in. Opt-in: populated only when the
-    // persisted record itself carries sender-supplied checksums (empty for legacy/checksum-less
-    // records). Forwarded verbatim by TWritePersistentBuffersRequestActor when re-replicating a
-    // record via TEvReadThenWritePersistentBuffers.
+    // TEvWritePersistentBuffer.Checksums, no identity/salt mixed in. Successful writes always store
+    // checksums, so a successful read of a live record returns exactly one value per aligned block.
+    // Forwarded verbatim by TWritePersistentBuffersRequestActor when re-replicating a record via
+    // TEvReadThenWritePersistentBuffers.
     repeated fixed64 Checksums = 7;
 }
 

--- a/ydb/core/protos/blobstorage_ddisk_internal.proto
+++ b/ydb/core/protos/blobstorage_ddisk_internal.proto
@@ -2,31 +2,67 @@ syntax = "proto3";
 
 package NKikimrBlobStorage.NDDisk.NInternal;
 
-// SignatureDDiskChunkMap; when it is an entrypoint, it contains a full snapshot; otherwise just increments
+// SignatureDDiskChunkMap; when it is an entrypoint, it contains a full snapshot; otherwise just
+// increments. Log-order invariants:
+//  - a durable TIncrement always references a fully formatted IntegrityExtent (and, when it
+//    carries an IntegrityChunk, a fully formatted IntegrityChunk);
+//  - an IntegrityChunk record is logged no later than the first TIncrement that references it
+//    (piggybacked on that increment).
 
 message TChunkMapLogRecord {
+    // Location of the IntegrityExtent that covers one data chunk.
+    message TExtentRef {
+        uint32 IntegrityChunkIdx = 1; // in local PDisk coordinates
+        uint32 ExtentSlot = 2; // slot within the integrity chunk
+        uint64 VChunkGeneration = 3; // bumps on allocate/free/allocate (lost-write protection)
+    }
+
     message TTabletRecord {
         message TChunkRef {
             uint64 VChunkIndex = 1; // in tablet's namespace
             uint32 ChunkIdx = 2; // in local PDisk coordinates
+            TExtentRef ExtentRef = 3;
         }
 
         uint64 TabletId = 1;
         repeated TChunkRef ChunkRefs = 2;
     }
 
-    message TSnapshot {
-        repeated TTabletRecord TabletRecords = 1;
+    // A chunk owned by the DDisk for integrity metadata.
+    message TIntegrityChunkRecord {
+        uint32 ChunkIdx = 1;
+        uint64 Generation = 2; // bumps when the chunk is reinitialized/reused
     }
 
-    message TIncrement {
+    message TSnapshot {
+        repeated TTabletRecord TabletRecords = 1;
+        repeated TIntegrityChunkRecord IntegrityChunks = 2;
+        // High watermark of the generation counter (VChunkGeneration and IntegrityChunkGeneration
+        // values are drawn from one monotonic per-DDisk counter). Restored as the maximum of this
+        // field and every generation seen in the restored records, so allocate/free/allocate
+        // cycles keep bumping generations across restarts even when the freed entity no longer
+        // appears in any record.
+        uint64 GenerationCounter = 3;
+    }
+
+    message TDataChunkIncrement {
         uint64 TabletId = 1;
         uint64 VChunkIndex = 2;
         uint32 ChunkIdx = 3;
+        TExtentRef ExtentRef = 4;
     }
 
-    TSnapshot Snapshot = 1;
-    TIncrement Increment = 2;
+    // One allocation's log record. IntegrityChunk is set when this allocation also took the
+    // extent's integrity chunk from the reserve; replay applies it before DataChunk.
+    message TIncrement {
+        optional TIntegrityChunkRecord IntegrityChunk = 1;
+        TDataChunkIncrement DataChunk = 2;
+    }
+
+    oneof Record {
+        TSnapshot Snapshot = 1;
+        TIncrement Increment = 2;
+    }
 }
 
 // SignaturePersistentBufferChunkMap; always contains full snapshot

--- a/ydb/tests/functional/nbs/common.py
+++ b/ydb/tests/functional/nbs/common.py
@@ -98,30 +98,48 @@ class NbsTestBase:
 
         execute_ydbd(self.cluster, "token", ['admin', 'bs', 'config', 'invoke', '--proto', define_ddisk_pool])
 
+    def create_partition(self, disk_id, blocks_count=DEFAULT_DISK_BLOCKS_COUNT):
+        """
+        Create a disk and return the parsed CreatePartition JSON result.
+        """
+        proc = execute_dstool_grpc(
+            self.cluster,
+            "token",
+            [
+                'nbs',
+                'partition',
+                'create',
+                '--pool',
+                self.ddisk_pool_name,
+                '--block-size=4096',
+                f'--blocks-count={blocks_count}',
+                '--type=ssd',
+                '--disk-id',
+                disk_id,
+            ],
+            check_exit_code=False,
+            return_process=True,
+        )
+
+        stdout = proc.std_out.decode('utf-8')
+        stderr = proc.std_err.decode('utf-8')
+
+        try:
+            output = json.loads(stdout)
+        except json.JSONDecodeError as e:
+            assert False, (
+                f"CreatePartition for disk {disk_id} did not return JSON: "
+                f"{e}; stdout={stdout}, stderr={stderr}"
+            )
+
+        return output
+
     def create_disk(self, disk_id, blocks_count=DEFAULT_DISK_BLOCKS_COUNT):
         """
         Create a disk with specified number of blocks.
         Returns the partition tablet id.
         """
-        output = json.loads(
-            execute_dstool_grpc(
-                self.cluster,
-                "token",
-                [
-                    'nbs',
-                    'partition',
-                    'create',
-                    '--pool',
-                    self.ddisk_pool_name,
-                    '--block-size=4096',
-                    f'--blocks-count={blocks_count}',
-                    '--type=ssd',
-                    '--disk-id',
-                    disk_id,
-                ],
-            )
-        )
-
+        output = self.create_partition(disk_id, blocks_count)
         assert output.get('status') == 'SUCCESS', (
             f"CreatePartition failed for disk {disk_id}: {output}"
         )

--- a/ydb/tests/functional/nbs/common.py
+++ b/ydb/tests/functional/nbs/common.py
@@ -7,6 +7,7 @@ import re
 import string
 import requests
 import time
+import urllib.parse
 
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
@@ -17,6 +18,8 @@ from ydb.tests.functional.nbs.helpers import execute_ydbd, execute_dstool_grpc
 logger = logging.getLogger(__name__)
 
 DEFAULT_DISK_BLOCKS_COUNT = 1048576
+DBG_LINK_RE = re.compile(r'page=dbg&dbg=(\d+)')
+PBUFFER_PB_RE = re.compile(r'persistent_buffer\?pb=([^"\'&\s]+)')
 
 
 class NbsTestBase:
@@ -97,24 +100,129 @@ class NbsTestBase:
 
     def create_disk(self, disk_id, blocks_count=DEFAULT_DISK_BLOCKS_COUNT):
         """
-        Create a disk with specified number of blocks
+        Create a disk with specified number of blocks.
+        Returns the partition tablet id.
         """
-        execute_dstool_grpc(
-            self.cluster,
-            "token",
-            [
-                'nbs',
-                'partition',
-                'create',
-                '--pool',
-                self.ddisk_pool_name,
-                '--block-size=4096',
-                f'--blocks-count={blocks_count}',
-                '--type=ssd',
-                '--disk-id',
-                disk_id,
-            ],
+        output = json.loads(
+            execute_dstool_grpc(
+                self.cluster,
+                "token",
+                [
+                    'nbs',
+                    'partition',
+                    'create',
+                    '--pool',
+                    self.ddisk_pool_name,
+                    '--block-size=4096',
+                    f'--blocks-count={blocks_count}',
+                    '--type=ssd',
+                    '--disk-id',
+                    disk_id,
+                ],
+            )
         )
+
+        assert output.get('status') == 'SUCCESS', (
+            f"CreatePartition failed for disk {disk_id}: {output}"
+        )
+        tablet_id = output.get('tabletId', '')
+        assert tablet_id, f"CreatePartition did not return tabletId: {output}"
+        return tablet_id
+
+    def mon_base_url(self):
+        node = self.cluster.nodes[1]
+        return f'http://{node.host}:{node.mon_port}'
+
+    def fetch_mon(self, path):
+        url = f'{self.mon_base_url()}{path}'
+        response = requests.get(url, timeout=30)
+        assert response.status_code == 200, (
+            f"Mon request failed: {url} status={response.status_code} body={response.text[:500]}"
+        )
+        return response.text
+
+    def fetch_partition_dbg_page(self, tablet_id, dbg_index=None, allow_missing=False):
+        path = f'/tablets/app?TabletID={tablet_id}&page=dbg'
+        if dbg_index is not None:
+            path += f'&dbg={dbg_index}'
+        if not allow_missing:
+            return self.fetch_mon(path)
+
+        url = f'{self.mon_base_url()}{path}'
+        response = requests.get(url, timeout=30)
+        # After SchemeShard drops the volume, Hive deletes the tablet; the mon
+        # proxy may return a non-200 / "tablet not found" page.
+        if response.status_code != 200:
+            return ''
+        return response.text
+
+    @staticmethod
+    def pbuffer_node_id(pb_service_id):
+        # ActorId::ToString is "[nodeId:poolId:localId]".
+        match = re.fullmatch(r'\[(\d+):\d+:\d+\]', pb_service_id)
+        assert match, f"unexpected PBuffer service id format: {pb_service_id}"
+        return int(match.group(1))
+
+    def fetch_pbuffer_page(self, pb_service_ids):
+        """
+        Fetch Persistent Buffer mon pages for the given service ids (grouped by
+        node — the mon actor only lists local PBuffers), with tablet LSN table.
+        """
+        by_node = {}
+        for pb in pb_service_ids:
+            by_node.setdefault(self.pbuffer_node_id(pb), []).append(pb)
+
+        pages = []
+        for node_id, pbs in sorted(by_node.items()):
+            params = [
+                ('formPresent', '1'),
+                ('describeFreeSpace', '0'),
+                ('showTablets', '1'),
+                ('autoRefresh', '0'),
+            ]
+            for pb in pbs:
+                params.append(('pb', pb))
+            query = urllib.parse.urlencode(params, doseq=True)
+            pages.append(
+                self.fetch_mon(f'/node/{node_id}/actors/persistent_buffer?{query}')
+            )
+        return '\n'.join(pages)
+
+    @staticmethod
+    def parse_dbg_indexes(html):
+        return [int(x) for x in DBG_LINK_RE.findall(html)]
+
+    @staticmethod
+    def parse_pbuffer_service_ids(html):
+        ids = []
+        for encoded in PBUFFER_PB_RE.findall(html):
+            ids.append(urllib.parse.unquote(encoded))
+        return ids
+
+    def collect_pbuffer_service_ids(self, tablet_id, dbg_indexes):
+        pb_ids = []
+        seen = set()
+        for dbg_index in dbg_indexes:
+            html = self.fetch_partition_dbg_page(tablet_id, dbg_index)
+            for pb_id in self.parse_pbuffer_service_ids(html):
+                if pb_id not in seen:
+                    seen.add(pb_id)
+                    pb_ids.append(pb_id)
+        return pb_ids
+
+    def wait_until(self, predicate, timeout_seconds=60, sleep_seconds=1, description=''):
+        deadline = time.time() + timeout_seconds
+        last_error = None
+        while time.time() < deadline:
+            try:
+                if predicate():
+                    return
+                last_error = None
+            except AssertionError as e:
+                last_error = e
+            time.sleep(sleep_seconds)
+        detail = f': {last_error}' if last_error else ''
+        assert False, f'Timed out waiting for {description or "condition"}{detail}'
 
     def delete_disk(self, disk_id):
         """

--- a/ydb/tests/functional/nbs/test_nbs.py
+++ b/ydb/tests/functional/nbs/test_nbs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from common import NbsTestBase
+from common import DEFAULT_DISK_BLOCKS_COUNT, NbsTestBase
 from vhost_user_blk_client import (
     VIRTIO_BLK_S_OK,
     VhostUserBlkClient,
@@ -28,6 +28,42 @@ class TestNbs(NbsTestBase):
 
         # Verify the data matches (trimmed to the original length)
         assert read_data[: len(test_data)] == test_data
+
+    def test_nbs_disk_creation_idempotent(self):
+        """
+        Repeating CreatePartition for the same disk is ALREADY_EXISTS.
+        """
+
+        disk_id = self.generate_disk_id()
+        self.create_ddisk_pool()
+
+        first = self.create_partition(disk_id)
+        assert first.get('status') == 'SUCCESS', first
+        assert first.get('tabletId'), first
+
+        second = self.create_partition(disk_id)
+        assert second.get('status') == 'ALREADY_EXISTS', second
+        assert second.get('tabletId'), second
+        assert second['tabletId'] == first['tabletId'], (first, second)
+
+    def test_nbs_disk_creation_conflict(self):
+        """
+        CreatePartition with a conflicting config for the same disk id is not success.
+        """
+
+        disk_id = self.generate_disk_id()
+        self.create_ddisk_pool()
+
+        first = self.create_partition(disk_id)
+        assert first.get('status') == 'SUCCESS', first
+        assert first.get('tabletId'), first
+
+        conflict = self.create_partition(
+            disk_id,
+            blocks_count=DEFAULT_DISK_BLOCKS_COUNT * 2,
+        )
+        assert conflict.get('status') not in ('SUCCESS', 'ALREADY_EXISTS'), conflict
+        assert conflict.get('status') == 'GENERIC_ERROR', conflict
 
     def test_nbs_disk_deletion(self):
         """

--- a/ydb/tests/functional/nbs/test_nbs.py
+++ b/ydb/tests/functional/nbs/test_nbs.py
@@ -31,17 +31,64 @@ class TestNbs(NbsTestBase):
 
     def test_nbs_disk_deletion(self):
         """
-        Create nbs disk, wait until it is ready, then delete it
+        Create nbs disk, write data so PBuffers hold LSNs, delete it, then
+        verify the volume/tablet are gone and PBuffer tablet-LSN mon is empty.
         """
 
         disk_id = self.generate_disk_id()
         self.create_ddisk_pool()
-        self.create_disk(disk_id)
+        tablet_id = self.create_disk(disk_id)
         # Ensure the partition tablet is up before delete
-        self.get_load_actor_adapter_actor_id(disk_id)
+        actor_id = self.get_load_actor_adapter_actor_id(disk_id)
+
+        # Populate PBuffers so the mon page shows this tablet's LSNs before wipe.
+        self.write(actor_id, 0, self.generate_random_data(4096))
+
+        dbg_html_before = self.fetch_partition_dbg_page(tablet_id)
+        dbg_indexes = self.parse_dbg_indexes(dbg_html_before)
+        assert dbg_indexes, (
+            f"expected active DBGs on tablet mon before delete; html={dbg_html_before[:1000]}"
+        )
+
+        # Sample a few DBG details for PBuffer service ids (enough to cover hosts).
+        sample_dbgs = dbg_indexes[: min(3, len(dbg_indexes))]
+        pb_ids = self.collect_pbuffer_service_ids(tablet_id, sample_dbgs)
+        assert pb_ids, (
+            f"expected PBuffer links on DBG detail pages; dbgs={sample_dbgs}"
+        )
+
+        pbuffer_html_before = self.fetch_pbuffer_page(pb_ids)
+        assert tablet_id in pbuffer_html_before, (
+            f"expected tablet {tablet_id} LSNs on PBuffer mon before delete; "
+            f"html={pbuffer_html_before[:1500]}"
+        )
 
         deleted_disk_id = self.delete_disk(disk_id)
         assert deleted_disk_id == disk_id
+
+        # DestroyVolume completes before the RPC replies, so a second delete
+        # is already NOT_FOUND.
+        self.delete_disk_expect_failure(disk_id)
+
+        # After wipe/deallocate SchemeShard drops the volume; Hive may also
+        # drop the tablet so the mon proxy returns non-200.
+        def tablet_dbg_cleared():
+            html = self.fetch_partition_dbg_page(tablet_id, allow_missing=True)
+            return html == '' or not self.parse_dbg_indexes(html)
+
+        self.wait_until(tablet_dbg_cleared, description='tablet DBG mon cleared')
+
+        def pbuffer_page_empty():
+            html = self.fetch_pbuffer_page(pb_ids)
+            # Deallocated PBuffers report "No response"; wiped ones keep the PB
+            # heading but must not list this tablet's LSN row.
+            assert tablet_id not in html, (
+                f"tablet {tablet_id} still listed on PBuffer mon after delete; "
+                f"html={html[:2000]}"
+            )
+            return True
+
+        self.wait_until(pbuffer_page_empty, description='empty PBuffer tablet LSN mon')
 
     def test_nbs_disk_deletion_nonexistent(self):
         """


### PR DESCRIPTION
## Summary

Backport the PBuffer/DDisk integrity and cleanup batch to `nbs-26-3-1`, following the API/lifecycle backport #52749.

- Include the complete gRPC logging migration #45592, including changes outside NBS, as a prerequisite for #50063.
- Add DDisk integrity extent management and tests, fix the I/O/chunk-deletion race, and include the direct block group in PBuffer identity.
- Add resource cleanup on disk removal, DDisk checksums, CreatePartition result/status handling, and batched configuration persistence.
- Preserve PBuffer barriers during recovery even when the namespace has no live records (#52469).

## Source commits

All ten source commits are cherry-picked in their original relative history order. Original authors, author dates, commit messages and co-author trailers are preserved. No squash, additional merge commit, or path-filtered patches are used.

| Source PR | Original commit |
| --- | --- |
| #45592 — [YDB_LOG] Migrate ydb/core/grpc_services | `caef7282cafe2391d951c55a6f788cac9f2b2565` |
| #50079 — DDisk integrity extents management | `9f37e6cd50f7a28392444aee90534cf701853b29` |
| #50243 — Fix a race between I/O and chunk deletion | `3867d219925857750c32d87dc505b8117dcb374c` |
| #50507 — Add more ddisk integrity tests | `b141c63eb3d3346834409404c15639bc5ce25243` |
| #50591 — NPB add dbg key | `9e690eb83017f27344e31cf44af195ae20c02cc4` |
| #50063 — [NBS-6794] Cleanup nbs2 resources on disk removal | `e4eca3830b06b419bc2c22325e54e6c45e1b37ca` |
| #50614 — DDisk checksums | `2c88ac7eb911e9989e29a766522707526a0b28b4` |
| #50612 — NBS-7368: Return CreatePartition TabletId and map NBS errors to YDB statuses | `7ab0a529814bbfa5db8607171d6f337c30ee5306` |
| #50898 — [NBS-7572] Batch persisting VChunkConfig changes and Ahead-behind fields changes | `a164113cd18185229983d69d2c79150462255d5b` |
| #52469 — Preserve PersistentBuffer barriers without live records on recovery | `4c309aca9994ebed96c6adc72d58c52bb0273d4d` |
