### PR TITLE
docs: document Query Service session closure metric

### DIFF
--- a/ydb/docs/ru/core/reference/ydb-sdk/observability/metrics/opentelemetry.md
+++ b/ydb/docs/ru/core/reference/ydb-sdk/observability/metrics/opentelemetry.md
@@ -50,12 +50,12 @@
 - `client_cancelled` — клиент закрыл незавершённый поток результатов запроса;
 - `attach_closed` — сервер закрыл работающий поток `AttachSession`;
 - `transport_error` — сессия выведена из работы из-за транспортной ошибки, в том числе ошибки `Unavailable` при выполнении запроса или ошибки потока `AttachSession`;
-- `node_shutdown` — получен server hint `NodeShutdown` (`shutdown_node`);
-- `session_shutdown` — получен server hint `SessionShutdown`;
+- `node_shutdown` — сервер сообщил клиенту о завершении работы узла (`NodeShutdown`; значение в протоколе — `shutdown_node`);
+- `session_shutdown` — сервер сообщил клиенту о завершении сессии (`SessionShutdown`);
 - `bad_session` — сервер вернул статус `BadSession` или `SessionExpired`;
 - `session_busy` — сервер вернул статус `SessionBusy`.
 
-Конкретный SDK публикует только те причины, которые он может различить в своём жизненном цикле сессии.
+Поддерживаемые значения `reason` зависят от SDK: каждый SDK передаёт только те причины закрытия сессии, которые распознаёт его реализация.
 
 ## Подключение к SDK {#integration}
 

--- a/ydb/docs/ru/core/reference/ydb-sdk/observability/metrics/opentelemetry.md
+++ b/ydb/docs/ru/core/reference/ydb-sdk/observability/metrics/opentelemetry.md
@@ -50,8 +50,8 @@
 - `client_cancelled` — клиент закрыл незавершённый поток результатов запроса;
 - `attach_closed` — сервер закрыл работающий поток `AttachSession`;
 - `transport_error` — сессия выведена из работы из-за транспортной ошибки, в том числе ошибки `Unavailable` при выполнении запроса или ошибки потока `AttachSession`;
-- `node_shutdown` — сервер сообщил клиенту о завершении работы узла (`NodeShutdown`; значение в протоколе — `shutdown_node`);
-- `session_shutdown` — сервер сообщил клиенту о завершении сессии (`SessionShutdown`);
+- `node_shutdown` — сервер сообщил клиенту о штатном завершении работы узла;
+- `session_shutdown` — сервер сообщил клиенту о штатном завершении сессии;
 - `bad_session` — сервер вернул статус `BadSession` или `SessionExpired`;
 - `session_busy` — сервер вернул статус `SessionBusy`.
 

--- a/ydb/docs/ru/core/reference/ydb-sdk/observability/metrics/opentelemetry.md
+++ b/ydb/docs/ru/core/reference/ydb-sdk/observability/metrics/opentelemetry.md
@@ -46,13 +46,14 @@
 
 - `pool_idle_timeout` — пул удалил неактивную сессию по таймауту;
 - `pool_graceful_shutdown` — пул штатно завершил работу и закрыл свои сессии;
-- `client_query_timeout` — клиент не дождался окончания потока результатов запроса, поэтому сессия закрыта во избежание последующей ошибки `SessionBusy`;
-- `query_stream_cancelled_by_client` — клиент отменил поток результатов запроса;
-- `attach_stream_closed_by_server` — работающий поток `AttachSession` штатно завершён сервером без server hint;
-- `attach_stream_transport_error` — работающий поток `AttachSession` завершён с transport/gRPC-ошибкой;
+- `client_timeout` — поток результатов запроса превысил клиентский транспортный таймаут;
+- `client_cancelled` — клиент закрыл незавершённый поток результатов запроса;
+- `attach_closed` — сервер закрыл работающий поток `AttachSession`;
+- `transport_error` — сессия выведена из работы из-за транспортной ошибки, в том числе ошибки `Unavailable` при выполнении запроса или ошибки потока `AttachSession`;
 - `node_shutdown` — получен server hint `NodeShutdown` (`shutdown_node`);
 - `session_shutdown` — получен server hint `SessionShutdown`;
