### PR TITLE
Raise RAM requirements for ut_balancing and dstool tests

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/ut_balancing/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ut_balancing/ya.make
@@ -1,7 +1,7 @@
 UNITTEST_FOR(ydb/core/blobstorage/ut_blobstorage)
 
     SIZE(MEDIUM)
-    REQUIREMENTS(cpu:2)
+    REQUIREMENTS(cpu:2 ram:16)
 
     FORK_SUBTESTS()
 

--- a/ydb/tests/functional/dstool/ya.make
+++ b/ydb/tests/functional/dstool/ya.make
@@ -3,7 +3,11 @@ PY3TEST()
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)
 SIZE(MEDIUM)
 
-REQUIREMENTS(cpu:4)
+IF (SANITIZER_TYPE)
+    REQUIREMENTS(ram:16 cpu:4)
+ELSE()
+    REQUIREMENTS(cpu:4)
+ENDIF()
 
 TEST_SRCS(
     conftest.py


### PR DESCRIPTION
### Changelog entry
<!-- Describe the change for the release notes -->
Test infrastructure: raise RAM requirements for `ut_blobstorage/ut_balancing` and `tests/functional/dstool` (sanitizer builds).

### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
Both suites are killed by memory in Arcadia import CI (8 GB task limit, reported as "0 tests", `RS_RAM_REQUIREMENTS_EXCEEDED`):

* `ydb/core/blobstorage/ut_blobstorage/ut_balancing` — `VDiskBalancing::TestRandom_Block42` reaches ~8.3 GB RSS on all 5 toolchains (asan/msan/hardening/relwithdebinfo/sandboxing). `REQUIREMENTS(cpu:2)` → `REQUIREMENTS(cpu:2 ram:16)`.
* `ydb/tests/functional/dstool` under msan — 8 × `ydbd` at 1.1–1.5 GB each ≈ 12.2 GB. Added `REQUIREMENTS(ram:16 cpu:4)` for `SANITIZER_TYPE` only (same pattern as `ydb/tests/functional/api`, `backup`); non-sanitizer builds keep `cpu:4`.

Chosen over muting so the tests keep running.

Made with [Cursor](https://cursor.com)