### PR TITLE
[NBS-7383] Fixed ddisk sync hung

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -396,7 +396,6 @@ void TBlocksDirtyMap::FlushFinished(
         auto& inflight = item->Value;
 
         inflight.ConfirmFlush(route.DestinationHostIndex);
-        InflightFlushFinished(item->Range);
     }
 
     for (TPBufferKey pBufferKey: flushFailed) {
@@ -408,7 +407,6 @@ void TBlocksDirtyMap::FlushFinished(
         auto& inflight = item->Value;
 
         inflight.FlushFailed(route.DestinationHostIndex);
-        InflightFlushFinished(item->Range);
     }
 }
 
@@ -710,8 +708,37 @@ void TBlocksDirtyMap::UnRegister(TPBufferKey pBufferKey, EQueueType queueType)
     }
 }
 
+void TBlocksDirtyMap::InflightFlushFinished(
+    TPBufferKey pBufferKey,
+    THostIndex host)
+{
+    if (InflightDDiskSyncMap.Empty()) {
+        return;
+    }
+
+    auto inflight = Inflight.GetValue(pBufferKey);
+    Y_ABORT_UNLESS(inflight);
+
+    InflightDDiskSyncMap.EnumerateOverlapping(
+        inflight->Range,
+        [&](TInflightDDiskSyncMap::TFindItem& item)
+        {
+            auto& sync = item.Value;
+            if (!sync.SyncStartTrigger.IsReady() &&
+                sync.DestinationHost == host &&
+                !HasInflightFlush(host, item.Range))
+            {
+                sync.SyncStartTrigger.TrySetValue();
+            }
+
+            return TInflightDDiskSyncMap::EEnumerateContinuation::Continue;
+        });
+}
+
 void TBlocksDirtyMap::FlushCompleted(TPBufferKey pBufferKey, THostMask ddisks)
 {
+    Y_DEBUG_ABORT_UNLESS(Inflight.GetValue(pBufferKey));
+
     AddToAheadAndBehindOnFlushCompleted(pBufferKey, ddisks);
 }
 
@@ -1085,21 +1112,6 @@ bool TBlocksDirtyMap::HasInflightFlush(THostIndex host, TBlockRange64 range)
             return TInflightMap::EEnumerateContinuation::Continue;
         });
     return hasOverlaps;
-}
-
-void TBlocksDirtyMap::InflightFlushFinished(TBlockRange64 range)
-{
-    InflightDDiskSyncMap.EnumerateOverlapping(
-        range,
-        [&](TInflightDDiskSyncMap::TFindItem& item)
-        {
-            auto& sync = item.Value;
-            if (!HasInflightFlush(sync.DestinationHost, item.Range)) {
-                sync.SyncStartTrigger.TrySetValue();
-            }
-
-            return TInflightDDiskSyncMap::EEnumerateContinuation::Continue;
-        });
 }
 
 bool TBlocksDirtyMap::CheckEraseAbility(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
@@ -143,6 +143,9 @@ public:
     // IReadyQueue implementation
     void Register(TPBufferKey pBufferKey, EQueueType queueType) override;
     void UnRegister(TPBufferKey pBufferKey, EQueueType queueType) override;
+    void InflightFlushFinished(
+        TPBufferKey pBufferKey,
+        THostIndex host) override;
     void FlushCompleted(TPBufferKey pBufferKey, THostMask ddisks) override;
     void DataToPBufferAdded(
         THostIndex host,
@@ -225,7 +228,6 @@ private:
         THostMask ddisks);
 
     [[nodiscard]] bool HasInflightFlush(THostIndex host, TBlockRange64 range);
-    void InflightFlushFinished(TBlockRange64 range);
 
     [[nodiscard]] bool HasOlderUnflushedOverlap(
         TPBufferKey pBufferKey,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
@@ -326,6 +326,8 @@ void TInflightInfo::UpdateHosts(
             // Nothing to do.
         } break;
     }
+
+    CheckInvariants();
 }
 
 void TInflightInfo::LockPBuffer()
@@ -445,9 +447,69 @@ void TInflightInfo::SetState(EState newState)
     }
 
     State = newState;
