### PR TITLE
Add visual cluster placement templates to YDB benchmark

### DIFF
--- a/ydb/tools/ydb_bench/lib/cluster_templates.py
+++ b/ydb/tools/ydb_bench/lib/cluster_templates.py
@@ -1,0 +1,151 @@
+"""Saved placement specifications; deliberately does not launch cluster processes."""
+
+import json
+import threading
+import uuid
+from datetime import datetime, timezone
+
+from ydb.tools.ydb_bench.lib.common import BenchmarkError, atomic_write_json
+from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES
+
+
+def _text(value, label, limit=200):
+    if not isinstance(value, str) or not value.strip() or len(value) > limit:
+        raise BenchmarkError("{} must contain 1 to {} characters".format(label, limit))
+    return value.strip()
+
+
+def _integer(value, label, maximum=65536):
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise BenchmarkError("{} must be between 1 and {}".format(label, maximum))
+    return value
+
+
+def validate_affinity(value):
+    if not isinstance(value, dict):
+        raise BenchmarkError("Affinity must be an object")
+    if value.get("kind") == "manual":
+        cpus = value.get("cpus")
+        if (
+            not isinstance(cpus, list)
+            or not 1 <= len(cpus) <= 65536
+            or any(type(cpu) is not int or not 0 <= cpu <= 1048575 for cpu in cpus)
+            or len(set(cpus)) != len(cpus)
+        ):
+            raise BenchmarkError("Select unique logical CPU IDs")
+        return {"kind": "manual", "cpus": sorted(cpus)}
+    if value.get("kind") != "strategy" or value.get("mode") not in AFFINITY_MODES:
+        raise BenchmarkError("Unknown affinity strategy")
+    scope = value.get("scope", "exclusive")
+    if scope not in ("exclusive", "chiplet", "numa"):
+        raise BenchmarkError("Unknown affinity scope")
+    mode = value["mode"]
+    # Migrate the experimental independent scope to the corresponding placement.
+    if scope == "numa":
+        mode = "pack-numa"
+    result = {
+        "kind": "strategy",
+        "mode": mode,
+        "count": _integer(value.get("count"), "Affinity CPU count"),
+    }
+    return result
+
+
+def validate_template(value, host_ids):
+    if not isinstance(value, dict):
+        raise BenchmarkError("Template must be an object")
+    name = _text(value.get("name"), "Template name")
+    nodes = value.get("nodes")
+    if not isinstance(nodes, list) or not 1 <= len(nodes) <= 64:
+        raise BenchmarkError("A template must contain 1 to 64 nodes")
+    result, names = [], set()
+    for node in nodes:
+        if not isinstance(node, dict):
+            raise BenchmarkError("Node must be an object")
+        node_name = _text(node.get("name"), "Node name", 80)
+        if node_name in names:
+            raise BenchmarkError("Node names must be unique")
+        names.add(node_name)
+        role, host = node.get("role"), node.get("host_id")
+        if role not in ("static", "dynamic", "cli"):
+            raise BenchmarkError("Unknown node role")
+        if not isinstance(host, str) or host not in host_ids:
+            raise BenchmarkError("Select a registered host for every node")
+        item = {
+            "name": node_name,
+            "role": role,
+            "host_id": host,
+            "binary": _text(node.get("binary"), "Binary path or version", 1000),
+            "affinity": validate_affinity(node.get("affinity")),
+        }
+        if role != "cli":
+            item["vcpu"] = _integer(node.get("vcpu"), "Actor-system vCPU")
+            flags = node.get("actor_system", {})
+            if not isinstance(flags, dict):
+                raise BenchmarkError("Actor-system settings must be an object")
+            item["actor_system"] = {}
+            for key in ("use_shared_threads", "use_united_pool", "use_ring_queue"):
+                flag = flags.get(key, key == "use_ring_queue")
+                if type(flag) is not bool:
+                    raise BenchmarkError("Actor-system flags must be boolean")
+                item["actor_system"][key] = flag
+        if role == "static":
+            disk = node.get("sector_map")
+            if not isinstance(disk, dict):
+                raise BenchmarkError("Static nodes require SectorMap settings")
+            item["sector_map"] = {
+                "count": _integer(disk.get("count"), "SectorMap count", 64),
+                "size_gib": _integer(disk.get("size_gib"), "SectorMap size", 1048576),
+            }
+        result.append(item)
+    return {"schema_version": 1, "name": name, "nodes": result}
+
+
+class ClusterTemplateStore:
+    def __init__(self, output):
+        self.path = output / ".cluster-templates.json"
+        self.lock = threading.RLock()
+
+    def list(self):
+        with self.lock:
+            if not self.path.exists():
+                return []
+            try:
+                if self.path.stat().st_size > 16 * 1024 * 1024:
+                    raise ValueError("too large")
+                records = json.loads(self.path.read_text(encoding="utf-8"))
+                if not isinstance(records, list) or any(not isinstance(item, dict) for item in records):
+                    raise ValueError("invalid records")
+                return records
+            except (OSError, ValueError) as error:
+                raise BenchmarkError("Cannot read cluster templates; file was not changed") from error
+
+    def save(self, value, host_ids):
+        record = validate_template(value, host_ids)
+        with self.lock:
+            records = self.list()
+            previous = next((item for item in records if item["id"] == value.get("id")), None)
+            if value.get("id") and previous is None:
+                raise BenchmarkError("Template no longer exists")
+            if previous and value.get("revision") != previous["revision"]:
+                raise BenchmarkError("Template changed elsewhere; reload before saving")
+            if not previous and len(records) >= 100:
+                raise BenchmarkError("At most 100 cluster templates can be saved")
+            record.update(
+                id=previous["id"] if previous else uuid.uuid4().hex,
+                revision=previous["revision"] + 1 if previous else 1,
+                updated_at=datetime.now(timezone.utc).isoformat(),
+            )
+            atomic_write_json(self.path, [record] + [item for item in records if item["id"] != record["id"]])
+            return record
+
+    def delete(self, value):
+        if not isinstance(value, dict):
+            raise BenchmarkError("Template reference must be an object")
+        with self.lock:
+            records = self.list()
+            record = next((item for item in records if item["id"] == value.get("id")), None)
+            if record is None or record["revision"] != value.get("revision"):
+                raise BenchmarkError("Template changed or no longer exists; reload first")
+            atomic_write_json(self.path, [item for item in records if item["id"] != record["id"]])
+            return {"deleted": record["id"]}

--- a/ydb/tools/ydb_bench/lib/cluster_templates.py
+++ b/ydb/tools/ydb_bench/lib/cluster_templates.py
@@ -1,6 +1,7 @@
 """Saved placement specifications; deliberately does not launch cluster processes."""
 
 import json
+import re
 import threading
 import uuid
 from datetime import datetime, timezone
@@ -51,6 +52,15 @@ def validate_affinity(value):
     return result
 
 
+def _names(value, label):
+    if not isinstance(value, list) or len(value) > 64:
+        raise BenchmarkError("{} must be a list of at most 64 entries".format(label))
+    result = [_text(item, label, 80) for item in value]
+    if len(set(result)) != len(result):
+        raise BenchmarkError("{} must be unique".format(label))
+    return result
+
+
 def validate_template(value, host_ids):
     if not isinstance(value, dict):
         raise BenchmarkError("Template must be an object")
@@ -58,6 +68,41 @@ def validate_template(value, host_ids):
     nodes = value.get("nodes")
     if not isinstance(nodes, list) or not 1 <= len(nodes) <= 64:
         raise BenchmarkError("A template must contain 1 to 64 nodes")
+    selected_hosts = value.get("host_ids")
+    if selected_hosts is None:
+        selected_hosts = list(
+            dict.fromkeys(
+                node["host_id"] for node in nodes if isinstance(node, dict) and isinstance(node.get("host_id"), str)
+            )
+        )
+    selected_hosts = _names(selected_hosts, "Template hosts")
+    if any(host not in host_ids for host in selected_hosts):
+        raise BenchmarkError("Select registered template hosts")
+    centers = value.get("data_centers", [])
+    if not isinstance(centers, list) or len(centers) > 64 or any(not isinstance(dc, dict) for dc in centers):
+        raise BenchmarkError("Data centers must be a list of at most 64 objects")
+    dc_names = _names([dc.get("name") for dc in centers], "Data center names")
+    centers = [
+        {"name": name, "racks": _names(dc.get("racks", []), "Rack names")} for name, dc in zip(dc_names, centers)
+    ]
+    racks = {dc["name"]: dc["racks"] for dc in centers}
+    tenants = value.get("tenants", [])
+    if not isinstance(tenants, list) or len(tenants) > 64 or any(not isinstance(t, dict) for t in tenants):
+        raise BenchmarkError("Tenants must be a list of at most 64 objects")
+    paths = _names([t.get("path") for t in tenants], "Tenant paths")
+    normalized_tenants = []
+    for path, tenant in zip(paths, tenants):
+        if not re.fullmatch(r"/Root/[A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*", path):
+            raise BenchmarkError("Tenant path must start with /Root/ and contain valid path components")
+        if tenant.get("storage_kind") not in ("ssd", "hdd"):
+            raise BenchmarkError("Tenant storage kind must be ssd or hdd")
+        normalized_tenants.append(
+            {
+                "path": path,
+                "storage_kind": tenant["storage_kind"],
+                "storage_groups": _integer(tenant.get("storage_groups"), "Storage groups", 64),
+            }
+        )
     result, names = [], set()
     for node in nodes:
         if not isinstance(node, dict):
@@ -69,7 +114,7 @@ def validate_template(value, host_ids):
         role, host = node.get("role"), node.get("host_id")
         if role not in ("static", "dynamic", "cli"):
             raise BenchmarkError("Unknown node role")
-        if not isinstance(host, str) or host not in host_ids:
+        if not isinstance(host, str) or host not in selected_hosts:
             raise BenchmarkError("Select a registered host for every node")
         item = {
             "name": node_name,
@@ -78,6 +123,25 @@ def validate_template(value, host_ids):
             "binary": _text(node.get("binary"), "Binary path or version", 1000),
             "affinity": validate_affinity(node.get("affinity")),
         }
+        location = node.get("location", {})
+        if not isinstance(location, dict):
+            raise BenchmarkError("Logical location must be an object")
+        dc, rack, body = (location.get(key, "") for key in ("data_center", "rack", "body"))
+        if any(not isinstance(part, str) for part in (dc, rack, body)):
+            raise BenchmarkError("Logical location fields must be strings")
+        if role == "cli" and any((dc, rack, body)):
+            raise BenchmarkError("CLI load generators cannot have a logical location")
+        if (dc and dc not in racks) or (rack and rack not in racks.get(dc, [])) or (body and not rack):
+            raise BenchmarkError("Select an existing data center and rack for the logical server")
+        if dc and not rack:
+            if not racks[dc]:
+                racks[dc].append("rack-1")
+            rack = racks[dc][0]
+        item["location"] = {"data_center": dc, "rack": rack, "body": node_name if rack else ""}
+        tenant = node.get("tenant", "")
+        if not isinstance(tenant, str) or (tenant and (tenant not in paths or role != "dynamic")):
+            raise BenchmarkError("Only dynamic nodes can be assigned to an existing tenant")
+        item["tenant"] = tenant
         if role != "cli":
             item["vcpu"] = _integer(node.get("vcpu"), "Actor-system vCPU")
             flags = node.get("actor_system", {})
@@ -98,7 +162,14 @@ def validate_template(value, host_ids):
                 "size_gib": _integer(disk.get("size_gib"), "SectorMap size", 1048576),
             }
         result.append(item)
-    return {"schema_version": 1, "name": name, "nodes": result}
+    return {
+        "schema_version": 2,
+        "name": name,
+        "nodes": result,
+        "host_ids": selected_hosts,
+        "data_centers": centers,
+        "tenants": normalized_tenants,
+    }
 
 
 class ClusterTemplateStore:

--- a/ydb/tools/ydb_bench/lib/cluster_templates.py
+++ b/ydb/tools/ydb_bench/lib/cluster_templates.py
@@ -135,24 +135,13 @@ def validate_template(value, host_ids):
             raise BenchmarkError("Select an existing data center and rack for the logical server")
         if dc and not rack:
             if not racks[dc]:
-                racks[dc].append("rack-1")
+                racks[dc].append(dc + "-R1")
             rack = racks[dc][0]
         item["location"] = {"data_center": dc, "rack": rack, "body": node_name if rack else ""}
         tenant = node.get("tenant", "")
         if not isinstance(tenant, str) or (tenant and (tenant not in paths or role != "dynamic")):
             raise BenchmarkError("Only dynamic nodes can be assigned to an existing tenant")
         item["tenant"] = tenant
-        if role != "cli":
-            item["vcpu"] = _integer(node.get("vcpu"), "Actor-system vCPU")
-            flags = node.get("actor_system", {})
-            if not isinstance(flags, dict):
-                raise BenchmarkError("Actor-system settings must be an object")
-            item["actor_system"] = {}
-            for key in ("use_shared_threads", "use_united_pool", "use_ring_queue"):
-                flag = flags.get(key, key == "use_ring_queue")
-                if type(flag) is not bool:
-                    raise BenchmarkError("Actor-system flags must be boolean")
-                item["actor_system"][key] = flag
         if role == "static":
             disk = node.get("sector_map")
             if not isinstance(disk, dict):
@@ -163,7 +152,7 @@ def validate_template(value, host_ids):
             }
         result.append(item)
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "name": name,
         "nodes": result,
         "host_ids": selected_hosts,

--- a/ydb/tools/ydb_bench/lib/cluster_templates_ui.py
+++ b/ydb/tools/ydb_bench/lib/cluster_templates_ui.py
@@ -10,6 +10,8 @@ CSS = r"""
 .ct-zone-header{display:flex;flex-wrap:wrap;align-items:center;gap:.6rem}
 .ct-zone-header>strong{min-width:0;overflow-wrap:anywhere}
 .ct-remove{color:#b42332;border:0;background:transparent;font-size:22px;min-width:32px;min-height:32px;padding:0}
+.ct-edit{display:inline-flex;align-items:center;justify-content:center;border:0;background:transparent;min-width:32px;min-height:32px;padding:0;color:var(--muted)}
+.ct-edit:hover{color:var(--accent)}
 .ct-node-row{position:relative;margin:7px 0}
 .ct-node-row>.ct-remove{position:absolute;top:4px;right:5px}
 .ct-node{display:block;width:100%;text-align:left;margin:0;padding:10px 12px;overflow-wrap:anywhere}
@@ -48,7 +50,7 @@ overflow:auto;border:1px solid var(--line);border-radius:6px;background:#fff;col
 .ct-scope-bar.ct-double{box-shadow:0 -5px 0 var(--accent);margin-top:12px}
 .ct-pop-footer{display:flex;gap:10px;justify-content:flex-end;margin-top:14px}
 .ct-mask{overflow-wrap:anywhere;margin-top:10px}.ct-small-action{padding:2px 6px}
-@media(pointer:coarse){.ct-cpu{min-height:44px}.ct-remove{min-width:44px;min-height:44px}.ct-node-title{padding-right:42px}}
+@media(pointer:coarse){.ct-cpu{min-height:44px}.ct-remove,.ct-edit{min-width:44px;min-height:44px}.ct-node-title{padding-right:42px}}
 """
 
 JS = r"""
@@ -274,7 +276,10 @@ async function renderClusterTemplates(id){
           (record.nodes.some(n=>n.role!=='cli'&&!n.location?.data_center)?zone('Unassigned',['',''],node=>!node.location?.data_center):'');
       }
       if(view==='tenants')layout=record.tenants.map((tenant,i)=>zone(tenant.path,tenant.path,node=>node.role!=='static'&&node.tenant===tenant.path,
-        '<button data-ct-tenant="'+i+'">Edit</button>'+ctRemoveButton('data-ct-delete-tenant="'+i+'"','Remove tenant '+tenant.path),
+        '<button class=ct-edit data-ct-tenant="'+i+'" title="Edit tenant" aria-label="Edit tenant '+esc(tenant.path)+'">'+
+        '<svg width=16 height=16 viewBox="0 0 24 24" fill=none stroke=currentColor stroke-width=1.8 aria-hidden=true focusable=false>'+
+        '<path d="M15 5l4 4M4 20l4-1L20 7a2.8 2.8 0 0 0-4-4L4 15z"/></svg></button>'+
+        ctRemoveButton('data-ct-delete-tenant="'+i+'"','Remove tenant '+tenant.path),
         tenant.storage_kind.toUpperCase()+' · '+tenant.storage_groups+' storage groups')).join('')+
         (record.nodes.some(n=>n.role==='dynamic'&&!n.tenant)?zone('Unassigned','',node=>node.role==='dynamic'&&!node.tenant):'')+
         '<section class=ct-host><strong>Shared cluster infrastructure</strong>'+cards(node=>node.role==='static')+'</section>';

--- a/ydb/tools/ydb_bench/lib/cluster_templates_ui.py
+++ b/ydb/tools/ydb_bench/lib/cluster_templates_ui.py
@@ -1,11 +1,19 @@
 """Placement-template editor assets for the existing benchmark web application."""
 
 CSS = r"""
