### PR TITLE
Separate common PDisk code from its production implementation

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden.h
@@ -4,7 +4,9 @@
 #include <ydb/core/blobstorage/crypto/default.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_config.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_drivemodel_db.h>
-#include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_factory.h>
+#include <ydb/core/blobstorage/pdisk/subsystem/subsystem.h>
+#include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h>
+#include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_defs.h>
 #include <ydb/core/nbs/cloud/blockstore/config/protos/ddisk_config.pb.h>
 #include <ydb/library/pdisk_io/sector_map.h>
 

--- a/ydb/core/blobstorage/nodewarden/ya.make
+++ b/ydb/core/blobstorage/nodewarden/ya.make
@@ -63,7 +63,7 @@ PEERDIR(
     ydb/core/blobstorage/crypto
     ydb/core/blobstorage/ddisk
     ydb/core/blobstorage/groupinfo
-    ydb/core/blobstorage/pdisk
+    ydb/core/blobstorage/pdisk/common
     ydb/core/blobstorage/vdisk/localrecovery
     ydb/core/blobstorage/vdisk
     ydb/core/control/lib

--- a/ydb/core/blobstorage/pdisk/common/ya.make
+++ b/ydb/core/blobstorage/pdisk/common/ya.make
@@ -1,0 +1,42 @@
+LIBRARY()
+
+SRCDIR(
+    ydb/core/blobstorage/pdisk
+)
+
+SRCS(
+    blobstorage_pdisk_params.cpp
+    blobstorage_pdisk_drivemodel_db.cpp
+    drivedata_serializer.cpp
+    defs.h
+    blobstorage_pdisk.h
+    blobstorage_pdisk_config.h
+    blobstorage_pdisk_defs.h
+    blobstorage_pdisk_params.h
+    blobstorage_pdisk_drivemodel_db.h
+    drivedata_serializer.h
+    blobstorage_pdisk_data.h
+    blobstorage_pdisk_crypto.h
+    blobstorage_pdisk_state.h
+    blobstorage_pdisk_signature.h
+    blobstorage_pdisk_quota_record.h
+    blobstorage_pdisk_util_space_color.h
+)
+
+GENERATE_ENUM_SERIALIZATION(blobstorage_pdisk_state.h)
+GENERATE_ENUM_SERIALIZATION(blobstorage_pdisk_defs.h)
+
+PEERDIR(
+    library/cpp/monlib/service/pages
+    ydb/core/base
+    ydb/core/blobstorage/base
+    ydb/core/blobstorage/crypto
+    ydb/core/blobstorage/pdisk/subsystem
+    ydb/core/control/lib
+    ydb/core/protos
+    ydb/core/util
+    ydb/library/actors/core
+    ydb/library/pdisk_io
+)
+
+END()

--- a/ydb/core/blobstorage/pdisk/mock/ya.make
+++ b/ydb/core/blobstorage/pdisk/mock/ya.make
@@ -9,7 +9,7 @@ SRCS(
 
 PEERDIR(
     ydb/library/actors/core
-    ydb/core/blobstorage/pdisk
+    ydb/core/blobstorage/pdisk/common
 )
 
 END()

--- a/ydb/core/blobstorage/pdisk/ya.make
+++ b/ydb/core/blobstorage/pdisk/ya.make
@@ -26,7 +26,7 @@ PEERDIR(
     ydb/core/base
     ydb/core/base/services
     ydb/core/blobstorage/base
-    ydb/core/blobstorage/pdisk/subsystem
+    ydb/core/blobstorage/pdisk/common
     ydb/core/blobstorage/crypto
     ydb/core/blobstorage/groupinfo
     ydb/core/blobstorage/lwtrace_probes
@@ -40,8 +40,6 @@ PEERDIR(
     ydb/library/schlab/schine
 )
 
-GENERATE_ENUM_SERIALIZATION(blobstorage_pdisk_state.h)
-GENERATE_ENUM_SERIALIZATION(blobstorage_pdisk_defs.h)
 
 
 SRCS(
@@ -51,7 +49,6 @@ SRCS(
     blobstorage_pdisk_completion_impl.cpp
     blobstorage_pdisk_delayed_cost_loop.cpp
     blobstorage_pdisk_driveestimator.cpp
-    blobstorage_pdisk_drivemodel_db.cpp
     blobstorage_pdisk_impl.cpp
     blobstorage_pdisk_impl_http.cpp
     blobstorage_pdisk_impl_log.cpp
@@ -60,7 +57,6 @@ SRCS(
     blobstorage_pdisk_log_cache.cpp
     blobstorage_pdisk_logreader.cpp
     blobstorage_pdisk_mon.cpp
-    blobstorage_pdisk_params.cpp
     blobstorage_pdisk_requestimpl.cpp
     blobstorage_pdisk_syslogreader.cpp
     blobstorage_pdisk_sectorrestorator.cpp
@@ -69,12 +65,12 @@ SRCS(
     blobstorage_pdisk_util_flightcontrol.cpp
     blobstorage_pdisk_util_signal_event.cpp
     blobstorage_pdisk_writer.cpp
-    drivedata_serializer.cpp
 )
 
 END()
 
 RECURSE(
+    common
     metadata
     mock
 )

--- a/ydb/core/blobstorage/ut_blobstorage/lib/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/ya.make
@@ -24,7 +24,7 @@ PEERDIR(
     ydb/core/blobstorage/backpressure
     ydb/core/blobstorage/dsproxy/mock
     ydb/core/blobstorage/nodewarden
-    ydb/core/blobstorage/pdisk
+    ydb/core/blobstorage/pdisk/common
     ydb/core/blobstorage/pdisk/mock
     ydb/core/blobstorage/vdisk/common
     ydb/core/load_test/nbs

--- a/ydb/core/blobstorage/vdisk/hulldb/base/ya.make
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/ya.make
@@ -4,7 +4,7 @@ PEERDIR(
     library/cpp/monlib/service/pages
     ydb/core/base
     ydb/core/blobstorage/base
-    ydb/core/blobstorage/pdisk
+    ydb/core/blobstorage/pdisk/common
     ydb/core/blobstorage/vdisk/protos
 )
 

--- a/ydb/core/blobstorage/vdisk/localrecovery/ya.make
+++ b/ydb/core/blobstorage/vdisk/localrecovery/ya.make
@@ -2,7 +2,7 @@ LIBRARY()
 
 PEERDIR(
     ydb/core/base
-    ydb/core/blobstorage/pdisk
+    ydb/core/blobstorage/pdisk/common
     ydb/core/blobstorage/vdisk/common
     ydb/core/blobstorage/vdisk/hulldb
     ydb/core/control

--- a/ydb/core/blobstorage/ya.make
+++ b/ydb/core/blobstorage/ya.make
@@ -15,7 +15,7 @@ PEERDIR(
     ydb/core/blobstorage/lwtrace_probes
     ydb/core/blobstorage/nodewarden
     ydb/core/blobstorage/other
-    ydb/core/blobstorage/pdisk
+    ydb/core/blobstorage/pdisk/common
     ydb/core/blobstorage/storagepoolmon
     ydb/core/blobstorage/vdisk
 )

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -27,6 +27,7 @@
 
 #include <ydb/core/blobstorage/backpressure/unisched.h>
 #include <ydb/core/blobstorage/nodewarden/node_warden.h>
+#include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_factory.h>
 #include <ydb/core/blobstorage/other/mon_get_blob_page.h>
 #include <ydb/core/blobstorage/ddisk/persistent_buffer_mon.h>
 #include <ydb/core/blobstorage/vdisk/common/blobstorage_event_filter.h>

--- a/ydb/core/load_test/blobstorage/ya.make
+++ b/ydb/core/load_test/blobstorage/ya.make
@@ -14,7 +14,7 @@ PEERDIR(
     ydb/core/base
     ydb/core/blobstorage/backpressure
     ydb/core/blobstorage/base
-    ydb/core/blobstorage/pdisk
+    ydb/core/blobstorage/pdisk/common
     ydb/core/blobstorage/vdisk/common
     ydb/core/control/lib
     ydb/core/jaeger_tracing

--- a/ydb/core/load_test/keyvalue/ya.make
+++ b/ydb/core/load_test/keyvalue/ya.make
@@ -10,7 +10,7 @@ PEERDIR(
     library/cpp/time_provider
     ydb/core/base
     ydb/core/blobstorage/base
-    ydb/core/blobstorage/pdisk
+    ydb/core/blobstorage/pdisk/common
     ydb/core/control/lib
     ydb/core/keyvalue
     ydb/core/load_test/common

--- a/ydb/core/mind/ya.make
+++ b/ydb/core/mind/ya.make
@@ -60,7 +60,7 @@ PEERDIR(
     ydb/core/blobstorage/dsproxy/mock
     ydb/core/blobstorage/groupinfo
     ydb/core/blobstorage/incrhuge
-    ydb/core/blobstorage/pdisk
+    ydb/core/blobstorage/pdisk/common
     ydb/core/engine/minikql
     ydb/core/kesus/tablet
     ydb/core/keyvalue


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Reduce BlobStorage test build dependencies on the production PDisk implementation.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Extract shared PDisk types, helpers and enum serialization into pdisk/common while preserving existing include paths. Switch mock PDisk and consumers of the common contract to this library, removing the production PDisk implementation from the ut_restart_pdisk build graph. Keep production factory dependencies explicit at initialization sites.