+    CheckInvariants();
 
     if (State == EState::PBufferFlushed) {
+        ReadyQueue->UnRegister(PBufferKey, IReadyQueue::EQueueType::Flush);
         ReadyQueue->FlushCompleted(PBufferKey, FlushConfirmed);
+    }
+}
+
+void TInflightInfo::CheckInvariants() const
+{
+    Y_ABORT_UNLESS(WriteConfirmed.Exclude(WriteRequested).Empty());
+    Y_ABORT_UNLESS(
+        FlushConfirmed.Exclude(Disabled).Exclude(FlushRequested).Empty());
+    Y_ABORT_UNLESS(
+        FlushRequested.Exclude(Disabled).Exclude(DesiredDDisks).Empty());
+    Y_ABORT_UNLESS(EraseConfirmed.Exclude(EraseRequested).Empty());
+    Y_ABORT_UNLESS(EraseRequested.Exclude(WriteRequested).Empty());
+
+    switch (State) {
+        case EState::PBufferPendingWrite:
+            Y_ABORT_UNLESS(WriteRequested.Empty());
+            Y_ABORT_UNLESS(WriteConfirmed.Empty());
+            Y_ABORT_UNLESS(FlushRequested.Empty());
+            Y_ABORT_UNLESS(FlushConfirmed.Empty());
+            Y_ABORT_UNLESS(EraseRequested.Empty());
+            Y_ABORT_UNLESS(EraseConfirmed.Empty());
+            break;
+        case EState::PBufferIncompleteWrite:
+            Y_ABORT_UNLESS(FlushRequested.Empty());
+            Y_ABORT_UNLESS(FlushConfirmed.Empty());
+            Y_ABORT_UNLESS(EraseRequested.Empty());
+            Y_ABORT_UNLESS(EraseConfirmed.Empty());
+            Y_ABORT_UNLESS(
+                WriteConfirmed.Count() < QuorumDirectBlockGroupHostCount);
+            break;
+        case EState::PBufferWritten:
+            Y_ABORT_UNLESS(
+                WriteConfirmed.Count() >= QuorumDirectBlockGroupHostCount);
+            Y_ABORT_UNLESS(FlushRequested.Empty());
+            Y_ABORT_UNLESS(FlushConfirmed.Empty());
+            Y_ABORT_UNLESS(EraseRequested.Empty());
+            Y_ABORT_UNLESS(EraseConfirmed.Empty());
+            break;
+        case EState::PBufferFlushing:
+            Y_ABORT_UNLESS(
+                WriteConfirmed.Count() >= QuorumDirectBlockGroupHostCount);
+            Y_ABORT_UNLESS(EraseRequested.Empty());
+            Y_ABORT_UNLESS(EraseConfirmed.Empty());
+            break;
+        case EState::PBufferFlushed:
+        case EState::PBufferErasing:
+        case EState::PBufferErased:
+            Y_ABORT_UNLESS(
+                FlushConfirmed.Count() >= QuorumDirectBlockGroupHostCount);
+            Y_ABORT_UNLESS(GetInflightFlushes().Empty());
+            break;
+    }
+
+    if (State == EState::PBufferErased) {
+        Y_ABORT_UNLESS(
+            EraseConfirmed.Exclude(Disabled) ==
+            WriteRequested.Exclude(Disabled));
+        Y_ABORT_UNLESS(PBuffersLockCount == 0);
     }
 }
 
@@ -455,7 +517,7 @@ void TInflightInfo::MaybeAdvanceToFlushed()
 {
     Y_ABORT_UNLESS(State == EState::PBufferFlushing);
 
-    if (DesiredDDisks.Exclude(Disabled) == FlushConfirmed &&
+    if (DesiredDDisks.Exclude(Disabled) == FlushConfirmed.Exclude(Disabled) &&
         FlushConfirmed.Count() >= QuorumDirectBlockGroupHostCount)
     {
         SetState(EState::PBufferFlushed);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
@@ -199,6 +199,7 @@ void TInflightInfo::ConfirmFlush(THostIndex host)
     Y_ABORT_UNLESS(!FlushConfirmed.Get(host));
 
     FlushConfirmed.Set(host);
+    ReadyQueue->InflightFlushFinished(PBufferKey, host);
     MaybeAdvanceToFlushed();
 }
 
@@ -210,11 +211,12 @@ void TInflightInfo::FlushFailed(THostIndex host)
 
     FlushRequested.Reset(host);
     ReadyQueue->Register(PBufferKey, IReadyQueue::EQueueType::Flush);
+    ReadyQueue->InflightFlushFinished(PBufferKey, host);
 }
 
 THostMask TInflightInfo::GetInflightFlushes() const
 {
-    return FlushRequested;
+    return FlushRequested.Exclude(FlushConfirmed);
 }
 
 void TInflightInfo::RequestErase(THostIndex host)
@@ -284,8 +286,12 @@ void TInflightInfo::UpdateHosts(
         }
         case EState::PBufferFlushing: {
             // Just update DesiredDDisks and Disabled.
+            const auto droppedFlushes =
+                GetInflightFlushes().LogicalAnd(disabled);
+
             DesiredDDisks = DesiredDDisks.Include(added).Exclude(removed);
             Disabled = disabled;
+            FlushRequested = FlushRequested.Exclude(disabled);
 
             auto notRequestsFlushes =
                 DesiredDDisks.Exclude(Disabled).Exclude(FlushRequested);
@@ -295,6 +301,11 @@ void TInflightInfo::UpdateHosts(
                     PBufferKey,
                     IReadyQueue::EQueueType::Flush);
             }
+
+            for (const auto host: droppedFlushes) {
+                ReadyQueue->InflightFlushFinished(PBufferKey, host);
+            }
+
             MaybeAdvanceToFlushed();
             break;
         }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
