### PR TITLE
Normalize the default benchmark web route before rendering

### DIFF
--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -3130,7 +3130,8 @@ async function renderComparisons(){
   }catch(error){app.innerHTML=shell('comparisons',displayError(error))}
 }
     """
-    "async function compose(){const pieces=routeParts(),current=pieces.join('/');if(current==='runs')return renderRuns();if(current==='new')return renderN"
+    "async function compose(){if(!location.hash.slice(1))history.replaceState(history.state,'',location.pathname+location.search+'#runs');"
+    "const pieces=routeParts(),current=pieces.join('/');if(current==='runs')return renderRuns();if(current==='new')return renderN"
     "ew('builder');if(current==='new/yaml')return renderNew('yaml');if(current==='topology')return renderTopology();if(curren"
     "t==='comparisons'||pieces[0]==='comparisons')return renderSavedComparisons();if(pieces[0]==='attempt'&&[4,5].includes(pieces.length))"
     "return renderLocalYdbAttempt(pieces[1],pieces[2],pieces[3],pieces[4]);if(pieces[0]==='run'){if(pieces[2]"

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -3385,6 +3385,7 @@ if(groups[0].cores[0].cpus.length!==2||groups[1].cores[0].cpus[0]!==9)throw Erro
         script = (
             """
             const assert=require('node:assert/strict');let pieces,seen;
+            const location={hash:'#attempt/run/profile/7'};
             const routeParts=()=>pieces;
             const setRoute=()=>{throw Error('Unexpected redirect')};
             const renderLocalYdbAttempt=(...args)=>{seen=args};

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -7963,6 +7963,36 @@ class WebTest(unittest.TestCase):
         """
         subprocess.run([shutil.which("node"), "-e", script], check=True, capture_output=True, timeout=10)
 
+    @unittest.skipUnless(shutil.which("node"), "node is required for initial route checks")
+    def test_web_empty_route_is_normalized_before_render(self):
+        routes = 'function routeParts' + web._JS.split('function routeParts', 1)[1].split('function setRoute', 1)[0]
+        compose = (
+            'async function compose'
+            + web._JS.split('async function compose', 1)[1].split("addEventListener('hashchange'", 1)[0]
+        )
+        script = routes + compose + """
+const assert=require('assert');
+let location,history,rendered;
+const renderRuns=()=>{assert.strictEqual(location.hash,'#runs');rendered='runs'};
+const renderTopology=()=>{rendered='topology'};
+(async()=>{
+  for(const hash of ['', '#', '#runs', '#topology']){
+    for(const search of ['', '?host=peer-id']){
+      location={hash,pathname:'/',search};rendered=null;
+      const state={kept:true},calls=[];
+      history={state,replaceState:(value,title,url)=>{
+        assert.strictEqual(value,state);calls.push(url);location.hash=new URL(url,'http://host:31999').hash;
+      }};
+      await compose();
+      assert.strictEqual(rendered,hash==='#topology'?'topology':'runs');
+      assert.deepStrictEqual(calls,hash===''||hash==='#'?['/'+search+'#runs']:[]);
+      assert.strictEqual(location.search,search);
+    }
+  }
+})().catch(error=>{console.error(error);process.exitCode=1});
+"""
+        subprocess.run([shutil.which("node"), "-e", script], check=True, capture_output=True, timeout=10)
+
     def test_new_comparison_link_matches_new_run_style(self):
         comparisons = web._JS.split("async function renderSavedComparisons(){", 1)[1]
         self.assertNotIn('<div class=runs-heading><h1 class=page-title>Comparisons</h1>', comparisons)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Normalize the benchmark web entry URL to the Runs page when no route is specified.

### Description for reviewers <!-- (optional) description for those who read this PR -->

The router treats an empty fragment as Runs, while the federated Runs renderer in #52846 requires an explicit #runs fragment after loading hosts. This mismatch leaves a bare entry URL displaying Loading indefinitely. Normalize the fragment before dispatch with replaceState, preserving query parameters and avoiding an extra history entry. Existing explicit routes remain unchanged.