-- `query_execution_error` — при выполнении запроса возникла ошибка, после которой сессия выведена из работы.
+- `bad_session` — сервер вернул статус `BadSession` или `SessionExpired`;
+- `session_busy` — сервер вернул статус `SessionBusy`.
 
 Конкретный SDK публикует только те причины, которые он может различить в своём жизненном цикле сессии.
 

--- a/ydb/docs/ru/core/reference/ydb-sdk/observability/metrics/opentelemetry.md
+++ b/ydb/docs/ru/core/reference/ydb-sdk/observability/metrics/opentelemetry.md
@@ -16,6 +16,7 @@
 | Имя                                  | Тип         | Единица     | Описание                                                              |
 |--------------------------------------|-------------|-------------|-----------------------------------------------------------------------|
 | `ydb.query.session.create_time`      | Histogram   | `s`         | Длительность создания новой сессии.                                   |
+| `ydb.query.session.closed`           | Counter     | `{session}` | Монотонный счётчик закрытых сессий, разделённый по причинам закрытия, с момента создания пула. |
 | `ydb.query.session.pending_requests` | Counter     | `{request}` | Монотонный счётчик запросов на получение сессии, попавших в очередь ожидания, с момента создания пула. |
 | `ydb.query.session.timeouts`         | Counter     | `{timeout}` | Монотонный счётчик таймаутов при ожидании свободной сессии, с момента создания пула.                   |
 | `ydb.query.session.count`            | Gauge       | `{session}` | Текущее количество сессий в пуле, разделённое по состояниям.          |
@@ -39,6 +40,21 @@
 | `status_code`                 | `ydb.client.operation.failed`                                  | Код статуса {{ ydb-short-name }} (например, `BAD_REQUEST`, `SCHEME_ERROR`).                                     |
 | `ydb.query.session.pool.name` | Все метрики `ydb.query.session.*`                              | Имя пула сессий. По умолчанию формируется как `<endpoint>/<database>`; настраивается через API конкретного SDK. |
 | `ydb.query.session.state`     | `ydb.query.session.count`                                      | Состояние сессии: `idle` или `used`.                                                                            |
+| `reason`                      | `ydb.query.session.closed`                                     | Причина закрытия сессии. Допустимые значения перечислены ниже.                                                  |
+
+Допустимые значения атрибута `reason`:
+
+- `pool_idle_timeout` — пул удалил неактивную сессию по таймауту;
+- `pool_graceful_shutdown` — пул штатно завершил работу и закрыл свои сессии;
+- `client_query_timeout` — клиент не дождался окончания потока результатов запроса, поэтому сессия закрыта во избежание последующей ошибки `SessionBusy`;
+- `query_stream_cancelled_by_client` — клиент отменил поток результатов запроса;
+- `attach_stream_closed_by_server` — работающий поток `AttachSession` штатно завершён сервером без server hint;
+- `attach_stream_transport_error` — работающий поток `AttachSession` завершён с transport/gRPC-ошибкой;
+- `node_shutdown` — получен server hint `NodeShutdown` (`shutdown_node`);
+- `session_shutdown` — получен server hint `SessionShutdown`;
+- `query_execution_error` — при выполнении запроса возникла ошибка, после которой сессия выведена из работы.
+
+Конкретный SDK публикует только те причины, которые он может различить в своём жизненном цикле сессии.
 
 ## Подключение к SDK {#integration}
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Document the `ydb.query.session.closed` metric and supported Query Service session closure reasons.

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Document the `ydb.query.session.closed` counter and its attributes.
- List the supported session closure reasons, aligned with the .NET SDK implementation.
- Verified with `./ya make --build relwithdebinfo ydb/docs/ru/core`.

Tracker: https://st.yandex-team.ru/YDB-3470
