### PR TITLE
Fix ANALYZE finish races on cancel, deadline, and late save

### DIFF
--- a/ydb/core/statistics/aggregator/aggregator_impl.cpp
+++ b/ydb/core/statistics/aggregator/aggregator_impl.cpp
@@ -569,6 +569,10 @@ void TStatisticsAggregator::Handle(TEvStatistics::TEvSaveStatisticsQueryResponse
         {"tabletId", TabletID()},
         {"success", ev->Get()->Success});
 
+    if (!SaveQueryActorId || ev->Sender != SaveQueryActorId) {
+        return;
+    }
+
     SaveQueryActorId = {};
 
     if (ev->Get()->Success) {
@@ -710,8 +714,9 @@ void TStatisticsAggregator::SaveStatisticsToTable() {
     };
 
     if (items.empty()) {
-        Send(SelfId(), new TEvStatistics::TEvSaveStatisticsQueryResponse(
-            Ydb::StatusIds::SUCCESS, {}, TraversalPathId));
+        if (!AnalyzeActorId) {
+            DispatchFinishTraversalTx(NKikimrStat::TEvAnalyzeResponse::STATUS_SUCCESS);
+        }
         return;
     }
     size_t itemsSize = items.size();
@@ -1229,6 +1234,8 @@ void TStatisticsAggregator::ResetTraversalState(NIceDb::TNiceDb& db) {
         AnalyzeActorId = {};
     }
     SaveQueryActorId = {};
+    PendingSaveStatistics = false;
+    FinishingTraversal = false;
     PersistTraversal(db);
 
     StatisticsToSave.clear();

--- a/ydb/core/statistics/aggregator/aggregator_impl.h
+++ b/ydb/core/statistics/aggregator/aggregator_impl.h
@@ -355,6 +355,7 @@ private: // stored in local db
     TInstant TraversalStartTime;
     TActorId AnalyzeActorId;
     TActorId SaveQueryActorId;
+    bool FinishingTraversal = false;
 
     std::unordered_map<TPathId, TScheduleTraversal> ScheduleTraversals;
     std::unordered_map<ui64, std::unordered_set<TPathId>> ScheduleTraversalsBySchemeShard;

--- a/ydb/core/statistics/aggregator/tx_analyze_deadline.cpp
+++ b/ydb/core/statistics/aggregator/tx_analyze_deadline.cpp
@@ -13,7 +13,7 @@ struct TStatisticsAggregator::TTxAnalyzeDeadline : public TTxBase {
         TActorId ReplyToActorId;
     };
     std::vector<TDeadlineEntry> DeadlineExceeded;
-    bool ActiveDeadlineExceeded = false;
+    TString ActiveDeadlineOperationId;
 
     TTxAnalyzeDeadline(TSelf* self)
         : TTxBase(self)
@@ -40,7 +40,7 @@ struct TStatisticsAggregator::TTxAnalyzeDeadline : public TTxBase {
             } else {
                 if (operation.CreatedAt + Self->AnalyzeDeadline < now) {
                     if (Self->ForceTraversalOperationId == operation.OperationId) {
-                        ActiveDeadlineExceeded = true;
+                        ActiveDeadlineOperationId = operation.OperationId;
                     } else {
                         toFailDeadline.push_back(operation.OperationId);
                     }
@@ -87,10 +87,12 @@ struct TStatisticsAggregator::TTxAnalyzeDeadline : public TTxBase {
             }
         }
 
-        if (ActiveDeadlineExceeded) {
+        if (ActiveDeadlineOperationId
+                && Self->ForceTraversalOperationId == ActiveDeadlineOperationId)
+        {
             YDB_LOG_ERROR("TTxAnalyzeDeadline: active deadline exceeded",
                 {"tabletId", Self->TabletID()},
-                {"operationId", Self->ForceTraversalOperationId.Quote()});
+                {"operationId", ActiveDeadlineOperationId.Quote()});
             NYql::TIssues issues;
             issues.AddIssue(NYql::TIssue("ANALYZE deadline exceeded"));
             Self->DispatchFinishTraversalTx(

--- a/ydb/core/statistics/aggregator/tx_analyze_op_cancel.cpp
+++ b/ydb/core/statistics/aggregator/tx_analyze_op_cancel.cpp
@@ -72,7 +72,7 @@ struct TStatisticsAggregator::TTxAnalyzeOpCancel : public TTxBase {
         rec.SetStatus(Ydb::StatusIds::SUCCESS);
         ctx.Send(Request->Sender, response.Release(), 0, Request->Cookie);
 
-        if (IsActive) {
+        if (IsActive && Self->ForceTraversalOperationId == operationId) {
             Self->DispatchFinishTraversalTx(NKikimrStat::TEvAnalyzeResponse::STATUS_CANCELLED);
         }
     }

--- a/ydb/core/statistics/aggregator/tx_finish_trasersal.cpp
+++ b/ydb/core/statistics/aggregator/tx_finish_trasersal.cpp
@@ -108,6 +108,10 @@ struct TStatisticsAggregator::TTxFinishTraversal : public TTxBase {
 void TStatisticsAggregator::DispatchFinishTraversalTx(
         NKikimrStat::TEvAnalyzeResponse::EStatus status,
         NYql::TIssues issues) {
+    if (FinishingTraversal || (!TraversalPathId && !ForceTraversalOperationId)) {
+        return;
+    }
+    FinishingTraversal = true;
     Execute(
         new TTxFinishTraversal(this, status, std::move(issues)),
         TActivationContext::AsActorContext());

--- a/ydb/core/statistics/aggregator/ut/ut_analyze.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_analyze.cpp
@@ -676,19 +676,56 @@ Y_UNIT_TEST_SUITE(AnalyzeStatistics) {
         const auto tableInfo = PrepareTable(env, "Database", "Table", ColumnShard);
         auto sender = runtime.AllocateEdgeActor();
 
-        TBlockEvents<TEvStatistics::TEvSaveStatisticsQueryResponse> block(runtime);
+        size_t finals = 0;
+        TActorId saId;
+        auto resultWatch = runtime.AddObserver<TEvStatistics::TEvAnalyzeActorResult>(
+            [&](auto& ev) {
+                saId = ev->GetRecipientRewrite();
+                if (ev->Get()->Final) {
+                    ++finals;
+                }
+            });
+        Y_UNUSED(resultWatch);
+
+        TBlockEvents<TEvStatistics::TEvSaveStatisticsQueryResponse> block(runtime,
+            [&](auto& ev) {
+                return saId && ev->GetRecipientRewrite() == saId;
+            });
 
         auto analyzeRequest = MakeAnalyzeRequest({tableInfo.PathId});
         runtime.SendToPipe(tableInfo.SaTabletId, sender, analyzeRequest.release());
 
-        runtime.WaitFor("TEvSaveStatisticsQueryResponse", [&]{ return block.size(); });
+        runtime.WaitFor("op1 collected", [&]{ return finals >= 1 && !block.empty(); });
+        const size_t op1Saves = block.size();
         runtime.AdvanceCurrentTime(TDuration::Days(2));
 
-        auto analyzeResponse = runtime.GrabEdgeEventRethrow<TEvStatistics::TEvAnalyzeResponse>(sender);
+        auto analyzeResponse = runtime.GrabEdgeEventRethrow<TEvStatistics::TEvAnalyzeResponse>(
+            sender, TDuration::Seconds(30));
+        UNIT_ASSERT(analyzeResponse);
         const auto& record = analyzeResponse->Get()->Record;
         UNIT_ASSERT_VALUES_EQUAL(record.GetOperationId(), "operationId");
         UNIT_ASSERT_VALUES_EQUAL(record.GetStatus(), NKikimrStat::TEvAnalyzeResponse::STATUS_ERROR);
         UNIT_ASSERT(!record.GetIssues().empty());
+
+        auto analyzeRequest2 = MakeAnalyzeRequest({tableInfo.PathId}, "operationId2");
+        runtime.SendToPipe(tableInfo.SaTabletId, sender, analyzeRequest2.release());
+        runtime.WaitFor("op2 collected", [&]{ return finals >= 2 && block.size() > op1Saves; });
+
+        // Releasing only op1's blocked saves must not complete op2.
+        // Stop blocking first so a stale-triggered follow-up save can finish.
+        block.Stop();
+        block.Unblock(op1Saves);
+        auto staleResponse = runtime.GrabEdgeEventRethrow<TEvStatistics::TEvAnalyzeResponse>(
+            sender, TDuration::Seconds(3));
+        UNIT_ASSERT(!staleResponse);
+
+        block.Unblock();
+        auto response2 = runtime.GrabEdgeEventRethrow<TEvStatistics::TEvAnalyzeResponse>(
+            sender, TDuration::Seconds(30));
+        UNIT_ASSERT(response2);
+        UNIT_ASSERT_VALUES_EQUAL(response2->Get()->Record.GetOperationId(), "operationId2");
+        UNIT_ASSERT_VALUES_EQUAL(
+            response2->Get()->Record.GetStatus(), NKikimrStat::TEvAnalyzeResponse::STATUS_SUCCESS);
     }
 
     Y_UNIT_TEST_TWIN(AnalyzeCancel, ColumnShard) {


### PR DESCRIPTION
- Allow only one `FinishTraversal` at a time. Later save/cancel/deadline triggers do not enqueue another finish for the same traversal.
- Ignore `TEvSaveStatisticsQueryResponse` unless it comes from the registered save actor, so a late save cannot finish the next ANALYZE. Finish an empty batch directly (no fake `SelfId()` reply).
- On reset, clear `FinishingTraversal` and `PendingSaveStatistics`. Deadline and cancel `Complete` finish only if the operation id captured in `Execute` is still current.
