### PR TITLE
[SQS] Add cloud_id and folder_id labels to HTTP proxy metrics

### DIFF
--- a/ydb/core/http_proxy/sqs.cpp
+++ b/ydb/core/http_proxy/sqs.cpp
@@ -205,7 +205,9 @@ namespace NKikimr::NHttpProxy {
                     ConsumerName,
                     Method,
                     std::move(labels),
-                    HttpContext.DatabaseId);
+                    HttpContext.DatabaseId,
+                    HttpContext.CloudId,
+                    HttpContext.FolderId);
             }
 
             void ReplyWithYdbError(const TActorContext& ctx, NYdb::EStatus status, const TString& errorText, size_t issueCode = ISSUE_CODE_GENERIC) {

--- a/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 
 #include <library/cpp/json/json_reader.h>
+#include <library/cpp/json/json_writer.h>
 #include <library/cpp/json/writer/json_value.h>
 #include <library/cpp/string_utils/url/url.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -1419,6 +1420,98 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
             UNIT_ASSERT_VALUES_EQUAL(messages.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(messages[0].GetData(), "MessageBody-0");
             UNIT_ASSERT_VALUES_EQUAL(messages[1].GetData(), "");
+        }
+
+        TString FormatCounterLabels(const TVector<std::pair<TString, TString>>& labels) {
+            TStringBuilder out;
+            for (size_t i = 0; i < labels.size(); ++i) {
+                if (i > 0) {
+                    out << ", ";
+                }
+                out << labels[i].first << "=" << labels[i].second;
+            }
+            return out;
+        }
+
+        const NJson::TJsonValue* FindCounterSensor(
+            const NJson::TJsonValue& counters,
+            const TVector<std::pair<TString, TString>>& requiredLabels)
+        {
+            const NJson::TJsonValue* found = nullptr;
+            for (const auto& sensor : counters["sensors"].GetArraySafe()) {
+                if (!sensor.Has("labels") || !sensor["labels"].IsMap()) {
+                    continue;
+                }
+                const auto& labels = sensor["labels"].GetMapSafe();
+                bool match = true;
+                for (const auto& [key, value] : requiredLabels) {
+                    auto it = labels.find(key);
+                    if (it == labels.end() || it->second.GetStringRobust() != value) {
+                        match = false;
+                        break;
+                    }
+                }
+                if (match) {
+                    UNIT_ASSERT_C(!found, "duplicate sensor for " << FormatCounterLabels(requiredLabels));
+                    found = &sensor;
+                }
+            }
+            return found;
+        }
+
+        TString DumpSqsSensors(const NJson::TJsonValue& counters) {
+            TStringBuilder out;
+            for (const auto& sensor : counters["sensors"].GetArraySafe()) {
+                if (!sensor.Has("labels") || !sensor["labels"].IsMap()) {
+                    continue;
+                }
+                const auto name = sensor["labels"]["name"].GetStringRobust();
+                if (name.StartsWith("api.sqs.")) {
+                    out << NJson::WriteJson(sensor, true, true, true) << "\n";
+                }
+            }
+            return out;
+        }
+
+        void AssertSqsHttpSensor(
+            const NJson::TJsonValue& counters,
+            const TSqsTopicPaths& path,
+            const TString& name,
+            const TString& method,
+            const TVector<std::pair<TString, TString>>& extraLabels = {})
+        {
+            TVector<std::pair<TString, TString>> required{
+                {"name", name},
+                {"method", method},
+                {"cloud_id", "cloud4"},
+                {"folder_id", "folder4"},
+                {"database_id", "database4"},
+                {"database", path.Database},
+                {"topic", path.TopicName},
+                {"consumer", path.ConsumerName},
+            };
+            required.insert(required.end(), extraLabels.begin(), extraLabels.end());
+            const auto* sensor = FindCounterSensor(counters, required);
+            UNIT_ASSERT_C(sensor, "missing sensor " << name << " method=" << method
+                << " extra=[" << FormatCounterLabels(extraLabels) << "]\nSQS sensors:\n"
+                << DumpSqsSensors(counters));
+        }
+
+        Y_UNIT_TEST_F(TestCounters, TFixture) {
+            auto driver = MakeDriver(*this);
+            const TSqsTopicPaths path;
+            UNIT_ASSERT(CreateTopic(driver, path.TopicName, path.ConsumerName));
+
+            SendMessage({
+                {"QueueUrl", path.QueueUrl},
+                {"MessageBody", "MessageBody-0"},
+            });
+
+            const auto counters = NKikimr::NPersQueueTests::SendQuery(MonPort, "/counters/json");
+            AssertSqsHttpSensor(counters, path, "api.sqs.request.count", "SendMessage");
+            AssertSqsHttpSensor(counters, path, "api.sqs.response.count", "SendMessage", {{"code", "200"}});
+            AssertSqsHttpSensor(counters, path, "api.sqs.response.bytes", "SendMessage", {{"code", "200"}});
+            AssertSqsHttpSensor(counters, path, "api.sqs.response.duration_milliseconds", "SendMessage");
         }
 
         Y_UNIT_TEST_F(TestSendMessageBadQueueUrl, TFixture) {

--- a/ydb/services/sqs_topic/ut/utils_ut.cpp
+++ b/ydb/services/sqs_topic/ut/utils_ut.cpp
@@ -102,12 +102,16 @@ namespace {
             NActors::TActorId edge,
             TString consumer,
             bool firstClassCitizen,
-            TString databaseId = {}
+            TString databaseId = {},
+            TString cloudId = {},
+            TString folderId = {}
         )
             : Edge_(edge)
             , Consumer_(std::move(consumer))
             , FirstClassCitizen_(firstClassCitizen)
             , DatabaseId_(std::move(databaseId))
+            , CloudId_(std::move(cloudId))
+            , FolderId_(std::move(folderId))
         {
         }
 
@@ -115,14 +119,16 @@ namespace {
             NKikimr::AppData(ctx)->PQConfig.SetTopicsAreFirstClassCitizen(FirstClassCitizen_);
 
             auto* ev = new TEvMetricsLabelsResult;
-            if (DatabaseId_) {
+            if (DatabaseId_ || CloudId_ || FolderId_) {
                 ev->Labels = GetMetricsLabels(
                     "/Root/db",
                     "/Root/db/topic",
                     Consumer_,
                     "SendMessage",
                     {{"name", "api.sqs.request.count"}},
-                    DatabaseId_
+                    DatabaseId_,
+                    CloudId_,
+                    FolderId_
                 );
             } else {
                 ev->Labels = GetRequestMessageCountMetricsLabels(
@@ -141,6 +147,8 @@ namespace {
         TString Consumer_;
         bool FirstClassCitizen_;
         TString DatabaseId_;
+        TString CloudId_;
+        TString FolderId_;
     };
 
     TVector<std::pair<TString, TString>> CollectRequestMessageCountMetricsLabels(
@@ -158,13 +166,15 @@ namespace {
         return ev->Get()->Labels;
     }
 
-    TVector<std::pair<TString, TString>> CollectMetricsLabelsWithDatabaseId(
+    TVector<std::pair<TString, TString>> CollectMetricsLabelsWithIdentity(
         NKikimr::TTestActorRuntime& runtime,
-        const TString& databaseId
+        const TString& databaseId,
+        const TString& cloudId = {},
+        const TString& folderId = {}
     ) {
         const auto edge = runtime.AllocateEdgeActor();
         runtime.Register(
-            new TMetricsLabelsTestActor(edge, "ydb_sqs_consumer", true, databaseId),
+            new TMetricsLabelsTestActor(edge, "ydb_sqs_consumer", true, databaseId, cloudId, folderId),
             0,
             runtime.GetAppData().SystemPoolId
         );
@@ -202,15 +212,30 @@ Y_UNIT_TEST_SUITE(SqsTopicMetricsLabels) {
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "method"), "SendMessage");
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "topic"), "topic");
         UNIT_ASSERT(HasLabel(labels, "database_id"));
+        UNIT_ASSERT(HasLabel(labels, "cloud_id"));
+        UNIT_ASSERT(HasLabel(labels, "folder_id"));
     }
 
     Y_UNIT_TEST(IncludesDatabaseIdLabel) {
         NKikimr::TTestActorRuntime runtime(1, false);
         InitRuntime(runtime);
 
-        const auto labels = CollectMetricsLabelsWithDatabaseId(runtime, "database4");
+        const auto labels = CollectMetricsLabelsWithIdentity(runtime, "database4");
 
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "database_id"), "database4");
+        UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "database"), "/Root/db");
+        UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "name"), "api.sqs.request.count");
+    }
+
+    Y_UNIT_TEST(IncludesCloudIdAndFolderIdLabels) {
+        NKikimr::TTestActorRuntime runtime(1, false);
+        InitRuntime(runtime);
+
+        const auto labels = CollectMetricsLabelsWithIdentity(runtime, "database4", "cloud4", "folder4");
+
+        UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "database_id"), "database4");
+        UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "cloud_id"), "cloud4");
+        UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "folder_id"), "folder4");
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "database"), "/Root/db");
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "name"), "api.sqs.request.count");
     }