@@ -41,6 +41,13 @@ struct IReadyQueue
     // Removes the record's registration from the given queue.
     virtual void UnRegister(TPBufferKey pBufferKey, EQueueType queueType) = 0;
 
+    // Notifies that a flush request to the specified host stopped being
+    // in-flight. The request may have completed successfully, failed, or been
+    // dropped because the host was disabled.
+    virtual void InflightFlushFinished(
+        TPBufferKey pBufferKey,
+        THostIndex host) = 0;
+
     // Notifies of flushes completion to DDisks.
     virtual void FlushCompleted(TPBufferKey pBufferKey, THostMask ddisks) = 0;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
@@ -193,6 +193,7 @@ private:
         bool add) const;
 
     void SetState(EState newState);
+    void CheckInvariants() const;
 
     void MaybeAdvanceToFlushed();
     void MaybeAdvanceToErased();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
@@ -57,6 +57,12 @@ struct TTestReadyQueue: public IReadyQueue
         }
     }
 
+    void InflightFlushFinished(TPBufferKey pBufferKey, THostIndex host) override
+    {
+        ++InflightFlushFinishedCalls[pBufferKey];
+        InflightFlushFinishedHosts[pBufferKey].Set(host);
+    }
+
     void FlushCompleted(TPBufferKey pBufferKey, THostMask ddisks) override
     {
         ++FlushCompletedCalls[pBufferKey];
@@ -101,6 +107,13 @@ struct TTestReadyQueue: public IReadyQueue
         return it == FlushCompletedCalls.end() ? 0 : it->second;
     }
 
+    [[nodiscard]] size_t GetInflightFlushFinishedCalls(
+        TPBufferKey pBufferKey) const
+    {
+        auto it = InflightFlushFinishedCalls.find(pBufferKey);
+        return it == InflightFlushFinishedCalls.end() ? 0 : it->second;
+    }
+
     size_t GetLockedBytes(THostIndex host)
     {
         return PBufferCounters[host][EPBufferCounter::Locked];
@@ -116,6 +129,8 @@ struct TTestReadyQueue: public IReadyQueue
     THashSet<TPBufferKey> ReadyToErase;
     THashMap<TPBufferKey, THostMask> FlushCompletions;
     THashMap<TPBufferKey, size_t> FlushCompletedCalls;
+    THashMap<TPBufferKey, size_t> InflightFlushFinishedCalls;
+    THashMap<TPBufferKey, THostMask> InflightFlushFinishedHosts;
     TMap<THostIndex, TMap<EPBufferCounter, size_t>> PBufferCounters;
 };
 
@@ -234,6 +249,12 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(
             false,
             readyQueue.ReadyToErase.contains(MakeKey(123)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            inflightInfo.GetInflightFlushes().Get(THostIndex{0}));
+        UNIT_ASSERT_VALUES_EQUAL(
+            1u,
+            readyQueue.GetInflightFlushFinishedCalls(MakeKey(123)));
         inflightInfo.ConfirmFlush(THostIndex{1});
         UNIT_ASSERT_VALUES_EQUAL(
             false,
@@ -356,6 +377,9 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             false,
             readyQueue.ReadyToErase.contains(MakeKey(123)));
         inflightInfo.ConfirmFlush(THostIndex{2});
+        UNIT_ASSERT_VALUES_EQUAL(
+            4u,
+            readyQueue.GetInflightFlushFinishedCalls(MakeKey(123)));
         UNIT_ASSERT_VALUES_EQUAL(
             true,
             readyQueue.ReadyToErase.contains(MakeKey(123)));
@@ -1151,6 +1175,46 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         inflightInfo.ConfirmErase(THostIndex{2});
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferErased,
+            inflightInfo.GetState());
+    }
+
+    Y_UNIT_TEST(ShouldNotifyInflightFlushFinishedWhenHostDisabled)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(4),
+            THostMask::MakeEmpty(),
+            MakeKey(123),
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(4), MakePrimaryHosts(4));
+
+        for (THostIndex host: MakeDDisks(4)) {
+            Y_UNUSED(inflightInfo.RequestFlush(host));
+        }
+
+        inflightInfo.ConfirmFlush(THostIndex{0});
+        inflightInfo.ConfirmFlush(THostIndex{1});
+
+        const auto disabled = THostMask::MakeMask({THostIndex{2}});
+        inflightInfo.UpdateHosts(THostMask::MakeEmpty(), disabled, disabled);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            3u,
+            readyQueue.GetInflightFlushFinishedCalls(MakeKey(123)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushing,
+            inflightInfo.GetState());
+
+        inflightInfo.ConfirmFlush(THostIndex{3});
+        UNIT_ASSERT_VALUES_EQUAL(
+            4u,
+            readyQueue.GetInflightFlushFinishedCalls(MakeKey(123)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            1u,
+            readyQueue.GetFlushCompletedCalls(MakeKey(123)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushed,
             inflightInfo.GetState());
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
@@ -916,6 +916,78 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             inflightInfo.GetState());
     }
 