-.ct-hosts{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(260px,100%),1fr));gap:16px}
-.ct-host{padding:12px;background:var(--panel);border:1px solid var(--line);border-radius:6px;min-width:0}
+.ct-hosts{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(420px,100%),1fr));gap:24px;align-items:start}
+.ct-host{padding:0;background:transparent;border:0;min-width:0}
+.ct-hosts>.ct-host{border:1px solid var(--line);border-radius:6px;padding:12px}
+.ct-host>.ct-host{margin-top:12px}
+.ct-host>.runs-toolbar,.ct-host>.ct-zone-header{border-bottom:1px solid var(--line);padding-bottom:8px;margin:0 0 10px}
+.ct-host>.ct-host>.ct-zone-header{border:0;color:var(--muted);padding:0;margin:0 0 5px}
 .ct-zone-header{display:flex;flex-wrap:wrap;align-items:center;gap:.6rem}
 .ct-zone-header>strong{min-width:0;overflow-wrap:anywhere}
-.ct-node{display:block;width:100%;text-align:left;margin:8px 0;padding:10px;overflow-wrap:anywhere}
+.ct-remove{color:#b42332;border:0;background:transparent;font-size:22px;min-width:32px;min-height:32px;padding:0}
+.ct-node-row{position:relative;margin:7px 0}
+.ct-node-row>.ct-remove{position:absolute;top:4px;right:5px}
+.ct-node{display:block;width:100%;text-align:left;margin:0;padding:10px 12px;overflow-wrap:anywhere}
+.ct-node-title{display:block;font-weight:500;padding-right:30px}.ct-node-title em{font-style:normal;color:var(--muted);margin-left:10px}
 .ct-node span{display:block;color:var(--muted);margin-top:4px}
 .ct-node[aria-pressed=true]{border-color:var(--accent);box-shadow:inset 3px 0 var(--accent)}
 .ct-node[draggable=true]{cursor:grab}.ct-host.ct-drop{outline:2px solid var(--accent);background:var(--panel)}
@@ -40,7 +48,7 @@ overflow:auto;border:1px solid var(--line);border-radius:6px;background:#fff;col
 .ct-scope-bar.ct-double{box-shadow:0 -5px 0 var(--accent);margin-top:12px}
 .ct-pop-footer{display:flex;gap:10px;justify-content:flex-end;margin-top:14px}
 .ct-mask{overflow-wrap:anywhere;margin-top:10px}.ct-small-action{padding:2px 6px}
-@media(pointer:coarse){.ct-cpu{min-height:44px}}
+@media(pointer:coarse){.ct-cpu{min-height:44px}.ct-remove{min-width:44px;min-height:44px}.ct-node-title{padding-right:42px}}
 """
 
 JS = r"""
@@ -119,8 +127,7 @@ function ctMoveNode(record,index,kind,target,resetManual=false){
   }else throw Error('Unknown placement view');
 }
 function ctDefaultNode(host,role,index){
-  return {name:role+'-'+index,role,host_id:host,binary:'bundled',vcpu:8,
-    actor_system:{use_shared_threads:false,use_united_pool:false,use_ring_queue:true},
+  return {name:role+'-'+index,role,host_id:host,binary:'bundled',
     sector_map:{count:1,size_gib:64},affinity:{kind:'strategy',mode:'none',count:8}};
 }
 function ctNormalizeNodePlacement(n){
@@ -157,7 +164,22 @@ function ctRemoveHost(record,host,target){
   record.host_ids=record.host_ids.filter(h=>h!==host);
 }
 function ctAffinityLabel(value){const a=ctNormalizeAffinity(value);return a.kind==='manual'?'CPU '+cpuRanges(a.cpus):
-  a.mode==='none'?'No pinning':a.mode+' · '+a.count+' CPU';}
+  a.mode==='none'?'No pinning':a.mode;}
+function ctNextRack(dc){let i=1;while(dc.racks.includes(dc.name+'-R'+i))i++;return dc.name+'-R'+i;}
+function ctShortHost(name,names){
+  const short=name.split('.')[0];
+  return names.filter(other=>other.split('.')[0]===short).length>1?name:short;
+}
+function ctRemoveButton(attributes,label){return '<button class=ct-remove '+attributes+' title="'+esc(label)+'" aria-label="'+esc(label)+'">×</button>';}
+function ctNodeInfo(node,view,hostName){
+  const details=[];
+  if(view!=='physical')details.push('Host: '+hostName(node.host_id));
+  if(node.role!=='cli'){
+    if(view!=='logical')details.push([node.location?.data_center,node.location?.rack].filter(Boolean).join(' / ')||'No logical location');
+    if(view!=='tenants')details.push(node.role==='static'?'Shared infrastructure':'Tenant: '+(node.tenant||'Unassigned'));
+  }
+  return details.join(' · ');
+}
 async function renderClusterTemplates(id){
   clearRefresh();const generation=(renderClusterTemplates.version||0)+1,current=location.hash;
   renderClusterTemplates.version=generation;
@@ -166,6 +188,7 @@ async function renderClusterTemplates(id){
     const [records,directory]=await Promise.all([api('/api/cluster-templates'),api('/api/hosts')]);
     if(!active())return;
     const hosts=[directory.local,...directory.hosts],hostName=id=>hosts.find(h=>h.id===id)?.name||'Unavailable host';
+    const shortHost=id=>ctShortHost(hostName(id),hosts.map(h=>h.name));
     if(!id){
       app.innerHTML=shell('cluster-templates','<div class=runs-toolbar><span class=muted>Placement templates · this server</span>'+
         '<a class="button primary" href="#cluster-templates/new">New template</a></div>'+
@@ -184,7 +207,7 @@ async function renderClusterTemplates(id){
     record.nodes.forEach(ctNormalizeNodePlacement);
     record.nodes.forEach(n=>{
       const dc=record.data_centers.find(dc=>dc.name===n.location.data_center);
-      if(dc&&!n.location.rack){if(!dc.racks.length)dc.racks.push('rack-1');n.location.rack=dc.racks[0];ctNormalizeNodePlacement(n)}
+      if(dc&&!n.location.rack){if(!dc.racks.length)dc.racks.push(ctNextRack(dc));n.location.rack=dc.racks[0];ctNormalizeNodePlacement(n)}
     });
     let selected=0,saving=false,view='physical',dragged=null;
     let previewVersion=0;
@@ -199,7 +222,7 @@ async function renderClusterTemplates(id){
       nodes.forEach((node,i)=>{
         const p=plans.get(node),target=app.querySelector('[data-ct-plan="'+i+'"]');
         if(target){target.textContent=p.supported?(node.affinity.mode==='none'?'':
-          (p.reserved_cpus?'Reserve '+p.reserved_cpus.length+' CPU · affinity ':'')+p.cpus.length+' CPUs · '+cpuRanges(p.cpus)):p.reason;
+          'Affinity: '+cpuRanges(p.cpus)):p.reason;
           target.className=p.supported?'':'error'}
       });
     }
@@ -226,51 +249,48 @@ async function renderClusterTemplates(id){
       if(view==='physical'&&selected<0&&record.nodes.length)selected=0;
       const n=record.nodes[selected];
       const targets=[];
-      const card=(node,i)=>'<button class=ct-node draggable=true data-ct-node="'+i+'" aria-pressed="'+(selected===i)+'">'+esc(node.name)+' · '+esc(node.role)+
-        '<span>'+esc(hostName(node.host_id))+(node.role==='cli'?' · Load generator':
-        ' · '+esc([node.location?.data_center,node.location?.rack,node.location?.body].filter(Boolean).join(' / ')||'No logical location')+
-        ' · '+esc(node.role==='static'?'Shared infrastructure':node.tenant||'No tenant'))+'</span>'+
-        '<span>'+(node.role==='cli'?'':esc(node.vcpu)+' vCPU · ')+esc(ctAffinityLabel(node.affinity))+'</span>'+
-        '<span data-ct-plan="'+i+'">Calculating placement…</span></button>';
+      const card=(node,i)=>'<div class=ct-node-row><button class=ct-node draggable=true data-ct-node="'+i+'" aria-pressed="'+(selected===i)+'">'+
+        '<strong class=ct-node-title>'+esc(node.name)+'<em>'+esc(node.role)+'</em></strong>'+
+        '<span title="'+esc(hostName(node.host_id))+'">'+esc(ctNodeInfo(node,view,shortHost))+'</span>'+
+        (view==='physical'?'<span>'+esc(ctAffinityLabel(node.affinity))+'</span><span data-ct-plan="'+i+'">Calculating placement…</span>':'')+
+        '</button>'+ctRemoveButton('data-ct-remove-node="'+i+'"','Remove node '+node.name)+'</div>';
       const cards=filter=>record.nodes.map((node,i)=>(view==='physical'||node.role!=='cli')&&filter(node)?card(node,i):'').join('')||'<p class=ct-empty>No nodes</p>';
-      const zone=(title,target,filter,actions='',description='')=>{
+      const zone=(title,target,filter,actions='',description='',fullTitle='')=>{
         const index=targets.push(target)-1;
-        const content=view==='logical'&&target[1]?record.nodes.map((node,i)=>node.role!=='cli'&&filter(node)?
-          '<div class=ct-rack><span class=muted>Body · '+esc(node.name)+'</span>'+card(node,i)+'</div>':'').join('')||
-          '<p class=ct-empty>No nodes</p>':cards(filter);
-        return '<section class=ct-host data-ct-drop="'+index+'"><div class=ct-zone-header><strong>'+esc(title)+'</strong>'+
+        const content=cards(filter);
+        return '<section class=ct-host data-ct-drop="'+index+'"><div class=ct-zone-header><strong title="'+esc(fullTitle||title)+'">'+esc(title)+'</strong>'+
           (actions?'<div class=runs-actions>'+actions+'</div>':'')+'</div>'+
           (description?'<p class=muted>'+esc(description)+'</p>':'')+content+'</section>';
       };
       let layout='';
-      if(view==='physical')layout=record.host_ids.map((host,i)=>zone(hostName(host),host,node=>node.host_id===host,
-        '<button data-ct-delete-host="'+i+'">Remove host</button>')).join('');
+      if(view==='physical')layout=record.host_ids.map((host,i)=>zone(shortHost(host),host,node=>node.host_id===host,
+        ctRemoveButton('data-ct-delete-host="'+i+'"','Remove host '+hostName(host)),'',hostName(host))).join('');
       if(view==='logical'){
         layout=record.data_centers.map((dc,i)=>'<section class=ct-host><div class=runs-toolbar><strong>'+esc(dc.name)+
-          '</strong><div class=runs-actions><button data-ct-rack="'+i+'">+ Rack</button>'+
-          '<button data-ct-delete-dc="'+i+'">Delete DC</button></div></div>'+dc.racks.map((rack,j)=>
+          '</strong><div class=runs-actions><button data-ct-rack="'+i+'">Add rack</button>'+
+          ctRemoveButton('data-ct-delete-dc="'+i+'"','Remove DC '+dc.name)+'</div></div>'+dc.racks.map((rack,j)=>
             zone(rack,[dc.name,rack],node=>node.location?.data_center===dc.name&&node.location?.rack===rack,
-              '<button data-ct-delete-rack="'+i+':'+j+'">Delete rack</button>')).join('')+'</section>').join('')+
+              ctRemoveButton('data-ct-delete-rack="'+i+':'+j+'"','Remove rack '+rack))).join('')+'</section>').join('')+
           (record.nodes.some(n=>n.role!=='cli'&&!n.location?.data_center)?zone('Unassigned',['',''],node=>!node.location?.data_center):'');
       }
       if(view==='tenants')layout=record.tenants.map((tenant,i)=>zone(tenant.path,tenant.path,node=>node.role!=='static'&&node.tenant===tenant.path,
-        '<button data-ct-tenant="'+i+'">Edit</button><button data-ct-delete-tenant="'+i+'">Delete tenant</button>',
+        '<button data-ct-tenant="'+i+'">Edit</button>'+ctRemoveButton('data-ct-delete-tenant="'+i+'"','Remove tenant '+tenant.path),
         tenant.storage_kind.toUpperCase()+' · '+tenant.storage_groups+' storage groups')).join('')+
         (record.nodes.some(n=>n.role==='dynamic'&&!n.tenant)?zone('Unassigned','',node=>node.role==='dynamic'&&!node.tenant):'')+
         '<section class=ct-host><strong>Shared cluster infrastructure</strong>'+cards(node=>node.role==='static')+'</section>';
       app.innerHTML=shell('cluster-templates',
         '<div class=runs-toolbar><a href="#cluster-templates">Cluster templates</a><div class=runs-actions>'+
-        '<button id=ct-copy>Copy template</button>'+(record.id?'<button id=ct-delete>Delete</button>':'')+
+        '<button id=ct-copy>Copy template</button>'+(record.id?'<button id=ct-delete>Delete template</button>':'')+
         '<button id=ct-save class=primary>Save template</button></div></div><div id=ct-error></div>'+
         '<div class=ct-fields><label>Template name<input id=ct-name maxlength=200 value="'+esc(record.name)+'"></label></div>'+
         '<p class=muted>Placement only · does not start a cluster</p><div class="profile-tabs ct-placement-tabs">'+
         ['physical','logical','tenants'].map(v=>'<button data-ct-view="'+v+'" class="'+(view===v?'active':'')+'" aria-pressed="'+(view===v)+'">'+
           v[0].toUpperCase()+v.slice(1)+'</button>').join('')+'</div><div class="runs-toolbar ct-create-actions">'+
         (view==='physical'?'<button id=ct-add '+(!record.host_ids.length?'disabled':'')+'>Add node</button>':'')+'<button id=ct-group>'+
-        (view==='physical'?'Add host':view==='logical'?'+ DC':'Create tenant')+'</button></div><div class=ct-hosts>'+layout+'</div>'+
+        (view==='physical'?'Add host':view==='logical'?'Add DC':'Add tenant')+'</button></div><div class=ct-hosts>'+layout+'</div>'+
         (n?'<section class=ct-editor><div class=runs-toolbar><strong>'+esc(n.name)+'</strong><div class=runs-actions>'+
           (view==='physical'?'<button id=ct-duplicate>Duplicate node</button>':'')+
-          '<button id=ct-remove>Remove node</button></div></div><div class=ct-fields>'+
+          ctRemoveButton('id=ct-remove','Remove node '+n.name)+'</div></div><div class=ct-fields>'+
           '<label>Name<input data-ct-field=name maxlength=80 value="'+esc(n.name)+'"></label><label>Type<select data-ct-field=role>'+
           ['static','dynamic','cli'].map(v=>'<option '+(n.role===v?'selected':'')+'>'+v+'</option>').join('')+'</select></label>'+
           '<label>Host<select data-ct-field=host_id>'+(!hosts.some(h=>h.id===n.host_id)?'<option value="'+esc(n.host_id)+'">Unavailable host</option>':'')+
@@ -284,12 +304,10 @@ async function renderClusterTemplates(id){
           (n.role!=='dynamic'?'':'<label>Tenant<select id=ct-node-tenant><option value="">Unassigned</option>'+record.tenants.map(t=>
             '<option '+(n.tenant===t.path?'selected':'')+'>'+esc(t.path)+'</option>').join('')+'</select></label>')+
           '<label>Binary · bundled, version or path<input data-ct-field=binary value="'+esc(n.binary)+'"></label>'+
-          (n.role!=='cli'?'<label>Actor-system vCPU<input type=number min=1 max=65536 data-ct-field=vcpu value="'+n.vcpu+'"></label>':'')+
           '<label>CPU affinity<button id=ct-affinity aria-haspopup=dialog>'+esc(ctAffinityLabel(n.affinity))+'</button></label>'+
           (n.role==='static'?'<label>SectorMap count<input type=number min=1 max=64 data-ct-disk=count value="'+n.sector_map.count+'"></label>'+
             '<label>SectorMap size · GiB<input type=number min=1 max=1048576 data-ct-disk=size_gib value="'+n.sector_map.size_gib+'"></label>':'')+
-          '</div>'+(n.role!=='cli'?'<div class=ct-flags>'+['use_shared_threads','use_united_pool','use_ring_queue'].map(k=>
-            '<label><input type=checkbox data-ct-flag="'+k+'" '+(n.actor_system[k]?'checked':'')+'>'+esc(k)+'</label>').join('')+'</div>':'')+'</section>':''));
+          '</div></section>':''));
       const error=e=>{if(active())app.querySelector('#ct-error').innerHTML=displayError(e)};
       app.querySelector('#ct-name').oninput=e=>record.name=e.target.value;
       app.querySelectorAll('[data-ct-view]').forEach(b=>b.onclick=()=>{view=b.dataset.ctView;draw()});
@@ -309,7 +327,7 @@ async function renderClusterTemplates(id){
       app.querySelectorAll('[data-ct-location]').forEach(f=>f.onchange=()=>{
         if(f.dataset.ctLocation==='data_center'){
           const dc=record.data_centers.find(dc=>dc.name===f.value);
-          if(dc&&!dc.racks.length)dc.racks.push('rack-1');
+          if(dc&&!dc.racks.length)dc.racks.push(ctNextRack(dc));
           move(selected,'logical',[f.value,dc?.racks[0]||'']);
         }else move(selected,'logical',[n.location.data_center,f.value]);
       });
@@ -321,22 +339,21 @@ async function renderClusterTemplates(id){
           return;
         }
         n[field]=f.type==='number'?Number(f.value):f.value;
-        if(field==='role'){n.vcpu??=8;n.actor_system??=ctDefaultNode('',n.role,1).actor_system;n.sector_map??={count:1,size_gib:64};ctNormalizeNodePlacement(n)}
+        if(field==='role'){n.sector_map??={count:1,size_gib:64};ctNormalizeNodePlacement(n)}
         draw();
       });
       app.querySelectorAll('[data-ct-disk]').forEach(f=>f.onchange=()=>n.sector_map[f.dataset.ctDisk]=Number(f.value));
-      app.querySelectorAll('[data-ct-flag]').forEach(f=>f.onchange=()=>n.actor_system[f.dataset.ctFlag]=f.checked);
       const unique=role=>{let i=1;while(record.nodes.some(n=>n.name===role+'-'+i))i++;return role+'-'+i};
       const add=app.querySelector('#ct-add');if(add)add.onclick=()=>{if(record.nodes.length>=64)return error('At most 64 nodes');
         const node=ctDefaultNode(record.host_ids[0],'dynamic',1);node.location={data_center:'',rack:'',body:''};node.tenant='';
         node.name=unique('dynamic');record.nodes.push(node);selected=record.nodes.length-1;draw()};
-      const addName=(title,existing,submit)=>dialog(title,'<label>Name<input name=name required maxlength=80 autofocus></label>',data=>{
+      const addName=(title,existing,submit,suggested='')=>dialog(title,'<label>Name<input name=name required maxlength=80 autofocus value="'+esc(suggested)+'"></label>',data=>{
         const name=data.get('name').trim();if(!name||existing.includes(name))throw Error('Enter a unique name');
         if(existing.length>=64)throw Error('At most 64 entries');submit(name);
       });
       const editTenant=index=>{
         const t=record.tenants[index]||{path:'/Root/',storage_kind:'ssd',storage_groups:1};
-        dialog(index===undefined?'Create tenant':'Edit tenant','<label>Database path<input name=path required maxlength=80 value="'+esc(t.path)+'"></label>'+
+        dialog(index===undefined?'Add tenant':'Edit tenant','<label>Database path<input name=path required maxlength=80 value="'+esc(t.path)+'"></label>'+
           '<label>Storage kind<select name=kind>'+['ssd','hdd'].map(k=>'<option '+(t.storage_kind===k?'selected':'')+'>'+k+'</option>').join('')+'</select></label>'+
           '<label>Storage groups<input name=groups type=number min=1 max=64 required value="'+t.storage_groups+'"></label>',data=>{
             const path=data.get('path').trim();
@@ -351,7 +368,7 @@ async function renderClusterTemplates(id){
       app.querySelectorAll('[data-ct-delete-tenant]').forEach(b=>b.onclick=()=>{
         const t=record.tenants[+b.dataset.ctDeleteTenant],count=record.nodes.filter(n=>n.tenant===t.path).length;
         const remove=()=>ctRemoveTenant(record,t.path);
-        if(count)dialog('Delete tenant','<p>'+count+' nodes will have no tenant. Physical and logical placement will be kept.</p>',remove);
+        if(count)dialog('Remove tenant','<p>'+count+' nodes will have no tenant. Physical and logical placement will be kept.</p>',remove);
         else{remove();draw()}
       });
       app.querySelectorAll('[data-ct-delete-host]').forEach(b=>b.onclick=()=>{
@@ -365,12 +382,12 @@ async function renderClusterTemplates(id){
           data=>ctRemoveHost(record,host,data.get('host')));
       });
       app.querySelectorAll('[data-ct-rack]').forEach(b=>b.onclick=()=>{
-        const dc=record.data_centers[+b.dataset.ctRack];addName('Add rack',dc.racks,name=>dc.racks.push(name));
+        const dc=record.data_centers[+b.dataset.ctRack];addName('Add rack',dc.racks,name=>dc.racks.push(name),ctNextRack(dc));
       });
       const deleteLocation=(dc,rack)=>{
         const count=record.nodes.filter(n=>n.location?.data_center===dc.name&&(rack===undefined||n.location.rack===rack)).length;
         const remove=()=>ctRemoveLocation(record,dc.name,rack);
-        if(count)dialog(rack===undefined?'Delete DC':'Delete rack','<p>'+count+' nodes will move to Unassigned. '+
+        if(count)dialog(rack===undefined?'Remove DC':'Remove rack','<p>'+count+' nodes will move to Unassigned. '+
           'Physical placement and tenant assignments will be kept.</p>',remove);
         else{remove();draw()}
       };
@@ -382,12 +399,17 @@ async function renderClusterTemplates(id){
       group.disabled=view==='physical'&&!available.length;
       group.onclick=()=>{
         if(view==='tenants'){editTenant();return}
-        if(view==='logical'){addName('Add DC',record.data_centers.map(dc=>dc.name),name=>record.data_centers.push({name,racks:['rack-1']}));return}
+        if(view==='logical'){addName('Add DC',record.data_centers.map(dc=>dc.name),name=>record.data_centers.push({name,racks:[name+'-R1']}));return}
         dialog('Add host','<label>Host<select name=host>'+available.map(h=>'<option value="'+esc(h.id)+'">'+esc(h.name)+'</option>').join('')+'</select></label>',
           data=>{if(record.host_ids.length>=64)throw Error('At most 64 hosts');record.host_ids.push(data.get('host'))});
       };
+      const removeNode=index=>dialog('Remove node','<p>Remove '+esc(record.nodes[index].name)+' from this template? '+
+        'Its placement and tenant assignment will be removed. Running processes are not affected.</p>',()=>{
+        record.nodes.splice(index,1);selected=Math.max(0,Math.min(selected,record.nodes.length-1));
+      });
+      app.querySelectorAll('[data-ct-remove-node]').forEach(b=>b.onclick=()=>removeNode(+b.dataset.ctRemoveNode));
       if(n){
-        app.querySelector('#ct-remove').onclick=()=>{record.nodes.splice(selected,1);selected=Math.max(0,selected-1);draw()};
+        app.querySelector('#ct-remove').onclick=()=>removeNode(selected);
         const duplicate=app.querySelector('#ct-duplicate');if(duplicate)duplicate.onclick=()=>{if(record.nodes.length>=64)return error('At most 64 nodes');
           const copy=JSON.parse(JSON.stringify(n));copy.name=unique(n.role);ctNormalizeNodePlacement(copy);record.nodes.push(copy);selected=record.nodes.length-1;draw()};
         app.querySelector('#ct-affinity').onclick=e=>openAffinity(n,e.currentTarget);
@@ -403,7 +425,7 @@ async function renderClusterTemplates(id){
           if(id!==record.id)setRoute('cluster-templates/'+record.id);else{draw();app.querySelector('#ct-error').textContent='Saved'}
         }}catch(e){error(e)}finally{saving=false;const b=app.querySelector('#ct-save');if(b)b.disabled=false}
       };
-      refreshCards();
+      if(view==='physical')refreshCards();else previewVersion++;
     }
     async function openAffinity(node,anchor){
       const pop=document.createElement('div');pop.className='ct-pop';pop.setAttribute('popover','auto');

--- a/ydb/tools/ydb_bench/lib/cluster_templates_ui.py
+++ b/ydb/tools/ydb_bench/lib/cluster_templates_ui.py
@@ -1,0 +1,300 @@
+"""Placement-template editor assets for the existing benchmark web application."""
+
+CSS = r"""
+.ct-hosts{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(260px,100%),1fr));gap:16px}
+.ct-host{padding:12px;background:var(--panel);border:1px solid var(--line);border-radius:6px;min-width:0}
+.ct-node{display:block;width:100%;text-align:left;margin:8px 0;padding:10px;overflow-wrap:anywhere}
+.ct-node span{display:block;color:var(--muted);margin-top:4px}
+.ct-node[aria-pressed=true]{border-color:var(--accent);box-shadow:inset 3px 0 var(--accent)}
+.ct-editor{border-top:1px solid var(--line);margin-top:20px;padding-top:16px}
+.ct-fields{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(190px,100%),1fr));gap:12px}
+.ct-fields label{display:grid;gap:5px;min-width:0}.ct-fields input,.ct-fields select{width:100%;min-width:0}
+.ct-flags{display:flex;gap:16px;flex-wrap:wrap;margin-top:12px}
+.ct-pop{position:fixed;inset:auto;margin:0;padding:16px;width:min(680px,calc(100vw - 24px));max-height:80vh;
+overflow:auto;border:1px solid var(--line);border-radius:6px;background:#fff;color:var(--text);box-shadow:0 6px 24px #0003;z-index:200}
+.ct-pop::backdrop{background:transparent}.ct-pop-tabs{display:flex;gap:6px;border-bottom:1px solid var(--line);margin-bottom:12px}
+.ct-pop-tabs button{border:0;border-radius:0;border-bottom:2px solid transparent}
+.ct-pop-tabs button[aria-pressed=true]{color:var(--accent);border-bottom-color:var(--accent)}
+.ct-numas{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(240px,100%),1fr));gap:16px;margin-top:12px}
+.ct-chip{border-top:1px solid var(--line);padding-top:7px;margin-top:7px}
+.ct-group-title{display:flex;align-items:center;justify-content:space-between;gap:6px;margin-bottom:7px}
+.ct-cores{display:grid;grid-template-columns:repeat(auto-fit,minmax(42px,1fr));gap:5px}
+.ct-core{display:grid;gap:3px;padding:3px;background:var(--panel);border-radius:4px;align-content:start}
+.ct-cpu{padding:5px 1px;min-width:0;font-variant-numeric:tabular-nums}
+.ct-cpu[aria-pressed=true]{background:var(--accent);color:#fff}
+.ct-cpu.ct-overlap{border-bottom:3px solid var(--warn)}
+.ct-cpu.ct-other{position:relative;background:#e2e5eb;color:var(--text);opacity:1;padding-bottom:12px}
+.ct-cpu.ct-chiplet::after,.ct-cpu.ct-numa::after{content:'';position:absolute;left:20%;right:20%;bottom:4px;height:2px;background:var(--muted)}
+.ct-cpu.ct-numa::after{box-shadow:0 -4px 0 var(--muted)}
+.ct-scope-bar{height:3px;background:var(--accent);margin:8px 0}
+.ct-scope-bar.ct-double{box-shadow:0 -5px 0 var(--accent);margin-top:12px}
+.ct-pop-footer{display:flex;gap:10px;justify-content:flex-end;margin-top:14px}
+.ct-mask{overflow-wrap:anywhere;margin-top:10px}.ct-small-action{padding:2px 6px}
+@media(pointer:coarse){.ct-cpu{min-height:44px}}
+"""
+
+JS = r"""
+function ctNormalizeAffinity(a){
+  const result={...a};
+  if(result.kind==='strategy'&&result.scope==='numa')result.mode='pack-numa';
+  delete result.scope;return result;
+}
+function ctPlacementScope(a){
+  if(a.kind!=='strategy')return 'exclusive';
+  const mode=ctNormalizeAffinity(a).mode;
+  return mode==='pack-numa'?'numa':mode.endsWith('-chiplet')?'chiplet':'exclusive';
+}
+async function ctResolvePlacements(nodes,load){
+  const result=new Map();
+  await Promise.all([...new Set(nodes.map(n=>n.host_id))].map(async host=>{
+    const local=nodes.filter(n=>n.host_id===host),used=new Set(local.flatMap(n=>n.affinity.kind==='manual'?n.affinity.cpus:[]));
+    let blocked='';
+    const shared=n=>ctPlacementScope(n.affinity)!=='exclusive';
+    for(const node of [...local.filter(n=>!shared(n)),...local.filter(shared).sort((a,b)=>(ctPlacementScope(a.affinity)==='numa')-(ctPlacementScope(b.affinity)==='numa'))]){
+      const a={...ctNormalizeAffinity(node.affinity),scope:ctPlacementScope(node.affinity)};
+      if(a.kind==='manual'){result.set(node,{supported:true,cpus:[...a.cpus]});continue}
+      if(a.mode==='none'){result.set(node,{supported:true,cpus:[]});continue}
+      if(blocked){result.set(node,{supported:false,reason:'Placement blocked by '+blocked});continue}
+      try{
+        if(shared(node)){
+          const response=await load(host),t=response.topology;
+          if(!t?.allowed_cpus?.length)throw Error('Host topology unavailable');
+          const allowed=new Set(t.allowed_cpus),groups=(a.scope==='numa'?t.numa_nodes:t.chiplets)||[];
+          const units=groups.map((g,i)=>({cpus:g.cpus.filter(c=>allowed.has(c)),numa:g.numa_node??g.id??i}));
+          if(!Number.isInteger(a.count)||a.count<1)throw Error('Reserve must be a positive integer');
+          const reserve=[],cpus=new Set();
+          const occupied=u=>u.cpus.filter(c=>used.has(c)).length;
+          units.sort((x,y)=>a.mode.startsWith('spread-numa')?occupied(x)-occupied(y)||x.numa-y.numa:
+            x.numa-y.numa||occupied(x)-occupied(y));
+          for(const unit of units){
+            const free=unit.cpus.filter(c=>!used.has(c)&&!reserve.includes(c));
+            if(!free.length)continue;
+            // Keep SMT siblings adjacent when choosing accounting slots, without narrowing affinity.
+            const ordered=[...new Set((t.physical_cores||[]).flatMap(core=>core.filter(c=>free.includes(c))).concat(free))];
+            reserve.push(...ordered.slice(0,a.count-reserve.length));unit.cpus.forEach(c=>cpus.add(c));
+            if(reserve.length===a.count)break;
+          }
+          if(reserve.length!==a.count)throw Error('Not enough free CPU capacity for shared '+a.scope+' affinity');
+          result.set(node,{supported:true,cpus:[...cpus].sort((a,b)=>a-b),reserved_cpus:reserve,scope:a.scope});
+          reserve.forEach(c=>used.add(c));continue;
+        }
+        const response=await load(host,a,[...used]),p=response.placement;
+        if(!p?.supported)throw Error(p?.reason||'Placement preview unavailable');
+        if(used.size&&!Array.isArray(p.excluded_cpus))throw Error('Update this host to support joint placement');
+        if(!Array.isArray(p.cpus)||!p.cpus.length||p.cpus.some(c=>used.has(c)))throw Error('Host returned an overlapping placement');
+        result.set(node,p);p.cpus.forEach(c=>used.add(c));
+      }catch(e){result.set(node,{supported:false,reason:e.message||String(e)});blocked=node.name}
+    }
+  }));
+  return result;
+}
+function ctDefaultNode(host,role,index){
+  return {name:role+'-'+index,role,host_id:host,binary:'bundled',vcpu:8,
+    actor_system:{use_shared_threads:false,use_united_pool:false,use_ring_queue:true},
+    sector_map:{count:1,size_gib:64},affinity:{kind:'strategy',mode:'none',count:8}};
+}
+function ctAffinityLabel(value){const a=ctNormalizeAffinity(value);return a.kind==='manual'?'CPU '+cpuRanges(a.cpus):
+  a.mode==='none'?'No pinning':a.mode+' · '+a.count+' CPU';}
+async function renderClusterTemplates(id){
+  clearRefresh();const generation=(renderClusterTemplates.version||0)+1,current=location.hash;
+  renderClusterTemplates.version=generation;
+  const active=()=>generation===renderClusterTemplates.version&&location.hash===current;
+  try{
+    const [records,directory]=await Promise.all([api('/api/cluster-templates'),api('/api/hosts')]);
+    if(!active())return;
+    const hosts=[directory.local,...directory.hosts],hostName=id=>hosts.find(h=>h.id===id)?.name||'Unavailable host';
+    if(!id){
+      app.innerHTML=shell('cluster-templates','<div class=runs-toolbar><span class=muted>Placement templates · this server</span>'+
+        '<a class="button primary" href="#cluster-templates/new">New template</a></div>'+
+        (records.length?'<div class=table-scroll><table><thead><tr><th>Template</th><th>Hosts</th><th>Nodes</th><th>Updated</th></tr></thead><tbody>'+
+        records.map(r=>'<tr><td><a href="#cluster-templates/'+enc(r.id)+'">'+esc(r.name)+'</a></td><td>'+
+          [...new Set(r.nodes.map(n=>hostName(n.host_id)))].map(esc).join(', ')+'</td><td>'+r.nodes.length+
+          '</td><td>'+humanTime(r.updated_at)+'</td></tr>').join('')+'</tbody></table></div>':'<p>No saved templates.</p>'));
+      return;
+    }
+    let record=id==='new'?{name:'New cluster',nodes:[ctDefaultNode(directory.local.id,'static',1),
+      ctDefaultNode(hosts[1]?.id||directory.local.id,'dynamic',1),ctDefaultNode(directory.local.id,'cli',1)]}:
+      JSON.parse(JSON.stringify(records.find(r=>r.id===id)||null));
+    if(!record)throw Error('Template no longer exists');
+    record.nodes.forEach(n=>n.affinity=ctNormalizeAffinity(n.affinity));
+    let selected=0,saving=false;
+    let previewVersion=0;
+    const topology=async(host,affinity,excluded=[])=>{
+      const query=affinity?.kind==='strategy'?'?mode='+enc(affinity.mode)+'&cpus='+enc(affinity.count)+'&exclude='+enc(excluded.join(',')):'';
+      return api('/api/hosts/'+enc(host)+'/api/system-topology'+query);
+    };
+    async function refreshCards(){
+      const version=++previewVersion,nodes=record.nodes.map(n=>({...n,affinity:JSON.parse(JSON.stringify(n.affinity))}));
+      const plans=await ctResolvePlacements(nodes,topology);
+      if(!active()||version!==previewVersion)return;
+      nodes.forEach((node,i)=>{
+        const p=plans.get(node),target=app.querySelector('[data-ct-plan="'+i+'"]');
+        if(target){target.textContent=p.supported?(node.affinity.mode==='none'?'':
+          (p.reserved_cpus?'Reserve '+p.reserved_cpus.length+' CPU · affinity ':'')+p.cpus.length+' CPUs · '+cpuRanges(p.cpus)):p.reason;
+          target.className=p.supported?'':'error'}
+      });
+    }
+    function draw(){
+      if(!active())return;
+      const n=record.nodes[selected];
+      const groups=[...new Set(record.nodes.map(n=>n.host_id))];
+      app.innerHTML=shell('cluster-templates',
+        '<div class=runs-toolbar><a href="#cluster-templates">Cluster templates</a><div class=runs-actions>'+
+        '<button id=ct-copy>Copy template</button>'+(record.id?'<button id=ct-delete>Delete</button>':'')+
+        '<button id=ct-save class=primary>Save template</button></div></div><div id=ct-error></div>'+
+        '<div class=ct-fields><label>Template name<input id=ct-name maxlength=200 value="'+esc(record.name)+'"></label></div>'+
+        '<p class=muted>Placement only · does not start a cluster</p><div class=ct-hosts>'+groups.map(host=>
+          '<section class=ct-host><strong>'+esc(hostName(host))+'</strong>'+record.nodes.map((node,i)=>node.host_id!==host?'':
+            '<button class=ct-node data-ct-node="'+i+'" aria-pressed="'+(selected===i)+'">'+esc(node.name)+' · '+esc(node.role)+
+            '<span>'+(node.role==='cli'?'':esc(node.vcpu)+' vCPU · ')+esc(ctAffinityLabel(node.affinity))+'</span>'+
+            '<span data-ct-plan="'+i+'">Calculating placement…</span></button>').join('')+
+          '</section>').join('')+'</div><p><button id=ct-add>Add node</button></p>'+
+        (n?'<section class=ct-editor><div class=runs-toolbar><strong>'+esc(n.name)+'</strong><div class=runs-actions>'+
+          '<button id=ct-duplicate>Duplicate node</button><button id=ct-remove>Remove node</button></div></div><div class=ct-fields>'+
+          '<label>Name<input data-ct-field=name maxlength=80 value="'+esc(n.name)+'"></label><label>Type<select data-ct-field=role>'+
+          ['static','dynamic','cli'].map(v=>'<option '+(n.role===v?'selected':'')+'>'+v+'</option>').join('')+'</select></label>'+
+          '<label>Host<select data-ct-field=host_id>'+(!hosts.some(h=>h.id===n.host_id)?'<option value="'+esc(n.host_id)+'">Unavailable host</option>':'')+
+          hosts.map(h=>'<option value="'+esc(h.id)+'" '+(n.host_id===h.id?'selected':'')+'>'+esc(h.name)+'</option>').join('')+'</select></label>'+
+          '<label>Binary · bundled, version or path<input data-ct-field=binary value="'+esc(n.binary)+'"></label>'+
+          (n.role!=='cli'?'<label>Actor-system vCPU<input type=number min=1 max=65536 data-ct-field=vcpu value="'+n.vcpu+'"></label>':'')+
+          '<label>CPU affinity<button id=ct-affinity aria-haspopup=dialog>'+esc(ctAffinityLabel(n.affinity))+'</button></label>'+
+          (n.role==='static'?'<label>SectorMap count<input type=number min=1 max=64 data-ct-disk=count value="'+n.sector_map.count+'"></label>'+
+            '<label>SectorMap size · GiB<input type=number min=1 max=1048576 data-ct-disk=size_gib value="'+n.sector_map.size_gib+'"></label>':'')+
+          '</div>'+(n.role!=='cli'?'<div class=ct-flags>'+['use_shared_threads','use_united_pool','use_ring_queue'].map(k=>
+            '<label><input type=checkbox data-ct-flag="'+k+'" '+(n.actor_system[k]?'checked':'')+'>'+esc(k)+'</label>').join('')+'</div>':'')+'</section>':''));
+      const error=e=>{if(active())app.querySelector('#ct-error').innerHTML=displayError(e)};
+      app.querySelector('#ct-name').oninput=e=>record.name=e.target.value;
+      app.querySelectorAll('[data-ct-node]').forEach(b=>b.onclick=()=>{selected=+b.dataset.ctNode;draw()});
+      app.querySelectorAll('[data-ct-field]').forEach(f=>f.onchange=()=>{
+        const field=f.dataset.ctField;n[field]=f.type==='number'?Number(f.value):f.value;
+        if(field==='role'){n.vcpu??=8;n.actor_system??=ctDefaultNode('',n.role,1).actor_system;n.sector_map??={count:1,size_gib:64}}
+        if(field==='host_id')n.affinity={kind:'strategy',mode:'none',count:8};
+        draw();
+      });
+      app.querySelectorAll('[data-ct-disk]').forEach(f=>f.onchange=()=>n.sector_map[f.dataset.ctDisk]=Number(f.value));
+      app.querySelectorAll('[data-ct-flag]').forEach(f=>f.onchange=()=>n.actor_system[f.dataset.ctFlag]=f.checked);
+      const unique=role=>{let i=1;while(record.nodes.some(n=>n.name===role+'-'+i))i++;return role+'-'+i};
+      app.querySelector('#ct-add').onclick=()=>{if(record.nodes.length>=64)return error('At most 64 nodes');
+        const node=ctDefaultNode(directory.local.id,'dynamic',1);node.name=unique('dynamic');record.nodes.push(node);selected=record.nodes.length-1;draw()};
+      if(n){
+        app.querySelector('#ct-remove').onclick=()=>{record.nodes.splice(selected,1);selected=Math.max(0,selected-1);draw()};
+        app.querySelector('#ct-duplicate').onclick=()=>{if(record.nodes.length>=64)return error('At most 64 nodes');
+          const copy=JSON.parse(JSON.stringify(n));copy.name=unique(n.role);record.nodes.push(copy);selected=record.nodes.length-1;draw()};
+        app.querySelector('#ct-affinity').onclick=e=>openAffinity(n,e.currentTarget);
+      }
+      app.querySelector('#ct-copy').onclick=()=>{delete record.id;delete record.revision;record.name+=' copy';draw()};
+      const del=app.querySelector('#ct-delete');if(del)del.onclick=async()=>{
+        if(!confirm('Delete template "'+record.name+'"?'))return;
+        try{await api('/api/cluster-templates/delete',jsonOptions({id:record.id,revision:record.revision}));if(active())setRoute('cluster-templates')}catch(e){error(e)}
+      };
+      app.querySelector('#ct-save').onclick=async e=>{
+        if(saving)return;saving=true;e.currentTarget.disabled=true;
+        try{record=await api('/api/cluster-templates',jsonOptions(record));if(active()){
+          if(id!==record.id)setRoute('cluster-templates/'+record.id);else{draw();app.querySelector('#ct-error').textContent='Saved'}
+        }}catch(e){error(e)}finally{saving=false;const b=app.querySelector('#ct-save');if(b)b.disabled=false}
+      };
+      refreshCards();
+    }
+    async function openAffinity(node,anchor){
+      const pop=document.createElement('div');pop.className='ct-pop';pop.setAttribute('popover','auto');
+      pop.setAttribute('role','dialog');pop.setAttribute('aria-label','CPU affinity');app.appendChild(pop);
+      const rect=anchor.getBoundingClientRect();pop.style.left=Math.max(12,Math.min(rect.left,innerWidth-704))+'px';
+      pop.style.top=Math.max(12,Math.min(rect.bottom+6,innerHeight-360))+'px';
+      let closed=false,request=0,data=null,mask=[],message='',busy=false;
+      let popupPreviews=new Map(),popupErrors=[];
+      const draft=JSON.parse(JSON.stringify(node.affinity));
+      const close=()=>{if(closed)return;closed=true;removeEventListener('hashchange',close);pop.dispatchEvent(new Event('ct-cleanup'));
+        if(pop.isConnected){if(pop.hidePopover)try{pop.hidePopover()}catch{}pop.remove()}if(anchor.isConnected)anchor.focus()};
+      addEventListener('hashchange',close);
+      if(pop.showPopover){pop.addEventListener('toggle',e=>{if(e.newState==='closed')close()});pop.showPopover()}
+      else{const outside=e=>{if(!pop.contains(e.target)&&e.target!==anchor)close()};setTimeout(()=>{if(!closed)document.addEventListener('pointerdown',outside)},0);
+        pop.addEventListener('ct-cleanup',()=>document.removeEventListener('pointerdown',outside),{once:true})}
+      pop.addEventListener('keydown',e=>{if(e.key==='Escape'){e.preventDefault();close()}});
+      const alive=()=>!closed&&active()&&pop.isConnected;
+      async function refresh(){
+        const version=++request;busy=true;message='';paint();
+        try{
+          const originals=record.nodes.filter(n=>n.host_id===node.host_id);
+          const nodes=originals.map(n=>({...n,affinity:n===node?JSON.parse(JSON.stringify(draft)):n.affinity}));
+          const plans=await ctResolvePlacements(nodes,topology);
+          const response=await topology(node.host_id);if(!alive()||version!==request)return;
+          data=response;
+          popupPreviews=new Map();popupErrors=[];nodes.forEach((n,i)=>{const p=plans.get(n);
+            if(p.supported)popupPreviews.set(originals[i],p);else if(originals[i]!==node)popupErrors.push(n.name+': '+p.reason)});
+          if(draft.kind==='strategy'){
+            const p=plans.get(nodes[originals.indexOf(node)]);
+            if(!p?.supported)throw Error(p?.reason||'Placement preview unavailable');
+            mask=p.cpus||[];
+          }else mask=[...draft.cpus];
+          const allowed=new Set(data.topology.allowed_cpus);if(mask.some(c=>!allowed.has(c)))throw Error('Some selected CPUs are no longer available');
+        }catch(e){if(alive()&&version===request)message=e.message||String(e)}
+        finally{if(alive()&&version===request){busy=false;paint()}}
+      }
+      function paint(){
+        if(!alive())return;
+        const manual=draft.kind==='manual',t=data?.topology,owners=new Map();
+        record.nodes.filter(x=>x!==node&&x.host_id===node.host_id).forEach(x=>{
+          const p=popupPreviews.get(x),cpus=x.affinity.kind==='manual'?x.affinity.cpus:p?.reserved_cpus||p?.cpus||[];
+          cpus.forEach(c=>owners.set(c,{name:x.name,scope:p?.scope||'exclusive'}));
+        });
+        const used=new Set(owners.keys()),own=popupPreviews.get(node),reserved=own?.reserved_cpus||mask;
+        const groups=t?.numa_nodes?.length?t.numa_nodes:[{id:0,cpus:t?.allowed_cpus||[]}];
+        pop.innerHTML='<div class=runs-toolbar><strong>CPU affinity · '+esc(hostName(node.host_id))+'</strong><button id=ct-close aria-label="Close affinity picker">×</button></div>'+
+          '<div class=ct-pop-tabs><button data-kind=strategy aria-pressed="'+!manual+'">Strategy</button>'+
+          '<button data-kind=manual aria-pressed="'+manual+'">Manual</button></div>'+
+          (!manual?'<div class=ct-fields><label>Placement<select id=ct-mode '+(busy?'disabled':'')+'>'+ (data?.affinity||[{mode:draft.mode,supported:true}]).map(a=>
+            '<option value="'+esc(a.mode)+'" '+(draft.mode===a.mode?'selected':'')+' '+(!a.supported?'disabled':'')+'>'+esc(a.mode)+'</option>').join('')+
+            '</select></label>'+
+            '<label>CPU reserve<input id=ct-count type=number min=1 max=65536 value="'+draft.count+'" '+
+            (busy||draft.mode==='none'?'disabled':'')+'></label></div>':'')+
+          (busy?'<p role=status>Loading placement…</p>':'')+(message?displayError(message):'')+
+          (t?'<div class=ct-numas>'+groups.map((g,gi)=>{
+            const allowed=new Set(g.cpus),chips=(t.chiplets||[]).filter(c=>c.numa_node===g.id);
+            const covered=new Set(chips.flatMap(c=>c.cpus));const rest=g.cpus.filter(c=>!covered.has(c));
+            if(rest.length)chips.push({cpus:rest,label:'Other CPUs'});
+            return '<section><div class=ct-group-title><strong>NUMA '+esc(g.id)+'</strong>'+
+              (manual?'<button class=ct-small-action data-numa="'+gi+'">Select NUMA</button>':'')+'</div>'+
+              chips.map((ch,ci)=>{
+                const cpus=ch.cpus.filter(c=>allowed.has(c)),set=new Set(cpus),cores=[],seen=new Set();
+                for(const core of t.physical_cores||[]){const items=core.filter(c=>set.has(c));if(items.length){cores.push(items);items.forEach(c=>seen.add(c))}}
+                cpus.filter(c=>!seen.has(c)).forEach(c=>cores.push([c]));
+                return '<div class=ct-chip><div class=ct-group-title><span>'+esc(ch.label||'Chiplet '+ci)+' · '+
+                  cpus.filter(c=>!used.has(c)&&!reserved.includes(c)).length+'/'+cpus.length+' free</span>'+
+                  (manual?'<button class=ct-small-action data-cpus="'+cpus.join(',')+'">Select</button>':'')+'</div>'+
+                  (own?.scope&&cpus.some(c=>mask.includes(c))?'<div class="ct-scope-bar '+(own.scope==='numa'?'ct-double':'')+'"></div>':'')+'<div class=ct-cores>'+cores.map(core=>
+                    '<div class=ct-core>'+core.map(c=>'<button class="ct-cpu '+(used.has(c)?'ct-other ct-'+owners.get(c).scope:'')+'" data-cpus="'+c+'" title="'+
+                      esc(used.has(c)?owners.get(c).name+' · '+owners.get(c).scope+' reservation':'CPU '+c)+'" aria-label="CPU '+c+
+                      (used.has(c)?', '+esc(owners.get(c).name)+' '+owners.get(c).scope+' reservation':'')+'" aria-pressed="'+reserved.includes(c)+'" '+
+                      (!manual||busy?'disabled':'')+'>'+c+'</button>').join('')+'</div>').join('')+'</div></div>';
+              }).join('')+'</section>';
+          }).join('')+'</div>':'')+
+          '<div class=ct-mask>'+(!manual&&draft.mode==='none'?'No pinning':mask.length+' logical CPUs · '+esc(cpuRanges(mask)))+'</div>'+
+          '<button type=button class=ct-small-action title="Vertical pairs are SMT siblings. Grey cells reserve capacity for other nodes: '+
+          'one line means chiplet, two mean NUMA; no line means fixed placement. Bars show the selected node affinity. Reservations are not CPU quotas.">?</button>'+
+          popupErrors.map(e=>displayError(e)).join('')+
+          '<div class=ct-pop-footer><button id=ct-cancel>Cancel</button><button id=ct-apply class=primary '+
+          (busy||message||!data||(manual&&!mask.length)?'disabled':'')+'>Apply</button></div>';
+        pop.querySelector('#ct-close').onclick=close;pop.querySelector('#ct-cancel').onclick=close;
+        pop.querySelectorAll('[data-kind]').forEach(b=>b.onclick=()=>{
+          draft.kind=b.dataset.kind;if(draft.kind==='manual')draft.cpus=[...mask];else{draft.mode??='pack-numa-pack-chiplet';draft.count??=mask.length||8}refresh()
+        });
+        function toggle(cpus){if(busy)return;const remove=cpus.every(c=>mask.includes(c)),set=new Set(mask);
+          cpus.forEach(c=>remove?set.delete(c):set.add(c));mask=[...set].sort((a,b)=>a-b);draft.cpus=mask;
+          message=mask.some(c=>!data.topology.allowed_cpus.includes(c))?'Some selected CPUs are no longer available':'';refresh()}
+        pop.querySelectorAll('[data-cpus]').forEach(b=>b.onclick=()=>toggle(b.dataset.cpus.split(',').filter(Boolean).map(Number)));
+        pop.querySelectorAll('[data-numa]').forEach(b=>b.onclick=()=>toggle(groups[+b.dataset.numa].cpus));
+        const mode=pop.querySelector('#ct-mode');if(mode)mode.onchange=()=>{draft.mode=mode.value;delete draft.scope;refresh()};
+        const count=pop.querySelector('#ct-count');if(count)count.onchange=()=>{draft.count=Number(count.value);refresh()};
+        pop.querySelector('#ct-apply').onclick=()=>{
+          node.affinity=manual?{kind:'manual',cpus:[...mask]}:{kind:'strategy',mode:draft.mode,count:draft.count};
+          close();draw();app.querySelector('#ct-affinity')?.focus();
+        };
+        const height=pop.getBoundingClientRect().height;
+        pop.style.top=Math.max(12,Math.min(rect.bottom+6,innerHeight-height-12))+'px';
+      }
+      refresh();
+    }
+    draw();
+  }catch(e){if(active())app.innerHTML=shell('cluster-templates',displayError(e))}
+}
+"""

--- a/ydb/tools/ydb_bench/lib/cluster_templates_ui.py
+++ b/ydb/tools/ydb_bench/lib/cluster_templates_ui.py
@@ -3,9 +3,19 @@
 CSS = r"""
 .ct-hosts{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(260px,100%),1fr));gap:16px}
 .ct-host{padding:12px;background:var(--panel);border:1px solid var(--line);border-radius:6px;min-width:0}
+.ct-zone-header{display:flex;flex-wrap:wrap;align-items:center;gap:.6rem}
+.ct-zone-header>strong{min-width:0;overflow-wrap:anywhere}
 .ct-node{display:block;width:100%;text-align:left;margin:8px 0;padding:10px;overflow-wrap:anywhere}
 .ct-node span{display:block;color:var(--muted);margin-top:4px}
 .ct-node[aria-pressed=true]{border-color:var(--accent);box-shadow:inset 3px 0 var(--accent)}
+.ct-node[draggable=true]{cursor:grab}.ct-host.ct-drop{outline:2px solid var(--accent);background:var(--panel)}
+.ct-empty{color:var(--muted);padding:14px 0}.ct-placement-tabs{display:flex;gap:.35rem;margin:16px 0;border-bottom:1px solid var(--line)}
+.ct-placement-tabs button{padding:.6rem .8rem;border:1px solid transparent;border-radius:6px 6px 0 0;background:transparent;color:var(--muted);margin-bottom:-1px}
+.ct-placement-tabs button[aria-pressed=true]{background:#fff;color:var(--text);font-weight:650;border-color:var(--line);border-bottom-color:#fff}
+.ct-rack{margin-top:12px;padding:10px;border:1px solid var(--line);border-radius:4px;min-height:70px}
+.ct-dialog{width:min(440px,calc(100vw - 32px));border:1px solid var(--line);border-radius:6px;padding:20px}
+.ct-dialog::backdrop{background:#0004}
+.ct-create-actions{justify-content:flex-end}
 .ct-editor{border-top:1px solid var(--line);margin-top:20px;padding-top:16px}
 .ct-fields{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(190px,100%),1fr));gap:12px}
 .ct-fields label{display:grid;gap:5px;min-width:0}.ct-fields input,.ct-fields select{width:100%;min-width:0}
@@ -88,10 +98,63 @@ async function ctResolvePlacements(nodes,load){
   }));
   return result;
 }
+function ctMoveNode(record,index,kind,target,resetManual=false){
+  const n=record.nodes[index];if(!n)throw Error('Node no longer exists');
+  if(n.role==='cli'&&kind!=='physical')throw Error('CLI load generators only have physical placement');
+  if(kind==='physical'){
+    if(!record.host_ids.includes(target))throw Error('Select a template host');
+    if(n.host_id===target)return;
+    if(n.affinity.kind==='manual'&&!resetManual)throw Error('Clear the manual CPU mask before moving to another host');
+    if(n.affinity.kind==='manual')n.affinity={kind:'strategy',mode:'none',count:n.vcpu||8};
+    n.host_id=target;
+  }else if(kind==='logical'){
+    const [dc,rack]=target;
+    if((dc&&!record.data_centers.some(d=>d.name===dc&&(!rack||d.racks.includes(rack))))||(!dc&&rack))throw Error('Unknown rack');
+    if(dc&&!rack)throw Error('Select a rack');
+    n.location={data_center:dc,rack,body:rack?n.name:''};
+  }else if(kind==='tenants'){
+    if(n.role==='static')throw Error('Static nodes are shared cluster infrastructure');
+    if(target&&!record.tenants.some(t=>t.path===target))throw Error('Unknown tenant');
+    n.tenant=target;
+  }else throw Error('Unknown placement view');
+}
 function ctDefaultNode(host,role,index){
   return {name:role+'-'+index,role,host_id:host,binary:'bundled',vcpu:8,
     actor_system:{use_shared_threads:false,use_united_pool:false,use_ring_queue:true},
     sector_map:{count:1,size_gib:64},affinity:{kind:'strategy',mode:'none',count:8}};
+}
+function ctNormalizeNodePlacement(n){
+  n.location??={data_center:'',rack:'',body:''};n.tenant??='';
+  if(n.role==='cli')n.location={data_center:'',rack:'',body:''};
+  if(n.role!=='dynamic')n.tenant='';
+  if(n.role!=='cli')n.location.body=n.location.rack?n.name:'';
+}
+function ctRenameNode(record,node,value){
+  const name=value.trim();
+  if(!name||name.length>80)throw Error('Node name must contain 1 to 80 characters');
+  if(record.nodes.some(other=>other!==node&&other.name.trim()===name))throw Error('Node names must be unique');
+  node.name=name;ctNormalizeNodePlacement(node);
+}
+function ctRemoveLocation(record,dcName,rack){
+  const dc=record.data_centers.find(d=>d.name===dcName);
+  if(!dc||rack!==undefined&&!dc.racks.includes(rack))throw Error('Location no longer exists');
+  record.nodes.forEach(n=>{
+    if(n.location?.data_center===dcName&&(rack===undefined||n.location.rack===rack))n.location={data_center:'',rack:'',body:''};
+  });
+  if(rack===undefined)record.data_centers=record.data_centers.filter(d=>d!==dc);
+  else dc.racks=dc.racks.filter(r=>r!==rack);
+}
+function ctRemoveTenant(record,path){
+  if(!record.tenants.some(t=>t.path===path))throw Error('Tenant no longer exists');
+  record.nodes.forEach(n=>{if(n.tenant===path)n.tenant=''});
+  record.tenants=record.tenants.filter(t=>t.path!==path);
+}
+function ctRemoveHost(record,host,target){
+  if(!record.host_ids.includes(host))throw Error('Host no longer exists');
+  const nodes=record.nodes.filter(n=>n.host_id===host);
+  if(nodes.length&&(!record.host_ids.includes(target)||target===host))throw Error('Select another template host for these nodes');
+  nodes.forEach(n=>ctMoveNode(record,record.nodes.indexOf(n),'physical',target,true));
+  record.host_ids=record.host_ids.filter(h=>h!==host);
 }
 function ctAffinityLabel(value){const a=ctNormalizeAffinity(value);return a.kind==='manual'?'CPU '+cpuRanges(a.cpus):
   a.mode==='none'?'No pinning':a.mode+' · '+a.count+' CPU';}
@@ -113,11 +176,17 @@ async function renderClusterTemplates(id){
       return;
     }
     let record=id==='new'?{name:'New cluster',nodes:[ctDefaultNode(directory.local.id,'static',1),
-      ctDefaultNode(hosts[1]?.id||directory.local.id,'dynamic',1),ctDefaultNode(directory.local.id,'cli',1)]}:
+      ctDefaultNode(directory.local.id,'dynamic',1),ctDefaultNode(directory.local.id,'cli',1)]}:
       JSON.parse(JSON.stringify(records.find(r=>r.id===id)||null));
     if(!record)throw Error('Template no longer exists');
     record.nodes.forEach(n=>n.affinity=ctNormalizeAffinity(n.affinity));
-    let selected=0,saving=false;
+    record.host_ids??=[...new Set(record.nodes.map(n=>n.host_id))];record.data_centers??=[];record.tenants??=[];
+    record.nodes.forEach(ctNormalizeNodePlacement);
+    record.nodes.forEach(n=>{
+      const dc=record.data_centers.find(dc=>dc.name===n.location.data_center);
+      if(dc&&!n.location.rack){if(!dc.racks.length)dc.racks.push('rack-1');n.location.rack=dc.racks[0];ctNormalizeNodePlacement(n)}
+    });
+    let selected=0,saving=false,view='physical',dragged=null;
     let previewVersion=0;
     const topology=async(host,affinity,excluded=[])=>{
       const query=affinity?.kind==='strategy'?'?mode='+enc(affinity.mode)+'&cpus='+enc(affinity.count)+'&exclude='+enc(excluded.join(',')):'';
@@ -134,27 +203,86 @@ async function renderClusterTemplates(id){
           target.className=p.supported?'':'error'}
       });
     }
+    function dialog(title,fields,submit){
+      const pop=document.createElement('dialog');pop.className='ct-dialog';pop.setAttribute('aria-label',title);
+      pop.innerHTML='<form><h3>'+esc(title)+'</h3><div class=ct-fields>'+fields+'</div><p class=error role=alert></p>'+
+        '<div class=ct-pop-footer><button type=button>Cancel</button><button class=primary type=submit>'+esc(title)+'</button></div></form>';
+      app.appendChild(pop);pop.onclose=()=>pop.remove();pop.querySelector('[type=button]').onclick=()=>pop.close();
+      pop.querySelector('form').onsubmit=e=>{e.preventDefault();try{submit(new FormData(e.currentTarget));pop.close();draw()}
+        catch(error){pop.querySelector('[role=alert]').textContent=error.message}};pop.showModal();
+    }
+    function move(index,kind,target){
+      const n=record.nodes[index];
+      if(kind==='physical'&&n.host_id!==target&&n.affinity.kind==='manual'){
+        draw();
+        dialog('Move node','<p>Move '+esc(n.name)+' to '+esc(hostName(target))+' and clear its manual CPU mask? '+
+          'Select affinity again on the destination host.</p>',()=>ctMoveNode(record,index,kind,target,true));return;
+      }
+      try{ctMoveNode(record,index,kind,target);draw()}catch(e){app.querySelector('#ct-error').innerHTML=displayError(e)}
+    }
     function draw(){
       if(!active())return;
+      if(view!=='physical'&&record.nodes[selected]?.role==='cli')selected=record.nodes.findIndex(n=>n.role!=='cli');
+      if(view==='physical'&&selected<0&&record.nodes.length)selected=0;
       const n=record.nodes[selected];
-      const groups=[...new Set(record.nodes.map(n=>n.host_id))];
+      const targets=[];
+      const card=(node,i)=>'<button class=ct-node draggable=true data-ct-node="'+i+'" aria-pressed="'+(selected===i)+'">'+esc(node.name)+' · '+esc(node.role)+
+        '<span>'+esc(hostName(node.host_id))+(node.role==='cli'?' · Load generator':
+        ' · '+esc([node.location?.data_center,node.location?.rack,node.location?.body].filter(Boolean).join(' / ')||'No logical location')+
+        ' · '+esc(node.role==='static'?'Shared infrastructure':node.tenant||'No tenant'))+'</span>'+
+        '<span>'+(node.role==='cli'?'':esc(node.vcpu)+' vCPU · ')+esc(ctAffinityLabel(node.affinity))+'</span>'+
+        '<span data-ct-plan="'+i+'">Calculating placement…</span></button>';
+      const cards=filter=>record.nodes.map((node,i)=>(view==='physical'||node.role!=='cli')&&filter(node)?card(node,i):'').join('')||'<p class=ct-empty>No nodes</p>';
+      const zone=(title,target,filter,actions='',description='')=>{
+        const index=targets.push(target)-1;
+        const content=view==='logical'&&target[1]?record.nodes.map((node,i)=>node.role!=='cli'&&filter(node)?
+          '<div class=ct-rack><span class=muted>Body · '+esc(node.name)+'</span>'+card(node,i)+'</div>':'').join('')||
+          '<p class=ct-empty>No nodes</p>':cards(filter);
+        return '<section class=ct-host data-ct-drop="'+index+'"><div class=ct-zone-header><strong>'+esc(title)+'</strong>'+
+          (actions?'<div class=runs-actions>'+actions+'</div>':'')+'</div>'+
+          (description?'<p class=muted>'+esc(description)+'</p>':'')+content+'</section>';
+      };
+      let layout='';
+      if(view==='physical')layout=record.host_ids.map((host,i)=>zone(hostName(host),host,node=>node.host_id===host,
+        '<button data-ct-delete-host="'+i+'">Remove host</button>')).join('');
+      if(view==='logical'){
+        layout=record.data_centers.map((dc,i)=>'<section class=ct-host><div class=runs-toolbar><strong>'+esc(dc.name)+
+          '</strong><div class=runs-actions><button data-ct-rack="'+i+'">+ Rack</button>'+
+          '<button data-ct-delete-dc="'+i+'">Delete DC</button></div></div>'+dc.racks.map((rack,j)=>
+            zone(rack,[dc.name,rack],node=>node.location?.data_center===dc.name&&node.location?.rack===rack,
+              '<button data-ct-delete-rack="'+i+':'+j+'">Delete rack</button>')).join('')+'</section>').join('')+
+          (record.nodes.some(n=>n.role!=='cli'&&!n.location?.data_center)?zone('Unassigned',['',''],node=>!node.location?.data_center):'');
+      }
+      if(view==='tenants')layout=record.tenants.map((tenant,i)=>zone(tenant.path,tenant.path,node=>node.role!=='static'&&node.tenant===tenant.path,
+        '<button data-ct-tenant="'+i+'">Edit</button><button data-ct-delete-tenant="'+i+'">Delete tenant</button>',
+        tenant.storage_kind.toUpperCase()+' · '+tenant.storage_groups+' storage groups')).join('')+
+        (record.nodes.some(n=>n.role==='dynamic'&&!n.tenant)?zone('Unassigned','',node=>node.role==='dynamic'&&!node.tenant):'')+
+        '<section class=ct-host><strong>Shared cluster infrastructure</strong>'+cards(node=>node.role==='static')+'</section>';
       app.innerHTML=shell('cluster-templates',
         '<div class=runs-toolbar><a href="#cluster-templates">Cluster templates</a><div class=runs-actions>'+
         '<button id=ct-copy>Copy template</button>'+(record.id?'<button id=ct-delete>Delete</button>':'')+
         '<button id=ct-save class=primary>Save template</button></div></div><div id=ct-error></div>'+
         '<div class=ct-fields><label>Template name<input id=ct-name maxlength=200 value="'+esc(record.name)+'"></label></div>'+
-        '<p class=muted>Placement only · does not start a cluster</p><div class=ct-hosts>'+groups.map(host=>
-          '<section class=ct-host><strong>'+esc(hostName(host))+'</strong>'+record.nodes.map((node,i)=>node.host_id!==host?'':
-            '<button class=ct-node data-ct-node="'+i+'" aria-pressed="'+(selected===i)+'">'+esc(node.name)+' · '+esc(node.role)+
-            '<span>'+(node.role==='cli'?'':esc(node.vcpu)+' vCPU · ')+esc(ctAffinityLabel(node.affinity))+'</span>'+
-            '<span data-ct-plan="'+i+'">Calculating placement…</span></button>').join('')+
-          '</section>').join('')+'</div><p><button id=ct-add>Add node</button></p>'+
+        '<p class=muted>Placement only · does not start a cluster</p><div class="profile-tabs ct-placement-tabs">'+
+        ['physical','logical','tenants'].map(v=>'<button data-ct-view="'+v+'" class="'+(view===v?'active':'')+'" aria-pressed="'+(view===v)+'">'+
+          v[0].toUpperCase()+v.slice(1)+'</button>').join('')+'</div><div class="runs-toolbar ct-create-actions">'+
+        (view==='physical'?'<button id=ct-add '+(!record.host_ids.length?'disabled':'')+'>Add node</button>':'')+'<button id=ct-group>'+
+        (view==='physical'?'Add host':view==='logical'?'+ DC':'Create tenant')+'</button></div><div class=ct-hosts>'+layout+'</div>'+
         (n?'<section class=ct-editor><div class=runs-toolbar><strong>'+esc(n.name)+'</strong><div class=runs-actions>'+
-          '<button id=ct-duplicate>Duplicate node</button><button id=ct-remove>Remove node</button></div></div><div class=ct-fields>'+
+          (view==='physical'?'<button id=ct-duplicate>Duplicate node</button>':'')+
+          '<button id=ct-remove>Remove node</button></div></div><div class=ct-fields>'+
           '<label>Name<input data-ct-field=name maxlength=80 value="'+esc(n.name)+'"></label><label>Type<select data-ct-field=role>'+
           ['static','dynamic','cli'].map(v=>'<option '+(n.role===v?'selected':'')+'>'+v+'</option>').join('')+'</select></label>'+
           '<label>Host<select data-ct-field=host_id>'+(!hosts.some(h=>h.id===n.host_id)?'<option value="'+esc(n.host_id)+'">Unavailable host</option>':'')+
-          hosts.map(h=>'<option value="'+esc(h.id)+'" '+(n.host_id===h.id?'selected':'')+'>'+esc(h.name)+'</option>').join('')+'</select></label>'+
+          hosts.filter(h=>record.host_ids.includes(h.id)).map(h=>'<option value="'+esc(h.id)+'" '+(n.host_id===h.id?'selected':'')+'>'+esc(h.name)+'</option>').join('')+'</select></label>'+
+          (n.role==='cli'?'':'<label>DC<select data-ct-location=data_center><option value="">Unassigned</option>'+record.data_centers.map(dc=>
+            '<option '+(n.location?.data_center===dc.name?'selected':'')+'>'+esc(dc.name)+'</option>').join('')+'</select></label>'+
+          '<label>Rack<select data-ct-location=rack '+(!n.location?.data_center?'disabled':'')+'>'+
+          (record.data_centers.find(dc=>dc.name===n.location?.data_center)?.racks||[]).map(rack=>
+            '<option '+(n.location?.rack===rack?'selected':'')+'>'+esc(rack)+'</option>').join('')+'</select></label>'+
+          '<label>Body<input readonly value="'+esc(n.location?.rack?n.name:'Unassigned')+'"></label>')+
+          (n.role!=='dynamic'?'':'<label>Tenant<select id=ct-node-tenant><option value="">Unassigned</option>'+record.tenants.map(t=>
+            '<option '+(n.tenant===t.path?'selected':'')+'>'+esc(t.path)+'</option>').join('')+'</select></label>')+
           '<label>Binary · bundled, version or path<input data-ct-field=binary value="'+esc(n.binary)+'"></label>'+
           (n.role!=='cli'?'<label>Actor-system vCPU<input type=number min=1 max=65536 data-ct-field=vcpu value="'+n.vcpu+'"></label>':'')+
           '<label>CPU affinity<button id=ct-affinity aria-haspopup=dialog>'+esc(ctAffinityLabel(n.affinity))+'</button></label>'+
@@ -164,22 +292,104 @@ async function renderClusterTemplates(id){
             '<label><input type=checkbox data-ct-flag="'+k+'" '+(n.actor_system[k]?'checked':'')+'>'+esc(k)+'</label>').join('')+'</div>':'')+'</section>':''));
       const error=e=>{if(active())app.querySelector('#ct-error').innerHTML=displayError(e)};
       app.querySelector('#ct-name').oninput=e=>record.name=e.target.value;
-      app.querySelectorAll('[data-ct-node]').forEach(b=>b.onclick=()=>{selected=+b.dataset.ctNode;draw()});
+      app.querySelectorAll('[data-ct-view]').forEach(b=>b.onclick=()=>{view=b.dataset.ctView;draw()});
+      const clearDrag=()=>{dragged=null;app.querySelectorAll('.ct-drop').forEach(b=>b.classList.remove('ct-drop'))};
+      app.onkeydown=e=>{if(e.key==='Escape')clearDrag()};
+      app.querySelectorAll('[data-ct-node]').forEach(b=>{
+        b.onclick=()=>{selected=+b.dataset.ctNode;draw()};
+        b.ondragstart=e=>{dragged=+b.dataset.ctNode;e.dataTransfer.effectAllowed='move';e.dataTransfer.setData('text/plain',record.nodes[dragged].name)};
+        b.ondragend=clearDrag;
+      });
+      app.querySelectorAll('[data-ct-drop]').forEach(b=>{
+        const valid=()=>dragged!==null&&(view==='physical'||record.nodes[dragged].role!=='cli')&&(view!=='tenants'||record.nodes[dragged].role==='dynamic');
+        b.ondragover=e=>{if(valid()){e.preventDefault();e.stopPropagation();e.dataTransfer.dropEffect='move';b.classList.add('ct-drop')}};
+        b.ondragleave=e=>{if(!b.contains(e.relatedTarget))b.classList.remove('ct-drop')};
+        b.ondrop=e=>{e.preventDefault();e.stopPropagation();if(valid()){const index=dragged;clearDrag();move(index,view,targets[+b.dataset.ctDrop])}};
+      });
+      app.querySelectorAll('[data-ct-location]').forEach(f=>f.onchange=()=>{
+        if(f.dataset.ctLocation==='data_center'){
+          const dc=record.data_centers.find(dc=>dc.name===f.value);
+          if(dc&&!dc.racks.length)dc.racks.push('rack-1');
+          move(selected,'logical',[f.value,dc?.racks[0]||'']);
+        }else move(selected,'logical',[n.location.data_center,f.value]);
+      });
+      const tenantSelect=app.querySelector('#ct-node-tenant');if(tenantSelect)tenantSelect.onchange=()=>move(selected,'tenants',tenantSelect.value);
       app.querySelectorAll('[data-ct-field]').forEach(f=>f.onchange=()=>{
-        const field=f.dataset.ctField;n[field]=f.type==='number'?Number(f.value):f.value;
-        if(field==='role'){n.vcpu??=8;n.actor_system??=ctDefaultNode('',n.role,1).actor_system;n.sector_map??={count:1,size_gib:64}}
-        if(field==='host_id')n.affinity={kind:'strategy',mode:'none',count:8};
+        const field=f.dataset.ctField;if(field==='host_id'){move(selected,'physical',f.value);return}
+        if(field==='name'){
+          try{ctRenameNode(record,n,f.value);draw()}catch(e){draw();error(e)}
+          return;
+        }
+        n[field]=f.type==='number'?Number(f.value):f.value;
+        if(field==='role'){n.vcpu??=8;n.actor_system??=ctDefaultNode('',n.role,1).actor_system;n.sector_map??={count:1,size_gib:64};ctNormalizeNodePlacement(n)}
         draw();
       });
       app.querySelectorAll('[data-ct-disk]').forEach(f=>f.onchange=()=>n.sector_map[f.dataset.ctDisk]=Number(f.value));
       app.querySelectorAll('[data-ct-flag]').forEach(f=>f.onchange=()=>n.actor_system[f.dataset.ctFlag]=f.checked);
       const unique=role=>{let i=1;while(record.nodes.some(n=>n.name===role+'-'+i))i++;return role+'-'+i};
-      app.querySelector('#ct-add').onclick=()=>{if(record.nodes.length>=64)return error('At most 64 nodes');
-        const node=ctDefaultNode(directory.local.id,'dynamic',1);node.name=unique('dynamic');record.nodes.push(node);selected=record.nodes.length-1;draw()};
+      const add=app.querySelector('#ct-add');if(add)add.onclick=()=>{if(record.nodes.length>=64)return error('At most 64 nodes');
+        const node=ctDefaultNode(record.host_ids[0],'dynamic',1);node.location={data_center:'',rack:'',body:''};node.tenant='';
+        node.name=unique('dynamic');record.nodes.push(node);selected=record.nodes.length-1;draw()};
+      const addName=(title,existing,submit)=>dialog(title,'<label>Name<input name=name required maxlength=80 autofocus></label>',data=>{
+        const name=data.get('name').trim();if(!name||existing.includes(name))throw Error('Enter a unique name');
+        if(existing.length>=64)throw Error('At most 64 entries');submit(name);
+      });
+      const editTenant=index=>{
+        const t=record.tenants[index]||{path:'/Root/',storage_kind:'ssd',storage_groups:1};
+        dialog(index===undefined?'Create tenant':'Edit tenant','<label>Database path<input name=path required maxlength=80 value="'+esc(t.path)+'"></label>'+
+          '<label>Storage kind<select name=kind>'+['ssd','hdd'].map(k=>'<option '+(t.storage_kind===k?'selected':'')+'>'+k+'</option>').join('')+'</select></label>'+
+          '<label>Storage groups<input name=groups type=number min=1 max=64 required value="'+t.storage_groups+'"></label>',data=>{
+            const path=data.get('path').trim();
+            if(!/^\/Root\/[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)*$/.test(path))throw Error('Use /Root/name with valid path components');
+            if(record.tenants.some((v,i)=>i!==index&&v.path===path))throw Error('Tenant already exists');
+            const value={path,storage_kind:data.get('kind'),storage_groups:Number(data.get('groups'))};
+            if(index===undefined){if(record.tenants.length>=64)throw Error('At most 64 tenants');record.tenants.push(value)}
+            else{record.tenants[index]=value;record.nodes.forEach(n=>{if(n.tenant===t.path)n.tenant=path})}
+          });
+      };
+      app.querySelectorAll('[data-ct-tenant]').forEach(b=>b.onclick=()=>editTenant(+b.dataset.ctTenant));
+      app.querySelectorAll('[data-ct-delete-tenant]').forEach(b=>b.onclick=()=>{
+        const t=record.tenants[+b.dataset.ctDeleteTenant],count=record.nodes.filter(n=>n.tenant===t.path).length;
+        const remove=()=>ctRemoveTenant(record,t.path);
+        if(count)dialog('Delete tenant','<p>'+count+' nodes will have no tenant. Physical and logical placement will be kept.</p>',remove);
+        else{remove();draw()}
+      });
+      app.querySelectorAll('[data-ct-delete-host]').forEach(b=>b.onclick=()=>{
+        const host=record.host_ids[+b.dataset.ctDeleteHost],nodes=record.nodes.filter(n=>n.host_id===host);
+        if(!nodes.length){ctRemoveHost(record,host);draw();return}
+        const destinations=record.host_ids.filter(h=>h!==host);
+        if(!destinations.length){error('Add another host to the template before removing a host with nodes');return}
+        dialog('Remove host','<p>Move '+nodes.length+' nodes to another host. Logical placement and tenants will be kept. '+
+          'Manual CPU masks will be cleared; placement strategies will be recalculated.</p><label>Destination host<select name=host>'+
+          destinations.map(h=>'<option value="'+esc(h)+'">'+esc(hostName(h))+'</option>').join('')+'</select></label>',
+          data=>ctRemoveHost(record,host,data.get('host')));
+      });
+      app.querySelectorAll('[data-ct-rack]').forEach(b=>b.onclick=()=>{
+        const dc=record.data_centers[+b.dataset.ctRack];addName('Add rack',dc.racks,name=>dc.racks.push(name));
+      });
+      const deleteLocation=(dc,rack)=>{
+        const count=record.nodes.filter(n=>n.location?.data_center===dc.name&&(rack===undefined||n.location.rack===rack)).length;
+        const remove=()=>ctRemoveLocation(record,dc.name,rack);
+        if(count)dialog(rack===undefined?'Delete DC':'Delete rack','<p>'+count+' nodes will move to Unassigned. '+
+          'Physical placement and tenant assignments will be kept.</p>',remove);
+        else{remove();draw()}
+      };
+      app.querySelectorAll('[data-ct-delete-dc]').forEach(b=>b.onclick=()=>deleteLocation(record.data_centers[+b.dataset.ctDeleteDc]));
+      app.querySelectorAll('[data-ct-delete-rack]').forEach(b=>b.onclick=()=>{
+        const [i,j]=b.dataset.ctDeleteRack.split(':').map(Number),dc=record.data_centers[i];deleteLocation(dc,dc.racks[j]);
+      });
+      const group=app.querySelector('#ct-group'),available=hosts.filter(h=>!record.host_ids.includes(h.id));
+      group.disabled=view==='physical'&&!available.length;
+      group.onclick=()=>{
+        if(view==='tenants'){editTenant();return}
+        if(view==='logical'){addName('Add DC',record.data_centers.map(dc=>dc.name),name=>record.data_centers.push({name,racks:['rack-1']}));return}
+        dialog('Add host','<label>Host<select name=host>'+available.map(h=>'<option value="'+esc(h.id)+'">'+esc(h.name)+'</option>').join('')+'</select></label>',
+          data=>{if(record.host_ids.length>=64)throw Error('At most 64 hosts');record.host_ids.push(data.get('host'))});
+      };
       if(n){
         app.querySelector('#ct-remove').onclick=()=>{record.nodes.splice(selected,1);selected=Math.max(0,selected-1);draw()};
-        app.querySelector('#ct-duplicate').onclick=()=>{if(record.nodes.length>=64)return error('At most 64 nodes');
-          const copy=JSON.parse(JSON.stringify(n));copy.name=unique(n.role);record.nodes.push(copy);selected=record.nodes.length-1;draw()};
+        const duplicate=app.querySelector('#ct-duplicate');if(duplicate)duplicate.onclick=()=>{if(record.nodes.length>=64)return error('At most 64 nodes');
+          const copy=JSON.parse(JSON.stringify(n));copy.name=unique(n.role);ctNormalizeNodePlacement(copy);record.nodes.push(copy);selected=record.nodes.length-1;draw()};
         app.querySelector('#ct-affinity').onclick=e=>openAffinity(n,e.currentTarget);
       }
       app.querySelector('#ct-copy').onclick=()=>{delete record.id;delete record.revision;record.name+=' copy';draw()};

--- a/ydb/tools/ydb_bench/lib/topology.py
+++ b/ydb/tools/ydb_bench/lib/topology.py
@@ -401,7 +401,7 @@ def _plan_units(mode, topology):
     return [unit for group in nested for unit in group]
 
 
-def plan_affinity(mode, topology, required_cpus):
+def plan_affinity(mode, topology, required_cpus, excluded_cpus=()):
     if mode == "none":
         return AffinityPlacement(mode=mode, cpus=None)
     if not hasattr(os, "sched_setaffinity"):
@@ -425,8 +425,17 @@ def plan_affinity(mode, topology, required_cpus):
             return _unsupported(mode, "spread-chiplet requires at least two chiplets in a NUMA node")
 
     units = _plan_units(mode, topology)
+    excluded = set(excluded_cpus)
+    units = [unit for unit in units if not excluded.intersection(unit)]
     cpus = _select_units(units, required_cpus)
     if not cpus:
+        if excluded:
+            return _unsupported(
+                mode,
+                "Not enough free CPU placement units for {} CPUs; other nodes reserve the remaining units".format(
+                    required_cpus
+                ),
+            )
         return _unsupported(mode, "{} allowed CPUs are required by this placement".format(required_cpus))
     return AffinityPlacement(mode=mode, cpus=cpus)
 

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -40,6 +40,8 @@ from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES, discover_topology, 
 from ydb.tools.ydb_bench.lib.ydb_telemetry import read_metrics
 from ydb.tools.ydb_bench.lib.hosts import HostDirectory, allowed_path, allowed_post_path, open_peer, request_peer
 from ydb.tools.ydb_bench.lib.federation import Federation, split_reference
+from ydb.tools.ydb_bench.lib.cluster_templates import ClusterTemplateStore
+from ydb.tools.ydb_bench.lib import cluster_templates_ui
 
 _CSP = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
 _STREAM_CHUNK_SIZE = 1024 * 1024
@@ -467,7 +469,8 @@ async function renderHosts(){
 }
 function shell(current,body,breadcrumb=''){
   queueMicrotask(refreshActiveBanner);
-  const navigation=[['runs','Runs'],['topology','System topology'],['comparisons','Comparisons'],['hosts','Hosts']];
+  const navigation=[['runs','Runs'],['topology','System topology'],['comparisons','Comparisons'],['hosts','Hosts'],
+    ['cluster-templates','Cluster templates']];
   const section=current==='new'?'runs':current;
   return '<div class=shell><div class=content><header class=topbar><a class=brand href="#runs">YDB benchmark</a>'+
     '<nav class=primary-nav aria-label="Main navigation">'+navigation.map(([id,label])=>
@@ -3396,7 +3399,8 @@ async function renderComparisons(){
 }
     """
     "async function compose(){if(!location.hash.slice(1))history.replaceState(history.state,'',location.pathname+location.search+'#runs');"
-    "const pieces=routeParts(),current=pieces.join('/');if(current==='hosts')return renderHosts();if(current==='runs')return renderRuns();if(current==='new')return renderN"
+    "const pieces=routeParts(),current=pieces.join('/');if(pieces[0]==='cluster-templates')return renderClusterTemplates(pieces[1]);"
+    "if(current==='hosts')return renderHosts();if(current==='runs')return renderRuns();if(current==='new')return renderN"
     "ew('builder');if(current==='new/yaml')return renderNew('yaml');if(current==='topology')return renderTopology();if(curren"
     "t==='comparisons'||pieces[0]==='comparisons')return renderSavedComparisons();if(pieces[0]==='attempt'&&[4,5].includes(pieces.length))"
     "return renderLocalYdbAttempt(pieces[1],pieces[2],pieces[3],pieces[4]);if(pieces[0]==='run'){"
@@ -3405,6 +3409,10 @@ async function renderComparisons(){
     "'runs')}\n"
     "addEventListener('hashchange',compose);setInterval(refreshActiveBanner,3000);compose();\n"
 )
+
+
+_CSS += cluster_templates_ui.CSS
+_JS += cluster_templates_ui.JS
 
 
 class _RunServiceHTTPServer(ThreadingHTTPServer):
@@ -4118,6 +4126,7 @@ class RunService:
         self.output = Path(output).resolve()
         self.output.mkdir(parents=True, exist_ok=True)
         self.hosts = HostDirectory(self.output)
+        self.cluster_templates = ClusterTemplateStore(self.output)
         self.executor = executor or self._unsupported_executor
         self.event_limit, self.tail_limit = event_limit, tail_limit
         self.perf_available = perf_available
@@ -4512,9 +4521,9 @@ class RunService:
                 "queued": sum(run["store"].manifest["state"] == "queued" for run in self._queue),
             }
 
-    def topology(self):
+    def topology(self, mode=None, count=None, excluded=()):
         topology = discover_topology()
-        return {
+        result = {
             "topology": topology_record(topology),
             "affinity": [
                 {
@@ -4526,6 +4535,23 @@ class RunService:
                 for mode in AFFINITY_MODES
             ],
         }
+        if mode is not None:
+            if mode not in AFFINITY_MODES or type(count) is not int or not 1 <= count <= 65536:
+                raise BenchmarkError("Invalid affinity mode or CPU count")
+            if len(excluded) > 65536 or any(type(cpu) is not int or not 0 <= cpu <= 1048575 for cpu in excluded):
+                raise BenchmarkError("Invalid excluded CPU list")
+            placement = (
+                plan_affinity(mode, topology, count, excluded_cpus=excluded)
+                if excluded
+                else plan_affinity(mode, topology, count)
+            )
+            result["placement"] = {
+                "supported": placement.supported,
+                "cpus": None if placement.cpus is None else list(placement.cpus),
+                "reason": placement.reason,
+                "excluded_cpus": sorted(set(excluded)),
+            }
+        return result
 
     def cpu_usage(self):
         result = self._cpu_sampler.sample()
@@ -5633,7 +5659,19 @@ def _handler(service):
             if path == "/api/cpu-usage":
                 return self._json(200, service.cpu_usage())
             if path == "/api/system-topology":
-                return self._json(200, service.topology())
+                try:
+                    query = parse_qs(parsed.query)
+                    mode = query.get("mode", [None])[-1]
+                    count = int(query.get("cpus", ["0"])[-1]) if mode is not None else None
+                    excluded = tuple(int(cpu) for cpu in query.get("exclude", [""])[-1].split(",") if cpu)
+                    return self._json(200, service.topology(mode, count, excluded))
+                except (BenchmarkError, ValueError) as error:
+                    return self._json(400, {"error": str(error)})
+            if path == "/api/cluster-templates":
+                try:
+                    return self._json(200, service.cluster_templates.list())
+                except BenchmarkError as error:
+                    return self._json(400, {"error": str(error)})
             if path == "/api/runs":
                 filters = {
                     name: values[-1]
@@ -5838,6 +5876,17 @@ def _handler(service):
                     return self._json(403, {"error": "remote operation is not allowed"})
                 if path == "/api/import":
                     return self._json(201, import_archive(service.output, self._raw_body()))
+                if path in ("/api/cluster-templates", "/api/cluster-templates/delete"):
+                    origin = self.headers.get("Origin")
+                    if self.headers.get("Content-Type", "").split(";")[0] != "application/json" or (
+                        origin and urlparse(origin).netloc != self.headers.get("Host")
+                    ):
+                        return self._json(403, {"error": "same-origin JSON request required"})
+                    value = self._json_body()
+                    if path.endswith("/delete"):
+                        return self._json(200, service.cluster_templates.delete(value))
+                    host_ids = {service.hosts.id} | {host["id"] for host in service.hosts.list()}
+                    return self._json(201, service.cluster_templates.save(value, host_ids))
                 if path == "/api/validate":
                     options = self._options()
                     return self._json(200, service.validate(options["yaml"], options["perf"]))

--- a/ydb/tools/ydb_bench/lib/ya.make
+++ b/ydb/tools/ydb_bench/lib/ya.make
@@ -4,6 +4,8 @@ PY_SRCS(
     __init__.py
     actors_core.py
     cli.py
+    cluster_templates.py
+    cluster_templates_ui.py
     common.py
     config.py
     import_results.py

--- a/ydb/tools/ydb_bench/tests/test_cluster_templates.py
+++ b/ydb/tools/ydb_bench/tests/test_cluster_templates.py
@@ -64,6 +64,7 @@ class ClusterTemplatesTest(unittest.TestCase):
     def test_invalid_nodes_do_not_write(self):
         for field, value in (
             ("host_id", "missing"),
+            ("host_id", []),
             ("vcpu", True),
             ("role", "unknown"),
             ("sector_map", {"count": 0, "size_gib": 64}),
@@ -78,6 +79,155 @@ class ClusterTemplatesTest(unittest.TestCase):
                 with self.assertRaises(BenchmarkError):
                     self.store.save(item, {"amd", "sas"})
         self.assertFalse(self.store.path.exists())
+
+    def test_three_views_roundtrip_and_legacy_migration(self):
+        legacy = cluster_templates.validate_template(self.value, {"amd", "sas"})
+        self.assertEqual(legacy["host_ids"], ["amd", "sas"])
+        self.assertEqual(legacy["data_centers"], [])
+        self.assertEqual(legacy["nodes"][0]["tenant"], "")
+        legacy["host_ids"].append("empty-host")
+        legacy["data_centers"] = [
+            {"name": "dc-1", "racks": ["rack-1", "empty-rack"]},
+            {"name": "empty-dc", "racks": []},
+        ]
+        legacy["tenants"] = [{"path": "/Root/orders", "storage_kind": "ssd", "storage_groups": 2}]
+        legacy["nodes"][1].update(
+            tenant="/Root/orders", location={"data_center": "dc-1", "rack": "rack-1", "body": "server-1"}
+        )
+        saved = self.store.save(legacy, {"amd", "sas", "empty-host"})
+        legacy["nodes"][1]["location"]["body"] = "compute-1"
+        for field in ("host_ids", "data_centers", "tenants", "nodes"):
+            self.assertEqual(saved[field], legacy[field])
+        self.assertEqual(cluster_templates.ClusterTemplateStore(self.root).list(), [saved])
+
+    def test_invalid_placement_references(self):
+        for field, value in (
+            ("host_ids", ["amd"]),
+            ("host_ids", ["amd", "sas", "unknown"]),
+            ("host_ids", ["amd", "amd", "sas"]),
+            ("data_centers", [{"name": "dc", "racks": ["r", "r"]}]),
+            ("data_centers", [{"name": "dc", "racks": []}, {"name": "dc", "racks": []}]),
+            ("tenants", [{"path": "/Root/../bad", "storage_kind": "ssd", "storage_groups": 1}]),
+            ("tenants", [{"path": "/Root/a", "storage_kind": "ssd", "storage_groups": 0}]),
+        ):
+            with self.subTest(field=field, value=value):
+                with self.assertRaises(BenchmarkError):
+                    self.store.save(dict(self.value, **{field: value}), {"amd", "sas"})
+        for node_index, updates in (
+            (0, {"tenant": "/Root/a"}),
+            (1, {"tenant": "/Root/missing"}),
+            (1, {"location": {"data_center": "missing"}}),
+            (1, {"location": {"data_center": "dc", "rack": "missing"}}),
+            (1, {"location": {"body": "server"}}),
+        ):
+            value = copy.deepcopy(self.value)
+            value["data_centers"] = [{"name": "dc", "racks": ["r"]}]
+            value["tenants"] = [{"path": "/Root/a", "storage_kind": "ssd", "storage_groups": 1}]
+            value["nodes"][node_index].update(updates)
+            with self.assertRaises(BenchmarkError):
+                self.store.save(value, {"amd", "sas"})
+        self.assertFalse(self.store.path.exists())
+
+    def test_cli_has_only_physical_placement(self):
+        value = copy.deepcopy(self.value)
+        value["data_centers"] = [{"name": "dc", "racks": ["r"]}]
+        value["tenants"] = [{"path": "/Root/a", "storage_kind": "ssd", "storage_groups": 1}]
+        node = value["nodes"][1]
+        node["role"] = "cli"
+        saved = cluster_templates.validate_template(value, {"amd", "sas"})
+        self.assertEqual(saved["nodes"][1]["tenant"], "")
+        self.assertFalse(any(saved["nodes"][1]["location"].values()))
+        for update in (
+            {"tenant": "/Root/a"},
+            {"location": {"data_center": "dc"}},
+            {"location": {"data_center": "dc", "rack": "r", "body": "server"}},
+        ):
+            invalid = copy.deepcopy(value)
+            invalid["nodes"][1].update(update)
+            with self.assertRaises(BenchmarkError):
+                cluster_templates.validate_template(invalid, {"amd", "sas"})
+
+    @unittest.skipUnless(shutil.which("node"), "Node.js is required")
+    def test_moves_change_only_the_selected_view(self):
+        script = cluster_templates_ui.JS.split("function ctDefaultNode")[0] + r"""
+const assert=require('assert');
+const n={name:'compute',host_id:'amd',role:'dynamic',vcpu:8,affinity:{kind:'manual',cpus:[0,1]},tenant:'/Root/a',
+  location:{data_center:'dc',rack:'r1',body:'server'}};
+const record={nodes:[n],host_ids:['amd','sas'],data_centers:[{name:'dc',racks:['r1','r2']}],tenants:[{path:'/Root/a'},{path:'/Root/b'}]};
+const original=JSON.stringify(n);
+assert.throws(()=>ctMoveNode(record,0,'physical','sas'));assert.equal(JSON.stringify(n),original);
+ctMoveNode(record,0,'logical',['dc','r2']);assert.equal(n.host_id,'amd');assert.equal(n.tenant,'/Root/a');assert.equal(n.location.body,'compute');
+ctMoveNode(record,0,'tenants','/Root/b');assert.equal(n.location.rack,'r2');assert.equal(n.host_id,'amd');
+ctMoveNode(record,0,'physical','sas',true);assert.equal(n.affinity.mode,'none');assert.equal(n.location.rack,'r2');assert.equal(n.tenant,'/Root/b');
+n.affinity={kind:'strategy',mode:'pack-numa',count:8};ctMoveNode(record,0,'physical','amd');assert.equal(n.affinity.mode,'pack-numa');
+for(const [view,target] of [['physical','missing'],['logical',['dc','missing']],['tenants','/Root/missing']]){
+  const before=JSON.stringify(n);assert.throws(()=>ctMoveNode(record,0,view,target));assert.equal(JSON.stringify(n),before);
+}
+n.role='static';assert.throws(()=>ctMoveNode(record,0,'tenants','/Root/a'));
+n.role='cli';
+for(const [view,target] of [['logical',['dc','r1']],['tenants','/Root/a']]){
+  const before=JSON.stringify(n);assert.throws(()=>ctMoveNode(record,0,view,target));assert.equal(JSON.stringify(n),before);
+}
+ctMoveNode(record,0,'physical','sas');assert.equal(n.host_id,'sas');
+"""
+        subprocess.check_call([shutil.which("node"), "-e", script], timeout=10)
+        subprocess.run(
+            [shutil.which("node"), "--check"], input=cluster_templates_ui.JS, text=True, check=True, timeout=10
+        )
+
+    def test_default_rack_and_individual_bodies(self):
+        value = copy.deepcopy(self.value)
+        value["data_centers"] = [{"name": "dc", "racks": []}]
+        for node in value["nodes"]:
+            node["location"] = {"data_center": "dc"}
+        saved = self.store.save(value, {"amd", "sas"})
+        self.assertEqual(saved["data_centers"], [{"name": "dc", "racks": ["rack-1"]}])
+        for node in saved["nodes"]:
+            self.assertEqual(node["location"], {"data_center": "dc", "rack": "rack-1", "body": node["name"]})
+            node["location"]["body"] = "shared-old-body"
+        updated = self.store.save(saved, {"amd", "sas"})
+        self.assertEqual([n["location"]["body"] for n in updated["nodes"]], ["storage-1", "compute-1"])
+
+    @unittest.skipUnless(shutil.which("node"), "Node.js is required")
+    def test_removal_preserves_nodes_and_other_placements(self):
+        script = cluster_templates_ui.JS.split("async function renderClusterTemplates")[0] + r"""
+const assert=require('assert');
+const make=()=>({host_ids:['a','b','empty'],data_centers:[{name:'dc',racks:['r1','r2']}],tenants:[{path:'/Root/a'}],nodes:[
+  {name:'n1',role:'dynamic',host_id:'a',vcpu:8,affinity:{kind:'manual',cpus:[0]},tenant:'/Root/a',location:{data_center:'dc',rack:'r1',body:'n1'}},
+  {name:'n2',role:'static',host_id:'a',affinity:{kind:'strategy',mode:'pack-numa',count:8},tenant:'',location:{data_center:'dc',rack:'r2',body:'n2'}}]});
+let r=make();ctRemoveLocation(r,'dc','r1');assert.equal(r.nodes.length,2);assert.equal(r.nodes[0].location.data_center,'');
+assert.equal(r.nodes[0].tenant,'/Root/a');assert.equal(r.nodes[0].host_id,'a');assert.equal(r.nodes[1].location.rack,'r2');
+assert.deepEqual(r.data_centers[0].racks,['r2']);ctRemoveLocation(r,'dc');assert.deepEqual(r.data_centers,[]);
+assert.equal(r.nodes[1].location.data_center,'');
+r=make();ctRemoveTenant(r,'/Root/a');assert.equal(r.nodes.length,2);assert.equal(r.nodes[0].tenant,'');
+assert.equal(r.nodes[0].location.rack,'r1');assert.equal(r.nodes[0].host_id,'a');assert.deepEqual(r.tenants,[]);
+r=make();const before=JSON.stringify(r);assert.throws(()=>ctRemoveHost(r,'a','a'));assert.equal(JSON.stringify(r),before);
+assert.throws(()=>ctRemoveHost(r,'a','missing'));assert.equal(JSON.stringify(r),before);
+ctRemoveHost(r,'empty');assert.deepEqual(r.host_ids,['a','b']);ctRemoveHost(r,'a','b');assert.deepEqual(r.host_ids,['b']);
+assert.equal(r.nodes.length,2);assert(r.nodes.every(n=>n.host_id==='b'));assert.equal(r.nodes[0].affinity.mode,'none');
+assert.equal(r.nodes[1].affinity.mode,'pack-numa');assert.equal(r.nodes[0].tenant,'/Root/a');assert.equal(r.nodes[0].location.rack,'r1');
+const n=r.nodes[0];n.name='renamed';ctNormalizeNodePlacement(n);assert.equal(n.location.body,'renamed');
+assert.throws(()=>ctMoveNode(r,0,'logical',['dc','']));
+"""
+        subprocess.check_call([shutil.which("node"), "-e", script], timeout=10)
+
+    @unittest.skipUnless(shutil.which("node"), "Node.js is required")
+    def test_node_rename_rejects_collision_before_mutating_body(self):
+        script = cluster_templates_ui.JS.split("async function renderClusterTemplates")[0] + r"""
+const assert=require('assert');
+const a={name:'a',role:'static',tenant:'',location:{data_center:'dc',rack:'r1',body:'a'}};
+const b={name:'b',role:'dynamic',tenant:'/Root/t',location:{data_center:'dc2',rack:'r2',body:'b'}};
+const record={nodes:[a,b]};
+for(const invalid of ['a',' a ','','   ','x'.repeat(81)]){
+  const before=JSON.stringify(record);assert.throws(()=>ctRenameNode(record,b,invalid));assert.equal(JSON.stringify(record),before);
+}
+ctRenameNode(record,b,' b ');assert.equal(b.name,'b');
+ctRenameNode(record,b,' renamed ');assert.equal(b.name,'renamed');assert.equal(b.location.body,'renamed');
+assert.equal(b.location.data_center,'dc2');assert.equal(b.location.rack,'r2');assert.equal(b.tenant,'/Root/t');
+assert.equal(a.name,'a');assert.equal(a.location.body,'a');
+b.role='cli';ctRenameNode(record,b,'load');assert.equal(b.location.body,'');assert.equal(b.tenant,'');
+"""
+        subprocess.check_call([shutil.which("node"), "-e", script], timeout=10)
 
     def test_shared_affinity_roundtrip(self):
         for scope in ("chiplet", "numa"):

--- a/ydb/tools/ydb_bench/tests/test_cluster_templates.py
+++ b/ydb/tools/ydb_bench/tests/test_cluster_templates.py
@@ -46,10 +46,36 @@ class ClusterTemplatesTest(unittest.TestCase):
     def tearDown(self):
         self.temporary.cleanup()
 
+    def test_actor_system_settings_belong_to_runs_not_templates(self):
+        self.value["nodes"][0]["actor_system"] = {"use_united_pool": True}
+        saved = self.store.save(self.value, {"amd", "sas"})
+        for node in saved["nodes"]:
+            self.assertNotIn("vcpu", node)
+            self.assertNotIn("actor_system", node)
+        self.assertEqual(saved["nodes"][1]["affinity"]["count"], 8)
+        self.store.save(saved, {"amd", "sas"})
+
+    @unittest.skipUnless(shutil.which("node"), "Node.js is required")
+    def test_view_specific_node_information_and_rack_names(self):
+        script = cluster_templates_ui.JS.split("async function renderClusterTemplates")[0] + r"""
+const assert=require('assert');
+const n={name:'compute',role:'dynamic',host_id:'amd',tenant:'/Root/bench',location:{data_center:'dc',rack:'dc-R1',body:'compute'}};
+assert.equal(ctNodeInfo(n,'physical',()=> 'AMD'),'dc / dc-R1 · Tenant: /Root/bench');
+assert.equal(ctNodeInfo(n,'logical',()=> 'AMD'),'Host: AMD · Tenant: /Root/bench');
+assert.equal(ctNodeInfo(n,'tenants',()=> 'AMD'),'Host: AMD · dc / dc-R1');
+assert.equal(ctNodeInfo({...n,role:'cli'},'physical',()=> 'AMD'),'');
+assert.equal(ctNextRack({name:'dc',racks:['dc-R1','dc-R3']}),'dc-R2');
+assert.equal(ctNextRack({name:'other',racks:[]}),'other-R1');
+assert.equal(ctShortHost('amd.example.net',['amd.example.net','sas.example.net']),'amd');
+assert.equal(ctShortHost('amd.a.net',['amd.a.net','amd.b.net']),'amd.a.net');
+assert.equal(ctDefaultNode('amd','dynamic',1).actor_system,undefined);
+"""
+        subprocess.run([shutil.which("node"), "-e", script], check=True, capture_output=True, text=True)
+
     def test_durable_roundtrip_revision_and_delete(self):
         self.assertEqual(self.store.list(), [])
         saved = self.store.save(self.value, {"amd", "sas"})
-        self.assertEqual(saved["nodes"][0]["vcpu"], 8)
+        self.assertNotIn("vcpu", saved["nodes"][0])
         self.assertEqual(len(saved["nodes"][0]["affinity"]["cpus"]), 16)
         self.assertEqual(cluster_templates.ClusterTemplateStore(self.root).list(), [saved])
         changed = self.store.save(dict(saved, name="Updated"), {"amd", "sas"})
@@ -65,10 +91,8 @@ class ClusterTemplatesTest(unittest.TestCase):
         for field, value in (
             ("host_id", "missing"),
             ("host_id", []),
-            ("vcpu", True),
             ("role", "unknown"),
             ("sector_map", {"count": 0, "size_gib": 64}),
-            ("actor_system", {"use_shared_threads": "false"}),
             ("affinity", {"kind": "manual", "cpus": [0, 0]}),
             ("affinity", {"kind": "manual", "cpus": []}),
             ("affinity", {"kind": "strategy", "mode": "unknown", "count": 8}),
@@ -181,9 +205,9 @@ ctMoveNode(record,0,'physical','sas');assert.equal(n.host_id,'sas');
         for node in value["nodes"]:
             node["location"] = {"data_center": "dc"}
         saved = self.store.save(value, {"amd", "sas"})
-        self.assertEqual(saved["data_centers"], [{"name": "dc", "racks": ["rack-1"]}])
+        self.assertEqual(saved["data_centers"], [{"name": "dc", "racks": ["dc-R1"]}])
         for node in saved["nodes"]:
-            self.assertEqual(node["location"], {"data_center": "dc", "rack": "rack-1", "body": node["name"]})
+            self.assertEqual(node["location"], {"data_center": "dc", "rack": "dc-R1", "body": node["name"]})
             node["location"]["body"] = "shared-old-body"
         updated = self.store.save(saved, {"amd", "sas"})
         self.assertEqual([n["location"]["body"] for n in updated["nodes"]], ["storage-1", "compute-1"])

--- a/ydb/tools/ydb_bench/tests/test_cluster_templates.py
+++ b/ydb/tools/ydb_bench/tests/test_cluster_templates.py
@@ -1,0 +1,231 @@
+import copy
+import json
+import shutil
+import subprocess
+from pathlib import Path
+import tempfile
+import threading
+import unittest
+from unittest import mock
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from ydb.tools.ydb_bench.lib import cluster_templates, cluster_templates_ui, topology as topology_module, web
+from ydb.tools.ydb_bench.lib.common import BenchmarkError
+from ydb.tools.ydb_bench.lib.topology import CpuTopology
+
+
+class ClusterTemplatesTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.store = cluster_templates.ClusterTemplateStore(self.root)
+        self.value = {
+            "name": "AMD / SAS",
+            "nodes": [
+                {
+                    "name": "storage-1",
+                    "role": "static",
+                    "host_id": "amd",
+                    "binary": "bundled",
+                    "vcpu": 8,
+                    "sector_map": {"count": 1, "size_gib": 64},
+                    "affinity": {"kind": "manual", "cpus": list(range(16))},
+                },
+                {
+                    "name": "compute-1",
+                    "role": "dynamic",
+                    "host_id": "sas",
+                    "binary": "/bin/ydbd",
+                    "vcpu": 4,
+                    "affinity": {"kind": "strategy", "mode": "pack-numa", "count": 8},
+                },
+            ],
+        }
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def test_durable_roundtrip_revision_and_delete(self):
+        self.assertEqual(self.store.list(), [])
+        saved = self.store.save(self.value, {"amd", "sas"})
+        self.assertEqual(saved["nodes"][0]["vcpu"], 8)
+        self.assertEqual(len(saved["nodes"][0]["affinity"]["cpus"]), 16)
+        self.assertEqual(cluster_templates.ClusterTemplateStore(self.root).list(), [saved])
+        changed = self.store.save(dict(saved, name="Updated"), {"amd", "sas"})
+        with self.assertRaises(BenchmarkError):
+            self.store.save(saved, {"amd", "sas"})
+        with self.assertRaises(BenchmarkError):
+            self.store.delete(saved)
+        self.assertEqual(self.store.list(), [changed])
+        self.store.delete(changed)
+        self.assertEqual(self.store.list(), [])
+
+    def test_invalid_nodes_do_not_write(self):
+        for field, value in (
+            ("host_id", "missing"),
+            ("vcpu", True),
+            ("role", "unknown"),
+            ("sector_map", {"count": 0, "size_gib": 64}),
+            ("actor_system", {"use_shared_threads": "false"}),
+            ("affinity", {"kind": "manual", "cpus": [0, 0]}),
+            ("affinity", {"kind": "manual", "cpus": []}),
+            ("affinity", {"kind": "strategy", "mode": "unknown", "count": 8}),
+        ):
+            with self.subTest(field=field, value=value):
+                item = copy.deepcopy(self.value)
+                item["nodes"][0][field] = value
+                with self.assertRaises(BenchmarkError):
+                    self.store.save(item, {"amd", "sas"})
+        self.assertFalse(self.store.path.exists())
+
+    def test_shared_affinity_roundtrip(self):
+        for scope in ("chiplet", "numa"):
+            value = copy.deepcopy(self.value)
+            value["nodes"][0]["affinity"] = {
+                "kind": "strategy",
+                "mode": "pack-numa-pack-chiplet",
+                "count": 8,
+                "scope": scope,
+            }
+            saved = self.store.save(value, {"amd", "sas"})
+            affinity = saved["nodes"][0]["affinity"]
+            self.assertNotIn("scope", affinity)
+            self.assertEqual(affinity["mode"], "pack-numa" if scope == "numa" else "pack-numa-pack-chiplet")
+        for scope in ("bad", [], True):
+            with self.assertRaises(BenchmarkError):
+                cluster_templates.validate_affinity(
+                    {"kind": "strategy", "mode": "pack-numa-pack-chiplet", "count": 8, "scope": scope}
+                )
+
+    @unittest.skipUnless(shutil.which("node"), "Node.js is required")
+    def test_shared_ui_reserves_capacity_not_whole_masks(self):
+        script = cluster_templates_ui.JS.split("function ctDefaultNode")[0] + r"""
+const assert=require('assert');
+const node=(name,scope='chiplet')=>({host_id:'a',name,affinity:{kind:'strategy',mode:scope==='numa'?'pack-numa':'pack-numa-pack-chiplet',count:8}});
+const all=Array.from({length:32},(_,i)=>i);
+const load=async()=>({topology:{allowed_cpus:all,numa_nodes:[{id:0,cpus:all}],
+  chiplets:[{numa_node:0,cpus:all.slice(0,16)},{numa_node:0,cpus:all.slice(16)}]}});
+(async()=>{
+  const a=node('a'),b=node('b'),c=node('c'),d=node('d'),e=node('e');
+  let r=await ctResolvePlacements([a,b,c,d,e],load);
+  assert.deepEqual(r.get(a).cpus,all.slice(0,16));
+  assert.deepEqual(r.get(b).cpus,all.slice(16));
+  assert.deepEqual(r.get(c).cpus,r.get(a).cpus);
+  assert.equal(new Set([a,b,c,d].flatMap(n=>r.get(n).reserved_cpus)).size,32);
+  assert.equal(r.get(e).supported,false);
+  const manual={host_id:'a',name:'fixed',affinity:{kind:'manual',cpus:all.slice(0,8)}};
+  r=await ctResolvePlacements([a,manual],load);
+  assert.deepEqual(r.get(a).cpus,all.slice(16));
+  const numa=node('numa','numa');
+  r=await ctResolvePlacements([numa,a,manual],load);
+  assert.deepEqual(r.get(numa).cpus,all);
+  assert(!r.get(numa).reserved_cpus.some(c=>r.get(a).reserved_cpus.includes(c)||manual.affinity.cpus.includes(c)));
+  assert.equal(r.get(numa).reserved_cpus.length,8);
+  const remote={...a,host_id:'b'};
+  r=await ctResolvePlacements([a,remote],load);
+  assert.deepEqual(r.get(a).reserved_cpus,r.get(remote).reserved_cpus);
+})().catch(e=>{console.error(e);process.exitCode=1});
+"""
+        subprocess.check_call([shutil.which("node"), "-e", script], timeout=10)
+
+    def test_overlap_allowed_and_duplicate_names_rejected(self):
+        item = copy.deepcopy(self.value)
+        item["nodes"].append(dict(item["nodes"][0], name="storage-2"))
+        self.store.save(item, {"amd", "sas"})
+        item["nodes"][-1]["name"] = "storage-1"
+        with self.assertRaises(BenchmarkError):
+            self.store.save(item, {"amd", "sas"})
+
+    def test_corrupt_storage_is_not_overwritten(self):
+        self.store.path.write_text("not json", encoding="utf-8")
+        with self.assertRaises(BenchmarkError):
+            self.store.save(self.value, {"amd", "sas"})
+        self.assertEqual(self.store.path.read_text(), "not json")
+
+    def test_topology_preview_uses_existing_planner(self):
+        topology = CpuTopology(
+            tuple(range(4)), ((0, tuple(range(4))),), ((0, tuple(range(4))),), physical_cores=((0, 2), (1, 3))
+        )
+        service = web.RunService(self.root)
+        with mock.patch.object(web, "discover_topology", return_value=topology):
+            with mock.patch.object(web, "plan_affinity", wraps=web.plan_affinity) as planner:
+                result = service.topology("none", 8)
+                self.assertTrue(result["placement"]["supported"])
+                self.assertIsNone(result["placement"]["cpus"])
+                planner.assert_any_call("none", topology, 8)
+            with self.assertRaises(BenchmarkError):
+                service.topology("bad", 8)
+
+    def test_record_is_only_a_specification(self):
+        saved = self.store.save(self.value, {"amd", "sas"})
+        self.assertNotIn("pid", json.dumps(saved))
+        self.assertEqual(list(self.root.iterdir()), [self.store.path])
+
+    def test_joint_placement_keeps_chiplets_whole(self):
+        topology = CpuTopology(tuple(range(8)), ((0, tuple(range(8))),), ((0, (0, 1, 2, 3)), (0, (4, 5, 6, 7))))
+        with mock.patch.object(topology_module.os, "sched_setaffinity", create=True):
+            first = topology_module.plan_affinity("pack-numa-pack-chiplet", topology, 1)
+            second = topology_module.plan_affinity("pack-numa-pack-chiplet", topology, 1, first.cpus)
+            self.assertEqual(first.cpus, (0, 1, 2, 3))
+            self.assertEqual(second.cpus, (4, 5, 6, 7))
+            self.assertFalse(
+                topology_module.plan_affinity("pack-numa-pack-chiplet", topology, 1, tuple(range(8))).supported
+            )
+            self.assertEqual(
+                topology_module.plan_affinity("pack-numa-pack-chiplet", topology, 1, (1,)).cpus, second.cpus
+            )
+
+    @unittest.skipUnless(shutil.which("node"), "Node.js is required")
+    def test_joint_ui_allocator_reserves_manual_masks_and_separates_hosts(self):
+        script = cluster_templates_ui.JS.split("function ctDefaultNode")[0] + r"""
+const assert=require('assert');
+const strategy=(host,name)=>({host_id:host,name,affinity:{kind:'strategy',mode:'pack-numa-pack-chiplet-pack-core',count:1}});
+const a=strategy('a','first'),b=strategy('a','second'),c=strategy('b','first');
+const manual={host_id:'a',name:'manual',affinity:{kind:'manual',cpus:[0,1]}};
+const calls=[];
+async function load(host,affinity,excluded){
+  calls.push({host,excluded:[...excluded]});
+  const cpus=[[0,1],[2,3],[4,5]].find(unit=>!unit.some(c=>excluded.includes(c)));
+  return {placement:cpus?{supported:true,cpus,excluded_cpus:excluded}:{supported:false,reason:'No free CPUs'}};
+}
+(async()=>{
+  const result=await ctResolvePlacements([a,b,c,manual],load);
+  assert.deepEqual(result.get(a).cpus,[2,3]);assert.deepEqual(result.get(b).cpus,[4,5]);
+  assert.deepEqual(result.get(c).cpus,[0,1]);assert.deepEqual(manual.affinity.cpus,[0,1]);
+  const last=strategy('a','last');
+  const exhausted=await ctResolvePlacements([a,b,last,manual],load);
+  assert.equal(exhausted.get(last).supported,false);
+  const old=await ctResolvePlacements([a,manual],async()=>({placement:{supported:true,cpus:[2,3]}}));
+  assert.equal(old.get(a).supported,false);
+})().catch(e=>{console.error(e);process.exitCode=1});
+"""
+        subprocess.check_call([shutil.which("node"), "-e", script], timeout=10)
+
+    def test_http_save_list_preview_and_origin_guard(self):
+        server = web.make_server("127.0.0.1", 0, self.root)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        base = "http://127.0.0.1:{}".format(server.server_address[1])
+        try:
+            with urlopen(base + "/api/hosts") as response:
+                host_id = json.load(response)["local"]["id"]
+            value = copy.deepcopy(self.value)
+            for node in value["nodes"]:
+                node["host_id"] = host_id
+            body = json.dumps(value).encode()
+            request = Request(base + "/api/cluster-templates", data=body, headers={"Content-Type": "application/json"})
+            with urlopen(request) as response:
+                saved = json.load(response)
+            with urlopen(base + "/api/cluster-templates") as response:
+                self.assertEqual(json.load(response), [saved])
+            with urlopen(base + "/api/hosts/" + host_id + "/api/system-topology?mode=none&cpus=8") as response:
+                self.assertIsNone(json.load(response)["placement"]["cpus"])
+            request.add_header("Origin", "http://untrusted.invalid")
+            with self.assertRaises(HTTPError) as error:
+                urlopen(request)
+            self.assertEqual(error.exception.code, 403)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)

--- a/ydb/tools/ydb_bench/tests/ya.make
+++ b/ydb/tools/ydb_bench/tests/ya.make
@@ -4,6 +4,7 @@ TEST_SRCS(
     test_ydb_bench.py
     test_ydb_telemetry.py
     test_hosts.py
+    test_cluster_templates.py
 )
 
 PEERDIR(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add saved benchmark cluster templates with physical, logical and tenant placement views and CPU affinity previews.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Templates describe placement only and do not start cluster processes. The editor supports host, rack and tenant assignment, drag-and-drop, and shared chiplet/NUMA capacity previews. Template storage validates references and uses revisions to prevent stale updates.