### PR TITLE
Accelerate benchmark SLO search and refine rejected boundaries

### DIFF
--- a/ydb/tools/ydb_bench/lib/load_control.py
+++ b/ydb/tools/ydb_bench/lib/load_control.py
@@ -376,6 +376,35 @@ def _latency_probe(config, low, high, measured, predictive):
     return min(high - 1, max(low + 1, low + int((high - low) * fraction)))
 
 
+def _latency_growth_probe(config, current, measured, attempt_count):
+    search = config["search"]
+    fallback = _next_geometric(current, search["maximum"], search["multiplier"])
+    lower = max((load for load, record in measured.items() if load < current and record["passed"]), default=None)
+    if lower is None:
+        return fallback
+    objective = config["objective"]
+    metric = objective.get("latency_metric", objective["percentile"] + "_ms")
+    left, right = measured[lower].get(metric), measured[current].get(metric)
+    if not all(isinstance(value, (int, float)) and math.isfinite(value) for value in (left, right)):
+        return fallback
+    # Small or flat changes are dominated by measurement noise and percentile rounding.
+    if left < 0 or right - left < max(0.05 * right, 0.01 * objective["max_ms"]):
+        return fallback
+    distance = (objective["max_ms"] - right) / (right - left) * (current - lower)
+    if not math.isfinite(distance) or distance <= 0:
+        return fallback
+    # Approach the predicted crossing without treating extrapolated loads as evidence.
+    candidate = min(search["maximum"], current * 4, current + int(0.85 * distance))
+    if candidate <= fallback:
+        return fallback
+    # A wider first-failure bracket must still fit the existing 64-attempt budget.
+    failure_cost = 1 + 2 * _binary_probe_count(current, candidate, 1)
+    success_cost = _maximum_latency_attempts({**search, "start": candidate})
+    if attempt_count + max(failure_cost, success_cost) > MAX_AUTOMATIC_SEARCH_ATTEMPTS:
+        return fallback
+    return candidate
+
+
 def _run_latency(config, measure, on_attempt, previous_attempts=()):
     search = config["search"]
     attempts = list(previous_attempts)
@@ -416,7 +445,7 @@ def _run_latency(config, measure, on_attempt, previous_attempts=()):
                     "lower-bound",
                     passing_load=current,
                 )
-            current = _next_geometric(current, search["maximum"], search["multiplier"])
+            current = _latency_growth_probe(config, current, measured, len(attempts))
         else:
             first_fail = current
             break
@@ -433,6 +462,14 @@ def _run_latency(config, measure, on_attempt, previous_attempts=()):
     # Reuse closer evidence when resuming after a rejected verification.
     high = min(load for load, record in measured.items() if not record["passed"])
     low = max(load for load, record in measured.items() if record["passed"] and load < high)
+    # Verification can reject an otherwise passing boundary by a single load step.
+    # Try its immediate predecessor once before returning to bracket refinement.
+    if measured[high].get("verification_rejected") and high - low > 1:
+        candidate = high - 1
+        if sample(candidate)["passed"]:
+            low = candidate
+        else:
+            high = candidate
     predictive = True
     while high - low > 1:
         candidate = _latency_probe(config, low, high, measured, predictive)

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -4159,6 +4159,62 @@ const editorApi=path=>{assert.equal(path,'/api/activity-status');return new Prom
             any(event.get("fields", {}).get("progress", {}).get("phase") == "resuming-search" for event in events)
         )
 
+    def test_latency_initial_extrapolation_and_guards(self):
+        config = {
+            "parameter": "threads",
+            "search": {"start": 10, "maximum": 100, "multiplier": 2, "resolution_percent": 50},
+            "objective": {"type": "latency-slo", "percentile": "p99", "max_ms": 20, "max_errors": 0},
+        }
+        measured = {10: {"passed": True, "p99_ms": 5}, 20: {"passed": True, "p99_ms": 8}}
+        self.assertEqual(load_control._latency_growth_probe(config, 20, measured, 2), 54)
+        self.assertEqual(load_control._latency_growth_probe(config, 20, measured, 63), 40)
+        for value in (5, 4, 5.01, float("nan"), float("inf"), None):
+            with self.subTest(latency=value):
+                measured[20]["p99_ms"] = value
+                self.assertEqual(load_control._latency_growth_probe(config, 20, measured, 2), 40)
+        measured[20]["p99_ms"] = 6
+        self.assertEqual(load_control._latency_growth_probe(config, 20, measured, 2), 80)
+        config["search"]["maximum"] = 55
+        self.assertEqual(load_control._latency_growth_probe(config, 20, measured, 2), 55)
+        config["objective"]["latency_metric"] = "custom_ms"
+        self.assertEqual(load_control._latency_growth_probe(config, 20, measured, 2), 40)
+        measured[10]["custom_ms"], measured[20]["custom_ms"] = 5, 8
+        self.assertEqual(load_control._latency_growth_probe(config, 20, measured, 2), 54)
+
+    def test_latency_rejected_verification_probes_predecessor_first(self):
+        config = {
+            "parameter": "threads",
+            "search": {"start": 1, "maximum": 256, "multiplier": 2, "resolution_percent": 2},
+            "objective": {"type": "latency-slo", "percentile": "p99", "max_ms": 20, "max_errors": 0},
+        }
+        previous = [
+            {"load": 84, "passed": True, "p99_ms": 19, "errors": 0},
+            {
+                "load": 88,
+                "passed": False,
+                "p99_ms": 20,
+                "verification_rejected": True,
+                "verification_metrics": {"p99_ms": 21, "errors": 0},
+            },
+            {"load": 89, "passed": False, "p99_ms": 21, "errors": 0},
+        ]
+        for boundary in (87, 86, 84):
+            with self.subTest(boundary=boundary):
+                sampled = []
+
+                def measure(load):
+                    sampled.append(load)
+                    return {"throughput": load, "errors": 0, "p99_ms": 20 if load <= boundary else 21}
+
+                result = load_control.search_load(config, measure, previous_attempts=previous)
+                self.assertEqual(sampled[0], 87)
+                self.assertEqual(result.selected_load, boundary)
+                self.assertEqual(result.failing_load, boundary + 1)
+                self.assertTrue(all(84 < load < 88 for load in sampled))
+                self.assertEqual(len(sampled), len(set(sampled)))
+                if boundary == 87:
+                    self.assertEqual(sampled, [87])
+
     def test_latency_prediction_finds_an_exact_boundary_and_reuses_rejected_evidence(self):
         config = {
             "parameter": "threads",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Accelerate benchmark latency-SLO discovery and probe the next lower load after verification rejects a boundary.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Initial growth can extrapolate toward the SLO crossing from two passing latency measurements, with geometric fallback for noisy or invalid slopes and a guard for the existing attempt budget. When verification rejects a measured boundary, generic bracket refinement could skip its immediate predecessor; the resumed search now probes that predecessor first and reuses existing evidence.