+    Y_UNIT_TEST(ShouldCompleteFlushWhenConfirmedHostIsDisabled)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(4),
+            THostMask::MakeEmpty(),
+            MakeKey(123),
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(4), MakePrimaryHosts(4));
+
+        for (THostIndex host: MakeDDisks(4)) {
+            Y_UNUSED(inflightInfo.RequestFlush(host));
+        }
+
+        // Confirm three hosts, then disable one of the confirmed hosts.
+        inflightInfo.ConfirmFlush(THostIndex{0});
+        inflightInfo.ConfirmFlush(THostIndex{1});
+        inflightInfo.ConfirmFlush(THostIndex{2});
+
+        const auto disabled = THostMask::MakeMask({THostIndex{2}});
+        inflightInfo.UpdateHosts(THostMask::MakeEmpty(), disabled, disabled);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushing,
+            inflightInfo.GetState());
+
+        // The remaining enabled desired hosts are 0, 1 and 3.
+        inflightInfo.ConfirmFlush(THostIndex{3});
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushed,
+            inflightInfo.GetState());
+    }
+
+    Y_UNIT_TEST(ShouldKeepFlushedStateWhenDisabledHostIsEnabledAgain)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(4),
+            THostMask::MakeEmpty(),
+            MakeKey(123),
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(4), MakePrimaryHosts(4));
+
+        for (THostIndex host: MakeDDisks(4)) {
+            Y_UNUSED(inflightInfo.RequestFlush(host));
+        }
+
+        inflightInfo.ConfirmFlush(THostIndex{0});
+        inflightInfo.ConfirmFlush(THostIndex{1});
+        inflightInfo.ConfirmFlush(THostIndex{2});
+
+        const auto disabled = THostMask::MakeMask({THostIndex{3}});
+        inflightInfo.UpdateHosts(THostMask::MakeEmpty(), disabled, disabled);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushed,
+            inflightInfo.GetState());
+
+        // The PBuffer is already flushed. Re-enabling the host must not make
+        // the old PBuffer flush again or invalidate its completed state.
+        inflightInfo.UpdateHosts(
+            THostMask::MakeEmpty(),
+            THostMask::MakeEmpty(),
+            THostMask::MakeEmpty());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushed,
+            inflightInfo.GetState());
+    }
+
     // In the erasing state, disabling the last non-erased host lets the erase
     // complete because EraseConfirmed\Disabled == WriteRequested\Disabled.
     Y_UNIT_TEST(ShouldUpdateHostsCompleteEraseWhenDisablingPendingHost)
@@ -1216,6 +1288,48 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferFlushed,
             inflightInfo.GetState());
+    }
+
+    Y_UNIT_TEST(ShouldRemoveFlushRegistrationWhenFlushCompletesAfterFailure)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(4),
+            THostMask::MakeEmpty(),
+            MakeKey(123),
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(4), MakePrimaryHosts(4));
+
+        for (THostIndex host: MakeDDisks(4)) {
+            Y_UNUSED(inflightInfo.RequestFlush(host));
+        }
+
+        // Keep the PBuffer locked so erase registration cannot hide a stale
+        // flush registration.
+        inflightInfo.LockPBuffer();
+        inflightInfo.FlushFailed(THostIndex{3});
+        inflightInfo.ConfirmFlush(THostIndex{0});
+        inflightInfo.ConfirmFlush(THostIndex{1});
+        inflightInfo.ConfirmFlush(THostIndex{2});
+
+        const auto disabled = THostMask::MakeMask({THostIndex{3}});
+        inflightInfo.UpdateHosts(THostMask::MakeEmpty(), disabled, disabled);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushed,
+            inflightInfo.GetState());
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToFlush.contains(MakeKey(123)));
+
+        inflightInfo.UnlockPBuffer();
+        for (THostIndex host: MakeDDisks(3)) {
+            inflightInfo.RequestErase(host);
+        }
+        for (THostIndex host: MakeDDisks(3)) {
+            inflightInfo.ConfirmErase(host);
+        }
     }
 
     // FlushCompleted is emitted when the PBuffer becomes flushed even if it is


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

1. Prevent sync hangs by notifying waiters on every flush completion
2. Enforce dirty map state and flush lifecycle invariants

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