--- a/ydb/services/sqs_topic/ut/utils_ut.cpp
+++ b/ydb/services/sqs_topic/ut/utils_ut.cpp
@@ -212,8 +212,8 @@ Y_UNIT_TEST_SUITE(SqsTopicMetricsLabels) {
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "method"), "SendMessage");
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "topic"), "topic");
         UNIT_ASSERT(HasLabel(labels, "database_id"));
-        UNIT_ASSERT(HasLabel(labels, "cloud_id"));
-        UNIT_ASSERT(HasLabel(labels, "folder_id"));
+        UNIT_ASSERT(!HasLabel(labels, "cloud_id"));
+        UNIT_ASSERT(!HasLabel(labels, "folder_id"));
     }
 
     Y_UNIT_TEST(IncludesDatabaseIdLabel) {
@@ -225,6 +225,19 @@ Y_UNIT_TEST_SUITE(SqsTopicMetricsLabels) {
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "database_id"), "database4");
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "database"), "/Root/db");
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "name"), "api.sqs.request.count");
+        UNIT_ASSERT(!HasLabel(labels, "cloud_id"));
+        UNIT_ASSERT(!HasLabel(labels, "folder_id"));
+    }
+
+    Y_UNIT_TEST(OmitsCloudIdAndFolderIdWhenEmpty) {
+        NKikimr::TTestActorRuntime runtime(1, false);
+        InitRuntime(runtime);
+
+        const auto labels = CollectMetricsLabelsWithIdentity(runtime, "database4", "", "");
+
+        UNIT_ASSERT(!HasLabel(labels, "cloud_id"));
+        UNIT_ASSERT(!HasLabel(labels, "folder_id"));
+        UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "database_id"), "database4");
     }
 
     Y_UNIT_TEST(IncludesCloudIdAndFolderIdLabels) {
@@ -238,6 +251,19 @@ Y_UNIT_TEST_SUITE(SqsTopicMetricsLabels) {
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "folder_id"), "folder4");
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "database"), "/Root/db");
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "name"), "api.sqs.request.count");
+    }
+
+    Y_UNIT_TEST(IncludesBothCloudAndFolderWhenOnlyOneIsSet) {
+        NKikimr::TTestActorRuntime runtime(1, false);
+        InitRuntime(runtime);
+
+        const auto cloudOnly = CollectMetricsLabelsWithIdentity(runtime, "database4", "cloud4", "");
+        UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(cloudOnly, "cloud_id"), "cloud4");
+        UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(cloudOnly, "folder_id"), "");
+
+        const auto folderOnly = CollectMetricsLabelsWithIdentity(runtime, "database4", "", "folder4");
+        UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(folderOnly, "cloud_id"), "");
+        UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(folderOnly, "folder_id"), "folder4");
     }
 
     Y_UNIT_TEST(ConvertOldConsumerNameForSharedConsumerInFederation) {

--- a/ydb/services/sqs_topic/utils.cpp
+++ b/ydb/services/sqs_topic/utils.cpp
@@ -83,7 +83,9 @@ namespace NKikimr::NSqsTopic {
         const TString& consumerName,
         const TString& method,
         TVector<std::pair<TString, TString>>&& labels,
-        const TString& databaseId
+        const TString& databaseId,
+        const TString& cloudId,
+        const TString& folderId
     ) {
         TString fullDatabasePath = databasePath + "/";
         TString adjustedTopicPath;
@@ -96,6 +98,8 @@ namespace NKikimr::NSqsTopic {
         TVector<std::pair<TString, TString>> common{
             {"database", databasePath},
             {"database_id", databaseId},
+            {"cloud_id", cloudId},
+            {"folder_id", folderId},
             {"method", method},
             {"topic", adjustedTopicPath},
             {"consumer", ConvertOldConsumerName(consumerName)},

--- a/ydb/services/sqs_topic/utils.cpp
+++ b/ydb/services/sqs_topic/utils.cpp
@@ -98,12 +98,14 @@ namespace NKikimr::NSqsTopic {
         TVector<std::pair<TString, TString>> common{
             {"database", databasePath},
             {"database_id", databaseId},
-            {"cloud_id", cloudId},
-            {"folder_id", folderId},
-            {"method", method},
-            {"topic", adjustedTopicPath},
-            {"consumer", ConvertOldConsumerName(consumerName)},
         };
+        if (!cloudId.empty() || !folderId.empty()) {
+            common.emplace_back("cloud_id", cloudId);
+            common.emplace_back("folder_id", folderId);
+        }
+        common.emplace_back("method", method);
+        common.emplace_back("topic", adjustedTopicPath);
+        common.emplace_back("consumer", ConvertOldConsumerName(consumerName));
         std::move(labels.begin(), labels.end(), std::back_inserter(common));
         return common;
     }

--- a/ydb/services/sqs_topic/utils.h
+++ b/ydb/services/sqs_topic/utils.h
@@ -40,7 +40,9 @@ namespace NKikimr::NSqsTopic {
         const TString& consumer,
         const TString& method,
         TVector<std::pair<TString, TString>>&& labels,
-        const TString& databaseId = {}
+        const TString& databaseId = {},
+        const TString& cloudId = {},
+        const TString& folderId = {}
     );
 
     TVector<std::pair<TString, TString>> GetRequestMessageCountMetricsLabels(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

SQS HTTP proxy counters now include `cloud_id` and `folder_id` labels, matching Kinesis metrics so serverless monitoring can attribute traffic per cloud and folder.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Kinesis (`api.http.data_streams.*`) already emitted `cloud_id` and `folder_id`; SQS-over-topic (`api.sqs.*`) did not, because `AddCommonLabels` never passed `HttpContext.CloudId` / `FolderId` into `GetMetricsLabels`.

- Write `cloud_id` and `folder_id` from `GetMetricsLabels`, same as Kinesis counters.
- Pass `HttpContext.CloudId` and `HttpContext.FolderId` from the SQS HTTP proxy.
- Cover the labels in `SqsTopicMetricsLabels` unit tests and a live `TestCounters` HTTP proxy test that reads `/counters/json` after `SendMessage`.